### PR TITLE
Harden SERA Memory System

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -12,6 +12,7 @@
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@qdrant/js-client-rest": "^1.17.0",
         "@xenova/transformers": "^2.17.2",
+        "async-mutex": "^0.5.0",
         "axios": "^1.7.8",
         "cors": "^2.8.6",
         "dockerode": "^4.0.9",
@@ -1288,6 +1289,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/async-mutex": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/asynckit": {
@@ -4668,9 +4678,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",

--- a/core/package.json
+++ b/core/package.json
@@ -32,6 +32,7 @@
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@qdrant/js-client-rest": "^1.17.0",
     "@xenova/transformers": "^2.17.2",
+    "async-mutex": "^0.5.0",
     "axios": "^1.7.8",
     "cors": "^2.8.6",
     "dockerode": "^4.0.9",

--- a/core/src/memory/Reflector.ts
+++ b/core/src/memory/Reflector.ts
@@ -16,6 +16,9 @@ export class Reflector {
   /** Number of oldest entries to summarise per compaction cycle. */
   static readonly DEFAULT_BATCH_SIZE = 5;
 
+  /** Configurable override for threshold. */
+  static compactionThreshold: number | undefined;
+
   /**
    * Run a compaction cycle if the core block exceeds the threshold.
    * Returns the summary entry if compaction occurred, or null otherwise.
@@ -25,7 +28,7 @@ export class Reflector {
     llmProvider: LLMProvider,
     opts?: { threshold?: number; batchSize?: number },
   ): Promise<MemoryEntry | null> {
-    const threshold = opts?.threshold ?? Reflector.DEFAULT_THRESHOLD;
+    const threshold = opts?.threshold ?? Reflector.compactionThreshold ?? Reflector.DEFAULT_THRESHOLD;
     const batchSize = opts?.batchSize ?? Reflector.DEFAULT_BATCH_SIZE;
 
     const coreBlock = await memoryManager.getBlock('core');
@@ -42,18 +45,38 @@ export class Reflector {
       .map(e => `## ${e.title}\n${e.content}`)
       .join('\n\n---\n\n');
 
-    const response = await llmProvider.chat([
-      {
-        role: 'system',
-        content:
-          'You are a memory compaction assistant. Summarise the following knowledge entries ' +
-          'into a single concise summary paragraph that preserves all key facts and decisions. ' +
-          'Do NOT add any preamble or explanation — output only the summary.',
-      },
-      { role: 'user', content: contentForSummary },
-    ]);
-
-    const summaryContent = response.content.trim();
+    let summaryContent = '';
+    try {
+      const response = await llmProvider.chat([
+        {
+          role: 'system',
+          content:
+            'You are a memory compaction assistant. Summarise the following knowledge entries ' +
+            'into a single concise summary paragraph that preserves all key facts and decisions. ' +
+            'Do NOT add any preamble or explanation — output only the summary.',
+        },
+        { role: 'user', content: contentForSummary },
+      ]);
+      summaryContent = response.content.trim();
+    } catch (err) {
+      console.warn(`[Reflector] First summarisation attempt failed. Retrying... Error:`, err);
+      try {
+        const retryResponse = await llmProvider.chat([
+          {
+            role: 'system',
+            content:
+              'You are a memory compaction assistant. Summarise the following knowledge entries ' +
+              'into a single concise summary paragraph that preserves all key facts and decisions. ' +
+              'Do NOT add any preamble or explanation — output only the summary.',
+          },
+          { role: 'user', content: contentForSummary },
+        ]);
+        summaryContent = retryResponse.content.trim();
+      } catch (retryErr) {
+        console.error(`[Reflector] Summarisation failed after retry. Skipping compaction. Error:`, retryErr);
+        return null;
+      }
+    }
 
     // Collect the IDs of compacted entries for the ref chain
     const compactedIds = toCompact.map(e => e.id);
@@ -74,7 +97,7 @@ export class Reflector {
     }
 
     console.log(
-      `[Reflector] Compacted ${toCompact.length} core entries into archive summary "${summaryEntry.title}"`,
+      `[Reflector] Metrics: Compacted ${toCompact.length} core entries into 1 archive summary entry (ID: ${summaryEntry.id}). Summary Title: "${summaryEntry.title}"`
     );
 
     return summaryEntry;

--- a/core/src/memory/blocks/MemoryBlockStore.test.ts
+++ b/core/src/memory/blocks/MemoryBlockStore.test.ts
@@ -222,4 +222,84 @@ describe('MemoryBlockStore', () => {
     const results = await store.search('matching', 3);
     expect(results).toHaveLength(3);
   });
+
+  // ── Edge Cases ──────────────────────────────────────────────────────────────
+
+  it('should skip malformed YAML frontmatter without crashing', async () => {
+    const dir = path.join(tmpDir, 'blocks', 'core');
+    await fs.mkdir(dir, { recursive: true });
+
+    // Write a deliberately broken file
+    await fs.writeFile(
+      path.join(dir, 'broken.md'),
+      '---\nmissing id and title and type\n---\nSome content'
+    );
+
+    // Write a valid file
+    await store.addEntry('core', { title: 'Valid Entry', content: 'Valid content' });
+
+    // Should load the valid one and ignore the broken one
+    const block = await store.loadBlock('core');
+    expect(block.entries).toHaveLength(1);
+    expect(block.entries[0]!.title).toBe('Valid Entry');
+  });
+
+  it('should handle concurrent writes to the same block type', async () => {
+    const promises: Promise<any>[] = [];
+    for (let i = 0; i < 20; i++) {
+      promises.push(
+        store.addEntry('core', { title: `Concurrent Entry ${i}`, content: `Content ${i}` })
+      );
+    }
+
+    await Promise.all(promises);
+
+    const block = await store.loadBlock('core');
+    expect(block.entries).toHaveLength(20);
+  });
+
+  it('should handle concurrent updates to the same entry gracefully', async () => {
+    const entry = await store.addEntry('core', { title: 'Shared Entry', content: 'Initial' });
+
+    const promises: Promise<any>[] = [];
+    for (let i = 0; i < 10; i++) {
+      promises.push(store.updateEntry(entry.id, `Update ${i}`));
+    }
+
+    await Promise.all(promises);
+
+    const retrieved = await store.getEntry(entry.id);
+    expect(retrieved).not.toBeNull();
+    expect(retrieved!.content).toMatch(/Update \d/);
+  });
+
+  it('should handle very large content', async () => {
+    // 150KB of content
+    const largeContent = 'A'.repeat(150 * 1024);
+
+    const entry = await store.addEntry('core', {
+      title: 'Large Entry',
+      content: largeContent
+    });
+
+    const retrieved = await store.getEntry(entry.id);
+    expect(retrieved).not.toBeNull();
+    expect(retrieved!.content).toBe(largeContent);
+  });
+
+  it('should handle special characters in titles', async () => {
+    const weirdTitle = 'My @Weird #Title! (With spaces)';
+    const entry = await store.addEntry('core', { title: weirdTitle, content: 'Special characters.' });
+
+    expect(entry.title).toBe(weirdTitle);
+
+    const retrieved = await store.getEntry(entry.id);
+    expect(retrieved).not.toBeNull();
+    expect(retrieved!.title).toBe(weirdTitle);
+
+    // Check slugified filename
+    const dir = path.join(tmpDir, 'blocks', 'core');
+    const files = await fs.readdir(dir);
+    expect(files).toContain('my-weird-title-with-spaces.md');
+  });
 });

--- a/core/src/memory/blocks/MemoryBlockStore.ts
+++ b/core/src/memory/blocks/MemoryBlockStore.ts
@@ -2,6 +2,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import matter from 'gray-matter';
 import { v4 as uuidv4 } from 'uuid';
+import { Mutex } from 'async-mutex';
 import type {
   MemoryBlockType,
   MemoryEntry,
@@ -21,9 +22,17 @@ import { MEMORY_BLOCK_TYPES } from './types.js';
  */
 export class MemoryBlockStore {
   private readonly basePath: string;
+  private readonly fileMutexes = new Map<string, Mutex>();
 
   constructor(basePath: string) {
     this.basePath = basePath;
+  }
+
+  private getMutex(filepath: string): Mutex {
+    if (!this.fileMutexes.has(filepath)) {
+      this.fileMutexes.set(filepath, new Mutex());
+    }
+    return this.fileMutexes.get(filepath)!;
   }
 
   // ── Helpers ─────────────────────────────────────────────────────────────────
@@ -61,21 +70,32 @@ export class MemoryBlockStore {
     return matter.stringify(entry.content, frontmatter);
   }
 
-  /** Parse a markdown file into a MemoryEntry. */
-  private parse(fileContent: string): MemoryEntry {
-    const parsed = matter(fileContent);
-    const data = parsed.data as Record<string, unknown>;
-    return {
-      id: data.id as string,
-      title: data.title as string,
-      type: data.type as MemoryBlockType,
-      content: parsed.content.trim(),
-      refs: (data.refs as string[] | undefined) ?? [],
-      tags: (data.tags as string[] | undefined) ?? [],
-      source: (data.source as MemorySource | undefined) ?? 'system',
-      createdAt: data.createdAt as string,
-      updatedAt: data.updatedAt as string,
-    };
+  /** Parse a markdown file into a MemoryEntry. Returns null if invalid/corrupted. */
+  private parse(fileContent: string): MemoryEntry | null {
+    try {
+      const parsed = matter(fileContent);
+      const data = parsed.data as Record<string, unknown>;
+
+      if (!data.id || !data.title || !data.type) {
+         console.warn(`[MemoryBlockStore] Skipping entry: Missing required frontmatter fields (id, title, type).`);
+         return null;
+      }
+
+      return {
+        id: data.id as string,
+        title: data.title as string,
+        type: data.type as MemoryBlockType,
+        content: parsed.content.trim(),
+        refs: Array.isArray(data.refs) ? data.refs.map(String) : [],
+        tags: Array.isArray(data.tags) ? data.tags.map(String) : [],
+        source: (data.source as MemorySource | undefined) ?? 'system',
+        createdAt: (data.createdAt as string) || new Date().toISOString(),
+        updatedAt: (data.updatedAt as string) || new Date().toISOString(),
+      };
+    } catch (err) {
+      console.warn(`[MemoryBlockStore] Skipping entry: Failed to parse frontmatter. Error:`, err);
+      return null;
+    }
   }
 
   /** Find the filepath for an entry by scanning all block dirs.  Returns null if not found. */
@@ -92,9 +112,13 @@ export class MemoryBlockStore {
         if (!file.endsWith('.md')) continue;
         const filepath = path.join(dir, file);
         const raw = await fs.readFile(filepath, 'utf8');
-        const parsed = matter(raw);
-        if ((parsed.data as Record<string, unknown>).id === id) {
-          return { filepath, type };
+        try {
+          const parsed = matter(raw);
+          if ((parsed.data as Record<string, unknown>).id === id) {
+            return { filepath, type };
+          }
+        } catch (err) {
+          console.warn(`[MemoryBlockStore] Failed to read frontmatter while searching for ID ${id} in ${filepath}. Error:`, err);
         }
       }
     }
@@ -119,8 +143,12 @@ export class MemoryBlockStore {
 
     for (const file of files) {
       if (!file.endsWith('.md')) continue;
-      const raw = await fs.readFile(path.join(dir, file), 'utf8');
-      entries.push(this.parse(raw));
+      const filepath = path.join(dir, file);
+      const raw = await fs.readFile(filepath, 'utf8');
+      const parsedEntry = this.parse(raw);
+      if (parsedEntry) {
+        entries.push(parsedEntry);
+      }
     }
 
     // Sort by creation date (oldest first)
@@ -157,7 +185,13 @@ export class MemoryBlockStore {
     };
     const filename = `${this.slugify(entry.title)}.md`;
     const filepath = path.join(this.blockDir(type), filename);
-    await fs.writeFile(filepath, this.serialize(entry), 'utf8');
+
+    const release = await this.getMutex(filepath).acquire();
+    try {
+      await fs.writeFile(filepath, this.serialize(entry), 'utf8');
+    } finally {
+      release();
+    }
     return entry;
   }
 
@@ -165,39 +199,73 @@ export class MemoryBlockStore {
   async getEntry(id: string): Promise<MemoryEntry | null> {
     const result = await this.findEntryFile(id);
     if (!result) return null;
-    const raw = await fs.readFile(result.filepath, 'utf8');
-    return this.parse(raw);
+
+    const release = await this.getMutex(result.filepath).acquire();
+    try {
+      const raw = await fs.readFile(result.filepath, 'utf8');
+      return this.parse(raw);
+    } catch {
+      return null;
+    } finally {
+      release();
+    }
   }
 
   /** Update an entry's content. */
   async updateEntry(id: string, content: string): Promise<MemoryEntry | null> {
     const result = await this.findEntryFile(id);
     if (!result) return null;
-    const raw = await fs.readFile(result.filepath, 'utf8');
-    const entry = this.parse(raw);
-    entry.content = content;
-    entry.updatedAt = new Date().toISOString();
-    await fs.writeFile(result.filepath, this.serialize(entry), 'utf8');
-    return entry;
+
+    const release = await this.getMutex(result.filepath).acquire();
+    try {
+      const raw = await fs.readFile(result.filepath, 'utf8');
+      const entry = this.parse(raw);
+      if (!entry) return null;
+
+      entry.content = content;
+      entry.updatedAt = new Date().toISOString();
+      await fs.writeFile(result.filepath, this.serialize(entry), 'utf8');
+      return entry;
+    } finally {
+      release();
+    }
   }
 
   /** Delete an entry by UUID. */
   async deleteEntry(id: string): Promise<boolean> {
     const result = await this.findEntryFile(id);
     if (!result) return false;
-    await fs.unlink(result.filepath);
-    return true;
+
+    const release = await this.getMutex(result.filepath).acquire();
+    try {
+      await fs.unlink(result.filepath);
+      this.fileMutexes.delete(result.filepath);
+      return true;
+    } catch {
+      return false;
+    } finally {
+      release();
+    }
   }
 
   /** Move an entry to a different block type (preserves ID and refs). */
   async moveEntry(id: string, toType: MemoryBlockType): Promise<MemoryEntry | null> {
     const result = await this.findEntryFile(id);
     if (!result) return null;
-    const raw = await fs.readFile(result.filepath, 'utf8');
-    const entry = this.parse(raw);
 
-    // Delete from old location
-    await fs.unlink(result.filepath);
+    const releaseOld = await this.getMutex(result.filepath).acquire();
+    let entry: MemoryEntry | null = null;
+    try {
+      const raw = await fs.readFile(result.filepath, 'utf8');
+      entry = this.parse(raw);
+      if (!entry) return null;
+
+      // Delete from old location
+      await fs.unlink(result.filepath);
+      this.fileMutexes.delete(result.filepath);
+    } finally {
+      releaseOld();
+    }
 
     // Write to new location
     entry.type = toType;
@@ -205,7 +273,13 @@ export class MemoryBlockStore {
     await this.ensureBlockDir(toType);
     const filename = `${this.slugify(entry.title)}.md`;
     const filepath = path.join(this.blockDir(toType), filename);
-    await fs.writeFile(filepath, this.serialize(entry), 'utf8');
+
+    const releaseNew = await this.getMutex(filepath).acquire();
+    try {
+      await fs.writeFile(filepath, this.serialize(entry), 'utf8');
+    } finally {
+      releaseNew();
+    }
     return entry;
   }
 
@@ -215,28 +289,44 @@ export class MemoryBlockStore {
   async addRef(fromId: string, toId: string): Promise<boolean> {
     const result = await this.findEntryFile(fromId);
     if (!result) return false;
-    const raw = await fs.readFile(result.filepath, 'utf8');
-    const entry = this.parse(raw);
-    if (!entry.refs.includes(toId)) {
-      entry.refs.push(toId);
-      entry.updatedAt = new Date().toISOString();
-      await fs.writeFile(result.filepath, this.serialize(entry), 'utf8');
+
+    const release = await this.getMutex(result.filepath).acquire();
+    try {
+      const raw = await fs.readFile(result.filepath, 'utf8');
+      const entry = this.parse(raw);
+      if (!entry) return false;
+
+      if (!entry.refs.includes(toId)) {
+        entry.refs.push(toId);
+        entry.updatedAt = new Date().toISOString();
+        await fs.writeFile(result.filepath, this.serialize(entry), 'utf8');
+      }
+      return true;
+    } finally {
+      release();
     }
-    return true;
   }
 
   /** Remove an explicit ref. */
   async removeRef(fromId: string, toId: string): Promise<boolean> {
     const result = await this.findEntryFile(fromId);
     if (!result) return false;
-    const raw = await fs.readFile(result.filepath, 'utf8');
-    const entry = this.parse(raw);
-    const idx = entry.refs.indexOf(toId);
-    if (idx === -1) return false;
-    entry.refs.splice(idx, 1);
-    entry.updatedAt = new Date().toISOString();
-    await fs.writeFile(result.filepath, this.serialize(entry), 'utf8');
-    return true;
+
+    const release = await this.getMutex(result.filepath).acquire();
+    try {
+      const raw = await fs.readFile(result.filepath, 'utf8');
+      const entry = this.parse(raw);
+      if (!entry) return false;
+
+      const idx = entry.refs.indexOf(toId);
+      if (idx === -1) return false;
+      entry.refs.splice(idx, 1);
+      entry.updatedAt = new Date().toISOString();
+      await fs.writeFile(result.filepath, this.serialize(entry), 'utf8');
+      return true;
+    } finally {
+      release();
+    }
   }
 
   // ── Graph ───────────────────────────────────────────────────────────────────
@@ -248,8 +338,10 @@ export class MemoryBlockStore {
 
     // Build title → id index for wikilink resolution
     const titleToId = new Map<string, string>();
+    const idToTitle = new Map<string, string>();
     for (const entry of allEntries) {
       titleToId.set(entry.title.toLowerCase(), entry.id);
+      idToTitle.set(entry.id, entry.title);
     }
 
     const nodes: GraphNode[] = allEntries.map(e => ({
@@ -265,6 +357,11 @@ export class MemoryBlockStore {
     for (const entry of allEntries) {
       // Explicit refs
       for (const ref of entry.refs) {
+        if (!idToTitle.has(ref)) {
+          console.warn(`[MemoryBlockStore] Broken explicit ref found in entry "${entry.title}" (${entry.id}): refers to non-existent ID ${ref}`);
+          continue;
+        }
+
         const key = `${entry.id}->${ref}`;
         if (!edgeSet.has(key)) {
           edgeSet.add(key);
@@ -276,17 +373,76 @@ export class MemoryBlockStore {
       const wikilinks = this.parseWikilinks(entry.content);
       for (const title of wikilinks) {
         const targetId = titleToId.get(title.toLowerCase());
-        if (targetId && targetId !== entry.id) {
-          const key = `${entry.id}->${targetId}`;
-          if (!edgeSet.has(key)) {
-            edgeSet.add(key);
-            edges.push({ from: entry.id, to: targetId, kind: 'wikilink' });
+        if (targetId) {
+          if (targetId !== entry.id) {
+            const key = `${entry.id}->${targetId}`;
+            if (!edgeSet.has(key)) {
+              edgeSet.add(key);
+              edges.push({ from: entry.id, to: targetId, kind: 'wikilink' });
+            }
           }
+        } else {
+          console.warn(`[MemoryBlockStore] Broken wikilink found in entry "${entry.title}" (${entry.id}): [[${title}]] does not exist.`);
         }
       }
     }
 
     return { nodes, edges };
+  }
+
+  /** Scan for orphaned refs and broken wikilinks, and clean up broken explicit refs. */
+  async repair(): Promise<void> {
+    console.log(`[MemoryBlockStore] Starting repair process...`);
+    const blocks = await this.loadAll();
+    const allEntries = blocks.flatMap(b => b.entries);
+
+    const validIds = new Set<string>(allEntries.map(e => e.id));
+    const titleToId = new Map<string, string>();
+    for (const entry of allEntries) {
+      titleToId.set(entry.title.toLowerCase(), entry.id);
+    }
+
+    let repairedCount = 0;
+
+    for (const entry of allEntries) {
+      let changed = false;
+      const validRefs: string[] = [];
+
+      for (const ref of entry.refs) {
+        if (validIds.has(ref)) {
+          validRefs.push(ref);
+        } else {
+          console.warn(`[MemoryBlockStore] Repairing: Removing broken ref to ${ref} from entry "${entry.title}" (${entry.id})`);
+          changed = true;
+        }
+      }
+
+      // Optional: We can't automatically rewrite markdown content to remove broken [[Wikilinks]] easily without context,
+      // but we can log them clearly.
+      const wikilinks = this.parseWikilinks(entry.content);
+      for (const title of wikilinks) {
+        if (!titleToId.has(title.toLowerCase())) {
+          console.warn(`[MemoryBlockStore] Repair Warning: Broken wikilink [[${title}]] found in entry "${entry.title}" (${entry.id})`);
+        }
+      }
+
+      if (changed) {
+        entry.refs = validRefs;
+        entry.updatedAt = new Date().toISOString();
+        const result = await this.findEntryFile(entry.id);
+        if (result) {
+          const release = await this.getMutex(result.filepath).acquire();
+          try {
+            await fs.writeFile(result.filepath, this.serialize(entry), 'utf8');
+            repairedCount++;
+          } finally {
+            release();
+          }
+        }
+      }
+    }
+
+    console.log(`[MemoryBlockStore] Repair complete. Repaired ${repairedCount} entries.`);
   }
 
   // ── Search ──────────────────────────────────────────────────────────────────

--- a/core/src/memory/manager.ts
+++ b/core/src/memory/manager.ts
@@ -19,6 +19,9 @@ export class MemoryManager {
   public readonly circleId?: string;
   public readonly agentId?: string;
 
+  // Simple in-memory rate limiting state
+  private static readonly writeTimestamps = new Map<string, number[]>();
+
   constructor(opts?: { circleId?: string; agentId?: string; basePath?: string }) {
     const rootPath = opts?.basePath
       ?? process.env.MEMORY_PATH
@@ -42,27 +45,58 @@ export class MemoryManager {
     }
   }
 
+  // ── Rate Limiting ─────────────────────────────────────────────────────────
+
+  private checkRateLimit(): void {
+    const key = this.agentId ?? this.circleId ?? 'global';
+    const now = Date.now();
+    const timestamps = MemoryManager.writeTimestamps.get(key) ?? [];
+
+    // Filter out timestamps older than 1 minute
+    const recent = timestamps.filter(t => now - t < 60000);
+    recent.push(now);
+
+    MemoryManager.writeTimestamps.set(key, recent);
+
+    if (recent.length > 10) {
+      console.warn(`[MemoryManager] Rate limit warning: More than 10 memory entries written in the last minute by ${key}.`);
+    }
+  }
+
   // ── Entry Operations (delegates to store) ─────────────────────────────────
 
   async addEntry(type: MemoryBlockType, opts: CreateEntryOptions): Promise<MemoryEntry> {
+    if (!type || typeof type !== 'string') throw new Error('Invalid type parameter');
+    if (!opts || typeof opts !== 'object') throw new Error('Invalid options parameter');
+    if (!opts.title || typeof opts.title !== 'string') throw new Error('opts.title is required');
+    if (typeof opts.content !== 'string') throw new Error('opts.content is required');
+
+    this.checkRateLimit();
     return this.store.addEntry(type, opts);
   }
 
   async getEntry(id: string): Promise<MemoryEntry | null> {
+    if (!id || typeof id !== 'string') throw new Error('Invalid id parameter');
     return this.store.getEntry(id);
   }
 
   async updateEntry(id: string, content: string): Promise<MemoryEntry | null> {
+    if (!id || typeof id !== 'string') throw new Error('Invalid id parameter');
+    if (typeof content !== 'string') throw new Error('Invalid content parameter');
+
+    this.checkRateLimit();
     return this.store.updateEntry(id, content);
   }
 
   async deleteEntry(id: string): Promise<boolean> {
+    if (!id || typeof id !== 'string') throw new Error('Invalid id parameter');
     return this.store.deleteEntry(id);
   }
 
   // ── Block Operations ────────────────────────────────────────────────────────
 
   async getBlock(type: MemoryBlockType): Promise<MemoryBlock> {
+    if (!type || typeof type !== 'string') throw new Error('Invalid type parameter');
     return this.store.loadBlock(type);
   }
 
@@ -73,10 +107,16 @@ export class MemoryManager {
   // ── Ref Operations ──────────────────────────────────────────────────────────
 
   async addRef(fromId: string, toId: string): Promise<boolean> {
+    if (!fromId || typeof fromId !== 'string') throw new Error('Invalid fromId parameter');
+    if (!toId || typeof toId !== 'string') throw new Error('Invalid toId parameter');
+    this.checkRateLimit();
     return this.store.addRef(fromId, toId);
   }
 
   async removeRef(fromId: string, toId: string): Promise<boolean> {
+    if (!fromId || typeof fromId !== 'string') throw new Error('Invalid fromId parameter');
+    if (!toId || typeof toId !== 'string') throw new Error('Invalid toId parameter');
+    this.checkRateLimit();
     return this.store.removeRef(fromId, toId);
   }
 
@@ -89,7 +129,13 @@ export class MemoryManager {
   // ── Search ──────────────────────────────────────────────────────────────────
 
   async search(query: string, limit?: number): Promise<MemoryEntry[]> {
-    return this.store.search(query, limit);
+    if (typeof query !== 'string') return [];
+    if (!query.trim()) return [];
+    if (limit !== undefined && (typeof limit !== 'number' || limit <= 0)) {
+       throw new Error('Limit must be a positive number');
+    }
+    const results = await this.store.search(query, limit);
+    return results || [];
   }
 
   // ── Context Assembly ────────────────────────────────────────────────────────
@@ -133,6 +179,8 @@ export class MemoryManager {
    * Preserves ID, refs, and all metadata.
    */
   async archiveEntry(entryId: string): Promise<MemoryEntry | null> {
+    if (!entryId || typeof entryId !== 'string') throw new Error('Invalid entryId parameter');
+    this.checkRateLimit();
     return this.store.moveEntry(entryId, 'archive');
   }
 }


### PR DESCRIPTION
This pull request introduces critical hardening features for the SERA memory systems:

1. **MemoryBlockStore Hardening:**
   - Implemented file-level locking via `async-mutex` to prevent race conditions during concurrent file modifications.
   - Refactored `parse` and load operations to gracefully skip rather than crash on missing/corrupted frontmatter.
   - Added validation warnings for broken wikilinks in `getGraph()`.
   - Introduced a new `repair()` method that proactively scrubs broken explicit references.

2. **MemoryManager Hardening:**
   - Put robust input validation into `addEntry`, `getEntry`, `updateEntry`, `deleteEntry`, `getBlock`, `addRef`, `removeRef`, `search`, and `archiveEntry`.
   - In-memory rate limiting implementation logs a warning if >10 writes happen in 60s per agent or globally.
   - Updated `search()` to smoothly return `[]` gracefully.

3. **Reflector Hardening:**
   - Exposed `compactionThreshold` to permit configurable compaction triggers.
   - Added LLM fallback handling in `compactIfNeeded` with explicit retries.
   - Logs metric outputs detailing compacted entry counts, explicitly providing summarization results on success.

4. **Testing Improvements:** Added extensive edge case tests correctly ensuring these additions operate optimally against very large entry contents, unique naming bugs, YAML disruptions, and concurrent thread writes.

---
*PR created automatically by Jules for task [3640010781725200484](https://jules.google.com/task/3640010781725200484) started by @TKCen*