### PR TITLE
Refactor: Decouple authorization from security levels

### DIFF
--- a/core/src/agents/manifest/AgentManifestLoader.ts
+++ b/core/src/agents/manifest/AgentManifestLoader.ts
@@ -116,6 +116,15 @@ export class AgentManifestLoader {
     AgentManifestLoader.requireString(meta, 'displayName', `${ctx} metadata`);
     AgentManifestLoader.requireString(meta, 'circle', `${ctx} metadata`);
 
+    if (meta['additionalCircles'] !== undefined) {
+      if (!Array.isArray(meta['additionalCircles']) || !meta['additionalCircles'].every(c => typeof c === 'string')) {
+        throw new ManifestValidationError(
+          `"additionalCircles" must be an array of strings${ctx}`,
+          'metadata.additionalCircles',
+        );
+      }
+    }
+
     // Default icon
     if (meta['icon'] === undefined) {
       meta['icon'] = '🤖';
@@ -158,6 +167,23 @@ export class AgentManifestLoader {
             'resources.maxLlmTokensPerHour',
           );
         }
+      }
+    }
+
+    // ── permissions ───────────────────────────────────────────────────────────
+    if (obj['permissions']) {
+      const perms = obj['permissions'] as Record<string, unknown>;
+      if (perms['canExec'] !== undefined && typeof perms['canExec'] !== 'boolean') {
+        throw new ManifestValidationError(
+          `"canExec" must be a boolean${ctx}`,
+          'permissions.canExec',
+        );
+      }
+      if (perms['canSpawnSubagents'] !== undefined && typeof perms['canSpawnSubagents'] !== 'boolean') {
+        throw new ManifestValidationError(
+          `"canSpawnSubagents" must be a boolean${ctx}`,
+          'permissions.canSpawnSubagents',
+        );
       }
     }
 

--- a/core/src/agents/manifest/types.ts
+++ b/core/src/agents/manifest/types.ts
@@ -12,6 +12,7 @@ export interface AgentMetadata {
   displayName: string;
   icon: string;
   circle: string;
+  additionalCircles?: string[];
   tier: SecurityTier;
 }
 
@@ -84,6 +85,12 @@ export interface MemoryConfig {
   sharedKnowledge?: string;
 }
 
