### PR TITLE
feat: add interactive memory graph visualization

### DIFF
--- a/core/core.log
+++ b/core/core.log
@@ -1,0 +1,29 @@
+
+> core@1.0.0 dev
+> NODE_OPTIONS='--loader ts-node/esm' nodemon src/index.ts
+
+(node:9574) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`:
+--import 'data:text/javascript,import { register } from "node:module"; import { pathToFileURL } from "node:url"; register("ts-node/esm", pathToFileURL("./"));'
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:9574) [DEP0180] DeprecationWarning: fs.Stats constructor is deprecated.
+(Use `node --trace-deprecation ...` to show where the warning was created)
+[33m[nodemon] 3.1.14[39m
+[33m[nodemon] to restart at any time, enter `rs`[39m
+[33m[nodemon] watching path(s): *.*[39m
+[33m[nodemon] watching extensions: ts,json[39m
+[32m[nodemon] starting `node src/index.ts`[39m
+(node:9626) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`:
+--import 'data:text/javascript,import { register } from "node:module"; import { pathToFileURL } from "node:url"; register("ts-node/esm", pathToFileURL("./"));'
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:9626) [DEP0180] DeprecationWarning: fs.Stats constructor is deprecated.
+(Use `node --trace-deprecation ...` to show where the warning was created)
+
+node:internal/modules/run_main:123
+    triggerUncaughtException(
+    ^
+[Object: null prototype] {
+  [Symbol(nodejs.util.inspect.custom)]: [Function: [nodejs.util.inspect.custom]]
+}
+
+Node.js v22.22.1
+[31m[nodemon] app crashed - waiting for file changes before starting...[39m

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10,10 +10,12 @@
       "dependencies": {
         "centrifuge": "^5.5.3",
         "clsx": "^2.1.1",
+        "force-graph": "^1.51.2",
         "lucide-react": "^0.577.0",
         "next": "16.1.6",
         "react": "19.2.3",
         "react-dom": "19.2.3",
+        "react-force-graph-2d": "^1.29.1",
         "tailwind-merge": "^3.5.0",
         "tailwindcss-animate": "^1.0.7"
       },
@@ -1582,6 +1584,12 @@
         "tailwindcss": "4.2.1"
       }
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "25.0.0",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-25.0.0.tgz",
+      "integrity": "sha512-XKLA6syeBUaPzx4j3qwMqzzq+V4uo72BnlbOjmuljLrRqdsd3qnzvZZoxvMHZ23ndsRS4aufU6JOZYpCbU6T1A==",
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -2207,6 +2215,15 @@
         "win32"
       ]
     },
