### PR TITLE
Fix typecheck error in ScheduleService.test.ts

### DIFF
--- a/core/src/services/ScheduleService.test.ts
+++ b/core/src/services/ScheduleService.test.ts
@@ -60,7 +60,14 @@ describe('ScheduleService', () => {
         .mockResolvedValueOnce({ rows: [mockDbSchedule] }) // manual reconcile call
         .mockResolvedValueOnce({ rows: [{ name: '22222222-2222-4222-a222-222222222222' }] }); // stale job
 
-      await service.start('postgres://localhost/test');
+      const mockBoss = {
+        createQueue: vi.fn().mockResolvedValue(undefined),
+        work: vi.fn().mockResolvedValue(undefined),
+        schedule: vi.fn().mockResolvedValue(undefined),
+        unschedule: vi.fn().mockResolvedValue(undefined),
+      };
+
+      await service.start(mockBoss as unknown as import('pg-boss').PgBoss);
       await service.reconcile();
 
       const boss = (


### PR DESCRIPTION
Fixed a typecheck error in `core/src/services/ScheduleService.test.ts` where a string was being passed where a PgBoss mock was expected. Other TODOs in the codebase are skipped per instructions because they reference Epics or require architectural changes.

---
*PR created automatically by Jules for task [5153400720725356352](https://jules.google.com/task/5153400720725356352) started by @TKCen*