### PR TITLE
docs: write epic spec docs for Epics 21-24

### DIFF
--- a/docs/epics/21-acp-ide-bridge.md
+++ b/docs/epics/21-acp-ide-bridge.md
@@ -1,0 +1,119 @@
+# Epic 21: ACP / IDE Bridge
+
+## Overview
+
+A bi-directional bridge between SERA's agent team and developer IDEs (VS Code, JetBrains, Neovim) using the **Agent Communication Protocol (ACP)**. Developers can interact with SERA agents directly from their editor — routing tasks to the architect, developer, or QA agent, seeing agent thoughts in real time, and receiving code edits as workspace changes. ACP extends SERA's reach from dashboard-only into the developer's primary workflow surface.
+
+## Context
+
+- ACP is a stdio-based protocol (similar to LSP/MCP) that connects an IDE extension to sera-core
+- Each IDE session maps to a SERA operator identity and can target specific agents or circles
+- Agent thoughts, tool calls, and code edits stream back through the bridge in real time
+- The bridge is an authenticated channel (Epic 18) — it reuses the same ingress/egress model as Discord or Slack
+- Reference implementation: OpenClaw ACP (`src/acp/server.ts`, `src/acp/translator.ts`, `src/acp/session-mapper.ts`)
+
+## Dependencies
+
+- Epic 09 (Real-Time Messaging) — Centrifugo for streaming agent responses
+- Epic 18 (Integration Channels) — ACP as a channel type with ingress/egress routing
+
+---
+
+## Stories
+
+### Story 21.1: ACP stdio server
+
+**As** sera-core
+**I want** an ACP stdio server that IDE extensions can connect to
+**So that** agents are accessible from any IDE with an ACP-compatible extension
+
+**Acceptance Criteria:**
+- [ ] `AcpServer` class in `core/src/acp/` — listens on stdio (stdin/stdout JSON-RPC)
+- [ ] Implements ACP handshake: `initialize` → `initialized` with capability negotiation
+- [ ] Server advertises capabilities: `agentRouting`, `streaming`, `codeEdits`, `thinking`
+- [ ] Graceful shutdown on `shutdown` request or broken pipe
+- [ ] Health check via `ping` → `pong` round-trip
+
+### Story 21.2: Session mapping and authentication
+
+**As** an operator using an IDE
+**I want** my ACP session to authenticate with SERA and map to my identity
+**So that** agent interactions respect my permissions and audit trail
+
+**Acceptance Criteria:**
+- [ ] `AcpSessionMapper` — maps each stdio connection to an operator identity
+- [ ] Authentication via API key passed in `initialize` params or environment variable
+- [ ] Session tracks: operator ID, active agent, working directory, IDE metadata (type, version)
+- [ ] Session stored in `acp_sessions` table for audit and reconnection
+- [ ] Multiple concurrent sessions supported (one per IDE window)
+
+### Story 21.3: Agent routing from IDE
+
+**As** a developer in VS Code
+**I want** to route my message to a specific SERA agent (architect, developer, QA)
+**So that** I get the right expertise for my current task
+
+**Acceptance Criteria:**
+- [ ] `acp/route` request with `agentId` or `agentName` parameter
+- [ ] Falls back to circle routing if no agent specified (circle picks best responder)
+- [ ] Agent list queryable via `acp/agents` request — returns available agents with status
+- [ ] Routing creates a chat session (reuses Epic 09 chat flow internally)
+
+### Story 21.4: Streaming thoughts and responses
+
+**As** a developer
+**I want** to see agent thinking, tool calls, and responses streaming in my IDE
+**So that** I can follow the agent's reasoning without switching to the dashboard
+
+**Acceptance Criteria:**
+- [ ] ACP notifications: `agent/thinking` (reasoning tokens), `agent/toolCall` (tool name + args), `agent/response` (content chunks)
+- [ ] Mapped from Centrifugo stream events to ACP notification format
+- [ ] Thinking level configurable per session: `full`, `summary`, `none`
+- [ ] Streaming cancellation via `acp/cancel` request
+
+### Story 21.5: Code edit integration
+
+**As** a developer
+**I want** agent-produced code changes to appear as workspace edits in my IDE
+**So that** I can review, accept, or reject them inline
+
+**Acceptance Criteria:**
+- [ ] `agent/codeEdit` notification with: file path, range, new content, description
+- [ ] Edits delivered as workspace edit operations (not raw file writes)
+- [ ] Agent can request file content via `workspace/readFile` request
+- [ ] Agent can query project structure via `workspace/listFiles` request
+- [ ] Working directory context sent with each session
+
+### Story 21.6: Sub-agent spawning from IDE
+
+**As** a developer
+**I want** to spawn a sub-agent for a specific task from my IDE
+**So that** I can delegate focused work (e.g., "write tests for this file") without leaving my editor
+
+**Acceptance Criteria:**
+- [ ] `acp/spawnAgent` request — creates a task-scoped agent instance
+- [ ] Sub-agent inherits parent session's working directory and file context
+- [ ] Sub-agent results stream back through the same ACP session
+- [ ] Sub-agent lifecycle visible in IDE (running, completed, failed)
+
+---
+
+## DB Schema
+
+```sql
+-- Story 21.2: ACP session tracking
+CREATE TABLE acp_sessions (
+  id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  operator_id   uuid NOT NULL REFERENCES operators(id),
+  agent_id      uuid REFERENCES agent_instances(id),
+  ide_type      text NOT NULL,               -- 'vscode' | 'jetbrains' | 'neovim'
+  ide_version   text,
+  working_dir   text,
+  status        text NOT NULL DEFAULT 'active',  -- 'active' | 'disconnected'
+  connected_at  timestamptz NOT NULL DEFAULT now(),
+  last_ping_at  timestamptz NOT NULL DEFAULT now(),
+  disconnected_at timestamptz
+);
+
+CREATE INDEX idx_acp_sessions_operator ON acp_sessions(operator_id, status);
+```

