### PR TITLE
fix: egress proxy crash-loop — CRLF and hostname default

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Ensure shell scripts always use LF line endings (required for Linux containers)
+*.sh text eol=lf
+*.conf text eol=lf
+entrypoint* text eol=lf
+
+# Dockerfiles should also use LF
+Dockerfile* text eol=lf

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -263,7 +263,7 @@ app.get('/api/health/detail', async (_req, res) => {
   }
 
   // Squid egress proxy check
-  const squidHost = process.env['SQUID_HOST'] ?? 'squid';
+  const squidHost = process.env['SQUID_HOST'] ?? 'sera-egress-proxy';
   const squidPort = process.env['SQUID_PORT'] ?? '3128';
   const squidStart = Date.now();
   try {


### PR DESCRIPTION
## Summary
- Add `.gitattributes` to enforce LF line endings for `*.sh`, `*.conf`, `Dockerfile*` — prevents CRLF from breaking shell scripts in Linux containers
- Fix health check default hostname from `squid` to `sera-egress-proxy` (matches docker-compose service name)

## Runtime Verification
Before: egress proxy crash-loops with `exec /entrypoint.sh: no such file or directory`, health shows `squid: degraded`
After: `docker compose up -d` → egress proxy starts healthy, `GET /api/health/detail` reports all 6 components healthy

## Test plan
- [ ] `bun run ci` passes
- [ ] `docker compose up -d` → `sera-egress-proxy` container is healthy
- [ ] `GET /api/health/detail` shows `squid: healthy`

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)