### PR TITLE
Implement Provider Delete Endpoint

### DIFF
--- a/core/src/__tests__/provider_deletion.test.ts
+++ b/core/src/__tests__/provider_deletion.test.ts
@@ -1,0 +1,112 @@
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ProviderRegistry } from '../llm/ProviderRegistry.js';
+import { LlmRouter } from '../llm/LlmRouter.js';
+import { CircuitBreakerService } from '../llm/CircuitBreakerService.js';
+import fs from 'fs';
+
+vi.mock('fs', () => {
+  const mockReadFileSync = vi.fn().mockImplementation((path: string) => {
+    if (path === '/fake/path.json') {
+      return JSON.stringify({
+        providers: [
+          {
+            modelName: 'static-model',
+            api: 'openai-completions',
+            provider: 'openai',
+            enabled: true,
+          },
+          {
+            modelName: 'dynamic-model',
+            api: 'openai-completions',
+            provider: 'openai',
+            dynamicProviderId: 'dp-1',
+            enabled: true,
+          },
+        ],
+      });
+    }
+    throw new Error('File not found: ' + path);
+  });
+
+  const mockExistsSync = vi.fn().mockImplementation((path: string) => {
+    if (path === '/fake/path.json') return true;
+    return false;
+  });
+
+  const mockWriteFile = vi.fn().mockResolvedValue(undefined);
+
+  return {
+    default: {
+      promises: {
+        writeFile: mockWriteFile,
+      },
+      readFileSync: mockReadFileSync,
+      existsSync: mockExistsSync,
+    },
+    promises: {
+      writeFile: mockWriteFile,
+    },
+    readFileSync: mockReadFileSync,
+    existsSync: mockExistsSync,
+  };
+});
+
+describe('Provider Deletion/Disabling', () => {
+  let registry: ProviderRegistry;
+  let router: LlmRouter;
+  let cbService: CircuitBreakerService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    registry = new ProviderRegistry('/fake/path.json');
+    router = new LlmRouter(registry);
+    cbService = new CircuitBreakerService(router);
+  });
+
+  it('should disable static providers instead of deleting them', async () => {
+    const modelName = 'static-model';
+
+    // Initial state
+    const models = await router.listModels();
+    expect(models.find(m => m.modelName === modelName)?.enabled).toBe(true);
+
+    // Unregister (static)
+    await router.deleteModel(modelName);
+
+    // Verify in registry
+    const updatedModels = await router.listModels();
+    const staticModel = updatedModels.find(m => m.modelName === modelName);
+    expect(staticModel).toBeDefined();
+    expect(staticModel?.enabled).toBe(false);
+
+    // Verify resolve throws
+    expect(() => registry.resolve(modelName)).toThrow(`Provider for model '${modelName}' is disabled.`);
+  });
+
+  it('should fully delete dynamic providers', async () => {
+    const modelName = 'dynamic-model';
+
+    // Initial state
+    const models = await router.listModels();
+    expect(models.find(m => m.modelName === modelName)).toBeDefined();
+
+    // Unregister (dynamic)
+    await router.deleteModel(modelName);
+
+    // Verify in registry
+    const updatedModels = await router.listModels();
+    const dynamicModel = updatedModels.find(m => m.modelName === modelName);
+    expect(dynamicModel).toBeUndefined();
+  });
+
+  it('should remove circuit breaker when requested', () => {
+    // Trigger breaker creation
+    (cbService as any).getBreakerForProvider('openai');
+    expect((cbService as any).breakers.has('openai')).toBe(true);
+
+    // Remove breaker
+    cbService.removeBreaker('openai');
+    expect((cbService as any).breakers.has('openai')).toBe(false);
+  });
+});

--- a/core/src/llm/CircuitBreakerService.ts
+++ b/core/src/llm/CircuitBreakerService.ts
@@ -183,4 +183,17 @@ export class CircuitBreakerService {
       },
     };
   }
+
+  /**
+   * Remove the circuit breaker for a provider.
+   * Called when a provider is deleted or disabled.
+   */
+  removeBreaker(provider: string): void {
+    const breaker = this.breakers.get(provider);
+    if (breaker) {
+      breaker.shutdown();
+      this.breakers.delete(provider);
+      logger.info(`Circuit breaker removed for provider=${provider}`);
+    }
+  }
 }

--- a/core/src/llm/LlmRouter.ts
+++ b/core/src/llm/LlmRouter.ts
@@ -342,6 +342,7 @@ export interface ModelListItem {
   baseUrl?: string;
   description?: string;
   dynamicProviderId?: string;
+  enabled?: boolean;
 }
 
 // ── LlmRouter ─────────────────────────────────────────────────────────────────
@@ -466,6 +467,7 @@ export class LlmRouter {
       if (cfg.baseUrl !== undefined) item.baseUrl = cfg.baseUrl;
       if (cfg.description !== undefined) item.description = cfg.description;
       if (cfg.dynamicProviderId !== undefined) item.dynamicProviderId = cfg.dynamicProviderId;
+      if (cfg.enabled !== undefined) item.enabled = cfg.enabled;
       return item;
     });
   }

