### PR TITLE
fix: install git in core Dockerfile for KnowledgeGitService

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:22-slim AS base
 WORKDIR /app
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y curl unzip && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y curl unzip git && rm -rf /var/lib/apt/lists/*
 RUN curl -fsSL https://bun.sh/install | bash
 ENV PATH="/root/.bun/bin:$PATH"
 
@@ -14,7 +14,7 @@ RUN rm -rf node_modules && bun install --production --frozen-lockfile
 
 FROM node:22-slim AS runner
 WORKDIR /app
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y curl git && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/package.json ./


### PR DESCRIPTION
## Changes

Adds `git` package to the Dockerfile dependencies in both the base and runner stages.

- Added `git` to the apt-get install command in the base stage
- Added `git` to the apt-get install command in the runner stage

## Reason

The `KnowledgeGitService` requires `git` to be installed in the container to function properly. This change ensures the necessary git binary is available in the runtime environment.