### PR TITLE
fix(core): align SandboxBoundary schema with YAML spec wrapper

### DIFF
--- a/core/src/agents/registry.service.ts
+++ b/core/src/agents/registry.service.ts
@@ -359,7 +359,12 @@ export class AgentRegistry {
         updated_at = NOW()
       RETURNING *;
     `;
-    const res = await this.pool.query(query, [name, source, boundary.linux, boundary.capabilities]);
+    const res = await this.pool.query(query, [
+      name,
+      source,
+      boundary.spec.linux,
+      boundary.spec.capabilities,
+    ]);
     return {
       status: existing ? 'updated' : 'added',
       name: res.rows[0].name,

--- a/core/src/agents/schemas.ts
+++ b/core/src/agents/schemas.ts
@@ -142,13 +142,15 @@ export const SandboxBoundarySchema = z.object({
     name: z.string(),
     description: z.string().optional(),
   }),
-  linux: z.object({
-    capabilities: z.array(z.string()),
-    seccomp: z.string(),
-    readonlyRootfs: z.boolean().optional(),
-    runAsNonRoot: z.boolean().optional(),
+  spec: z.object({
+    linux: z.object({
+      capabilities: z.array(z.string()),
+      seccomp: z.string().optional(),
+      readOnlyRootfs: z.boolean().optional(),
+      runAsNonRoot: z.boolean().optional(),
+    }),
+    capabilities: z.record(z.any()),
   }),
-  capabilities: z.record(z.any()),
 });
 
 export type AgentTemplate = z.infer<typeof AgentTemplateSchema>;


### PR DESCRIPTION
## Summary
- SandboxBoundary Zod schema expected `linux`/`capabilities` at root level, but all YAML files nest them under `spec` (consistent with every other SERA resource kind)
- `seccomp` was required in schema but absent from all tier YAML files — made optional
- `readonlyRootfs` renamed to `readOnlyRootfs` to match YAML
- Updated `upsertSandboxBoundary` to read from `boundary.spec.*`

**Impact:** This was preventing all sandbox boundaries from being imported into the DB, making every agent start fail with "Boundary tier-X not found".

## Test plan
- [x] `bun run format` + `bun run ci` pass
- [x] Typecheck clean
- [ ] Runtime: reload registry → verify boundaries appear in DB → start agent succeeds

Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)