+// ── Permissions ─────────────────────────────────────────────────────────────────
+export interface PermissionsConfig {
+  canExec?: boolean;
+  canSpawnSubagents?: boolean;
+}
+
 // ── Full Manifest ───────────────────────────────────────────────────────────────
 export interface AgentManifest {
   apiVersion: string;
@@ -98,13 +105,14 @@ export interface AgentManifest {
   resources?: ResourcesConfig;
   workspace?: WorkspaceConfig;
   memory?: MemoryConfig;
+  permissions?: PermissionsConfig;
 }
 
 // ── Known field names for validation ────────────────────────────────────────────
 export const KNOWN_TOP_LEVEL_FIELDS = new Set([
   'apiVersion', 'kind', 'metadata', 'identity', 'model',
   'tools', 'skills', 'subagents', 'intercom', 'resources',
-  'workspace', 'memory',
+  'workspace', 'memory', 'permissions',
 ]);
 
 export const VALID_TIERS: readonly SecurityTier[] = [1, 2, 3] as const;

--- a/core/src/routes/sandbox.ts
+++ b/core/src/routes/sandbox.ts
@@ -64,14 +64,6 @@ export function createSandboxRouter(
         return res.status(403).json({ error: 'Agent manifest must define a valid security tier' });
       }
 
-      if (manifest.metadata.tier === 1 && type === 'subagent') {
-        throw new PolicyViolationError(
-          `Agent "${manifest.metadata.name}" (Tier 1) cannot spawn subagents`,
-          manifest.metadata.name,
-          'spawn_tier_violation',
-        );
-      }
-
       const result = await sandboxManager.spawn(manifest, {
         agentName: manifest.metadata.name,
         type,

--- a/core/src/sandbox/SandboxManager.ts
+++ b/core/src/sandbox/SandboxManager.ts
@@ -154,12 +154,12 @@ export class SandboxManager {
       );
     }
 
-    // Tier 1 agents cannot exec shell commands
-    if (manifest.metadata.tier === 1) {
+    // Check if agent is permitted to exec
+    if (!TierPolicy.canExec(manifest)) {
       throw new PolicyViolationError(
-        `Agent "${manifest.metadata.name}" (Tier 1) cannot exec commands`,
+        `Agent "${manifest.metadata.name}" is not permitted to exec commands`,
         manifest.metadata.name,
-        'exec_tier_violation',
+        'exec_not_permitted',
       );
     }
 

--- a/core/src/sandbox/TierPolicy.test.ts
+++ b/core/src/sandbox/TierPolicy.test.ts
@@ -25,7 +25,7 @@ function makeManifest(overrides?: Partial<AgentManifest>): AgentManifest {
       name: 'test-model',
     },
     ...overrides,
-  };
+  } as AgentManifest;
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────────────
@@ -48,6 +48,73 @@ describe('TierPolicy', () => {
       const limits = TierPolicy.getTierLimits(3);
       expect(limits.networkMode).toBe('bridge');
       expect(limits.filesystemMode).toBe('rw');
+    });
+  });
+
+  describe('canExec', () => {
+    it('should return true for Tier 2 by default', () => {
+      const manifest = makeManifest({ metadata: { name: 't2', displayName: 'T2', icon: '🤖', circle: 'c', tier: 2 } });
+      expect(TierPolicy.canExec(manifest)).toBe(true);
+    });
+
+    it('should return false for Tier 1 by default', () => {
+      const manifest = makeManifest({ metadata: { name: 't1', displayName: 'T1', icon: '🤖', circle: 'c', tier: 1 } });
+      expect(TierPolicy.canExec(manifest)).toBe(false);
+    });
+
+    it('should honor explicit permission override for Tier 1', () => {
+      const manifest = makeManifest({
+        metadata: { name: 't1', displayName: 'T1', icon: '🤖', circle: 'c', tier: 1 },
+        permissions: { canExec: true }
+      });
+      expect(TierPolicy.canExec(manifest)).toBe(true);
+    });
+
+    it('should honor explicit permission override for Tier 2', () => {
+      const manifest = makeManifest({
+        metadata: { name: 't2', displayName: 'T2', icon: '🤖', circle: 'c', tier: 2 },
+        permissions: { canExec: false }
+      });
+      expect(TierPolicy.canExec(manifest)).toBe(false);
+    });
+  });
+
+  describe('canSpawnSubagents', () => {
+    it('should return true for Tier 2 by default', () => {
+      const manifest = makeManifest({ metadata: { name: 't2', displayName: 'T2', icon: '🤖', circle: 'c', tier: 2 } });
+      expect(TierPolicy.canSpawnSubagents(manifest)).toBe(true);
+    });
+
+    it('should return false for Tier 1 by default', () => {
+      const manifest = makeManifest({ metadata: { name: 't1', displayName: 'T1', icon: '🤖', circle: 'c', tier: 1 } });
+      expect(TierPolicy.canSpawnSubagents(manifest)).toBe(false);
+    });
+
+    it('should honor explicit permission override for Tier 1', () => {
+      const manifest = makeManifest({
+        metadata: { name: 't1', displayName: 'T1', icon: '🤖', circle: 'c', tier: 1 },
+        permissions: { canSpawnSubagents: true }
+      });
+      expect(TierPolicy.canSpawnSubagents(manifest)).toBe(true);
+    });
+  });
+
+  describe('isMemberOfCircle', () => {
+    it('should return true for primary circle', () => {
+      const manifest = makeManifest({ metadata: { name: 'a', displayName: 'A', icon: '🤖', circle: 'circle-a', tier: 2 } });
+      expect(TierPolicy.isMemberOfCircle(manifest, 'circle-a')).toBe(true);
+    });
+
+    it('should return true for additional circles', () => {
+      const manifest = makeManifest({
+        metadata: { name: 'a', displayName: 'A', icon: '🤖', circle: 'circle-a', additionalCircles: ['circle-b'], tier: 2 }
+      });
+      expect(TierPolicy.isMemberOfCircle(manifest, 'circle-b')).toBe(true);
+    });
+
+    it('should return false for unknown circles', () => {
+      const manifest = makeManifest({ metadata: { name: 'a', displayName: 'A', icon: '🤖', circle: 'circle-a', tier: 2 } });
+      expect(TierPolicy.isMemberOfCircle(manifest, 'circle-c')).toBe(false);
     });
   });
 
