### PR TITLE
fix(core): exclude app-level capabilities from sandbox escalation check

### DIFF
--- a/core/src/capability/resolver.ts
+++ b/core/src/capability/resolver.ts
@@ -1,5 +1,13 @@
 import type { AgentRegistry } from '../agents/registry.service.js';
 
+/**
+ * Application-level capability dimensions that bypass sandbox escalation checks.
+ * These control what the agent can do within SERA's API (management, delegation, etc.),
+ * NOT what the container can do at the OS/network level. They are orthogonal to
+ * SandboxBoundary capabilities and should pass through without restriction from tiers.
+ */
+const APPLICATION_LEVEL_CAPABILITIES = new Set(['seraManagement', 'delegation']);
+
 export class CapabilityEscalationError extends Error {
   constructor(dimension: string, expected: unknown, actual: unknown) {
     const expectedStr = JSON.stringify(expected);
@@ -50,11 +58,36 @@ export class CapabilityResolver {
     // Resolve manifest capabilities fully expanded
     const manifestCapabilities = await this.expandCapabilities(spec.capabilities || {});
 
-    // Explicit escalation check: manifest overrides cannot be broader than base (Boundary ∩ Policy)
-    this.verifyNoEscalation(baseCapabilities, manifestCapabilities);
+    // Explicit escalation check: manifest overrides cannot be broader than base (Boundary ∩ Policy).
+    // Application-level capabilities (seraManagement, etc.) are orthogonal to sandbox boundaries
+    // and bypass the escalation check — they control what the agent can do within SERA's API,
+    // not what the container can do at the OS level.
+    const sandboxManifestCaps: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(
+      (manifestCapabilities as Record<string, unknown>) || {}
+    )) {
+      if (!APPLICATION_LEVEL_CAPABILITIES.has(key)) {
+        sandboxManifestCaps[key] = value;
+      }
+    }
+    this.verifyNoEscalation(baseCapabilities, sandboxManifestCaps);
+
+    // Merge application-level capabilities into final result (bypass sandbox intersection)
+    const appLevelCaps: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(
+      (manifestCapabilities as Record<string, unknown>) || {}
+    )) {
+      if (APPLICATION_LEVEL_CAPABILITIES.has(key)) {
+        appLevelCaps[key] = value;
+      }
+    }
+    const mergedCapabilities = {
+      ...((finalCapabilities as Record<string, unknown>) || {}),
+      ...appLevelCaps,
+    };
 
     // Final pass: Always-denied enforcement
-    const effectiveCapabilities = await this.applyAlwaysDenied(finalCapabilities);
+    const effectiveCapabilities = await this.applyAlwaysDenied(mergedCapabilities);
 
     return {
       spec,


### PR DESCRIPTION
## Summary
The capability resolver treated ALL manifest capability dimensions as sandbox-governed. Application-level dimensions like `seraManagement` and `delegation` don't exist in sandbox boundaries, so they were flagged as escalation — preventing the Sera bootstrap agent from starting.

**Fix:** Explicit `APPLICATION_LEVEL_CAPABILITIES` set that bypasses the escalation check. These capabilities still get included in the final resolved capabilities, they just skip the boundary intersection logic.

## Test plan
- [x] All 19 existing resolver tests pass (including escalation detection for actual sandbox dimensions)
- [x] `bun run format` + `bun run ci` pass
- [ ] Runtime: restart sera-core → Sera agent should start without escalation error

Closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)