### PR TITLE
Wire SERA dashboard pages to real API endpoints

### DIFF
--- a/web/src/app/agents/[id]/page.tsx
+++ b/web/src/app/agents/[id]/page.tsx
@@ -5,6 +5,23 @@ import { useState, useEffect } from 'react';
 import { Bot, ArrowLeft, Shield, Settings, BookOpen, Cpu, MessageSquare, Wrench, Users } from 'lucide-react';
 import Link from 'next/link';
 
+interface MemoryEntry {
+  id: string;
+  title: string;
+  type: string;
+  content: string;
+  refs: string[];
+  tags: string[];
+  source: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface MemoryBlock {
+  type: string;
+  entries: MemoryEntry[];
+}
+
 interface AgentDetail {
   name: string;
   displayName: string;
@@ -41,7 +58,7 @@ interface AgentDetail {
   };
 }
 
-type Tab = 'overview' | 'tools' | 'intercom';
+type Tab = 'overview' | 'tools' | 'intercom' | 'memory';
 
 const TIER_LABELS: Record<number, { label: string; class: string; desc: string }> = {
   1: { label: 'Tier 1 — Restricted', class: 'sera-badge-muted', desc: 'Read-only filesystem, no network' },
@@ -56,6 +73,8 @@ export default function AgentDetailPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<Tab>('overview');
+  const [memoryBlocks, setMemoryBlocks] = useState<MemoryBlock[]>([]);
+  const [loadingMemory, setLoadingMemory] = useState(false);
 
   useEffect(() => {
     fetch(`/api/core/agents/${agentName}`)
@@ -66,6 +85,16 @@ export default function AgentDetailPage() {
       .then(setAgent)
       .catch((err) => setError(err.message))
       .finally(() => setLoading(false));
+
+    setLoadingMemory(true);
+    fetch('/api/core/memory/blocks')
+      .then(async (res) => {
+        if (!res.ok) throw new Error('Failed to fetch memory');
+        return res.json();
+      })
+      .then(setMemoryBlocks)
+      .catch((err) => console.error('Error fetching memory:', err))
+      .finally(() => setLoadingMemory(false));
   }, [agentName]);
 
   if (loading) {
@@ -97,6 +126,7 @@ export default function AgentDetailPage() {
     { id: 'overview', label: 'Overview', icon: <Cpu size={15} /> },
     { id: 'tools', label: 'Tools & Skills', icon: <Wrench size={15} /> },
     { id: 'intercom', label: 'Intercom', icon: <MessageSquare size={15} /> },
+    { id: 'memory', label: 'Memory', icon: <BookOpen size={15} /> },
   ];
 
   return (
@@ -127,10 +157,16 @@ export default function AgentDetailPage() {
             </div>
           </div>
         </div>
-        <Link href={`/agents/${agent.name}/edit`} className="sera-btn-ghost">
-          <Settings size={16} />
-          Edit Manifest
-        </Link>
+        <div className="flex items-center gap-2">
+          <Link href={`/chat?agent=${agent.name}`} className="sera-btn-primary">
+            <MessageSquare size={16} />
+            Chat with this agent
+          </Link>
+          <Link href={`/agents/${agent.name}/edit`} className="sera-btn-ghost">
+            <Settings size={16} />
+            Edit Manifest
+          </Link>
+        </div>
       </div>
 
       {/* Tabs */}
@@ -328,6 +364,56 @@ export default function AgentDetailPage() {
                 ))}
               </div>
             </div>
+          )}
+        </div>
+      )}
+
+      {/* Memory Tab */}
+      {activeTab === 'memory' && (
+        <div className="space-y-6">
+          {loadingMemory ? (
+            <div className="flex items-center justify-center py-20">
+              <span className="text-sm text-sera-text-muted">Loading memory...</span>
+            </div>
+          ) : memoryBlocks.length === 0 ? (
+            <div className="sera-card-static p-8 text-center">
+              <BookOpen size={24} className="text-sera-text-dim mx-auto mb-3" />
+              <p className="text-sm text-sera-text-muted">No memory blocks found.</p>
+            </div>
+          ) : (
+            memoryBlocks.map((block) => (
+              <div key={block.type} className="sera-card-static p-5">
+                <h3 className="text-xs font-semibold uppercase tracking-[0.1em] text-sera-text-dim mb-4">
+                  {block.type} Block ({block.entries.length})
+                </h3>
+                {block.entries.length === 0 ? (
+                  <p className="text-xs text-sera-text-dim italic">No entries</p>
+                ) : (
+                  <div className="space-y-3">
+                    {block.entries.map((entry) => (
+                      <div key={entry.id} className="border border-sera-border rounded-lg p-3 bg-sera-bg/30">
+                        <div className="flex items-center justify-between mb-2">
+                          <h4 className="text-sm font-medium text-sera-text">{entry.title}</h4>
+                          <span className="text-[10px] text-sera-text-dim font-mono">
+                            {new Date(entry.createdAt).toLocaleString()}
+                          </span>
+                        </div>
+                        <p className="text-xs text-sera-text-muted whitespace-pre-wrap">{entry.content}</p>
+                        {entry.tags && entry.tags.length > 0 && (
+                          <div className="mt-2 flex flex-wrap gap-1">
+                            {entry.tags.map((tag) => (
+                              <span key={tag} className="text-[10px] bg-sera-surface px-1.5 py-0.5 rounded text-sera-text-dim">
+                                #{tag}
+                              </span>
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            ))
           )}
         </div>
       )}

--- a/web/src/app/settings/page.tsx
+++ b/web/src/app/settings/page.tsx
@@ -226,21 +226,28 @@ function ProviderCard({
 export default function SettingsPage() {
   const [tab, setTab] = useState<Tab>('providers');
   const [providers, setProviders] = useState<Provider[]>([]);
+  const [llmConfig, setLlmConfig] = useState<{ temperature?: number }>({});
   const [loading, setLoading] = useState(true);
 
-  const fetchProviders = async () => {
+  const fetchData = async () => {
     try {
-      const res = await fetch('/api/core/providers');
-      const data = await res.json();
+      const [providersRes, llmRes] = await Promise.all([
+        fetch('/api/core/providers'),
+        fetch('/api/core/config/llm')
+      ]);
+      const data = await providersRes.json();
       setProviders(data.providers);
+
+      const llmData = await llmRes.json();
+      setLlmConfig(llmData);
     } catch (err) {
-      console.error('Failed to fetch providers:', err);
+      console.error('Failed to fetch data:', err);
     } finally {
       setLoading(false);
     }
   };
 
-  useEffect(() => { fetchProviders(); }, []);
+  useEffect(() => { fetchData(); }, []);
 
   const handleSave = async (id: string, cfg: { baseUrl: string; apiKey: string; model: string }) => {
     await fetch(`/api/core/providers/${id}`, {
@@ -248,7 +255,7 @@ export default function SettingsPage() {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(cfg),
     });
-    await fetchProviders();
+    await fetchData();
   };
 
   const handleTest = async (id: string) => {
@@ -265,7 +272,7 @@ export default function SettingsPage() {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ providerId: id }),
     });
-    await fetchProviders();
+    await fetchData();
   };
 
   const localProviders = providers.filter(p => p.category === 'local');
@@ -408,16 +415,21 @@ export default function SettingsPage() {
                 </h3>
                 <div className="space-y-4">
                   <div className="space-y-1.5">
-                    <label className="text-[11px] font-medium text-sera-text-dim uppercase tracking-wider">
-                      Temperature
-                    </label>
+                    <div className="flex justify-between items-center mb-1">
+                      <label className="text-[11px] font-medium text-sera-text-dim uppercase tracking-wider">
+                        Temperature
+                      </label>
+                      <span className="text-xs text-sera-accent font-mono">{llmConfig?.temperature ?? 0.7}</span>
+                    </div>
                     <input
                       type="range"
                       min="0"
                       max="1"
                       step="0.1"
-                      defaultValue="0.7"
-                      className="w-full accent-sera-accent"
+                      value={llmConfig?.temperature ?? 0.7}
+                      readOnly
+                      className="w-full accent-sera-accent opacity-70 cursor-not-allowed"
+                      title="Temperature is currently configured via backend settings"
                     />
                     <div className="flex justify-between text-[10px] text-sera-text-dim">
                       <span>Precise (0)</span>


### PR DESCRIPTION
This change updates the SERA dashboard pages to ensure they correctly wire to real backend API endpoints. Specifically:
1. `agents/[id]/page.tsx`: Now fetches and displays the agent's memory blocks in a new tab, and includes a "Chat with this agent" button.
2. `settings/page.tsx`: Now fetches `/api/core/config/llm` in addition to the providers, mapping the agent default temperature configuration to the slider component.
3. Verified `agents`, `circles`, and `tools` root pages are already correctly wired.

---
*PR created automatically by Jules for task [3881724319953874142](https://jules.google.com/task/3881724319953874142) started by @TKCen*