--- a/docs/epics/22-canvas-a2ui.md
+++ b/docs/epics/22-canvas-a2ui.md
@@ -1,0 +1,123 @@
+# Epic 22: Canvas / Agent-Driven UI (A2UI)
+
+## Overview
+
+Agents can push dynamic, interactive UI components into the sera-web dashboard using the **A2UI** (Agent-to-UI) message format. This enables agents to visualize complex data, present decision trees, render rich previews of artifacts, and collect structured input — going beyond plain chat text. The canvas is a panel in sera-web that renders agent-pushed components in real time.
+
+## Context
+
+- A2UI is a flat, JSON-based component format designed to be LLM-friendly (easy for models to emit)
+- Components are pushed via Centrifugo channels — the canvas subscribes to the agent's UI channel
+- The format supports incremental updates (append, replace, clear) for streaming UIs
+- Reference format: OpenClaw A2UI v0.8 (JSONL with component types: Column, Row, Card, Text, Image, TextField)
+- Canvas is an optional overlay — agents work without it, but can produce richer output with it
+- Security: A2UI components are sandboxed (no arbitrary JS execution, no external resource loading)
+
+## Dependencies
+
+- Epic 09 (Real-Time Messaging) — Centrifugo for streaming A2UI messages
+- Epic 12/13 (Dashboard) — sera-web hosting the canvas panel
+
+---
+
+## Stories
+
+### Story 22.1: A2UI message format and schema
+
+**As** sera-core
+**I want** a well-defined A2UI message format
+**So that** agents can emit structured UI components and the dashboard can render them safely
+
+**Acceptance Criteria:**
+- [ ] A2UI TypeScript types in `core/src/a2ui/types.ts`:
+  ```typescript
+  interface A2UIMessage {
+    action: 'push' | 'replace' | 'clear' | 'snapshot'
+    components: A2UIComponent[]
+    targetPanel?: string       // default: 'main'
+  }
+
+  type A2UIComponent =
+    | { type: 'text'; content: string; variant?: 'heading' | 'body' | 'code' | 'caption' }
+    | { type: 'image'; src: string; alt?: string }           // src must be data: URI or /api/ path
+    | { type: 'card'; title: string; children: A2UIComponent[] }
+    | { type: 'row'; children: A2UIComponent[] }
+    | { type: 'column'; children: A2UIComponent[] }
+    | { type: 'textField'; id: string; label: string; placeholder?: string }
+    | { type: 'button'; id: string; label: string; action: string }
+    | { type: 'table'; headers: string[]; rows: string[][] }
+    | { type: 'progress'; label: string; value: number; max: number }
+    | { type: 'divider' }
+  ```
+- [ ] JSON Schema in `schemas/a2ui-message.json` for validation
+- [ ] Zod schema in `core/src/a2ui/schema.ts` for runtime validation
+
+### Story 22.2: Agent canvas tools
+
+**As** an agent
+**I want** built-in tools to push UI components to the operator's canvas
+**So that** I can present rich visualizations and interactive elements
+
+**Acceptance Criteria:**
+- [ ] `canvas.push` tool — append components to the canvas panel
+- [ ] `canvas.replace` tool — replace all canvas content
+- [ ] `canvas.clear` tool — clear the canvas
+- [ ] `canvas.snapshot` tool — capture current canvas state for memory/audit
+- [ ] Tools registered in agent tool inventory, available to all agents
+- [ ] Tool output published to Centrifugo channel: `a2ui:{agentInstanceId}`
+
+### Story 22.3: Canvas panel in sera-web
+
+**As** an operator viewing the dashboard
+**I want** a canvas panel that renders agent-pushed UI components
+**So that** I can see rich visualizations alongside the chat
+
+**Acceptance Criteria:**
+- [ ] `CanvasPanel` React component — renders A2UI component tree
+- [ ] Subscribes to Centrifugo `a2ui:{agentInstanceId}` channel
+- [ ] Supports incremental updates (push appends, replace overwrites, clear resets)
+- [ ] Panel toggleable from chat view — slides in from right
+- [ ] Responsive layout — stacks below chat on mobile
+- [ ] Components are sandboxed: no `dangerouslySetInnerHTML`, no external images, no script execution
+
+### Story 22.4: Interactive components and feedback
+
+**As** an operator
+**I want** to interact with canvas components (click buttons, fill text fields)
+**So that** agents can collect structured input and act on my decisions
+
+**Acceptance Criteria:**
+- [ ] Button clicks publish `a2ui:action` event to Centrifugo with `{ componentId, action }`
+- [ ] TextField submissions publish `a2ui:input` event with `{ componentId, value }`
+- [ ] Agent receives these events as tool responses in its conversation context
+- [ ] Debounced input — text fields don't fire on every keystroke
+
+### Story 22.5: Component catalog and rendering
+
+**As** sera-web
+**I want** a typed component catalog mapping A2UI types to React components
+**So that** new component types can be added without modifying the renderer
+
+**Acceptance Criteria:**
+- [ ] `ComponentCatalog` registry — maps `type` string to React component
+- [ ] Built-in renderers for all Story 22.1 component types
+- [ ] Unknown types render a fallback "unsupported component" placeholder
+- [ ] Components are styled with sera-web design tokens (dark theme compatible)
+- [ ] Catalog is extensible (plugin system can register custom renderers in future)
+
+---
+
+## DB Schema
+
+```sql
+-- Story 22.2: Canvas snapshots for audit/memory
+CREATE TABLE canvas_snapshots (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_instance_id uuid NOT NULL REFERENCES agent_instances(id),
+  operator_id     uuid REFERENCES operators(id),
+  components      jsonb NOT NULL,              -- A2UI component tree at snapshot time
+  created_at      timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_canvas_snapshots_agent ON canvas_snapshots(agent_instance_id, created_at DESC);
+```

