### PR TITLE
feat(core): implement knowledge merge conflict resolution

### DIFF
--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -432,7 +432,7 @@ app.use(
 );
 app.use('/api/mcp-servers', authMiddleware, createMCPRouter(mcpRegistry, skillRegistry));
 app.use('/api/agents/:id/tasks', createTasksRouter(intercomService));
-app.use('/api/knowledge', authMiddleware, createKnowledgeRouter());
+app.use('/api/knowledge', authMiddleware, createKnowledgeRouter(llmRouter));
 
 // Epic 17 — Delegation & Service Identity
 const delegationRouter = createDelegationRouter(intercomService);

--- a/core/src/memory/KnowledgeGitService.ts
+++ b/core/src/memory/KnowledgeGitService.ts
@@ -38,6 +38,14 @@ export interface MergeRequest {
   diffSummary?: string;
 }
 
+export type MergeStrategy = 'ours' | 'theirs' | 'llm';
+
+export interface MergeResolution {
+  strategy: MergeStrategy;
+  filesResolved: string[];
+  commitHash: string;
+}
+
 export interface GitLogEntry {
   commitHash: string;
   authorName: string;
@@ -291,6 +299,122 @@ export class KnowledgeGitService {
       updatedAt: updatedAt instanceof Date ? updatedAt.toISOString() : String(updatedAt),
       ...(row['diff_summary'] ? { diffSummary: row['diff_summary'] as string } : {}),
     };
+  }
+
+  // ── Merge conflict resolution ──────────────────────────────────────────────
+
+  /**
+   * Resolve a merge conflict for a given merge request using one of three strategies:
+   *  - 'ours'   — keep main's version of conflicting files
+   *  - 'theirs' — keep the agent branch's version of conflicting files
+   *  - 'llm'    — use an LLM to produce a merged version of each conflicting file
+   *
+   * After resolution, the merge completes and the merge request status is updated.
+   *
+   * @param llmMergeFn  For 'llm' strategy: function that takes (ours, theirs, filePath)
+   *                    and returns the merged content. Injected by the route layer.
+   */
+  async resolveMergeConflict(
+    requestId: string,
+    strategy: MergeStrategy,
+    resolvedBy: string,
+    llmMergeFn?: (ours: string, theirs: string, filePath: string) => Promise<string>
+  ): Promise<MergeResolution> {
+    // 1. Fetch the merge request
+    const result = await query(
+      `SELECT * FROM knowledge_merge_requests
+       WHERE id=$1 AND status IN ('pending','conflict')`,
+      [requestId]
+    );
+    const row = result.rows[0] as Record<string, unknown> | undefined;
+    if (!row) throw new Error(`Merge request ${requestId} not found or not in resolvable state`);
+
+    const circleId = row['circle_id'] as string;
+    const agentInstanceId = row['agent_instance_id'] as string;
+    const branch = row['branch'] as string;
+
+    const repoDir = this.repoPath(circleId);
+    const git = simpleGit(repoDir);
+
+    // 2. Attempt the merge to surface conflicts
+    await git.checkout('main');
+    let hasConflict = false;
+    try {
+      await git.merge([branch, '--no-ff', `--message=Merge ${branch} into main`]);
+      // No conflict — merge succeeded directly
+    } catch {
+      hasConflict = true;
+    }
+
+    const filesResolved: string[] = [];
+
+    if (hasConflict) {
+      // 3. Get list of conflicting files
+      const statusResult = await git.status();
+      const conflictedFiles = statusResult.conflicted;
+
+      if (conflictedFiles.length === 0) {
+        // Merge failed for a non-conflict reason — abort and re-throw
+        await git.merge(['--abort']).catch(() => {});
+        throw new Error(`Merge failed for ${branch} but no conflicting files detected`);
+      }
+
+      // 4. Resolve each conflicted file based on strategy
+      for (const file of conflictedFiles) {
+        const filePath = path.join(repoDir, file);
+
+        if (strategy === 'ours') {
+          await git.checkout(['--ours', '--', file]);
+          filesResolved.push(file);
+        } else if (strategy === 'theirs') {
+          await git.checkout(['--theirs', '--', file]);
+          filesResolved.push(file);
+        } else if (strategy === 'llm') {
+          if (!llmMergeFn) {
+            await git.merge(['--abort']).catch(() => {});
+            throw new Error('LLM merge function required for "llm" strategy');
+          }
+
+          // Extract ours and theirs versions
+          const oursContent = await git.show([`main:${file}`]).catch(() => '');
+          const theirsContent = await git.show([`${branch}:${file}`]).catch(() => '');
+
+          const mergedContent = await llmMergeFn(oursContent, theirsContent, file);
+          await fs.writeFile(filePath, mergedContent, 'utf-8');
+          filesResolved.push(file);
+        }
+
+        await git.add(file);
+      }
+
+      // 5. Complete the merge commit
+      await git.commit(`Resolve merge conflict (${strategy}): ${branch} into main`);
+    }
+
+    // 6. Get the resulting commit hash
+    const logResult = await git.log(['-1']);
+    const commitHash = logResult.latest?.hash ?? 'unknown';
+
+    // 7. Update merge request status
+    await query(
+      `UPDATE knowledge_merge_requests
+         SET status='merged', approved_by=$1, updated_at=now()
+       WHERE id=$2`,
+      [resolvedBy, requestId]
+    );
+
+    // 8. Re-index main branch
+    const namespace: MemoryNamespace =
+      circleId === SYSTEM_CIRCLE_ID ? 'global' : `circle:${circleId}`;
+    const store = new ScopedMemoryBlockStore(repoDir);
+    await this.vectorService.rebuildNamespace(namespace, repoDir, store, agentInstanceId);
+
+    logger.info(
+      `KnowledgeGitService: resolved conflict (${strategy}) for MR ${requestId}, ` +
+        `${filesResolved.length} files resolved, commit ${commitHash}`
+    );
+
+    return { strategy, filesResolved, commitHash };
   }
 
   // ── Diff ───────────────────────────────────────────────────────────────────