--- a/core/src/llm/ProviderRegistry.ts
+++ b/core/src/llm/ProviderRegistry.ts
@@ -59,6 +59,8 @@ export interface ProviderConfig {
   description?: string | undefined;
   /** ID of the dynamic provider that registered this model (internal). */
   dynamicProviderId?: string | undefined;
+  /** Whether this provider is enabled. Defaults to true. */
+  enabled?: boolean | undefined;
 }
 
 export interface DynamicProviderConfig {
@@ -222,11 +224,18 @@ export class ProviderRegistry {
    * Throws if no provider can be found.
    */
   resolve(modelName: string): ProviderConfig {
+    const checkEnabled = (cfg: ProviderConfig | null): ProviderConfig | null => {
+      if (cfg && cfg.enabled === false) {
+        throw new Error(`Provider for model '${cfg.modelName}' is disabled.`);
+      }
+      return cfg;
+    };
+
     // Handle 'default' model alias
     if (modelName === 'default') {
       if (this.defaultModelName) {
         const defaultCfg = this.configs.get(this.defaultModelName);
-        if (defaultCfg) return defaultCfg;
+        if (defaultCfg) return checkEnabled(defaultCfg)!;
         const autoDefault = this.autoDetect(this.defaultModelName);
         if (autoDefault) return autoDefault;
       }
@@ -236,7 +245,7 @@ export class ProviderRegistry {
     }
 
     const explicit = this.configs.get(modelName);
-    if (explicit) return explicit;
+    if (explicit) return checkEnabled(explicit)!;
 
     const auto = this.autoDetect(modelName);
     if (auto) return auto;
@@ -247,7 +256,7 @@ export class ProviderRegistry {
         `Model '${modelName}' not found, falling back to default '${this.defaultModelName}'`
       );
       const fallback = this.configs.get(this.defaultModelName);
-      if (fallback) return fallback;
+      if (fallback) return checkEnabled(fallback)!;
     }
 
     throw new Error(
@@ -260,9 +269,19 @@ export class ProviderRegistry {
     this.configs.set(config.modelName, config);
   }
 
-  /** Returns true if a provider was removed. */
+  /** Returns true if a provider was removed or disabled. */
   unregister(modelName: string): boolean {
-    return this.configs.delete(modelName);
+    const config = this.configs.get(modelName);
+    if (!config) return false;
+
+    if (config.dynamicProviderId) {
+      // Dynamic models can be fully removed
+      return this.configs.delete(modelName);
+    } else {
+      // Static models are just disabled
+      config.enabled = false;
+      return true;
+    }
   }
 
   /** Register multiple models for a specific dynamic provider, cleaning up old ones. */

--- a/core/src/routes/providers.ts
+++ b/core/src/routes/providers.ts
@@ -210,6 +210,46 @@ export function createProvidersRouter(
   // ── Static Providers ────────────────────────────────────────────────────────
 
   /**
+   * DELETE /api/providers/:modelName
+   * Removes a provider from the active registry.
+   * For static providers: marks as disabled.
+   * For dynamic providers: delegates to existing dynamic delete endpoint.
+   * Also stops health checks for removed providers.
+   */
+  router.delete(
+    '/:modelName',
+    requireRole(['admin', 'operator']),
+    async (req: Request, res: Response) => {
+      const modelName = String(req.params['modelName']);
+      try {
+        const models = await llmRouter.listModels();
+        const model = models.find((m) => m.modelName === modelName);
+
+        if (!model) {
+          res.status(404).json({ error: `Provider for model '${modelName}' not found` });
+          return;
+        }
+
+        if (model.dynamicProviderId) {
+          // It's a dynamic provider, delegate to DynamicProviderManager
+          await dynamicProviderManager.removeProvider(model.dynamicProviderId);
+        } else {
+          // It's a static provider, disable it in LlmRouter/Registry
+          await llmRouter.deleteModel(modelName);
+        }
+
+        // Stop health checks for the provider
+        circuitBreakerService.removeBreaker(model.provider ?? providerFromModel(modelName));
+
+        res.status(204).end();
+      } catch (err: unknown) {
+        logger.error(`Failed to delete provider ${modelName}:`, err);
+        res.status(502).json({ error: (err as Error).message });
+      }
+    }
+  );
+
+  /**
    * POST /api/providers/:modelName/test
    * Sends a minimal test completion to verify the provider is reachable.
    */


### PR DESCRIPTION
The `DELETE /api/providers/:modelName` endpoint is now implemented. It distinguishes between static providers (defined in `providers.json`) and dynamic providers. Static providers are marked as `enabled: false` to persist their configuration while removing them from active use, whereas dynamic providers are fully removed by delegating to the `DynamicProviderManager`. The implementation also ensures that health checks (circuit breakers) are stopped and removed for the affected providers. Unit tests have been added to verify these behaviors.

Fixes #170

---
*PR created automatically by Jules for task [4094872000598564469](https://jules.google.com/task/4094872000598564469) started by @TKCen*