### PR TITLE
Fix Settings page by registering missing configuration routes

### DIFF
--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -25,6 +25,7 @@ import { createLlmProxyRouter } from './routes/llmProxy.js';
 import { createHeartbeatRouter } from './routes/heartbeat.js';
 import { createBudgetRouter } from './routes/budget.js';
 import { createAuditRouter } from './routes/audit.js';
+import { createConfigRouter } from './routes/config.js';
 import { createOpenAICompatRouter } from './routes/openai-compat.js';
 import lspRouter, { lspManager } from './routes/lsp.js';
 import { SessionStore } from './sessions/SessionStore.js';
@@ -122,6 +123,7 @@ const startServer = async () => {
   app.use('/api/agents', createHeartbeatRouter(orchestrator, identityService));
   app.use('/api/budget', createBudgetRouter());
   app.use('/api/audit', createAuditRouter());
+  app.use('/api', createConfigRouter());
   app.use('/v1', createOpenAICompatRouter(orchestrator));
   app.use('/api/lsp', lspRouter);
 

--- a/core/src/routes/config.test.ts
+++ b/core/src/routes/config.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+// Mock config
+vi.mock('../lib/config.js', () => ({
+  config: {
+    llm: {
+      baseUrl: 'http://localhost:1234/v1',
+      apiKey: 'test-key',
+      model: 'test-model',
+    },
+    providers: {
+      activeProvider: 'openai',
+      providers: {
+        openai: { baseUrl: 'https://api.openai.com/v1', apiKey: 'sk-test', model: 'gpt-4o' }
+      }
+    },
+    saveLlmConfig: vi.fn(),
+    saveProviderConfig: vi.fn(),
+    setActiveProvider: vi.fn(),
+    getProviderConfig: vi.fn((id) => ({ baseUrl: 'https://api.openai.com/v1', apiKey: 'sk-test', model: 'gpt-4o' }))
+  }
+}));
+
+// Mock ProviderFactory
+vi.mock('../lib/llm/ProviderFactory.js', () => ({
+  ProviderFactory: {
+    createDefault: vi.fn(() => ({
+      chat: vi.fn().mockResolvedValue({ content: 'Mock response' })
+    })),
+    createFromModelConfig: vi.fn(() => ({
+      chat: vi.fn().mockResolvedValue({ content: 'Mock provider response' })
+    }))
+  }
+}));
+
+describe('Config Routes', () => {
+  let app: any;
+
+  beforeAll(async () => {
+    const { createConfigRouter } = await import('./config.js');
+    app = express();
+    app.use(express.json());
+    app.use('/api', createConfigRouter());
+  });
+
+  it('GET /api/config/llm should return current config', async () => {
+    const res = await request(app).get('/api/config/llm');
+    expect(res.status).toBe(200);
+    expect(res.body.model).toBe('test-model');
+  });
+
+  it('POST /api/config/llm should update config', async () => {
+    const newConfig = { model: 'new-model' };
+    const res = await request(app).post('/api/config/llm').send(newConfig);
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  it('GET /api/providers should return providers list', async () => {
+    const res = await request(app).get('/api/providers');
+    expect(res.status).toBe(200);
+    expect(res.body.activeProvider).toBe('openai');
+    expect(Array.isArray(res.body.providers)).toBe(true);
+    const openai = res.body.providers.find((p: any) => p.id === 'openai');
+    expect(openai.configured).toBe(true);
+    expect(openai.isActive).toBe(true);
+  });
+
+  it('PUT /api/providers/:id should update provider config', async () => {
+    const res = await request(app)
+      .put('/api/providers/openai')
+      .send({ baseUrl: 'new-url' });
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  it('POST /api/providers/active should set active provider', async () => {
+    const res = await request(app)
+      .post('/api/providers/active')
+      .send({ providerId: 'lmstudio' });
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.activeProvider).toBe('lmstudio');
+  });
+
+  it('POST /api/providers/:id/test should return success/fail based on connection', async () => {
+    // This will hit the catch block in the route because we are not mocking OpenAIProvider
+    // but the route should return success: false instead of 500.
+    const res = await request(app)
+      .post('/api/providers/openai/test')
+      .send({ baseUrl: 'http://invalid-url', apiKey: 'test-key', model: 'test-model' });
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(false);
+    expect(res.body).toHaveProperty('error');
+  });
+});

--- a/core/src/routes/config.ts
+++ b/core/src/routes/config.ts
@@ -1,0 +1,149 @@
+import { Router } from 'express';
+import type { Request, Response } from 'express';
+import { config } from '../lib/config.js';
+import { ProviderFactory } from '../lib/llm/ProviderFactory.js';
+import { PROVIDER_CATALOG } from '../lib/providers.js';
+import { Logger } from '../lib/logger.js';
+import { OpenAIProvider } from '../lib/llm/OpenAIProvider.js';
+
+const logger = new Logger('ConfigRouter');
+
+/**
+ * Config Router — handles system-wide LLM and Provider configuration.
+ *
+ * Endpoints:
+ *   GET  /config/llm          — get legacy LLM config
+ *   POST /config/llm          — update legacy LLM config
+ *   POST /config/llm/test     — test legacy LLM connection
+ *   GET  /providers           — list available providers & active status
+ *   PUT  /providers/:id       — update specific provider config
+ *   POST /providers/:id/test  — test specific provider connection
+ *   POST /providers/active    — set global active provider
+ */
+export function createConfigRouter(): Router {
+  const router = Router();
+
+  // ─── Legacy LLM Config ──────────────────────────────────────────────────────
+
+  /** GET /api/config/llm — Returns current legacy LLM configuration. */
+  router.get('/config/llm', (req: Request, res: Response) => {
+    res.json(config.llm);
+  });
+
+  /** POST /api/config/llm — Updates the legacy LLM configuration. */
+  router.post('/config/llm', (req: Request, res: Response) => {
+    try {
+      config.saveLlmConfig(req.body);
+      logger.info('Legacy LLM configuration updated');
+      res.json({ success: true });
+    } catch (err: any) {
+      logger.error('Failed to update LLM config:', err);
+      res.status(500).json({ error: err.message });
+    }
+  });
+
+  /** POST /api/config/llm/test — Tests the current LLM connection. */
+  router.post('/config/llm/test', async (req: Request, res: Response) => {
+    try {
+      const provider = ProviderFactory.createDefault();
+      const response = await provider.chat([{ role: 'user', content: 'Hello' }]);
+      res.json({
+        success: true,
+        model: config.llm.model,
+        response: response.content
+      });
+    } catch (err: any) {
+      logger.error('LLM test failed:', err);
+      res.json({ success: false, error: err.message });
+    }
+  });
+
+  // ─── Provider Management ────────────────────────────────────────────────────
+
+  /** GET /api/providers — Lists all available provider configurations. */
+  router.get('/providers', (req: Request, res: Response) => {
+    const providersConfig = config.providers;
+    const providers = PROVIDER_CATALOG.map(p => {
+      const savedConfig = providersConfig.providers[p.id] || null;
+      return {
+        ...p,
+        configured: !!savedConfig,
+        isActive: providersConfig.activeProvider === p.id,
+        savedConfig
+      };
+    });
+    res.json({
+      activeProvider: providersConfig.activeProvider,
+      providers
+    });
+  });
+
+  /** PUT /api/providers/:id — Updates settings for a specific provider. */
+  router.put('/providers/:id', (req: Request, res: Response) => {
+    try {
+      const { id } = req.params;
+      config.saveProviderConfig(id, req.body);
+      logger.info(`Provider configuration updated: ${id}`);
+      res.json({ success: true });
+    } catch (err: any) {
+      logger.error(`Failed to update provider config (${id}):`, err);
+      res.status(500).json({ error: err.message });
+    }
+  });
+
+  /** POST /api/providers/:id/test — Validates a specific provider connection. */
+  router.post('/providers/:id/test', async (req: Request, res: Response) => {
+    try {
+      const { id } = req.params;
+      const { baseUrl, apiKey, model } = req.body;
+
+      let provider;
+      if (baseUrl) {
+        // If parameters are passed in the body, test them directly
+        provider = new OpenAIProvider({
+          baseUrl,
+          apiKey: apiKey || 'not-needed',
+          model: model || 'model-identifier',
+        });
+      } else {
+        // Otherwise, use saved or catalog defaults
+        const providerConfig = config.getProviderConfig(id);
+        const catalogEntry = PROVIDER_CATALOG.find(p => p.id === id);
+
+        provider = ProviderFactory.createFromModelConfig({
+          provider: id,
+          name: providerConfig?.model || catalogEntry?.models[0]?.id || 'model-identifier',
+        });
+      }
+
+      const response = await provider.chat([{ role: 'user', content: 'Hello' }]);
+      res.json({
+        success: true,
+        provider: id,
+        response: response.content
+      });
+    } catch (err: any) {
+      // In tests, we might want to see the error, but we should not crash the test suite.
+      // The frontend expects success: false and the error message.
+      res.json({ success: false, error: err.message });
+    }
+  });
+
+  /** POST /api/providers/active — Sets a specific provider as the globally active LLM provider. */
+  router.post('/providers/active', (req: Request, res: Response) => {
+    try {
+      const { providerId } = req.body;
+      if (!providerId) {
+        return res.status(400).json({ error: 'providerId is required' });
+      }
+      config.setActiveProvider(providerId);
+      logger.info(`Active provider set to: ${providerId}`);
+      res.json({ success: true, activeProvider: providerId });
+    } catch (err: any) {
+      logger.error(`Failed to set active provider (${providerId}):`, err);
+      res.status(500).json({ error: err.message });
+    }
+  });
+
+  return router;
+}


### PR DESCRIPTION
The Settings page was broken because the backend routes it depends on were not registered. This PR implements the `config` router in the `core` service, providing endpoints for managing LLM configurations and provider catalogs as specified in `docs/API_SCHEMAS.md`. It also includes a comprehensive test suite to ensure the functionality and correctness of these new routes.

Fixes #62

---
*PR created automatically by Jules for task [10981226416974345598](https://jules.google.com/task/10981226416974345598) started by @TKCen*