--- a/core/src/routes/knowledge.test.ts
+++ b/core/src/routes/knowledge.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { createKnowledgeRouter } from './knowledge.js';
+
+// Mock KnowledgeGitService
+vi.mock('../memory/KnowledgeGitService.js', () => {
+  const mockInstance = {
+    log: vi.fn(),
+    listMergeRequests: vi.fn(),
+    approveMergeRequest: vi.fn(),
+    resolveMergeConflict: vi.fn(),
+  };
+  return {
+    KnowledgeGitService: {
+      getInstance: () => mockInstance,
+    },
+  };
+});
+
+// Mock Logger
+vi.mock('../lib/logger.js', () => ({
+  Logger: class {
+    info = vi.fn();
+    error = vi.fn();
+    warn = vi.fn();
+    debug = vi.fn();
+  },
+}));
+
+import { KnowledgeGitService } from '../memory/KnowledgeGitService.js';
+
+function createApp(llmRouter?: unknown) {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/knowledge', createKnowledgeRouter(llmRouter as never));
+  return app;
+}
+
+describe('Knowledge routes', () => {
+  const gitService = KnowledgeGitService.getInstance() as unknown as {
+    log: ReturnType<typeof vi.fn>;
+    listMergeRequests: ReturnType<typeof vi.fn>;
+    approveMergeRequest: ReturnType<typeof vi.fn>;
+    resolveMergeConflict: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('GET /api/knowledge/circles/:id/history', () => {
+    it('returns log entries', async () => {
+      const entries = [{ commitHash: 'abc123', authorName: 'test', timestamp: '2026-01-01' }];
+      gitService.log.mockResolvedValueOnce(entries);
+
+      const app = createApp();
+      const res = await request(app).get('/api/knowledge/circles/circle-1/history');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(entries);
+      expect(gitService.log).toHaveBeenCalledWith('circle-1');
+    });
+  });
+
+  describe('GET /api/knowledge/circles/:id/merge-requests', () => {
+    it('returns merge requests', async () => {
+      const requests = [{ id: 'mr-1', status: 'pending' }];
+      gitService.listMergeRequests.mockResolvedValueOnce(requests);
+
+      const app = createApp();
+      const res = await request(app).get('/api/knowledge/circles/circle-1/merge-requests');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(requests);
+    });
+  });
+
+  describe('POST /api/knowledge/circles/:id/merge-requests/:requestId/resolve', () => {
+    it('rejects invalid strategy', async () => {
+      const app = createApp();
+      const res = await request(app)
+        .post('/api/knowledge/circles/circle-1/merge-requests/mr-1/resolve')
+        .send({ strategy: 'invalid' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/Invalid strategy/);
+    });
+
+    it('resolves with "ours" strategy', async () => {
+      gitService.resolveMergeConflict.mockResolvedValueOnce({
+        strategy: 'ours',
+        filesResolved: ['doc.md'],
+        commitHash: 'abc123',
+      });
+
+      const app = createApp();
+      const res = await request(app)
+        .post('/api/knowledge/circles/circle-1/merge-requests/mr-1/resolve')
+        .send({ strategy: 'ours' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.strategy).toBe('ours');
+      expect(res.body.filesResolved).toEqual(['doc.md']);
+      expect(gitService.resolveMergeConflict).toHaveBeenCalledWith(
+        'mr-1',
+        'ours',
+        'operator',
+        undefined
+      );
+    });
+
+    it('resolves with "theirs" strategy', async () => {
+      gitService.resolveMergeConflict.mockResolvedValueOnce({
+        strategy: 'theirs',
+        filesResolved: ['notes.md', 'readme.md'],
+        commitHash: 'def456',
+      });
+
+      const app = createApp();
+      const res = await request(app)
+        .post('/api/knowledge/circles/circle-1/merge-requests/mr-1/resolve')
+        .send({ strategy: 'theirs' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.filesResolved).toHaveLength(2);
+    });
+
+    it('returns 503 for "llm" strategy when no LLM router', async () => {
+      const app = createApp(); // no llmRouter
+      const res = await request(app)
+        .post('/api/knowledge/circles/circle-1/merge-requests/mr-1/resolve')
+        .send({ strategy: 'llm' });
+
+      expect(res.status).toBe(503);
+      expect(res.body.error).toMatch(/unavailable/);
+    });
+
+    it('resolves with "llm" strategy when LLM router provided', async () => {
+      gitService.resolveMergeConflict.mockResolvedValueOnce({
+        strategy: 'llm',
+        filesResolved: ['knowledge.md'],
+        commitHash: 'ghi789',
+      });
+
+      const mockLlmRouter = {
+        getRegistry: () => ({ getDefaultModel: () => 'test-model' }),
+        chatCompletion: vi.fn().mockResolvedValue({
+          response: {
+            choices: [{ message: { content: 'merged content' } }],
+          },
+        }),
+      };
+
+      const app = createApp(mockLlmRouter);
+      const res = await request(app)
+        .post('/api/knowledge/circles/circle-1/merge-requests/mr-1/resolve')
+        .send({ strategy: 'llm' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.strategy).toBe('llm');
+      // The llmMergeFn should have been passed to resolveMergeConflict
+      expect(gitService.resolveMergeConflict).toHaveBeenCalledWith(
+        'mr-1',
+        'llm',
+        'operator',
+        expect.any(Function)
+      );
+    });
+
+    it('returns 500 on service error', async () => {
+      gitService.resolveMergeConflict.mockRejectedValueOnce(
+        new Error('Merge request mr-99 not found')
+      );
+
+      const app = createApp();
+      const res = await request(app)
+        .post('/api/knowledge/circles/circle-1/merge-requests/mr-1/resolve')
+        .send({ strategy: 'ours' });
+
+      expect(res.status).toBe(500);
+      expect(res.body.error).toMatch(/not found/);
+    });
+  });
+});

--- a/core/src/routes/knowledge.ts
+++ b/core/src/routes/knowledge.ts
@@ -4,8 +4,59 @@
 
 import { Router } from 'express';
 import { KnowledgeGitService } from '../memory/KnowledgeGitService.js';
+import type { MergeStrategy } from '../memory/KnowledgeGitService.js';
+import type { LlmRouter } from '../llm/LlmRouter.js';
+import { Logger } from '../lib/logger.js';
 
-export function createKnowledgeRouter(): Router {
+const logger = new Logger('KnowledgeRouter');
+
+const VALID_STRATEGIES: ReadonlySet<MergeStrategy> = new Set(['ours', 'theirs', 'llm']);
+
+/**
+ * Build an LLM-powered merge function using the platform's default model.
+ * The LLM is given both versions and asked to produce a unified result.
+ */
+function buildLlmMergeFn(llmRouter: LlmRouter) {
+  return async (ours: string, theirs: string, filePath: string): Promise<string> => {
+    const defaultModel = llmRouter.getRegistry().getDefaultModel();
+    if (!defaultModel) {
+      throw new Error('No default model configured — cannot perform LLM-assisted merge');
+    }
+
+    const { response } = await llmRouter.chatCompletion(
+      {
+        model: defaultModel,
+        messages: [
+          {
+            role: 'system',
+            content:
+              'You are a knowledge merge assistant. You are given two versions of a knowledge ' +
+              'document that have conflicting edits. Produce a single merged version that ' +
+              'preserves all unique information from both versions. Keep the same format ' +
+              '(markdown/YAML frontmatter if present). Output ONLY the merged document ' +
+              'content — no explanation, no code fences, no commentary.',
+          },
+          {
+            role: 'user',
+            content:
+              `File: ${filePath}\n\n` +
+              `=== VERSION A (current main) ===\n${ours}\n\n` +
+              `=== VERSION B (agent branch) ===\n${theirs}\n\n` +
+              'Produce the merged document:',
+          },
+        ],
+        temperature: 0.1,
+      },
+      'system:knowledge-merge'
+    );
+
+    const merged = response.choices[0]?.message?.content;
+    if (!merged) throw new Error('LLM returned empty merge result');
+    return merged;
+  };
+}
+
+export function createKnowledgeRouter(llmRouter?: LlmRouter): Router {
   const router = Router();
   const gitService = KnowledgeGitService.getInstance();
 
@@ -41,21 +92,58 @@ export function createKnowledgeRouter(): Router {
     }
   });
 
-  /** POST /api/knowledge/circles/:id/merge-requests/:requestId/resolve
-   *  Conflict resolution — accept ours, theirs, or flag for LLM-assisted merge.
+  /**
+   * POST /api/knowledge/circles/:id/merge-requests/:requestId/resolve
+   * Conflict resolution — accept ours, theirs, or use LLM-assisted merge.
    */
   router.post('/circles/:id/merge-requests/:requestId/resolve', async (req, res) => {
     try {
-      const { strategy } = req.body as { strategy: 'ours' | 'theirs' | 'llm' };
-      // DECISION: LLM-assisted merge is a stub. 'ours'/'theirs' are accepted
-      // but not yet implemented beyond acknowledgement.
+      const { strategy } = req.body as { strategy: string };
+
+      if (!strategy || !VALID_STRATEGIES.has(strategy as MergeStrategy)) {
+        res.status(400).json({
+          error: `Invalid strategy "${strategy}". Must be one of: ours, theirs, llm`,
+        });
+        return;
+      }
+
+      const mergeStrategy = strategy as MergeStrategy;
+
+      if (mergeStrategy === 'llm' && !llmRouter) {
+        res.status(503).json({
+          error: 'LLM-assisted merge is unavailable — no LLM router configured',
+        });
+        return;
+      }
+
+      const reqWithIdentity = req as unknown as { identity?: { id?: string } };
+      const resolvedBy = reqWithIdentity.identity?.id ?? 'operator';
+
+      const llmMergeFn =
+        mergeStrategy === 'llm' && llmRouter ? buildLlmMergeFn(llmRouter) : undefined;
+
+      const resolution = await gitService.resolveMergeConflict(
+        req.params.requestId!,
+        mergeStrategy,
+        resolvedBy,
+        llmMergeFn
+      );
+
+      logger.info(
+        `Merge conflict resolved: MR=${req.params.requestId} strategy=${mergeStrategy} ` +
+          `files=${resolution.filesResolved.length}`
+      );
+
       res.json({
         success: true,
-        strategy,
-        note: 'Resolution strategy acknowledged — operator action required to finalise',
+        strategy: resolution.strategy,
+        filesResolved: resolution.filesResolved,
+        commitHash: resolution.commitHash,
       });
     } catch (err: unknown) {
-      res.status(500).json({ error: err instanceof Error ? err.message : String(err) });
+      const message = err instanceof Error ? err.message : String(err);
+      logger.error(`Merge conflict resolution failed: ${message}`);
+      res.status(500).json({ error: message });
     }
   });
 


### PR DESCRIPTION
## Summary
- Replaces stubbed `POST /api/knowledge/circles/:id/merge-requests/:requestId/resolve` with functional conflict resolution
- Supports three strategies: `ours` (keep main), `theirs` (keep agent branch), `llm` (LLM-assisted merge)
- Adds `KnowledgeGitService.resolveMergeConflict()` with full git conflict handling
- Wires `LlmRouter` into knowledge routes for LLM-assisted merges using the platform's default model
- Input validation, proper error responses (400/503/500)

## Test plan
- [x] 8 unit tests covering all strategies, validation, error paths
- [x] `bun run format` + `bun run ci` pass
- [ ] E2E: create conflicting knowledge branches, test each strategy

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)