--- a/docs/epics/23-voice-interface.md
+++ b/docs/epics/23-voice-interface.md
@@ -1,0 +1,112 @@
+# Epic 23: Voice Interface
+
+## Overview
+
+Low-latency voice interaction for ambient agent access. Operators can talk to SERA agents hands-free — voice input is transcribed, routed to an agent, and the response is spoken back. This enables use cases where keyboard interaction is impractical: standing meetings, home automation oversight, mobile agent check-ins, and accessibility.
+
+The voice interface is delivered in two phases: **Phase 4** (browser-based, Web Speech API) and **Phase 5** (companion apps with wake words and continuous listening — deferred).
+
+## Context
+
+- Phase 4 uses browser-native Web Speech API for STT and either browser TTS or ElevenLabs for speech synthesis
+- Voice is a channel (Epic 18) — voice input becomes ingress events, voice output is egress
+- Agent thinking and tool calls can optionally be narrated (configurable verbosity)
+- Push-to-talk (PTT) is the default mode — continuous listening deferred to Phase 5
+- Reference: OpenClaw voice implementation (macOS/iOS/Android menu bar app, talk mode, camera/screen recording)
+
+## Dependencies
+
+- Epic 09 (Real-Time Messaging) — Centrifugo for streaming agent responses to voice TTS
+- Epic 12/13 (Dashboard) — sera-web hosting the voice controls
+- Epic 18 (Integration Channels) — voice as a channel type
+
+---
+
+## Stories
+
+### Story 23.1: Speech-to-text input
+
+**As** an operator
+**I want** to speak to SERA agents using my microphone
+**So that** I can interact hands-free without typing
+
+**Acceptance Criteria:**
+- [ ] `VoiceInput` React component — push-to-talk button with visual feedback (recording indicator)
+- [ ] Uses Web Speech API (`SpeechRecognition`) for real-time transcription
+- [ ] Interim transcription shown in chat input field as user speaks
+- [ ] Final transcript submitted as a chat message on PTT release
+- [ ] Language configurable (defaults to browser locale)
+- [ ] Microphone permission requested with clear UX explanation
+- [ ] Graceful fallback if Web Speech API unavailable (button disabled with tooltip)
+
+### Story 23.2: Text-to-speech output
+
+**As** an operator
+**I want** agent responses spoken aloud
+**So that** I can hear answers without reading the screen
+
+**Acceptance Criteria:**
+- [ ] `VoiceOutput` service — converts agent response text to speech
+- [ ] Default: browser `SpeechSynthesis` API (zero cost, works offline)
+- [ ] Optional: ElevenLabs API integration for higher-quality voices
+  - Configured via Settings page: API key, voice ID, model
+  - Falls back to browser TTS if ElevenLabs unavailable
+- [ ] TTS streams chunk-by-chunk as agent response arrives (low latency)
+- [ ] Speaking indicator shown in chat UI (audio wave animation)
+- [ ] Operator can interrupt (click or new PTT) to stop current TTS
+
+### Story 23.3: Voice routing and agent selection
+
+**As** an operator using voice
+**I want** to direct my voice message to a specific agent
+**So that** I get the right expertise without navigating the UI
+
+**Acceptance Criteria:**
+- [ ] Voice routing uses the currently-selected agent in chat view
+- [ ] Agent switch via voice command: "talk to [agent name]" detected as routing command
+- [ ] Confirmation feedback: "[Agent name] is listening" spoken before routing
+- [ ] If no agent selected, routes to default agent or circle
+
+### Story 23.4: Voice mode settings
+
+**As** an operator
+**I want** to configure voice behavior
+**So that** the voice interface matches my preferences and environment
+
+**Acceptance Criteria:**
+- [ ] Voice settings panel in Settings page:
+  - TTS provider: browser / ElevenLabs
+  - TTS voice selection (from available voices)
+  - Speech rate and pitch
+  - Narrate thinking: on / summary / off
+  - Narrate tool calls: on / off
+  - PTT key binding (default: Space when voice panel focused)
+- [ ] Settings persisted in `operator_preferences` table
+- [ ] Settings applied immediately (no page reload)
+
+### Story 23.5: Voice channel integration
+
+**As** sera-core
+**I want** voice interactions logged as channel events
+**So that** voice conversations appear in audit trail and chat history
+
+**Acceptance Criteria:**
+- [ ] Voice input creates ingress events on the `voice` channel type
+- [ ] Voice output creates egress events with TTS metadata (provider, voice, duration)
+- [ ] Chat history shows voice messages with a microphone icon indicator
+- [ ] Audit trail includes voice event metadata (transcription confidence, audio duration)
+
+---
+
+## DB Schema
+
+```sql
+-- Story 23.4: Voice preferences per operator
+-- Uses existing operator_preferences table with JSON key:
+-- key: 'voice_settings'
+-- value: { ttsProvider, voiceId, speechRate, pitch, narrateThinking, narrateToolCalls, pttKey }
+
+-- Story 23.5: Voice event metadata (extends existing audit_events)
+-- No new table — voice metadata stored in audit_events.metadata jsonb field:
+-- { channel: 'voice', transcriptionConfidence: 0.95, audioDurationMs: 3200, ttsProvider: 'browser' }
+```

