### PR TITLE
chore: schema-YAML sync test, Jules guardrails, post-merge CI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,3 +96,18 @@ See `docs/AGENT-WORKFLOW.md` for the full coordination protocol.
 - Don't create new files when editing an existing one would work
 - Don't touch files outside the scope of your assigned issue
 - Don't push directly to `main` — always use a feature branch + PR
+- **Don't commit log files** (`*.log`, `backend*.log`) — they may contain internal paths and config
+- **Don't commit test-only artifacts** without the actual implementation they claim to support
+- **Don't apply patterns from other frameworks** (e.g. Next.js `app/` directory) — follow existing project conventions
+- **Don't create empty PRs** — verify your branch has actual changes before opening a PR
+
+## PR quality checklist (self-check before opening)
+
+Every PR must pass this checklist. If any item fails, fix it before opening:
+
+- [ ] `git diff --stat` shows the expected files — no log files, no unrelated changes
+- [ ] Changes match the PR title/description — no extra files snuck in
+- [ ] Code follows existing patterns in the file being edited (not patterns from other frameworks)
+- [ ] No `any` types introduced, no `@ts-ignore` without a comment explaining why
+- [ ] The implementation is complete — not just a test file or stub claiming to be a feature
+- [ ] `bun run typecheck && bun run lint && bun test` all pass

--- a/core/src/agents/yaml-schema-sync.test.ts
+++ b/core/src/agents/yaml-schema-sync.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Schema–YAML sync test.
+ *
+ * Loads every YAML resource from the project's resource directories and
+ * validates them against the matching Zod schema. This catches silent drift
+ * where the YAML structure diverges from the code's expectations — the kind
+ * of bug that only surfaces at runtime when an agent tries to start.
+ *
+ * Runs as part of `bun run test` — no Docker or database required.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import yaml from 'js-yaml';
+import {
+  SandboxBoundarySchema,
+  CapabilityPolicySchema,
+  NamedListSchema,
+  AgentTemplateSchema,
+} from './schemas.js';
+
+const PROJECT_ROOT = path.resolve(import.meta.dirname, '..', '..', '..');
+
+function loadYamlFiles(dir: string): { name: string; data: unknown }[] {
+  const fullDir = path.join(PROJECT_ROOT, dir);
+  if (!fs.existsSync(fullDir)) return [];
+  return fs
+    .readdirSync(fullDir)
+    .filter((f) => f.endsWith('.yaml') || f.endsWith('.yml'))
+    .map((f) => ({
+      name: f,
+      data: yaml.load(fs.readFileSync(path.join(fullDir, f), 'utf8')),
+    }));
+}
+
+describe('YAML ↔ Zod schema sync', () => {
+  describe('sandbox-boundaries/', () => {
+    const files = loadYamlFiles('sandbox-boundaries');
+
+    it('has at least one boundary file', () => {
+      expect(files.length).toBeGreaterThan(0);
+    });
+
+    for (const file of files) {
+      it(`${file.name} validates against SandboxBoundarySchema`, () => {
+        const result = SandboxBoundarySchema.safeParse(file.data);
+        if (!result.success) {
+          // Pretty-print the validation errors for easy debugging
+          const formatted = result.error.issues
+            .map((i) => `  ${i.path.join('.')}: ${i.message}`)
+            .join('\n');
+          expect.fail(`${file.name} failed schema validation:\n${formatted}`);
+        }
+      });
+    }
+  });
+
+  describe('capability-policies/', () => {
+    const files = loadYamlFiles('capability-policies');
+
+    it('validates all policy files (if any exist)', () => {
+      for (const file of files) {
+        const result = CapabilityPolicySchema.safeParse(file.data);
+        if (!result.success) {
+          const formatted = result.error.issues
+            .map((i) => `  ${i.path.join('.')}: ${i.message}`)
+            .join('\n');
+          expect.fail(`${file.name} failed schema validation:\n${formatted}`);
+        }
+      }
+    });
+  });
+
+  describe('lists/', () => {
+    const listTypes = [
+      'network-allowlist',
+      'network-denylist',
+      'command-allowlist',
+      'command-denylist',
+      'secret-list',
+    ];
+
+    for (const type of listTypes) {
+      const files = loadYamlFiles(`lists/${type}`);
+      for (const file of files) {
+        it(`lists/${type}/${file.name} validates against NamedListSchema`, () => {
+          const result = NamedListSchema.safeParse(file.data);
+          if (!result.success) {
+            const formatted = result.error.issues
+              .map((i) => `  ${i.path.join('.')}: ${i.message}`)
+              .join('\n');
+            expect.fail(`${file.name} failed schema validation:\n${formatted}`);
+          }
+        });
+      }
+    }
+  });
+
+  describe('templates/', () => {
+    const builtinFiles = loadYamlFiles('templates/builtin');
+    const customFiles = loadYamlFiles('templates/custom');
+    const allFiles = [...builtinFiles, ...customFiles];
+
+    it('validates all template files (if any exist)', () => {
+      for (const file of allFiles) {
+        const result = AgentTemplateSchema.safeParse(file.data);
+        if (!result.success) {
+          const formatted = result.error.issues
+            .map((i) => `  ${i.path.join('.')}: ${i.message}`)
+            .join('\n');
+          expect.fail(`${file.name} failed schema validation:\n${formatted}`);
+        }
+      }
+    });
+  });
+});

--- a/docs/AGENT-WORKFLOW.md
+++ b/docs/AGENT-WORKFLOW.md
@@ -254,6 +254,16 @@ When the user says **"start the workflow"**, Claude Code runs this autonomous lo
 6. Repeat for next issue
 ```
 
+### Phase 2.5: Post-merge CI check
+```
+After merging multiple PRs in Phase 1, run CI on main to catch cross-PR conflicts:
+1. git pull origin main
+2. bash scripts/ci-check.sh           # format + full validate
+3. If failures → fix on main or revert the offending merge
+```
+This catches issues that individual PR CI wouldn't — e.g., two PRs that
+independently pass CI but conflict when both are on main.
+
 ### Phase 3: Runtime verification
 ```
 1. bash scripts/runtime-verify.sh     # restart + health checks


### PR DESCRIPTION
## Summary
- **Schema sync test** (`yaml-schema-sync.test.ts`): loads all YAML resource files and validates against Zod schemas at test time. Catches silent schema/YAML drift — would have caught #226 in CI instead of at runtime.
- **AGENTS.md guardrails**: explicit rules against log file commits, empty PRs, wrong-framework patterns, and incomplete stubs. Adds a PR self-check checklist.
- **Post-merge CI step**: Phase 2.5 in the workflow — run `ci-check.sh` on main after merging multiple PRs to catch cross-PR conflicts.

## Test plan
- [x] Schema sync test passes (7 tests: 3 boundary files + lists + policies + templates + count check)
- [x] `bun run format` + `bun run ci` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)