### PR TITLE
chore: fix Prettier formatting across 16 files

### DIFF
--- a/core/src/agents/BaseAgent.ts
+++ b/core/src/agents/BaseAgent.ts
@@ -168,11 +168,12 @@ export abstract class BaseAgent {
     const messages: ChatMessage[] = [
       {
         role: 'system',
-        content: IdentityService.generateStreamingSystemPrompt(
-          this.manifest,
-          circleContext,
-          dynamicContext
-        ) + degradationNotice,
+        content:
+          IdentityService.generateStreamingSystemPrompt(
+            this.manifest,
+            circleContext,
+            dynamicContext
+          ) + degradationNotice,
       },
       ...cleanHistory,
       { role: 'user', content: input },

--- a/core/src/agents/WorkerAgent.ts
+++ b/core/src/agents/WorkerAgent.ts
@@ -57,7 +57,8 @@ export class WorkerAgent extends BaseAgent {
       dynamicContext
     );
     if (memoryDegraded) {
-      systemPrompt += '\n\n**Note:** Knowledge search is currently unavailable (embedding service down). ' +
+      systemPrompt +=
+        '\n\n**Note:** Knowledge search is currently unavailable (embedding service down). ' +
         'Do not attempt to use knowledge-query or knowledge-store tools.';
     }
 

--- a/core/src/memory/blocks/ScopedMemoryBlockStore.ts
+++ b/core/src/memory/blocks/ScopedMemoryBlockStore.ts
@@ -190,7 +190,8 @@ export class ScopedMemoryBlockStore {
         }
         if (filters?.since && block.timestamp < filters.since) continue;
         if (filters?.before && block.timestamp >= filters.before) continue;
-        if (filters?.minImportance !== undefined && block.importance < filters.minImportance) continue;
+        if (filters?.minImportance !== undefined && block.importance < filters.minImportance)
+          continue;
 
         results.push(block);
       }

--- a/core/src/routes/agents.ts
+++ b/core/src/routes/agents.ts
@@ -252,7 +252,9 @@ export function createAgentRouter(orchestrator: Orchestrator, agentRegistry: Age
       // Delete from DB
       await agentRegistry.deleteInstance(id);
 
-      res.json({ deleted: { id: instance.id, name: instance.name, circle_id: instance.circle_id } });
+      res.json({
+        deleted: { id: instance.id, name: instance.name, circle_id: instance.circle_id },
+      });
     })
   );
 