--- a/docs/epics/24-a2a-federation.md
+++ b/docs/epics/24-a2a-federation.md
@@ -1,0 +1,201 @@
+# Epic 24: A2A Federation Protocol
+
+## Overview
+
+SERA uses a **dual-tier federation model** for multi-agent communication. Internal agents (same SERA instance) communicate via Centrifugo intercom — sub-millisecond, fully audited, budget-enforced. External agents (other SERA instances, third-party A2A agents) communicate via the **A2A (Agent-to-Agent) protocol** — a Linux Foundation standard for cross-platform agent interoperability.
+
+The A2A protocol enables SERA agents to collaborate with agents running on different platforms (Google ADK, LangGraph, CrewAI, etc.) through a standardized JSON-RPC interface with Agent Cards for capability discovery.
+
+## Context
+
+- **Internal** (Centrifugo): Core sees everything, enforces budgets, sub-ms latency, supports delegation/capability model
+- **External** (A2A): opaque agents, HTTP round-trips, OAuth2/mTLS security, no built-in metering
+- A2A endpoint in sera-core acts as the bridge — internal agents never speak A2A directly
+- Agent Cards are auto-generated from agent templates at `/.well-known/agent.json`
+- A2A is a Linux Foundation project with 50+ partners — broad ecosystem compatibility
+- Key decision: A2A for **external federation only**; internal communication stays on Centrifugo because Core needs visibility for governance, auditing, and budget enforcement
+
+| Aspect | Internal (Centrifugo) | External (A2A) |
+|---|---|---|
+| Latency | Sub-ms (pub/sub) | HTTP round-trips |
+| Visibility | Core sees all messages | Opaque |
+| Budget | Enforced by Core | Not built-in |
+| Auth | JWT (internal) | OAuth2 / mTLS |
+| Agent types | SERA-managed only | Any A2A-compatible |
+
+## Dependencies
+
+- Epic 09 (Real-Time Messaging) — Centrifugo intercom for internal tier
+- Epic 17 (Agent Identity & Delegation) — service identity tokens for A2A auth
+- Epic 18 (Integration Channels) — A2A as an inbound/outbound channel type
+
+---
+
+## Stories
+
+### Story 24.1: A2A inbound server
+
+**As** sera-core
+**I want** an A2A-compliant JSON-RPC endpoint
+**So that** external agents can discover and communicate with SERA agents
+
+**Acceptance Criteria:**
+- [ ] `A2AServer` in `core/src/a2a/server.ts` — Express router mounted at `/api/a2a`
+- [ ] Implements A2A JSON-RPC methods:
+  - `tasks/send` — receive a task from an external agent
+  - `tasks/get` — query task status
+  - `tasks/cancel` — cancel a running task
+  - `tasks/sendSubscribe` — SSE streaming for task updates
+- [ ] Request validation against A2A JSON Schema
+- [ ] Authentication: OAuth2 bearer token or mTLS client certificate
+- [ ] Rate limiting per external agent identity
+
+### Story 24.2: Agent Card generation
+
+**As** an operator
+**I want** SERA agents to be discoverable via standard Agent Cards
+**So that** external agents can find and understand what my agents can do
+
+**Acceptance Criteria:**
+- [ ] `GET /.well-known/agent.json` — serves the instance's root Agent Card
+- [ ] `GET /api/a2a/agents/:id/card` — serves per-agent Agent Cards
+- [ ] Agent Card auto-generated from agent template manifest:
+  ```json
+  {
+    "name": "sera-architect",
+    "description": "Architecture and design agent",
+    "url": "https://sera.example.com/api/a2a",
+    "version": "1.0.0",
+    "capabilities": {
+      "streaming": true,
+      "pushNotifications": true
+    },
+    "skills": [
+      { "id": "architecture-review", "name": "Architecture Review" }
+    ],
+    "authentication": {
+      "schemes": ["oauth2", "mtls"]
+    }
+  }
+  ```
+- [ ] Cards update automatically when templates change (no manual sync)
+- [ ] Capability filtering: only publicly-exposed skills appear in cards
+
+### Story 24.3: A2A outbound client
+
+**As** a SERA agent
+**I want** to send tasks to external A2A agents
+**So that** I can delegate work to agents outside my SERA instance
+
+**Acceptance Criteria:**
+- [ ] `A2AClient` in `core/src/a2a/client.ts` — HTTP client for A2A JSON-RPC
+- [ ] Discovers external agents via Agent Card URL
+- [ ] Sends tasks via `tasks/send` with message parts (text, file, data)
+- [ ] Supports streaming responses via `tasks/sendSubscribe` (SSE)
+- [ ] Agent tool: `a2a.delegate` — available to agents for delegating to external agents
+- [ ] Client handles retries, timeouts, and circuit breaking
+
+### Story 24.4: Instance pairing and trust
+
+**As** an operator
+**I want** to pair my SERA instance with other A2A-compatible platforms
+**So that** agents can federate across trusted instances
+
+**Acceptance Criteria:**
+- [ ] `PairingService` — manages trusted external agent registrations
+- [ ] Pairing flow: operator enters Agent Card URL → SERA fetches card → operator confirms trust
+- [ ] Paired agents stored in `a2a_paired_agents` table
+- [ ] Trust levels: `full` (all skills), `restricted` (selected skills only), `read-only` (status queries only)
+- [ ] Operator can revoke trust at any time from Settings page
+- [ ] Paired agents visible in Agents page with "external" badge
+
+### Story 24.5: Capability gate for federation
+
+**As** sera-core
+**I want** to control which agent capabilities are exposed via A2A
+**So that** internal agents don't accidentally expose sensitive operations externally
+
+**Acceptance Criteria:**
+- [ ] `FederationPolicy` in capability resolution — specifies which skills are A2A-visible
+- [ ] Default: no skills exposed (opt-in model)
+- [ ] Operator configures per-agent federation exposure in agent template
+- [ ] Inbound A2A tasks validated against federation policy before routing
+- [ ] Blocked requests return A2A-compliant error response
+
+### Story 24.6: A2A streaming and push notifications
+
+**As** an external agent
+**I want** to receive streaming updates for long-running tasks
+**So that** I can show progress to my user without polling
+
+**Acceptance Criteria:**
+- [ ] `tasks/sendSubscribe` returns SSE stream with task state updates
+- [ ] Stream events: `status-update`, `artifact`, `message`
+- [ ] Push notification support: external agent registers webhook for async updates
+- [ ] Push notifications stored in `a2a_push_subscriptions` table
+- [ ] Webhook delivery with HMAC signatures and retry logic
+
+### Story 24.7: Cross-instance circle membership
+
+**As** an operator
+**I want** to add external agents to my circles
+**So that** federated agents can participate in circle discussions and coordinated tasks
+
+**Acceptance Criteria:**
+- [ ] External agents representable as `CircleMember` with `source: 'a2a'`
+- [ ] Circle broadcasts to external members delivered via A2A `tasks/send`
+- [ ] External member responses collected and merged into circle context
+- [ ] Party mode (Epic 10) supports mixed internal + external participants
+- [ ] External member health status queryable via Agent Card endpoint
+
+---
+
+## DB Schema
+
+```sql
+-- Story 24.4: Paired external agents
+CREATE TABLE a2a_paired_agents (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_card_url  text NOT NULL UNIQUE,
+  name            text NOT NULL,
+  description     text,
+  trust_level     text NOT NULL DEFAULT 'restricted',  -- 'full' | 'restricted' | 'read-only'
+  allowed_skills  text[],                               -- null = all (when trust_level='full')
+  oauth_config    jsonb,                                -- client_id, token_endpoint, etc.
+  status          text NOT NULL DEFAULT 'active',       -- 'active' | 'revoked'
+  paired_at       timestamptz NOT NULL DEFAULT now(),
+  paired_by       uuid REFERENCES operators(id),
+  last_seen_at    timestamptz
+);
+
+CREATE INDEX idx_a2a_paired_status ON a2a_paired_agents(status);
+
+-- Story 24.6: Push notification subscriptions
+CREATE TABLE a2a_push_subscriptions (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  paired_agent_id uuid NOT NULL REFERENCES a2a_paired_agents(id) ON DELETE CASCADE,
+  webhook_url     text NOT NULL,
+  hmac_secret     text NOT NULL,
+  task_id         uuid,                                 -- null = all tasks from this agent
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  expires_at      timestamptz
+);
+
+CREATE INDEX idx_a2a_push_agent ON a2a_push_subscriptions(paired_agent_id);
+
+-- Story 24.1: Inbound A2A task tracking
+CREATE TABLE a2a_inbound_tasks (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  external_task_id text NOT NULL,
+  paired_agent_id uuid NOT NULL REFERENCES a2a_paired_agents(id),
+  target_agent_id uuid REFERENCES agent_instances(id),
+  status          text NOT NULL DEFAULT 'submitted',    -- 'submitted' | 'working' | 'completed' | 'failed' | 'canceled'
+  messages        jsonb NOT NULL DEFAULT '[]',
+  artifacts       jsonb NOT NULL DEFAULT '[]',
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  updated_at      timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_a2a_inbound_status ON a2a_inbound_tasks(status);
+CREATE INDEX idx_a2a_inbound_external ON a2a_inbound_tasks(external_task_id);
+```


### PR DESCRIPTION
## Summary
- **Epic 21** (ACP/IDE Bridge): 6 stories — stdio server, session mapping, agent routing, streaming thoughts, code edits, sub-agent spawning
- **Epic 22** (Canvas/A2UI): 5 stories — component format with TypeScript types, agent tools (push/replace/clear/snapshot), canvas panel, interactive components, component catalog
- **Epic 23** (Voice Interface): 5 stories — Web Speech API STT, browser/ElevenLabs TTS, voice routing, settings, channel integration
- **Epic 24** (A2A Federation): 7 stories — inbound JSON-RPC server, Agent Card auto-generation, outbound client, instance pairing with trust levels, capability gate, SSE streaming + push notifications, cross-instance circle membership

All docs follow the established epic format (overview, context, dependencies, stories with AC, DB schema). References ARCHITECTURE.md Epics 21-24 section and OpenClaw adoption decisions.

## Test plan
- [x] Docs only — no code changes, no CI impact
- [ ] Review: stories align with ARCHITECTURE.md design decisions
- [ ] Review: DB schemas are consistent with existing migration patterns

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)