### PR TITLE
feat: add DELETE /api/providers/:modelName endpoint

### DIFF
--- a/core/src/routes/providers.ts
+++ b/core/src/routes/providers.ts
@@ -210,6 +210,31 @@ export function createProvidersRouter(
   // ── Static Providers ────────────────────────────────────────────────────────
 
   /**
+   * DELETE /api/providers/:modelName
+   * Removes a model from the active provider registry and persists the change.
+   * For dynamic-provider models, delegates to DynamicProviderManager.
+   */
+  router.delete(
+    '/:modelName',
+    requireRole(['admin', 'operator']),
+    async (req: Request, res: Response) => {
+      const modelName = String(req.params['modelName']);
+      try {
+        await llmRouter.deleteModel(modelName);
+        logger.info(
+          `Provider deleted | model=${modelName} by operator=${req.operator?.sub ?? 'unknown'}`
+        );
+        res.status(204).end();
+      } catch (err: unknown) {
+        const msg = (err as Error).message;
+        const code =
+          msg.includes('not found') || msg.includes('No provider registered') ? 404 : 500;
+        res.status(code).json({ error: msg });
+      }
+    }
+  );
+
+  /**
    * POST /api/providers/:modelName/test
    * Sends a minimal test completion to verify the provider is reachable.
    */


### PR DESCRIPTION
## Summary
- Add `DELETE /api/providers/:modelName` endpoint to remove models from the active provider registry
- Uses existing `LlmRouter.deleteModel()` — persists changes to `providers.json`
- Requires `admin` or `operator` role
- Returns 204 on success, 404 if model not registered

## Runtime Verification
```bash
# Delete a provider
curl -X DELETE http://localhost:3001/api/providers/dp-agw-qwen2.5-0.5b-instruct \
  -H "Authorization: Bearer ..." → HTTP 204

# Nonexistent model
curl -X DELETE http://localhost:3001/api/providers/nonexistent \
  -H "Authorization: Bearer ..." → HTTP 404
```

## Test plan
- [ ] `bun run ci` passes
- [ ] DELETE existing model returns 204 and removes it from GET /api/providers
- [ ] DELETE nonexistent model returns 404

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)