### PR TITLE
Add PUT and DELETE handlers to API core proxy

### DIFF
--- a/web/src/app/api/core/[...path]/route.ts
+++ b/web/src/app/api/core/[...path]/route.ts
@@ -1,5 +1,30 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+async function handleResponse(response: Response) {
+  if (response.status === 204) {
+    return new NextResponse(null, { status: 204 });
+  }
+
+  const contentType = response.headers.get('content-type');
+  if (contentType && contentType.includes('application/json')) {
+    const data = await response.json();
+    return NextResponse.json(data, { status: response.status });
+  } else {
+    const text = await response.text();
+    return new NextResponse(text, {
+      status: response.status,
+      headers: {
+        'Content-Type': contentType || 'text/plain',
+      },
+    });
+  }
+}
+
+function handleError(error: unknown) {
+  const message = error instanceof Error ? error.message : String(error);
+  return NextResponse.json({ error: message }, { status: 500 });
+}
+
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ path: string[] }> }
@@ -12,15 +37,11 @@ export async function GET(
   try {
     const response = await fetch(url, {
       method: 'GET',
-      headers: {
-        'Content-Type': 'application/json',
-      },
     });
 
-    const data = await response.json();
-    return NextResponse.json(data, { status: response.status });
-  } catch (error: any) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    return await handleResponse(response);
+  } catch (error) {
+    return handleError(error);
   }
 }
 
@@ -30,21 +51,72 @@ export async function POST(
 ) {
   const { path } = await params;
   const pathSegments = path.join('/');
-  const url = `${process.env.CORE_API_URL || 'http://localhost:3001'}/api/${pathSegments}`;
+  const searchParams = request.nextUrl.searchParams.toString();
+  const url = `${process.env.CORE_API_URL || 'http://localhost:3001'}/api/${pathSegments}${searchParams ? `?${searchParams}` : ''}`;
 
   try {
-    const body = await request.json();
+    const contentType = request.headers.get('content-type');
+    let body = null;
+    if (contentType && contentType.includes('application/json')) {
+      body = await request.text();
+    }
+
     const response = await fetch(url, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(body),
+      headers: body ? { 'Content-Type': 'application/json' } : {},
+      body: body || undefined,
     });
 
-    const data = await response.json();
-    return NextResponse.json(data, { status: response.status });
-  } catch (error: any) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    return await handleResponse(response);
+  } catch (error) {
+    return handleError(error);
+  }
+}
+
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ path: string[] }> }
+) {
+  const { path } = await params;
+  const pathSegments = path.join('/');
+  const searchParams = request.nextUrl.searchParams.toString();
+  const url = `${process.env.CORE_API_URL || 'http://localhost:3001'}/api/${pathSegments}${searchParams ? `?${searchParams}` : ''}`;
+
+  try {
+    const contentType = request.headers.get('content-type');
+    let body = null;
+    if (contentType && contentType.includes('application/json')) {
+      body = await request.text();
+    }
+
+    const response = await fetch(url, {
+      method: 'PUT',
+      headers: body ? { 'Content-Type': 'application/json' } : {},
+      body: body || undefined,
+    });
+
+    return await handleResponse(response);
+  } catch (error) {
+    return handleError(error);
+  }
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ path: string[] }> }
+) {
+  const { path } = await params;
+  const pathSegments = path.join('/');
+  const searchParams = request.nextUrl.searchParams.toString();
+  const url = `${process.env.CORE_API_URL || 'http://localhost:3001'}/api/${pathSegments}${searchParams ? `?${searchParams}` : ''}`;
+
+  try {
+    const response = await fetch(url, {
+      method: 'DELETE',
+    });
+
+    return await handleResponse(response);
+  } catch (error) {
+    return handleError(error);
   }
 }


### PR DESCRIPTION
The proxy at `web/src/app/api/core/[...path]/route.ts` was missing `PUT` and `DELETE` handlers, preventing the frontend from performing actions like updating agent manifests or deleting sessions. This PR adds the missing methods and refactors the proxy logic to be more robust, including support for search parameters on all methods and graceful handling of `204 No Content` and non-JSON responses.

Fixes #61

---
*PR created automatically by Jules for task [12186456207829232853](https://jules.google.com/task/12186456207829232853) started by @TKCen*