### PR TITLE
Connect IntercomService to live Centrifugo HTTP API

### DIFF
--- a/core/src/agents/BaseAgent.ts
+++ b/core/src/agents/BaseAgent.ts
@@ -100,23 +100,23 @@ export abstract class BaseAgent {
 
   protected async observe(context: string): Promise<void> {
     console.log(`[${this.name}] Observing: ${context.substring(0, 50)}...`);
-    await this.publishThought('observe', context);
+    this.publishThought('observe', context).catch(err => console.error(err));
   }
 
   protected async plan(goal: string): Promise<string> {
     console.log(`[${this.name}] Planning for goal: ${goal}`);
-    await this.publishThought('plan', `Planning for: ${goal}`);
+    this.publishThought('plan', `Planning for: ${goal}`).catch(err => console.error(err));
     return `Plan for ${goal}`;
   }
 
   protected async act(action: any): Promise<any> {
     console.log(`[${this.name}] Acting: ${JSON.stringify(action)}`);
-    await this.publishThought('act', `Executing: ${JSON.stringify(action)}`);
+    this.publishThought('act', `Executing: ${JSON.stringify(action)}`).catch(err => console.error(err));
     return { status: 'success' };
   }
 
   protected async reflect(outcome: any): Promise<void> {
     console.log(`[${this.name}] Reflecting on outcome: ${JSON.stringify(outcome)}`);
-    await this.publishThought('reflect', `Outcome: ${JSON.stringify(outcome)}`);
+    this.publishThought('reflect', `Outcome: ${JSON.stringify(outcome)}`).catch(err => console.error(err));
   }
 }

--- a/core/src/agents/Orchestrator.ts
+++ b/core/src/agents/Orchestrator.ts
@@ -6,16 +6,28 @@ import { ProcessManager } from './process/ProcessManager.js';
 import type { ProcessType, ProcessTask, ProcessRunResult } from './process/types.js';
 import type { LLMProvider } from '../lib/llm/types.js';
 import type { AgentManifest } from './manifest/types.js';
+import type { IntercomService } from '../intercom/IntercomService.js';
 
 export class Orchestrator {
   private agents: Map<string, BaseAgent> = new Map();
   private manifests: Map<string, AgentManifest> = new Map();
   private primaryAgentName: string | undefined;
   private processManager: ProcessManager = new ProcessManager();
+  private intercom: IntercomService | undefined;
 
   /** Active file watcher (if any). */
   private watcher: fs.FSWatcher | undefined;
   private agentsDir: string | undefined;
+
+  /**
+   * Set the IntercomService and propagate to all loaded agents.
+   */
+  public setIntercom(intercom: IntercomService): void {
+    this.intercom = intercom;
+    for (const agent of this.agents.values()) {
+      agent.setIntercom(intercom);
+    }
+  }
 
   /**
    * Load agents from AGENT.yaml manifests in a directory.
@@ -66,6 +78,7 @@ export class Orchestrator {
     // Add new agents
     for (const manifest of diff.added) {
       const agent = AgentFactory.createAgent(manifest);
+      if (this.intercom) agent.setIntercom(this.intercom);
       this.agents.set(manifest.metadata.name, agent);
       this.manifests.set(manifest.metadata.name, manifest);
       console.log(`[Orchestrator] Added agent: ${manifest.metadata.name}`);
@@ -74,6 +87,7 @@ export class Orchestrator {
     // Update changed agents
     for (const manifest of diff.updated) {
       const agent = AgentFactory.createAgent(manifest);
+      if (this.intercom) agent.setIntercom(this.intercom);
       this.agents.set(manifest.metadata.name, agent);
       this.manifests.set(manifest.metadata.name, manifest);
       console.log(`[Orchestrator] Updated agent: ${manifest.metadata.name}`);

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -59,6 +59,8 @@ const intercomRouter = createIntercomRouter(intercomService, (agentName: string)
   return agentManifests.find(m => m.metadata.name === agentName);
 });
 
+orchestrator.setIntercom(intercomService);
+
 const mcpRegistry = MCPRegistry.getInstance();
 const memoryManager = new MemoryManager();
 

--- a/core/src/intercom/IntercomService.ts
+++ b/core/src/intercom/IntercomService.ts
@@ -58,6 +58,23 @@ export class IntercomService {
   }
 
   /**
+   * Check who is subscribed to a Centrifugo channel.
+   */
+  async presence(channel: string): Promise<Record<string, unknown>> {
+    try {
+      const res = await this.http.post('', {
+        method: 'presence',
+        params: { channel },
+      });
+      return res.data?.result?.presence || {};
+    } catch (err) {
+      const message = err instanceof AxiosError ? err.message : String(err);
+      console.error(`[Intercom] Failed to get presence for ${channel}: ${message}`);
+      return {};
+    }
+  }
+
+  /**
    * Retrieve channel history from Centrifugo.
    */
   async getHistory(channel: string, limit: number = 50): Promise<unknown[]> {


### PR DESCRIPTION
Connected the IntercomService to the live Centrifugo HTTP API for real-time agent thought streaming to the web UI.

- Added `presence(channel)` method to `IntercomService` to check channel subscribers
- Passed `IntercomService` to `Orchestrator` which now attaches it to all loaded agents
- Refactored `BaseAgent` thought streams (`observe`, `plan`, `act`, `reflect`) to execute synchronously without `await` to make them fire-and-forget, ensuring agent operations aren't blocked by network errors.

---
*PR created automatically by Jules for task [15674959570298908540](https://jules.google.com/task/15674959570298908540) started by @TKCen*