### PR TITLE
test: Add unit tests for agent-runtime modules

### DIFF
--- a/core/agent-runtime/src/__tests__/llmClient.test.ts
+++ b/core/agent-runtime/src/__tests__/llmClient.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import axios, { AxiosError } from 'axios';
+import { LLMClient, type ChatMessage } from '../llmClient.js';
+
+vi.mock('axios');
+const mockedAxios = vi.mocked(axios);
+
+describe('LLMClient', () => {
+  let mockPost: ReturnType<typeof vi.fn>;
+  let mockCreate: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockPost = vi.fn();
+    mockCreate = vi.fn().mockReturnValue({ post: mockPost });
+    mockedAxios.create = mockCreate;
+  });
+
+  describe('chat()', () => {
+    it('sends correct Authorization header', async () => {
+      const client = new LLMClient('http://core:3000', 'test-token', 'gpt-4');
+
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: 'Bearer test-token',
+          }),
+        })
+      );
+    });
+
+    it('parses OpenAI response with content', async () => {
+      mockPost.mockResolvedValueOnce({
+        data: {
+          choices: [
+            {
+              message: {
+                content: 'Hello world!',
+              },
+            },
+          ],
+        },
+      });
+
+      const client = new LLMClient('http://core:3000', 'test-token', 'gpt-4');
+      const messages: ChatMessage[] = [{ role: 'user', content: 'Hi' }];
+
+      const response = await client.chat(messages);
+      expect(response.content).toBe('Hello world!');
+      expect(response.toolCalls).toBeUndefined();
+    });
+
+    it('parses OpenAI response with tool_calls', async () => {
+      mockPost.mockResolvedValueOnce({
+        data: {
+          choices: [
+            {
+              message: {
+                content: null,
+                tool_calls: [
+                  {
+                    id: 'call_abc',
+                    type: 'function',
+                    function: {
+                      name: 'file-read',
+                      arguments: '{"path":"test.txt"}',
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      });
+
+      const client = new LLMClient('http://core:3000', 'test-token', 'gpt-4');
+      const messages: ChatMessage[] = [{ role: 'user', content: 'Read a file' }];
+
+      const response = await client.chat(messages);
+      expect(response.content).toBe('');
+      expect(response.toolCalls).toBeDefined();
+      expect(response.toolCalls?.length).toBe(1);
+      expect(response.toolCalls?.[0].id).toBe('call_abc');
+      expect(response.toolCalls?.[0].function.name).toBe('file-read');
+    });
+
+    it('throws on 429 budget-exceeded response', async () => {
+      const error = new AxiosError('Request failed with status code 429');
+      error.response = {
+        status: 429,
+        data: { error: { message: 'budget exceeded' } },
+        statusText: 'Too Many Requests',
+        headers: {},
+        config: {} as any,
+      };
+      mockPost.mockRejectedValueOnce(error);
+
+      const client = new LLMClient('http://core:3000', 'test-token', 'gpt-4');
+      const messages: ChatMessage[] = [{ role: 'user', content: 'Hi' }];
+
+      await expect(client.chat(messages)).rejects.toThrow(/budget exceeded/);
+    });
+  });
+});

--- a/core/agent-runtime/src/__tests__/manifest.test.ts
+++ b/core/agent-runtime/src/__tests__/manifest.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { loadManifest, generateSystemPrompt, type RuntimeManifest } from '../manifest.js';
+
+describe('manifest', () => {
+  let tempDir: string;
+  let validManifestPath: string;
+  let missingNameManifestPath: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sera-manifest-test-'));
+    validManifestPath = path.join(tempDir, 'valid-AGENT.yaml');
+    missingNameManifestPath = path.join(tempDir, 'invalid-AGENT.yaml');
+
+    const validYaml = `
+apiVersion: v1
+kind: Agent
+metadata:
+  name: test-agent
+  displayName: Test Agent
+  icon: robot
+  circle: default
+  tier: 1
+identity:
+  role: Helpful Assistant
+  description: A test agent.
+model:
+  provider: openai
+  name: gpt-4
+`;
+    fs.writeFileSync(validManifestPath, validYaml, 'utf-8');
+
+    const invalidYaml = `
+apiVersion: v1
+kind: Agent
+metadata:
+  displayName: No Name Agent
+identity:
+  role: Helpful Assistant
+  description: A test agent.
+model:
+  provider: openai
+  name: gpt-4
+`;
+    fs.writeFileSync(missingNameManifestPath, invalidYaml, 'utf-8');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  describe('loadManifest()', () => {
+    it('parses a valid AGENT.yaml and returns a typed RuntimeManifest', () => {
+      const manifest = loadManifest(validManifestPath);
+      expect(manifest.metadata.name).toBe('test-agent');
+      expect(manifest.metadata.displayName).toBe('Test Agent');
+      expect(manifest.identity.role).toBe('Helpful Assistant');
+    });
+
+    it('throws on missing file', () => {
+      const missingPath = path.join(tempDir, 'does-not-exist.yaml');
+      expect(() => loadManifest(missingPath)).toThrow(/Manifest not found/);
+    });
+
+    it('throws on manifest with missing metadata.name', () => {
+      expect(() => loadManifest(missingNameManifestPath)).toThrow(/missing metadata.name/);
+    });
+  });
+
+  describe('generateSystemPrompt()', () => {
+    it("includes the agent's role and description", () => {
+      const manifest: RuntimeManifest = {
+        apiVersion: 'v1',
+        kind: 'Agent',
+        metadata: {
+          name: 'test-agent',
+          displayName: 'Test Agent',
+          icon: 'robot',
+          circle: 'default',
+          tier: 1,
+        },
+        identity: {
+          role: 'Helpful Assistant',
+          description: 'A test agent.',
+        },
+        model: {
+          provider: 'openai',
+          name: 'gpt-4',
+        },
+      };
+
+      const prompt = generateSystemPrompt(manifest);
+      expect(prompt).toContain('Role: Helpful Assistant');
+      expect(prompt).toContain('Description: A test agent.');
+    });
+  });
+});

--- a/core/agent-runtime/src/__tests__/tools.test.ts
+++ b/core/agent-runtime/src/__tests__/tools.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { RuntimeToolExecutor } from '../tools.js';
+import type { ToolCall } from '../llmClient.js';
+
+describe('RuntimeToolExecutor', () => {
+  let tempDir: string;
+  let executor: RuntimeToolExecutor;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sera-tools-test-'));
+    executor = new RuntimeToolExecutor(tempDir);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  describe('executeTool()', () => {
+    it('handles file-read of a real temp file', () => {
+      const filePath = path.join(tempDir, 'test.txt');
+      fs.writeFileSync(filePath, 'hello world', 'utf-8');
+
+      const toolCall: ToolCall = {
+        id: 'call_123',
+        type: 'function',
+        function: {
+          name: 'file-read',
+          arguments: JSON.stringify({ path: 'test.txt' }),
+        },
+      };
+
+      const result = executor.executeTool(toolCall);
+      expect(result.role).toBe('tool');
+      expect(result.content).toBe('hello world');
+    });
+
+    it('handles file-write and creates the file', () => {
+      const toolCall: ToolCall = {
+        id: 'call_123',
+        type: 'function',
+        function: {
+          name: 'file-write',
+          arguments: JSON.stringify({ path: 'new-file.txt', content: 'new content' }),
+        },
+      };
+
+      const result = executor.executeTool(toolCall);
+      expect(result.role).toBe('tool');
+      expect(result.content).toContain('File written: new-file.txt');
+
+      const fileContent = fs.readFileSync(path.join(tempDir, 'new-file.txt'), 'utf-8');
+      expect(fileContent).toBe('new content');
+    });
+
+    it('blocks path traversal (../../etc/passwd)', () => {
+      const toolCall: ToolCall = {
+        id: 'call_123',
+        type: 'function',
+        function: {
+          name: 'file-read',
+          arguments: JSON.stringify({ path: '../../etc/passwd' }),
+        },
+      };
+
+      const result = executor.executeTool(toolCall);
+      expect(result.role).toBe('tool');
+      expect(result.content).toContain('Path traversal blocked');
+    });
+
+    it('handles shell-exec (echo hello)', () => {
+      const toolCall: ToolCall = {
+        id: 'call_123',
+        type: 'function',
+        function: {
+          name: 'shell-exec',
+          arguments: JSON.stringify({ command: 'echo hello' }),
+        },
+      };
+
+      const result = executor.executeTool(toolCall);
+      expect(result.role).toBe('tool');
+      expect(result.content.trim()).toBe('hello');
+    });
+  });
+
+  describe('getToolDefinitions()', () => {
+    it('returns all 3 built-in tools when no filter is given', () => {
+      const tools = executor.getToolDefinitions();
+      expect(tools.length).toBe(3);
+      expect(tools.map((t) => t.function.name).sort()).toEqual(['file-read', 'file-write', 'shell-exec']);
+    });
+
+    it('filters tools by allowed list', () => {
+      const tools = executor.getToolDefinitions(['file-read']);
+      expect(tools.length).toBe(1);
+      expect(tools[0].function.name).toBe('file-read');
+    });
+  });
+});


### PR DESCRIPTION
Added unit tests for `manifest.ts`, `tools.ts`, and `llmClient.ts` in the `core/agent-runtime` package to improve test coverage.

---
*PR created automatically by Jules for task [13267872973515541593](https://jules.google.com/task/13267872973515541593) started by @TKCen*