### PR TITLE
feat: Add LM Studio Provider Configuration and Native API Validation Script

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -8,7 +8,8 @@
     "dev": "NODE_OPTIONS='--loader ts-node/esm' nodemon src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js",
-    "test": "vitest run"
+    "test": "vitest run",
+    "validate-llm": "NODE_OPTIONS='--loader ts-node/esm' ts-node scripts/validate-llm.ts"
   },
   "keywords": [],
   "author": "",

--- a/core/scripts/validate-llm.ts
+++ b/core/scripts/validate-llm.ts
@@ -1,0 +1,68 @@
+import { config } from '../src/lib/config.js';
+
+async function validateLLM() {
+  const llmConfig = config.llm;
+
+  console.log(`Configured Provider: ${llmConfig.provider}`);
+  console.log(`Configured Base URL: ${llmConfig.baseUrl}`);
+  console.log(`Configured Model: ${llmConfig.model}`);
+
+  try {
+    let url = `${llmConfig.baseUrl}/models`;
+
+    if (llmConfig.provider === 'lm-studio') {
+      // LM Studio's native REST API is at /api/v1/models
+      // Parse the configured baseUrl to construct the correct native API endpoint
+      try {
+        const parsedUrl = new URL(llmConfig.baseUrl);
+        // Replace /v1 path with /api/v1 to use native API
+        if (parsedUrl.pathname === '/v1' || parsedUrl.pathname === '/v1/') {
+          parsedUrl.pathname = '/api/v1/models';
+        } else if (parsedUrl.pathname === '/api/v1' || parsedUrl.pathname === '/api/v1/') {
+          parsedUrl.pathname = '/api/v1/models';
+        } else {
+          // If no specific path or different path, just append /api/v1/models
+          parsedUrl.pathname = parsedUrl.pathname.replace(/\/+$/, '') + '/api/v1/models';
+        }
+        url = parsedUrl.toString();
+      } catch (e) {
+        // Fallback to string replacement if URL parsing fails
+        if (llmConfig.baseUrl.endsWith('/v1') || llmConfig.baseUrl.endsWith('/v1/')) {
+          url = llmConfig.baseUrl.replace(/\/v1\/?$/, '/api/v1/models');
+        } else {
+          url = `${llmConfig.baseUrl.replace(/\/+$/, '')}/api/v1/models`;
+        }
+      }
+    }
+
+    console.log(`Fetching models from: ${url}`);
+
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${llmConfig.apiKey}`
+      }
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const data = await response.json();
+    console.log('\nAvailable Models:');
+    if (data && data.data && Array.isArray(data.data)) {
+      data.data.forEach((model: any) => {
+        console.log(`- ${model.id}`);
+      });
+    } else {
+      console.log(JSON.stringify(data, null, 2));
+    }
+
+  } catch (error) {
+    console.error('Failed to validate LLM connection:', error);
+    process.exit(1);
+  }
+}
+
+validateLLM();

--- a/core/src/lib/config.ts
+++ b/core/src/lib/config.ts
@@ -4,15 +4,17 @@ import path from 'path';
 const CONFIG_PATH = path.join(process.cwd(), 'config', 'llm.json');
 
 export interface LLMConfig {
+  provider: 'lm-studio' | 'openai' | string;
   baseUrl: string;
   apiKey: string;
   model: string;
 }
 
 const defaultConfig: LLMConfig = {
-  baseUrl: process.env.LLM_BASE_URL || 'http://localhost:1234/v1',
+  provider: process.env.LLM_PROVIDER || 'lm-studio',
+  baseUrl: process.env.LM_STUDIO_URL || process.env.LLM_BASE_URL || 'http://localhost:1234/v1',
   apiKey: process.env.LLM_API_KEY || 'lm-studio',
-  model: process.env.LLM_MODEL || 'model-identifier',
+  model: process.env.LM_STUDIO_MODEL || process.env.LLM_MODEL || 'meta-llama-3-8b-instruct',
 };
 
 function loadConfig(): LLMConfig {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,6 +7,8 @@ services:
       dockerfile: Dockerfile
     container_name: sera-core
     restart: unless-stopped
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     volumes:
       - ./core:/app
       - /app/node_modules
@@ -19,9 +21,12 @@ services:
       - DATABASE_URL=postgresql://sera_user:sera_pass@sera-db:5432/sera_db
       - CENTRIFUGO_API_URL=http://centrifugo:8000/api
       - QDRANT_URL=http://qdrant:6333
+      - LLM_PROVIDER=${LLM_PROVIDER:-lm-studio}
+      - LM_STUDIO_URL=${LM_STUDIO_URL:-http://host.docker.internal:1234/v1}
+      - LM_STUDIO_MODEL=${LM_STUDIO_MODEL:-meta-llama-3-8b-instruct}
       - LLM_BASE_URL=${LLM_BASE_URL:-http://host.docker.internal:1234/v1}
       - LLM_API_KEY=${LLM_API_KEY:-lm-studio}
-      - LLM_MODEL=${LLM_MODEL:-model-identifier}
+      - LLM_MODEL=${LLM_MODEL:-meta-llama-3-8b-instruct}
     ports:
       - "3001:3001"
     networks:


### PR DESCRIPTION
Abstract LM Studio as an explicit LLM provider type and utilize its native `/api/v1/models` endpoint for connection validation. Configure environment variables correctly and route `docker-compose` `sera-core` container with `extra_hosts` to ensure proper host reachability. Add `validate-llm` npm script utility.

---
*PR created automatically by Jules for task [96936587378392876](https://jules.google.com/task/96936587378392876) started by @TKCen*