--- a/core/src/routes/intercom.ts
+++ b/core/src/routes/intercom.ts
@@ -16,7 +16,9 @@ import type { BridgeService } from '../intercom/BridgeService.js';
 
 export function createIntercomRouter(
   intercom: IntercomService,
-  resolveManifest: (agentName: string) => AgentManifest | undefined | Promise<AgentManifest | undefined>,
+  resolveManifest: (
+    agentName: string
+  ) => AgentManifest | undefined | Promise<AgentManifest | undefined>,
   bridge?: BridgeService
 ): Router {
   const router = Router();

--- a/core/src/routes/sandbox.ts
+++ b/core/src/routes/sandbox.ts
@@ -20,7 +20,9 @@ import { PolicyViolationError } from '../sandbox/TierPolicy.js';
 
 export function createSandboxRouter(
   sandboxManager: SandboxManager,
-  resolveManifest: (agentName: string) => AgentManifest | undefined | Promise<AgentManifest | undefined>
+  resolveManifest: (
+    agentName: string
+  ) => AgentManifest | undefined | Promise<AgentManifest | undefined>
 ): Router {
   const router = Router();
   const toolRunner = new ToolRunner(sandboxManager);
@@ -29,7 +31,10 @@ export function createSandboxRouter(
   /**
    * Helper: resolve manifest or return 404.
    */
-  async function getManifestOrFail(agentName: string | undefined, res: Response): Promise<AgentManifest | null> {
+  async function getManifestOrFail(
+    agentName: string | undefined,
+    res: Response
+  ): Promise<AgentManifest | null> {
     if (!agentName || typeof agentName !== 'string') {
       res.status(400).json({ error: 'agentName is required' });
       return null;

--- a/core/src/routes/schedules.ts
+++ b/core/src/routes/schedules.ts
@@ -22,23 +22,25 @@ export const createSchedulesRouter = () => {
 
       const { rows } = await pool.query(query, params);
       // Map snake_case DB columns to camelCase for the frontend
-      res.json(rows.map((r: Record<string, unknown>) => ({
-        id: r.id,
-        agentName: r.agent_name ?? r.agent_instance_id,
-        agentInstanceId: r.agent_instance_id,
-        name: r.name,
-        type: r.type ?? 'cron',
-        expression: r.cron_expression ?? r.expression,
-        taskPrompt: r.task_prompt,
-        status: r.status,
-        source: r.source ?? 'api',
-        lastRunAt: r.last_run_at,
-        lastRunStatus: r.last_run_status,
-        lastRunOutput: r.last_run_output,
-        nextRunAt: r.next_run_at,
-        createdAt: r.created_at,
-        updatedAt: r.updated_at,
-      })));
+      res.json(
+        rows.map((r: Record<string, unknown>) => ({
+          id: r.id,
+          agentName: r.agent_name ?? r.agent_instance_id,
+          agentInstanceId: r.agent_instance_id,
+          name: r.name,
+          type: r.type ?? 'cron',
+          expression: r.cron_expression ?? r.expression,
+          taskPrompt: r.task_prompt,
+          status: r.status,
+          source: r.source ?? 'api',
+          lastRunAt: r.last_run_at,
+          lastRunStatus: r.last_run_status,
+          lastRunOutput: r.last_run_output,
+          nextRunAt: r.next_run_at,
+          createdAt: r.created_at,
+          updatedAt: r.updated_at,
+        }))
+      );
     } catch (err: unknown) {
       res.status(500).json({ error: (err as Error).message });
     }

--- a/web/src/components/AgentForm.tsx
+++ b/web/src/components/AgentForm.tsx
@@ -14,8 +14,16 @@ import { MultiSelectPicker } from '@/components/MultiSelectPicker';
 import type { PickerItem } from '@/components/MultiSelectPicker';
 
 const TIERS = [
-  { value: '1', label: 'Tier 1', description: 'No network, read-only filesystem (most restricted)' },
-  { value: '2', label: 'Tier 2', description: 'Restricted network via egress proxy, read-only root' },
+  {
+    value: '1',
+    label: 'Tier 1',
+    description: 'No network, read-only filesystem (most restricted)',
+  },
+  {
+    value: '2',
+    label: 'Tier 2',
+    description: 'Restricted network via egress proxy, read-only root',
+  },
   { value: '3', label: 'Tier 3', description: 'Command-restricted, network via egress proxy' },
 ];
 

--- a/web/src/components/ChatSidebar.tsx
+++ b/web/src/components/ChatSidebar.tsx
@@ -36,10 +36,14 @@ interface ChatSidebarProps {
 
 function statusColor(status?: string | null): string {
   switch (status) {
-    case 'running': return 'bg-sera-success';
-    case 'stopped': return 'bg-sera-text-dim';
-    case 'error': return 'bg-sera-error';
-    default: return 'bg-sera-text-muted';
+    case 'running':
+      return 'bg-sera-success';
+    case 'stopped':
+      return 'bg-sera-text-dim';
+    case 'error':
+      return 'bg-sera-error';
+    default:
+      return 'bg-sera-text-muted';
   }
 }
 
@@ -75,15 +79,23 @@ function AgentDropdown({
         className="w-full flex items-center gap-2 bg-sera-surface border border-sera-border rounded px-2 py-1.5 text-xs text-sera-text hover:border-sera-accent transition-colors"
       >
         <span className={cn('w-2 h-2 rounded-full flex-shrink-0', statusColor(selected?.status))} />
-        <span className="flex-1 text-left truncate">{selected?.display_name ?? selected?.name ?? selectedAgent}</span>
-        <ChevronDown size={12} className={cn('text-sera-text-muted transition-transform', open && 'rotate-180')} />
+        <span className="flex-1 text-left truncate">
+          {selected?.display_name ?? selected?.name ?? selectedAgent}
+        </span>
+        <ChevronDown
+          size={12}
+          className={cn('text-sera-text-muted transition-transform', open && 'rotate-180')}
+        />
       </button>
       {open && (
         <div className="absolute z-50 top-full left-0 right-0 mt-1 bg-sera-surface border border-sera-border rounded shadow-lg max-h-48 overflow-y-auto">
           {agents.map((a) => (
             <button
               key={a.name}
-              onClick={() => { onAgentChange(a.name); setOpen(false); }}
+              onClick={() => {
+                onAgentChange(a.name);
+                setOpen(false);
+              }}
               className={cn(
                 'w-full flex items-center gap-2 px-2 py-1.5 text-xs text-left hover:bg-sera-surface-hover transition-colors',
                 a.name === selectedAgent && 'bg-sera-accent-soft text-sera-accent'

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -71,7 +71,7 @@ export async function request<T>(path: string, options: RequestInit = {}): Promi
 
   if (response.status === 204) return undefined as T;
 
-  const body = await response.json() as T;
+  const body = (await response.json()) as T;
 
   // Guard: backend may return 200 with { error: "..." } (e.g. via dev proxy)
   if (body && typeof body === 'object' && 'error' in body && !('id' in body)) {

--- a/web/src/lib/api/health.ts
+++ b/web/src/lib/api/health.ts
@@ -6,7 +6,9 @@ export function getHealthDetail(): Promise<HealthDetail> {
 }
 
 export async function getCircuitBreakers(): Promise<CircuitBreakerState[]> {
-  const data = await request<{ circuitBreakers: CircuitBreakerState[] }>('/system/circuit-breakers');
+  const data = await request<{ circuitBreakers: CircuitBreakerState[] }>(
+    '/system/circuit-breakers'
+  );
   return data.circuitBreakers ?? [];
 }
 

--- a/web/src/lib/api/usage.ts
+++ b/web/src/lib/api/usage.ts
@@ -47,7 +47,10 @@ export function patchAgentBudget(
 }
 
 export function resetAgentBudget(agentId: string): Promise<{ success: boolean }> {
-  return request<{ success: boolean }>(`/budget/agents/${encodeURIComponent(agentId)}/budget/reset`, {
-    method: 'POST',
-  });
+  return request<{ success: boolean }>(
+    `/budget/agents/${encodeURIComponent(agentId)}/budget/reset`,
+    {
+      method: 'POST',
+    }
+  );
 }

--- a/web/src/pages/AgentDetailPage.tsx
+++ b/web/src/pages/AgentDetailPage.tsx
@@ -198,7 +198,11 @@ export default function AgentDetailPage() {
         <DialogContent>
           <DialogHeader>
             <DialogTitle>
-              {confirmAction === 'stop' ? 'Stop agent' : confirmAction === 'delete' ? 'Delete agent' : 'Restart agent'}
+              {confirmAction === 'stop'
+                ? 'Stop agent'
+                : confirmAction === 'delete'
+                  ? 'Delete agent'
+                  : 'Restart agent'}
             </DialogTitle>
             <DialogDescription>
               {confirmAction === 'stop'
@@ -216,7 +220,9 @@ export default function AgentDetailPage() {
             </DialogClose>
             <Button
               size="sm"
-              variant={confirmAction === 'stop' || confirmAction === 'delete' ? 'danger' : 'outline'}
+              variant={
+                confirmAction === 'stop' || confirmAction === 'delete' ? 'danger' : 'outline'
+              }
               onClick={() => {
                 if (confirmAction === 'delete') {
                   void deleteAgent.mutateAsync(id).then(() => {
@@ -228,7 +234,11 @@ export default function AgentDetailPage() {
                 }
               }}
             >
-              {confirmAction === 'stop' ? 'Stop' : confirmAction === 'delete' ? 'Delete' : 'Restart'}
+              {confirmAction === 'stop'
+                ? 'Stop'
+                : confirmAction === 'delete'
+                  ? 'Delete'
+                  : 'Restart'}
             </Button>
           </div>
         </DialogContent>
@@ -248,7 +258,9 @@ function ManifestTab({ id }: { id: string }) {
   const overrides = (inst.overrides ?? {}) as Record<string, unknown>;
   const modelOv = overrides.model as Record<string, unknown> | undefined;
   const resolvedConfig = (inst.resolved_config ?? {}) as Record<string, unknown>;
-  const specResources = (resolvedConfig.resources ?? (resolvedConfig.spec as Record<string, unknown> | undefined)?.resources ?? {}) as Record<string, unknown>;
+  const specResources = (resolvedConfig.resources ??
+    (resolvedConfig.spec as Record<string, unknown> | undefined)?.resources ??
+    {}) as Record<string, unknown>;
   const resourcesOv = (overrides.resources ?? specResources) as Record<string, unknown> | undefined;
   const resolvedCaps = (inst.resolved_capabilities ?? {}) as Record<string, unknown>;
   const permissions = overrides.permissions as Record<string, unknown> | undefined;
@@ -372,14 +384,20 @@ function ManifestTab({ id }: { id: string }) {
           <div className="space-y-1 text-xs">
             {Object.entries(resolvedCaps).map(([key, value]) => (
               <div key={key} className="mb-2">
-                <span className="text-sera-text-muted text-[11px] uppercase tracking-wider">{key}</span>
+                <span className="text-sera-text-muted text-[11px] uppercase tracking-wider">
+                  {key}
+                </span>
                 {typeof value === 'object' && value !== null ? (
                   <div className="mt-1 ml-2 space-y-0.5">
                     {Object.entries(value as Record<string, unknown>).map(([k, v]) => (
                       <div key={k} className="flex items-start gap-2">
                         <span className="text-sera-text-dim min-w-[120px]">{k}:</span>
                         <span className="text-sera-text font-mono break-all">
-                          {Array.isArray(v) ? v.join(', ') : typeof v === 'object' ? JSON.stringify(v, null, 2) : String(v)}
+                          {Array.isArray(v)
+                            ? v.join(', ')
+                            : typeof v === 'object'
+                              ? JSON.stringify(v, null, 2)
+                              : String(v)}
                         </span>
                       </div>
                     ))}
@@ -755,7 +773,13 @@ function LogsTab({ id }: { id: string }) {
         />
         <div className="ml-auto flex items-center gap-2">
           <span className="text-xs text-sera-text-muted">Auto-refreshes every 3s</span>
-          <Button size="sm" variant="ghost" onClick={() => { void refetch(); }}>
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() => {
+              void refetch();
+            }}
+          >
             Refresh
           </Button>
         </div>

--- a/web/src/pages/CircleDetailPage.tsx
+++ b/web/src/pages/CircleDetailPage.tsx
@@ -78,7 +78,7 @@ export default function CircleDetailPage() {
   const knowledge = circle.knowledge;
   // DB circles have `constitution`, YAML circles have `projectContext.content`
   const projectContent =
-    (circle as unknown as Record<string, unknown>).constitution as string | undefined ??
+    ((circle as unknown as Record<string, unknown>).constitution as string | undefined) ??
     (typeof circle.projectContext === 'object' && circle.projectContext !== null
       ? ((circle.projectContext as Record<string, unknown>).content as string | undefined)
       : typeof circle.projectContext === 'string'

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -34,7 +34,13 @@ function StatCard({
       className="sera-card-static p-4 hover:border-sera-accent/40 transition-colors group"
     >
       <div className="flex items-center justify-between mb-2">
-        <Icon size={18} className={cn('text-sera-text-muted group-hover:text-sera-accent transition-colors', accent)} />
+        <Icon
+          size={18}
+          className={cn(
+            'text-sera-text-muted group-hover:text-sera-accent transition-colors',
+            accent
+          )}
+        />
       </div>
       <div className="text-2xl font-bold text-sera-text">{value}</div>
       <div className="text-xs text-sera-text-muted mt-0.5">{label}</div>
@@ -96,12 +102,7 @@ export default function DashboardPage() {
           accent="text-sera-success"
         />
         <StatCard label="Circles" value={circles?.length ?? 0} icon={Circle} to="/circles" />
-        <StatCard
-          label="Active schedules"
-          value={activeSchedules}
-          icon={Clock}
-          to="/schedules"
-        />
+        <StatCard label="Active schedules" value={activeSchedules} icon={Clock} to="/schedules" />
       </div>
 
       {/* Agent status breakdown */}

--- a/web/src/pages/SchedulesPage.tsx
+++ b/web/src/pages/SchedulesPage.tsx
@@ -1,5 +1,15 @@
 import { useState, useCallback } from 'react';
-import { Play, Pencil, Trash2, Check, X, Info, ChevronDown, ChevronRight, Plus } from 'lucide-react';
+import {
+  Play,
+  Pencil,
+  Trash2,
+  Check,
+  X,
+  Info,
+  ChevronDown,
+  ChevronRight,
+  Plus,
+} from 'lucide-react';
 import { toast } from 'sonner';
 import { formatDistanceToNow } from '@/lib/utils';
 import {
@@ -317,7 +327,12 @@ export default function SchedulesPage() {
   const [agentFilter, setAgentFilter] = useState('');
   const [statusFilter, setStatusFilter] = useState<'' | 'active' | 'paused'>('');
   const [showCreate, setShowCreate] = useState(false);
-  const [newSchedule, setNewSchedule] = useState({ agentName: '', name: '', expression: '', taskPrompt: '' });
+  const [newSchedule, setNewSchedule] = useState({
+    agentName: '',
+    name: '',
+    expression: '',
+    taskPrompt: '',
+  });
 
   const { data: schedules, isLoading } = useSchedules({
     agentName: agentFilter || undefined,
@@ -371,9 +386,7 @@ export default function SchedulesPage() {
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Create Schedule</DialogTitle>
-            <DialogDescription>
-              Create a new cron schedule for an agent.
-            </DialogDescription>
+            <DialogDescription>Create a new cron schedule for an agent.</DialogDescription>
           </DialogHeader>
           <div className="space-y-3 mt-2">
             <div>
@@ -385,7 +398,9 @@ export default function SchedulesPage() {
               >
                 <option value="">Select agent…</option>
                 {agentNames.map((n) => (
-                  <option key={n} value={n}>{n}</option>
+                  <option key={n} value={n}>
+                    {n}
+                  </option>
                 ))}
               </select>
             </div>
@@ -408,10 +423,14 @@ export default function SchedulesPage() {
                 placeholder="0 */6 * * *"
                 className="sera-input text-xs w-full font-mono"
               />
-              <p className="text-[10px] text-sera-text-dim mt-1">Standard 5-field cron: minute hour day month weekday</p>
+              <p className="text-[10px] text-sera-text-dim mt-1">
+                Standard 5-field cron: minute hour day month weekday
+              </p>
             </div>
             <div>
-              <label className="block text-xs text-sera-text-muted mb-1">Task Prompt (optional)</label>
+              <label className="block text-xs text-sera-text-muted mb-1">
+                Task Prompt (optional)
+              </label>
               <textarea
                 value={newSchedule.taskPrompt}
                 onChange={(e) => setNewSchedule((s) => ({ ...s, taskPrompt: e.target.value }))}
@@ -423,7 +442,9 @@ export default function SchedulesPage() {
           </div>
           <div className="flex gap-3 justify-end mt-4">
             <DialogClose asChild>
-              <Button variant="ghost" size="sm">Cancel</Button>
+              <Button variant="ghost" size="sm">
+                Cancel
+              </Button>
             </DialogClose>
             <Button
               size="sm"


### PR DESCRIPTION
## Summary
- Fixes CI format check failures on main
- Pure Prettier formatting — no logic changes
- 16 files affected (7 core, 9 web) from accumulated formatter drift in merged Jules PRs

## Test plan
- [x] `bun run format:check` passes locally
- [ ] CI format check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)