+    "node_modules/accessor-fn": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/accessor-fn/-/accessor-fn-1.5.3.tgz",
+      "integrity": "sha512-rkAofCwe/FvYFUlMB0v0gWmhqtfAtV1IUkdPbfhTUyYniu5LrC0A0UJkTH0Jv3S8SvwkmfuAlY+mQIJATdocMA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2512,6 +2529,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bezier-js": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/bezier-js/-/bezier-js-6.1.4.tgz",
+      "integrity": "sha512-PA0FW9ZpcHbojUCMu28z9Vg/fNkwTj5YhusSAjHHDfHDGLxJ6YUKrAN2vk1fP2MMOxVw4Oko16FMlRGVBGqLKg==",
+      "license": "MIT",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/Pomax/bezierjs/blob/master/FUNDING.md"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -2650,6 +2677,18 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/canvas-color-tracker": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/canvas-color-tracker/-/canvas-color-tracker-1.3.2.tgz",
+      "integrity": "sha512-ryQkDX26yJ3CXzb3hxUVNlg1NKE4REc5crLBq661Nxzr8TNd236SaEf2ffYLXyI5tSABSeguHLqcVq4vf9L3Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "tinycolor2": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/centrifuge": {
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/centrifuge/-/centrifuge-5.5.3.tgz",
@@ -2747,6 +2786,222 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-binarytree": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/d3-binarytree/-/d3-binarytree-1.0.2.tgz",
+      "integrity": "sha512-cElUNH+sHu95L04m92pG73t2MEJXKu+GeKUN1TJkFsu93E5W8E9Sc3kHEGJKgenGvj19m6upSn2EunvMgMD2Yw==",
+      "license": "MIT"
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force-3d": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/d3-force-3d/-/d3-force-3d-3.0.6.tgz",
+      "integrity": "sha512-4tsKHUPLOVkyfEffZo1v6sFHvGFwAIIjt/W8IThbp08DYAsXZck+2pSHEG5W1+gQgEvFLdZkYvmJAbRM2EzMnA==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-binarytree": "1",
+        "d3-dispatch": "1 - 3",
+        "d3-octree": "1",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-octree": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-octree/-/d3-octree-1.1.0.tgz",
+      "integrity": "sha512-F8gPlqpP+HwRPMO/8uOu5wjH110+6q4cgJvgJT6vlpy3BEaDIKlTZrgHKZSp/i1InRpVfh4puY/kvL6MxK930A==",
+      "license": "MIT"
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -3701,6 +3956,20 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/float-tooltip": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/float-tooltip/-/float-tooltip-1.7.5.tgz",
+      "integrity": "sha512-/kXzuDnnBqyyWyhDMH7+PfP8J/oXiAavGzcRxASOMRHFuReDtofizLLJsf7nnDLAfEaMW4pVWaXrAjtnglpEkg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-selection": "2 - 3",
+        "kapsule": "^1.16",
+        "preact": "10"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -3715,6 +3984,32 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/force-graph": {
+      "version": "1.51.2",
+      "resolved": "https://registry.npmjs.org/force-graph/-/force-graph-1.51.2.tgz",
+      "integrity": "sha512-zZNdMqx8qIQGurgnbgYIUsdXxSfvhfRSIdncsKGv/twUOZpwCsk9hPHmdjdcme1+epATgb41G0rkIGHJ0Wydng==",
+      "license": "MIT",
+      "dependencies": {
+        "@tweenjs/tween.js": "18 - 25",
+        "accessor-fn": "1",
+        "bezier-js": "3 - 6",
+        "canvas-color-tracker": "^1.3",
+        "d3-array": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-force-3d": "2 - 3",
+        "d3-scale": "1 - 4",
+        "d3-scale-chromatic": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-zoom": "2 - 3",
+        "float-tooltip": "^1.7",
+        "index-array-by": "1",
+        "kapsule": "^1.16",
+        "lodash-es": "4"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/function-bind": {
@@ -4059,6 +4354,15 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/index-array-by": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/index-array-by/-/index-array-by-1.4.2.tgz",
+      "integrity": "sha512-SP23P27OUKzXWEC/TOyWlwLviofQkCSCKONnc62eItjp69yCZZPqDQtr3Pw5gJDnPeUMqExmKydNZaJO0FU9pw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -4072,6 +4376,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-array-buffer": {
@@ -4521,6 +4834,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/jerrypick": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/jerrypick/-/jerrypick-1.1.2.tgz",
+      "integrity": "sha512-YKnxXEekXKzhpf7CLYA0A+oDP8V0OhICNCr5lv96FvSsDEmrb0GKM776JgQvHTMjr7DTTPEVv/1Ciaw0uEWzBA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -4535,7 +4857,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -4612,6 +4933,18 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/kapsule": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/kapsule/-/kapsule-1.16.3.tgz",
+      "integrity": "sha512-4+5mNNf4vZDSwPhKprKwz3330iisPrb08JyMgbsdFrimBCKNHecua/WBwvVg3n7vwx0C1ARjfhwIpbrbd9n5wg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash-es": "4"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/keyv": {
@@ -4935,6 +5268,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash-es": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -4952,7 +5291,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -5206,7 +5544,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5491,6 +5828,16 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/preact": {
+      "version": "10.29.0",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.0.tgz",
+      "integrity": "sha512-wSAGyk2bYR1c7t3SZ3jHcM6xy0lcBcDel6lODcs9ME6Th++Dx2KU+6D3HD8wMMKGA8Wpw7OMd3/4RGzYRpzwRg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -5505,7 +5852,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -5589,12 +5935,43 @@
         "react": "^19.2.3"
       }
     },
+    "node_modules/react-force-graph-2d": {
+      "version": "1.29.1",
+      "resolved": "https://registry.npmjs.org/react-force-graph-2d/-/react-force-graph-2d-1.29.1.tgz",
+      "integrity": "sha512-1Rl/1Z3xy2iTHKj6a0jRXGyiI86xUti81K+jBQZ+Oe46csaMikp47L5AjrzA9hY9fNGD63X8ffrqnvaORukCuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "force-graph": "^1.51",
+        "prop-types": "15",
+        "react-kapsule": "^2.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-kapsule": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/react-kapsule/-/react-kapsule-2.5.7.tgz",
+      "integrity": "sha512-kifAF4ZPD77qZKc4CKLmozq6GY1sBzPEJTIJb0wWFK6HsePJatK3jXplZn2eeAt3x67CDozgi7/rO8fNQ/AL7A==",
+      "license": "MIT",
+      "dependencies": {
+        "jerrypick": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      }
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -6246,6 +6623,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/tinycolor2": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
+      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",

--- a/web/package.json
+++ b/web/package.json
@@ -11,10 +11,12 @@
   "dependencies": {
     "centrifuge": "^5.5.3",
     "clsx": "^2.1.1",
+    "force-graph": "^1.51.2",
     "lucide-react": "^0.577.0",
     "next": "16.1.6",
     "react": "19.2.3",
     "react-dom": "19.2.3",
+    "react-force-graph-2d": "^1.29.1",
     "tailwind-merge": "^3.5.0",
     "tailwindcss-animate": "^1.0.7"
   },

--- a/web/src/app/insights/page.tsx
+++ b/web/src/app/insights/page.tsx
@@ -1,24 +1,272 @@
-import { BarChart3 } from 'lucide-react';
+"use client";
+
+import { useEffect, useState, useMemo } from 'react';
+import { Search, Filter, X, Tag } from 'lucide-react';
+import { GraphNode, MemoryGraphData } from "@/components/MemoryGraph";
+import MemoryGraphWrapper from "@/components/MemoryGraphWrapper";
+
+interface MemoryEntry {
+  id: string;
+  title: string;
+  type: string;
+  content: string;
+  refs: string[];
+  tags: string[];
+  source: string;
+  createdAt: string;
+  updatedAt: string;
+}
 
 export default function InsightsPage() {
+  const [graphData, setGraphData] = useState<MemoryGraphData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Filtering and Search State
+  const [searchQuery, setSearchQuery] = useState("");
+  const [typeFilter, setTypeFilter] = useState<string>("all");
+  const [tagFilter, setTagFilter] = useState<string>("all");
+
+  // Selected Node State
+  const [selectedNode, setSelectedNode] = useState<GraphNode | null>(null);
+  const [selectedEntry, setSelectedEntry] = useState<MemoryEntry | null>(null);
+  const [entryLoading, setEntryLoading] = useState(false);
+
+  useEffect(() => {
+    async function fetchGraph() {
+      try {
+        setLoading(true);
+        const res = await fetch('/api/memory/graph');
+        if (!res.ok) {
+          throw new Error('Failed to load memory graph');
+        }
+        const data = await res.json();
+        setGraphData(data);
+      } catch (err: any) {
+        setError(err.message);
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchGraph();
+  }, []);
+
+  useEffect(() => {
+    async function fetchEntry() {
+      if (!selectedNode) {
+        setSelectedEntry(null);
+        return;
+      }
+      try {
+        setEntryLoading(true);
+        const res = await fetch(`/api/memory/entries/${selectedNode.id}`);
+        if (!res.ok) {
+          throw new Error('Failed to load entry');
+        }
+        const data = await res.json();
+        setSelectedEntry(data);
+      } catch (err: any) {
+        console.error(err);
+        setSelectedEntry(null);
+      } finally {
+        setEntryLoading(false);
+      }
+    }
+    fetchEntry();
+  }, [selectedNode]);
+
+  // Extract all unique tags
+  const allTags = useMemo(() => {
+    if (!graphData) return [];
+    const tags = new Set<string>();
+    graphData.nodes.forEach(n => {
+      n.tags?.forEach(t => tags.add(t));
+    });
+    return Array.from(tags).sort();
+  }, [graphData]);
+
+  const filteredData = useMemo(() => {
+    if (!graphData) return { nodes: [], edges: [] };
+
+    let nodes = graphData.nodes;
+
+    if (typeFilter !== 'all') {
+      nodes = nodes.filter(n => n.type === typeFilter);
+    }
+
+    if (tagFilter !== 'all') {
+      nodes = nodes.filter(n => n.tags && n.tags.includes(tagFilter));
+    }
+
+    // Edges are only kept if both from and to are in the filtered nodes
+    const nodeIds = new Set(nodes.map(n => n.id));
+    const edges = graphData.edges.filter(e => nodeIds.has(e.from) && nodeIds.has(e.to));
+
+    return { nodes, edges };
+  }, [graphData, typeFilter, tagFilter]);
+
+  const handleNodeClick = (node: GraphNode) => {
+    setSelectedNode(node);
+  };
+
+  const closePanel = () => {
+    setSelectedNode(null);
+  };
+
   return (
-    <div className="p-8 max-w-5xl mx-auto">
+    <div className="p-8 max-w-[1400px] mx-auto h-full flex flex-col">
       <div className="sera-page-header">
         <div>
-          <h1 className="sera-page-title">Insights</h1>
-          <p className="text-sm text-sera-text-muted mt-1">Analytics and usage data for your agents</p>
+          <h1 className="sera-page-title">Knowledge Graph</h1>
+          <p className="text-sm text-sera-text-muted mt-1">Interactive visualization of your agents' memories and their connections.</p>
         </div>
       </div>
 
-      <div className="flex flex-col items-center justify-center py-24">
-        <div className="w-16 h-16 rounded-2xl bg-sera-surface border border-sera-border flex items-center justify-center mb-5">
-          <BarChart3 size={28} className="text-sera-text-dim" />
+      <div className="flex-1 flex gap-6 mt-4 min-h-0">
+        {/* Main Graph Area */}
+        <div className="flex-1 flex flex-col bg-sera-surface border border-sera-border rounded-xl shadow-sm overflow-hidden relative">
+
+          {/* Controls Bar */}
+          <div className="p-4 border-b border-sera-border flex gap-4 bg-sera-bg/50 items-center justify-between z-10 flex-wrap">
+            <div className="relative flex-1 min-w-[200px] max-w-md">
+              <Search size={18} className="absolute left-3 top-1/2 -translate-y-1/2 text-sera-text-muted" />
+              <input
+                type="text"
+                placeholder="Search memories by title or tags..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="w-full pl-10 pr-4 py-2 bg-sera-bg border border-sera-border rounded-lg text-sm text-sera-text placeholder:text-sera-text-dim focus:outline-none focus:border-sera-primary"
+              />
+              {searchQuery && (
+                <button
+                  onClick={() => setSearchQuery("")}
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-sera-text-muted hover:text-sera-text"
+                >
+                  <X size={14} />
+                </button>
+              )}
+            </div>
+
+            <div className="flex items-center gap-4 flex-wrap">
+              <div className="flex items-center gap-2">
+                <Tag size={18} className="text-sera-text-muted" />
+                <select
+                  value={tagFilter}
+                  onChange={(e) => setTagFilter(e.target.value)}
+                  className="bg-sera-bg border border-sera-border rounded-lg px-3 py-2 text-sm text-sera-text focus:outline-none focus:border-sera-primary appearance-none cursor-pointer pr-8 max-w-[150px]"
+                >
+                  <option value="all">All Tags</option>
+                  {allTags.map(t => (
+                    <option key={t} value={t}>{t}</option>
+                  ))}
+                </select>
+              </div>
+
+              <div className="flex items-center gap-2">
+                <Filter size={18} className="text-sera-text-muted" />
+                <select
+                  value={typeFilter}
+                  onChange={(e) => setTypeFilter(e.target.value)}
+                  className="bg-sera-bg border border-sera-border rounded-lg px-3 py-2 text-sm text-sera-text focus:outline-none focus:border-sera-primary appearance-none cursor-pointer pr-8"
+                >
+                  <option value="all">All Types</option>
+                  <option value="human">Human</option>
+                  <option value="persona">Persona</option>
+                  <option value="core">Core</option>
+                  <option value="archive">Archive</option>
+                </select>
+              </div>
+            </div>
+          </div>
+
+          {/* Graph Container */}
+          <div className="flex-1 relative">
+            {loading ? (
+              <div className="absolute inset-0 flex items-center justify-center">
+                <div className="animate-pulse text-sera-text-muted flex flex-col items-center gap-4">
+                  <div className="w-8 h-8 rounded-full border-2 border-sera-primary border-t-transparent animate-spin"></div>
+                  Loading graph data...
+                </div>
+              </div>
+            ) : error ? (
+              <div className="absolute inset-0 flex items-center justify-center text-red-500 p-6 text-center">
+                Error loading graph: {error}
+              </div>
+            ) : graphData ? (
+              <MemoryGraphWrapper
+                data={filteredData}
+                searchQuery={searchQuery}
+                onNodeClick={handleNodeClick}
+                className="rounded-none border-none border-t border-sera-border h-full absolute inset-0"
+              />
+            ) : null}
+          </div>
         </div>
-        <h2 className="text-lg font-semibold text-sera-text mb-2">Coming soon</h2>
-        <p className="text-sm text-sera-text-muted text-center max-w-md">
-          Track agent performance, token usage, session metrics, and system health
-          across all your agents and workflows.
-        </p>
+
+        {/* Side Panel for Node Details */}
+        {selectedNode && (
+          <div className="w-80 bg-sera-surface border border-sera-border rounded-xl shadow-sm flex flex-col overflow-hidden animate-in slide-in-from-right-4 duration-200">
+            <div className="p-4 border-b border-sera-border flex justify-between items-start bg-sera-bg/50">
+              <div>
+                <h3 className="font-medium text-sera-text truncate max-w-[220px]" title={selectedNode.title}>
+                  {selectedNode.title}
+                </h3>
+                <span className="text-xs px-2 py-0.5 rounded-full bg-sera-bg border border-sera-border text-sera-text-muted mt-2 inline-block capitalize">
+                  {selectedNode.type}
+                </span>
+              </div>
+              <button onClick={closePanel} className="text-sera-text-muted hover:text-sera-text p-1">
+                <X size={16} />
+              </button>
+            </div>
+
+            <div className="p-4 flex-1 overflow-y-auto">
+              <div className="mb-4">
+                <h4 className="text-xs font-semibold text-sera-text-dim uppercase tracking-wider mb-2">Tags</h4>
+                {selectedNode.tags && selectedNode.tags.length > 0 ? (
+                  <div className="flex flex-wrap gap-1.5">
+                    {selectedNode.tags.map(tag => (
+                      <span key={tag} className="text-[10px] px-1.5 py-0.5 bg-sera-bg border border-sera-border rounded text-sera-text-muted">
+                        #{tag}
+                      </span>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="text-xs text-sera-text-dim italic">No tags</p>
+                )}
+              </div>
+
+              <div className="mb-4">
+                <h4 className="text-xs font-semibold text-sera-text-dim uppercase tracking-wider mb-2">Content Preview</h4>
+                {entryLoading ? (
+                  <div className="animate-pulse flex flex-col gap-2">
+                    <div className="h-3 bg-sera-bg rounded w-3/4"></div>
+                    <div className="h-3 bg-sera-bg rounded w-full"></div>
+                    <div className="h-3 bg-sera-bg rounded w-5/6"></div>
+                  </div>
+                ) : selectedEntry ? (
+                  <div className="text-sm text-sera-text-muted bg-sera-bg p-3 rounded-lg border border-sera-border max-h-48 overflow-y-auto whitespace-pre-wrap font-mono text-xs">
+                    {selectedEntry.content}
+                  </div>
+                ) : (
+                  <p className="text-xs text-sera-text-dim italic">Failed to load entry content.</p>
+                )}
+              </div>
+
+              <div className="mt-auto pt-4 flex flex-col items-center">
+                 <p className="text-xs text-sera-text-dim text-center mb-2">
+                   Double-click node to open full details
+                 </p>
+                 <a
+                   href={`/memory/${selectedNode.id}`}
+                   className="w-full py-2 bg-sera-bg hover:bg-sera-surface border border-sera-border rounded-lg text-sm text-sera-text text-center transition-colors block"
+                 >
+                   Open Entry
+                 </a>
+              </div>
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/web/src/app/memory/[id]/page.tsx
+++ b/web/src/app/memory/[id]/page.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { ArrowLeft } from "lucide-react";
+
+interface MemoryEntry {
+  id: string;
+  title: string;
+  type: string;
+  content: string;
+  refs: string[];
+  tags: string[];
+  source: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export default function MemoryEntryPage() {
+  const params = useParams();
+  const router = useRouter();
+  const id = params.id as string;
+
+  const [entry, setEntry] = useState<MemoryEntry | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function fetchEntry() {
+      if (!id) return;
+      try {
+        setLoading(true);
+        const res = await fetch(`/api/memory/entries/${id}`);
+        if (!res.ok) {
+          throw new Error("Failed to load memory entry");
+        }
+        const data = await res.json();
+        setEntry(data);
+      } catch (err: any) {
+        setError(err.message);
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    fetchEntry();
+  }, [id]);
+
+  return (
+    <div className="p-8 max-w-5xl mx-auto h-full flex flex-col">
+      <div className="flex items-center space-x-4 mb-6">
+        <button
+          onClick={() => router.back()}
+          className="p-2 hover:bg-sera-surface rounded-full transition-colors text-sera-text-muted hover:text-sera-text"
+        >
+          <ArrowLeft size={20} />
+        </button>
+        <div>
+          <h1 className="text-2xl font-bold text-sera-text">
+            {loading ? "Loading..." : entry?.title || "Entry Not Found"}
+          </h1>
+          {entry && (
+            <div className="flex space-x-2 mt-2">
+              <span className="text-xs px-2 py-0.5 rounded-full bg-sera-surface text-sera-text-muted border border-sera-border">
+                {entry.type}
+              </span>
+              <span className="text-xs px-2 py-0.5 rounded-full bg-sera-surface text-sera-text-muted border border-sera-border">
+                {entry.source}
+              </span>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {loading && (
+        <div className="flex-1 flex items-center justify-center">
+          <div className="animate-pulse text-sera-text-muted">Loading entry...</div>
+        </div>
+      )}
+
+      {error && (
+        <div className="flex-1 flex items-center justify-center text-red-500">
+          {error}
+        </div>
+      )}
+
+      {entry && !loading && !error && (
+        <div className="flex-1 flex flex-col gap-6">
+          <div className="p-6 bg-sera-surface border border-sera-border rounded-lg shadow-sm font-mono text-sm text-sera-text whitespace-pre-wrap overflow-y-auto max-h-[60vh]">
+            {entry.content}
+          </div>
+
+          <div className="grid grid-cols-2 gap-6">
+            <div className="p-6 bg-sera-surface border border-sera-border rounded-lg">
+              <h3 className="text-sm font-semibold text-sera-text mb-3">Metadata</h3>
+              <div className="space-y-2 text-sm text-sera-text-muted">
+                <p><strong>ID:</strong> {entry.id}</p>
+                <p><strong>Created:</strong> {new Date(entry.createdAt).toLocaleString()}</p>
+                <p><strong>Updated:</strong> {new Date(entry.updatedAt).toLocaleString()}</p>
+              </div>
+            </div>
+
+            <div className="p-6 bg-sera-surface border border-sera-border rounded-lg">
+              <h3 className="text-sm font-semibold text-sera-text mb-3">Tags & Refs</h3>
+              <div className="mb-4">
+                <h4 className="text-xs font-semibold text-sera-text-dim uppercase tracking-wider mb-2">Tags</h4>
+                {entry.tags.length > 0 ? (
+                  <div className="flex flex-wrap gap-2">
+                    {entry.tags.map(tag => (
+                      <span key={tag} className="text-xs px-2 py-1 bg-sera-bg border border-sera-border rounded text-sera-text-muted">
+                        #{tag}
+                      </span>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="text-xs text-sera-text-dim">No tags.</p>
+                )}
+              </div>
+
+              <div>
+                <h4 className="text-xs font-semibold text-sera-text-dim uppercase tracking-wider mb-2">Refs</h4>
+                {entry.refs.length > 0 ? (
+                  <ul className="list-disc list-inside text-sm text-sera-text-muted">
+                    {entry.refs.map(ref => (
+                      <li key={ref}>
+                        <a href={`/memory/${ref}`} className="hover:text-sera-text hover:underline transition-colors">{ref}</a>
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p className="text-xs text-sera-text-dim">No references.</p>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/MemoryGraph.tsx
+++ b/web/src/components/MemoryGraph.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import React, { useEffect, useRef, useState, useMemo, useCallback } from "react";
+import ForceGraph2D, { ForceGraphMethods } from "react-force-graph-2d";
+import { useRouter } from "next/navigation";
+import { X, Search } from "lucide-react";
+
+export interface GraphNode {
+  id: string;
+  title: string;
+  type: string;
+  tags: string[];
+}
+
+export interface GraphEdge {
+  from: string;
+  to: string;
+  kind: "ref" | "wikilink";
+}
+
+export interface MemoryGraphData {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+}
+
+interface MemoryGraphProps {
+  data: MemoryGraphData;
+  onNodeClick?: (node: GraphNode) => void;
+  onNodeDoubleClick?: (node: GraphNode) => void;
+  searchQuery?: string;
+  className?: string;
+}
+
+const TYPE_COLORS: Record<string, string> = {
+  human: "#3b82f6",     // blue
+  persona: "#a855f7",   // purple
+  core: "#22c55e",      // green
+  archive: "#6b7280",   // gray
+};
+
+const DEFAULT_COLOR = "#9ca3af";
+
+export default function MemoryGraph({
+  data,
+  onNodeClick,
+  onNodeDoubleClick,
+  searchQuery = "",
+  className = ""
+}: MemoryGraphProps) {
+  const fgRef = useRef<ForceGraphMethods | undefined>(undefined);
+  const router = useRouter();
+  const [dimensions, setDimensions] = useState({ width: 800, height: 600 });
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Update dimensions on resize
+  useEffect(() => {
+    const updateDimensions = () => {
+      if (containerRef.current) {
+        const { clientWidth, clientHeight } = containerRef.current;
+        setDimensions({
+          width: clientWidth,
+          height: clientHeight || 600
+        });
+      }
+    };
+
+    updateDimensions();
+    window.addEventListener("resize", updateDimensions);
+    return () => window.removeEventListener("resize", updateDimensions);
+  }, []);
+
+  const handleNodeClick = useCallback((node: any) => {
+    if (onNodeClick) {
+      onNodeClick(node as GraphNode);
+    }
+  }, [onNodeClick]);
+
+  const handleNodeDoubleClick = useCallback((node: any) => {
+    if (onNodeDoubleClick) {
+      onNodeDoubleClick(node as GraphNode);
+    } else {
+      router.push(`/memory/${node.id}`);
+    }
+  }, [onNodeDoubleClick, router]);
+
+  // Transform data to fit react-force-graph
+  const graphData = useMemo(() => {
+    return {
+      nodes: data.nodes.map(n => ({ ...n })),
+      links: data.edges.map(e => ({ source: e.from, target: e.to, kind: e.kind })),
+    };
+  }, [data]);
+
+  // Handle node rendering and coloring based on search and type
+  const nodeCanvasObject = useCallback((node: any, ctx: CanvasRenderingContext2D, globalScale: number) => {
+    const label = node.title;
+    const fontSize = 12 / globalScale;
+    ctx.font = `${fontSize}px Sans-Serif`;
+
+    const isMatched = searchQuery
+      ? label.toLowerCase().includes(searchQuery.toLowerCase()) ||
+        (node.tags && node.tags.some((t: string) => t.toLowerCase().includes(searchQuery.toLowerCase())))
+      : true;
+
+    const color = TYPE_COLORS[node.type] || DEFAULT_COLOR;
+
+    // Draw node circle
+    ctx.beginPath();
+    ctx.arc(node.x, node.y, 5, 0, 2 * Math.PI, false);
+    ctx.fillStyle = isMatched ? color : "#374151"; // highlight or dim
+    ctx.fill();
+
+    // Node border for matches if searching
+    if (searchQuery && isMatched) {
+      ctx.lineWidth = 1.5 / globalScale;
+      ctx.strokeStyle = "#ffffff";
+      ctx.stroke();
+    }
+
+    // Draw text label
+    const textWidth = ctx.measureText(label).width;
+    const bckgDimensions = [textWidth, fontSize].map(n => n + fontSize * 0.2);
+
+    // Label background
+    if (isMatched) {
+      ctx.fillStyle = "rgba(15, 23, 42, 0.8)";
+      ctx.fillRect(
+        node.x - bckgDimensions[0] / 2,
+        node.y + 6,
+        bckgDimensions[0],
+        bckgDimensions[1]
+      );
+
+      ctx.textAlign = "center";
+      ctx.textBaseline = "middle";
+      ctx.fillStyle = "#e2e8f0";
+      ctx.fillText(label, node.x, node.y + 6 + fontSize / 2);
+    }
+  }, [searchQuery]);
+
+  return (
+    <div
+      ref={containerRef}
+      className={`w-full h-[600px] border border-sera-border rounded-lg overflow-hidden bg-[#0a0a0a] relative ${className}`}
+    >
+      <ForceGraph2D
+        ref={fgRef as any}
+        width={dimensions.width}
+        height={dimensions.height}
+        graphData={graphData}
+        nodeLabel="title"
+        nodeRelSize={5}
+        nodeCanvasObject={nodeCanvasObject}
+        linkColor={(link: any) => link.kind === "wikilink" ? "rgba(100, 116, 139, 0.5)" : "rgba(148, 163, 184, 0.6)"}
+        linkWidth={(link: any) => link.kind === "wikilink" ? 1 : 1.5}
+        linkLineDash={(link: any) => link.kind === "wikilink" ? [2, 2] : null}
+        onNodeClick={handleNodeClick}
+        onNodeDoubleClick={handleNodeDoubleClick}
+        d3AlphaDecay={0.02}
+        d3VelocityDecay={0.3}
+      />
+
+      {/* Legend */}
+      <div className="absolute top-4 left-4 bg-sera-surface/80 backdrop-blur-sm border border-sera-border p-3 rounded-md text-xs">
+        <h4 className="font-semibold text-sera-text mb-2">Node Types</h4>
+        <div className="flex flex-col gap-1.5">
+          {Object.entries(TYPE_COLORS).map(([type, color]) => (
+            <div key={type} className="flex items-center gap-2">
+              <span className="w-3 h-3 rounded-full" style={{ backgroundColor: color }}></span>
+              <span className="text-sera-text-muted capitalize">{type}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/MemoryGraphWrapper.tsx
+++ b/web/src/components/MemoryGraphWrapper.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import dynamic from 'next/dynamic';
+import React from 'react';
+
+// Use dynamic import with ssr: false to prevent Window is not defined error on server side
+const MemoryGraph = dynamic(() => import('./MemoryGraph'), {
+  ssr: false,
+  loading: () => (
+    <div className="w-full h-[600px] flex items-center justify-center border border-sera-border rounded-lg bg-[#0a0a0a]">
+      <div className="animate-pulse flex flex-col items-center gap-4 text-sera-text-muted">
+        <div className="w-8 h-8 rounded-full border-2 border-sera-primary border-t-transparent animate-spin"></div>
+        Loading graph visualization...
+      </div>
+    </div>
+  )
+});
+
+export default function MemoryGraphWrapper(props: any) {
+  return <MemoryGraph {...props} />;
+}


### PR DESCRIPTION
This PR introduces an interactive graph visualization of the system's memory entries to the Insights page, as well as a dedicated detail view for individual memory blocks.

Features:
- **Graph Component**: Uses `react-force-graph-2d` to render `GraphNode` and `GraphEdge` data. Nodes are color-coded by their memory type (human, persona, core, archive).
- **Search & Filters**: Added controls to filter nodes by memory type and tags, and a search bar to highlight specific nodes by title or tag.
- **Interactivity**: Clicking a node opens a side-panel displaying its title, type, tags, and a content preview. Double-clicking navigates to the full entry detail page.
- **Entry Details Page**: Implemented `/memory/[id]/page.tsx` to view the full content, metadata, refs, and tags of a memory entry.

Technical Details:
- Wrapped `MemoryGraph` in a `next/dynamic` component with `ssr: false` to avoid Next.js "window is not defined" hydration errors.
- Handled styling using the existing Tailwind CSS design system to match the dark theme and "holographic" aesthetic.
- Confirmed correct API paths (`/api/memory/graph` and `/api/memory/entries/:id`).

---
*PR created automatically by Jules for task [4000694220190841335](https://jules.google.com/task/4000694220190841335) started by @TKCen*