### PR TITLE
chore: add Dependabot version update config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,63 @@
+version: 2
+updates:
+  # Root bun workspace (core/ + web/)
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+      production-dependencies:
+        dependency-type: "production"
+
+  # Agent-runtime has its own package.json
+  - package-ecosystem: "npm"
+    directory: "/core/agent-runtime"
+    schedule:
+      interval: "weekly"
+
+  # Go modules — TUI
+  - package-ecosystem: "gomod"
+    directory: "/tui"
+    schedule:
+      interval: "weekly"
+
+  # Go modules — CLI
+  - package-ecosystem: "gomod"
+    directory: "/cli"
+    schedule:
+      interval: "weekly"
+
+  # Dockerfiles
+  - package-ecosystem: "docker"
+    directory: "/core"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "docker"
+    directory: "/core/sandbox"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "docker"
+    directory: "/web"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "docker"
+    directory: "/egress-proxy"
+    schedule:
+      interval: "weekly"
+
+  # Docker Compose
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` covering all package ecosystems: npm (root workspace + agent-runtime), Go modules (tui + cli), Docker (4 Dockerfiles + compose), and GitHub Actions
- npm updates are grouped by dev vs production dependencies to reduce PR noise
- All ecosystems checked weekly

## Test plan
- [ ] Verify Dependabot picks up the config and starts opening PRs
- [ ] Confirm grouped npm PRs appear as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)