### PR TITLE
Add budget API endpoint for token usage reporting

### DIFF
--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -37,6 +37,7 @@ import { IdentityService } from './auth/IdentityService.js';
 import { MeteringService } from './metering/MeteringService.js';
 import { createLlmProxyRouter } from './routes/llmProxy.js';
 import { createHeartbeatRouter } from './routes/heartbeat.js';
+import { createBudgetRouter } from './routes/budget.js';
 const app = express();
 
 // ── Workspace Root ───────────────────────────────────────────────────────────
@@ -130,6 +131,9 @@ app.use('/api/sessions', sessionRouter);
 app.use('/v1/llm', llmProxyRouter);
 const heartbeatRouter = createHeartbeatRouter(orchestrator, identityService);
 app.use('/api/agents', heartbeatRouter);
+
+const budgetRouter = createBudgetRouter();
+app.use('/api/budget', budgetRouter);
 
 /**
  * Health check endpoint.

--- a/core/src/routes/budget.ts
+++ b/core/src/routes/budget.ts
@@ -1,0 +1,97 @@
+import { Router } from 'express';
+import type { Request, Response } from 'express';
+import { query } from '../lib/database.js';
+import { Logger } from '../lib/logger.js';
+
+const logger = new Logger('BudgetRoute');
+
+export function createBudgetRouter(): Router {
+  const router = Router();
+
+  /**
+   * GET /api/budget
+   * Global totals (sum of all tokens across all agents, grouped by day for the last 7 days)
+   */
+  router.get('/', async (_req: Request, res: Response) => {
+    try {
+      const result = await query(
+        `SELECT
+           DATE_TRUNC('day', created_at) AS date,
+           SUM(total_tokens) AS total_tokens
+         FROM token_usage
+         WHERE created_at >= NOW() - INTERVAL '7 days'
+         GROUP BY DATE_TRUNC('day', created_at)
+         ORDER BY date ASC`
+      );
+
+      const usage = result.rows.map(row => ({
+        date: row.date.toISOString().split('T')[0],
+        totalTokens: parseInt(row.total_tokens, 10)
+      }));
+
+      res.json({ usage });
+    } catch (err: any) {
+      logger.error('Error fetching global budget:', err);
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  });
+
+  /**
+   * GET /api/budget/agents
+   * Per-agent rankings (sum tokens per agent, ordered by total descending)
+   */
+  router.get('/agents', async (_req: Request, res: Response) => {
+    try {
+      const result = await query(
+        `SELECT
+           agent_id,
+           SUM(total_tokens) AS total_tokens
+         FROM token_usage
+         GROUP BY agent_id
+         ORDER BY total_tokens DESC`
+      );
+
+      const rankings = result.rows.map(row => ({
+        agentId: row.agent_id,
+        totalTokens: parseInt(row.total_tokens, 10)
+      }));
+
+      res.json({ rankings });
+    } catch (err: any) {
+      logger.error('Error fetching agent rankings:', err);
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  });
+
+  /**
+   * GET /api/budget/agents/:id
+   * Single agent's usage history (last 7 days, grouped by day)
+   */
+  router.get('/agents/:id', async (req: Request, res: Response) => {
+    try {
+      const agentId = req.params.id;
+      const result = await query(
+        `SELECT
+           DATE_TRUNC('day', created_at) AS date,
+           SUM(total_tokens) AS total_tokens
+         FROM token_usage
+         WHERE agent_id = $1 AND created_at >= NOW() - INTERVAL '7 days'
+         GROUP BY DATE_TRUNC('day', created_at)
+         ORDER BY date ASC`,
+         [agentId]
+      );
+
+      const usage = result.rows.map(row => ({
+        date: row.date.toISOString().split('T')[0],
+        totalTokens: parseInt(row.total_tokens, 10)
+      }));
+
+      res.json({ agentId, usage });
+    } catch (err: any) {
+      logger.error(`Error fetching budget for agent ${req.params.id}:`, err);
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  });
+
+  return router;
+}


### PR DESCRIPTION
Creates a read-only API endpoint for token usage reporting using the existing token_usage table. It includes:
- Global token usage history (/api/budget)
- Agent usage rankings (/api/budget/agents)
- Single agent usage history (/api/budget/agents/:id)

---
*PR created automatically by Jules for task [8169317256486711428](https://jules.google.com/task/8169317256486711428) started by @TKCen*