@@ -168,6 +235,17 @@ describe('TierPolicy', () => {
       };
 
       expect(() => TierPolicy.validateSpawnPermission(manifest, request)).not.toThrow();
+    });
+
+    it('should reject subagent spawn for Tier 1 by default', () => {
+      const manifest = makeManifest({ metadata: { name: 't1', displayName: 'T1', icon: '🤖', circle: 'c', tier: 1 } });
+      const request: SpawnRequest = {
+        agentName: 't1',
+        type: 'subagent',
+        image: 'node:20',
+        subagentRole: 'researcher',
+      };
+      expect(() => TierPolicy.validateSpawnPermission(manifest, request)).toThrow(PolicyViolationError);
     });
   });
 

--- a/core/src/sandbox/TierPolicy.ts
+++ b/core/src/sandbox/TierPolicy.ts
@@ -65,6 +65,38 @@ export class TierPolicy {
   }
 
   /**
+   * Check if an agent is allowed to execute commands.
+   * Prioritizes explicit permissions over tier defaults.
+   */
+  static canExec(manifest: AgentManifest): boolean {
+    if (manifest.permissions?.canExec !== undefined) {
+      return manifest.permissions.canExec;
+    }
+    // Default: Tier 1 cannot exec
+    return manifest.metadata.tier !== 1;
+  }
+
+  /**
+   * Check if an agent is allowed to spawn subagents.
+   * Prioritizes explicit permissions over tier defaults.
+   */
+  static canSpawnSubagents(manifest: AgentManifest): boolean {
+    if (manifest.permissions?.canSpawnSubagents !== undefined) {
+      return manifest.permissions.canSpawnSubagents;
+    }
+    // Default: Tier 1 cannot spawn subagents
+    return manifest.metadata.tier !== 1;
+  }
+
+  /**
+   * Check if an agent is a member of a given circle.
+   */
+  static isMemberOfCircle(manifest: AgentManifest, circleId: string): boolean {
+    if (manifest.metadata.circle === circleId) return true;
+    return manifest.metadata.additionalCircles?.includes(circleId) ?? false;
+  }
+
+  /**
    * Apply manifest-level resource overrides (capped by tier maximums).
    * If the manifest specifies resources, they are used as long as they
    * don't exceed the tier ceiling.
@@ -101,6 +133,14 @@ export class TierPolicy {
 
     // Subagent validation
     if (request.type === 'subagent') {
+      if (!TierPolicy.canSpawnSubagents(manifest)) {
+        throw new PolicyViolationError(
+          `Agent "${agentName}" is not permitted to spawn subagents`,
+          agentName,
+          'spawn_not_permitted',
+        );
+      }
+
       if (!request.subagentRole) {
         throw new PolicyViolationError(
           `Subagent spawn request must specify a subagentRole`,

--- a/core/src/skills/builtins/file-list.ts
+++ b/core/src/skills/builtins/file-list.ts
@@ -39,7 +39,7 @@ export const fileListSkill: SkillDefinition = {
             : ['ls', '-F', '--color=never', containerPath];
 
           const result = await context.sandboxManager.exec(
-            { metadata: { name: context.agentName, tier: context.tier } } as any,
+            context.manifest,
             {
               containerId: context.containerId,
               agentName: context.agentName,

--- a/core/src/skills/builtins/file-read.ts
+++ b/core/src/skills/builtins/file-read.ts
@@ -36,7 +36,7 @@ export const fileReadSkill: SkillDefinition = {
         const containerPath = path.posix.join('/workspace', relativePath.replace(/\\/g, '/'));
 
         const result = await context.sandboxManager.exec(
-          { metadata: { name: context.agentName, tier: context.tier } } as any,
+          context.manifest,
           {
             containerId: context.containerId,
             agentName: context.agentName,

--- a/core/src/skills/builtins/file-write.ts
+++ b/core/src/skills/builtins/file-write.ts
@@ -46,7 +46,7 @@ export const fileWriteSkill: SkillDefinition = {
         const script = `mkdir -p "${dirPath}" && echo "${b64}" | base64 -d > "${containerPath}"`;
 
         const result = await context.sandboxManager.exec(
-          { metadata: { name: context.agentName, tier: context.tier } } as any,
+          context.manifest,
           {
             containerId: context.containerId,
             agentName: context.agentName,

--- a/core/src/skills/builtins/shell-exec.ts
+++ b/core/src/skills/builtins/shell-exec.ts
@@ -1,22 +1,22 @@
 import { execSync } from 'child_process';
 import type { SkillDefinition } from '../types.js';
+import { TierPolicy } from '../../sandbox/TierPolicy.js';
 
 /**
  * Built-in skill: shell-exec
  *
  * Executes a shell command in the workspace directory.
- * Only available to agents with tier >= 2.
  */
 export const shellExecSkill: SkillDefinition = {
   id: 'shell-exec',
-  description: 'Execute a shell command in the workspace directory. Only available to tier 2 and above.',
+  description: 'Execute a shell command in the workspace directory.',
   source: 'builtin',
   parameters: [
     { name: 'command', type: 'string', description: 'The shell command to execute', required: true },
   ],
   handler: async (params, context) => {
-    if (context.tier < 2) {
-      return { success: false, error: 'Agent tier must be 2 or higher to execute shell commands' };
+    if (!TierPolicy.canExec(context.manifest)) {
+      return { success: false, error: 'Agent is not permitted to execute shell commands' };
     }
 
     const command = params['command'];

--- a/core/src/skills/types.ts
+++ b/core/src/skills/types.ts
@@ -33,6 +33,7 @@ export interface AgentContext {
   agentName: string;
   workspacePath: string;
   tier: number;
+  manifest: import('../agents/manifest/types.js').AgentManifest;
   agentInstanceId: string | undefined;
   containerId: string | undefined;
   sandboxManager: import('../sandbox/SandboxManager.js').SandboxManager | undefined;

--- a/core/src/tools/ToolExecutor.ts
+++ b/core/src/tools/ToolExecutor.ts
@@ -56,6 +56,7 @@ export class ToolExecutor {
         agentName: manifest.metadata.name,
         workspacePath: manifest.workspace?.path || `workspaces/${manifest.metadata.name}`,
         tier: manifest.metadata.tier,
+        manifest,
         agentInstanceId,
         containerId,
         sandboxManager: this.sandboxManager,


### PR DESCRIPTION
Refactored the agent authorization system to use explicit permissions (canExec, canSpawnSubagents) and circle memberships defined in AGENT.yaml manifests, rather than relying strictly on abstract security tiers. Tiers now serve as sensible defaults that can be overridden by explicit manifest configuration.

Key changes:
- `AgentManifest` now supports a top-level `permissions` block.
- `AgentMetadata` supports `additionalCircles` for multi-circle membership.
- `TierPolicy` provides the central authorization logic, checking manifest permissions before falling back to tier-based defaults.
- `SandboxManager` and `shell-exec` skill now use `TierPolicy.canExec(manifest)` for authorization.
- `AgentContext` and `ToolExecutor` updated to propagate the full manifest to skills.

Fixes #43

---
*PR created automatically by Jules for task [7237924573964773934](https://jules.google.com/task/7237924573964773934) started by @TKCen*