### PR TITLE
Redirect root / to /chat instead of /agents

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from 'next/navigation';
 
 export default function Home() {
-  redirect('/agents');
+  redirect('/chat');
 }


### PR DESCRIPTION
Changed the root URL redirect in `web/src/app/page.tsx` from `/agents` to `/chat`. This ensures that the primary chat interface is the default landing page, as per the priority defined in Epic 0 of the implementation backlog. Verification was performed using a Playwright script and manual inspection of a screenshot.

Fixes #64

---
*PR created automatically by Jules for task [3555170860707141700](https://jules.google.com/task/3555170860707141700) started by @TKCen*