### PR TITLE
Fix ToolExecutor.test.ts mock assertion

### DIFF
--- a/core/src/tools/ToolExecutor.test.ts
+++ b/core/src/tools/ToolExecutor.test.ts
@@ -164,7 +164,14 @@ describe('ToolExecutor', () => {
       expect(result.role).toBe('tool');
       expect(result.tool_call_id).toBe('tc-1');
       expect(result.content).toContain('hello');
-      expect(registry.invoke).toHaveBeenCalledWith('test-skill', { input: 'world' });
+      expect(registry.invoke).toHaveBeenCalledWith('test-skill', { input: 'world' }, {
+        agentName: 'test-agent',
+        workspacePath: 'workspaces/test-agent',
+        tier: 2,
+        agentInstanceId: undefined,
+        containerId: undefined,
+        sandboxManager: undefined,
+      });
     });
 
     it('should return string data as-is', async () => {


### PR DESCRIPTION
Fixes the broken ToolExecutor test where registry.invoke was missing the `AgentContext` argument in its mock assertion.

---
*PR created automatically by Jules for task [1154057445897382559](https://jules.google.com/task/1154057445897382559) started by @TKCen*