### PR TITLE
feat(llm): implement real-time streaming for OpenAIProvider

### DIFF
--- a/core/src/agents/PrimaryAgent.ts
+++ b/core/src/agents/PrimaryAgent.ts
@@ -24,28 +24,33 @@ You MUST respond in JSON format with the following structure:
 
     this.history.push({ role: 'user', content: input });
 
-    const response = await this.llmProvider.chat([
+    const stream = this.llmProvider.chat([
       { role: 'system', content: this.systemPrompt },
       ...this.history
     ]);
 
-    this.history.push({ role: 'assistant', content: response.content });
+    let fullContent = '';
+    for await (const chunk of stream) {
+      fullContent += chunk;
+    }
+
+    this.history.push({ role: 'assistant', content: fullContent });
 
     try {
       // Basic extraction of JSON from the response
-      const jsonMatch = response.content.match(/\{[\s\S]*\}/);
+      const jsonMatch = fullContent.match(/\{[\s\S]*\}/);
       if (jsonMatch) {
         return JSON.parse(jsonMatch[0]);
       }
       return {
         thought: 'Received non-JSON response from LLM, assuming it is the final answer.',
-        finalAnswer: response.content
+        finalAnswer: fullContent
       };
     } catch (error) {
       console.error('Failed to parse agent response:', error);
       return {
         thought: 'I encountered an error parsing my own thoughts.',
-        finalAnswer: response.content
+        finalAnswer: fullContent
       };
     }
   }

--- a/core/src/lib/llm/OpenAIProvider.ts
+++ b/core/src/lib/llm/OpenAIProvider.ts
@@ -13,25 +13,35 @@ export class OpenAIProvider implements LLMProvider {
     });
   }
 
-  async chat(messages: ChatMessage[]): Promise<LLMResponse> {
+  async *chat(messages: ChatMessage[]): AsyncGenerator<string, void, unknown> {
     try {
-      const response = await this.client.chat.completions.create({
+      const stream = await this.client.chat.completions.create({
         model: config.llm.model,
         messages: messages as any, // types match logically
         temperature: 0.7,
+        stream: true,
       });
 
-      return {
-        content: response.choices[0]?.message?.content || '',
-        usage: {
-          promptTokens: response.usage?.prompt_tokens || 0,
-          completionTokens: response.usage?.completion_tokens || 0,
-          totalTokens: response.usage?.total_tokens || 0,
-        },
-      };
+      for await (const chunk of stream) {
+        const content = chunk.choices[0]?.delta?.content || '';
+        if (content) {
+          process.stdout.write(content);
+          yield content;
+        }
+      }
+      console.log(''); // newline after stream finishes
     } catch (error: any) {
-      console.error('LLM Chat Error:', error);
-      throw new Error(`LLM provider failed: ${error.message}`);
+      console.error('\nLLM Chat Error:', error);
+
+      let errorMessage = error.message || 'Unknown error occurred';
+
+      if (error.code === 'ECONNREFUSED' || error.message?.includes('ECONNREFUSED')) {
+        errorMessage = 'Connection Refused: Ensure LM Studio (or your local LLM) is running and accessible.';
+      } else if (error.status === 404 || error.message?.includes('not found') || error.code === 'model_not_found') {
+        errorMessage = 'Model Not Found: Check if the correct model is loaded in LM Studio/OpenAI.';
+      }
+
+      throw new Error(`LLM provider failed: ${errorMessage}`);
     }
   }
 }

--- a/core/src/lib/llm/types.ts
+++ b/core/src/lib/llm/types.ts
@@ -10,5 +10,5 @@ export interface LLMResponse {
 }
 
 export interface LLMProvider {
-  chat(messages: ChatMessage[]): Promise<LLMResponse>;
+  chat(messages: ChatMessage[]): AsyncGenerator<string, void, unknown>;
 }


### PR DESCRIPTION
This change introduces real-time token streaming to the `OpenAIProvider`, fulfilling the requirement for a "Zero-latency" experience with local LLMs (like LM Studio). 

Key changes include:
- Refactoring `LLMProvider.chat` to return an `AsyncGenerator<string, void, unknown>`.
- Updating `OpenAIProvider` to stream chunks natively from the OpenAI SDK, yielding them via the generator, and logging them directly to `process.stdout` in real-time.
- Adding specific error blocks for connection failures and missing models to provide user-friendly error messages that can be propagated up.
- Modifying `PrimaryAgent` to await and accumulate the streamed chunks without breaking existing logic.

---
*PR created automatically by Jules for task [1026262364312688454](https://jules.google.com/task/1026262364312688454) started by @TKCen*