### PR TITLE
Refactor: Extract PlatformPath utility for Windows Docker mounts

### DIFF
--- a/core/src/lib/PlatformPath.ts
+++ b/core/src/lib/PlatformPath.ts
@@ -1,0 +1,13 @@
+export class PlatformPath {
+  /**
+   * Normalizes a host path for Docker bind mounts on Windows.
+   * Converts "C:\path" to "/c/path" format.
+   * On non-Windows platforms or if the path is not absolute, returns the original path.
+   */
+  static normalizeDockerBindPath(hostPath: string): string {
+    if (process.platform === 'win32' && /^[a-zA-Z]:/.test(hostPath)) {
+      return `/${hostPath[0]!.toLowerCase()}${hostPath.slice(2).replace(/\\/g, '/')}`;
+    }
+    return hostPath;
+  }
+}

--- a/core/src/sandbox/SandboxManager.ts
+++ b/core/src/sandbox/SandboxManager.ts
@@ -14,6 +14,7 @@ import { PolicyViolationError } from './TierPolicy.js';
 import { StorageProviderFactory } from '../storage/StorageProvider.js';
 import { LocalStorageProvider } from '../storage/LocalStorageProvider.js';
 import { Logger } from '../lib/logger.js';
+import { PlatformPath } from '../lib/PlatformPath.js';
 import type { EgressAclManager } from './EgressAclManager.js';
 
 const logger = new Logger('SandboxManager');
@@ -110,26 +111,21 @@ export class SandboxManager {
 
     // 2. Memory mount (Story 3.3)
     const memoryHostDir = process.env.HOST_MEMORY_DIR ?? '/memory';
-    let memoryHostPath = `${memoryHostDir}/${finalInstanceId}`;
-    if (process.platform === 'win32' && /^[a-zA-Z]:/.test(memoryHostPath)) {
-      memoryHostPath = `/${memoryHostPath[0]!.toLowerCase()}${memoryHostPath.slice(2).replace(/\\/g, '/')}`;
-    }
+    const memoryHostPath = PlatformPath.normalizeDockerBindPath(
+      `${memoryHostDir}/${finalInstanceId}`
+    );
     fs.mkdirSync(memoryHostPath, { recursive: true });
     binds.push(`${memoryHostPath}:/memory:rw`);
 
     // 3. Knowledge mounts (Story 3.3)
     const knowledgeHostDir = process.env.HOST_KNOWLEDGE_DIR ?? '/knowledge';
-    let personalPath = `${knowledgeHostDir}/agents/${agentName}`;
-    if (process.platform === 'win32' && /^[a-zA-Z]:/.test(personalPath)) {
-      personalPath = `/${personalPath[0]!.toLowerCase()}${personalPath.slice(2).replace(/\\/g, '/')}`;
-    }
+    const personalPath = PlatformPath.normalizeDockerBindPath(
+      `${knowledgeHostDir}/agents/${agentName}`
+    );
     fs.mkdirSync(personalPath, { recursive: true });
     binds.push(`${personalPath}:/knowledge/personal:ro`);
 
-    let sharedPath = `${knowledgeHostDir}/shared`;
-    if (process.platform === 'win32' && /^[a-zA-Z]:/.test(sharedPath)) {
-      sharedPath = `/${sharedPath[0]!.toLowerCase()}${sharedPath.slice(2).replace(/\\/g, '/')}`;
-    }
+    const sharedPath = PlatformPath.normalizeDockerBindPath(`${knowledgeHostDir}/shared`);
     fs.mkdirSync(sharedPath, { recursive: true });
     binds.push(`${sharedPath}:/knowledge/shared:ro`);
 

--- a/core/src/storage/LocalStorageProvider.ts
+++ b/core/src/storage/LocalStorageProvider.ts
@@ -10,6 +10,7 @@
 
 import type { FilesystemMode } from '../sandbox/types.js';
 import type { StorageProvider, MountResult } from './StorageProvider.js';
+import { PlatformPath } from '../lib/PlatformPath.js';
 
 // ── LocalStorageProvider ────────────────────────────────────────────────────────
 
@@ -56,11 +57,7 @@ export class LocalStorageProvider implements StorageProvider {
     mode: FilesystemMode,
     workspacePath?: string
   ): string {
-    let hostPath = this.getHostPath(agentId, workspacePath);
-    // On Windows, Docker Desktop prefers /c/path format for bind mounts to avoid colon confusion
-    if (process.platform === 'win32' && /^[a-zA-Z]:/.test(hostPath)) {
-      hostPath = `/${hostPath[0]!.toLowerCase()}${hostPath.slice(2).replace(/\\/g, '/')}`;
-    }
+    const hostPath = PlatformPath.normalizeDockerBindPath(this.getHostPath(agentId, workspacePath));
     return `${hostPath}:${containerPath}:${mode}`;
   }
 }


### PR DESCRIPTION
This PR extracts the cross-cutting Windows path normalization pattern, which was previously duplicated in multiple places within `SandboxManager.ts` and `LocalStorageProvider.ts`. 

The logic checking `process.platform === 'win32' && /^[a-zA-Z]:/.test(hostPath)` and the subsequent path string manipulation have been consolidated into a new static utility method: `PlatformPath.normalizeDockerBindPath` located in `core/src/lib/PlatformPath.ts`.

This is a pure structural refactor. No behavior has been changed, and no public APIs have been renamed. Validations, type checks, and tests have all passed successfully.

---
*PR created automatically by Jules for task [18045204238798206846](https://jules.google.com/task/18045204238798206846) started by @TKCen*