### PR TITLE
feat(core): Obsidian-style wiki-links for knowledge entry linking

### DIFF
--- a/core/src/memory/blocks/scoped-types.ts
+++ b/core/src/memory/blocks/scoped-types.ts
@@ -28,6 +28,28 @@ export type MemoryScope = 'personal' | 'circle' | 'global';
 
 export type Importance = 1 | 2 | 3 | 4 | 5;
 
+export type LinkRelationship =
+  | 'relatedTo'
+  | 'expandsOn'
+  | 'contradicts'
+  | 'supersedes'
+  | 'references'
+  | 'derivedFrom';
+
+export const LINK_RELATIONSHIPS: readonly LinkRelationship[] = [
+  'relatedTo',
+  'expandsOn',
+  'contradicts',
+  'supersedes',
+  'references',
+  'derivedFrom',
+] as const;
+
+export interface KnowledgeLink {
+  target: string;
+  relationship: LinkRelationship;
+}
+
 export interface KnowledgeBlock {
   id: string;
   agentId: string;
@@ -38,6 +60,34 @@ export interface KnowledgeBlock {
   title: string;
   content: string;
   compacted?: boolean;
+}
+
+// ── Link extraction from markdown content ────────────────────────────────
+
+/** Wiki-link pattern: [[target-id]] or [[target-id|relationship]] */
+const WIKI_LINK_RE = /\[\[([a-f0-9-]+)(?:\|(\w+))?\]\]/g;
+
+/** Extract links from markdown content using wiki-link syntax. */
+export function extractLinks(content: string): KnowledgeLink[] {
+  const links: KnowledgeLink[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = WIKI_LINK_RE.exec(content)) !== null) {
+    const target = match[1]!;
+    const rel = match[2] as LinkRelationship | undefined;
+    links.push({
+      target,
+      relationship: rel && LINK_RELATIONSHIPS.includes(rel) ? rel : 'relatedTo',
+    });
+  }
+  return links;
+}
+
+/** Format a wiki-link for insertion into markdown content. */
+export function formatLink(targetId: string, relationship?: LinkRelationship): string {
+  if (relationship && relationship !== 'relatedTo') {
+    return `[[${targetId}|${relationship}]]`;
+  }
+  return `[[${targetId}]]`;
 }
 
 export interface KnowledgeBlockCreateOpts {

--- a/core/src/routes/memory.ts
+++ b/core/src/routes/memory.ts
@@ -4,6 +4,7 @@ import { ScopedMemoryBlockStore } from '../memory/blocks/ScopedMemoryBlockStore.
 import { VectorService } from '../services/vector.service.js';
 import type { MemoryNamespace } from '../services/vector.service.js';
 import { MemoryCompactionService } from '../memory/MemoryCompactionService.js';
+import { extractLinks } from '../memory/blocks/scoped-types.js';
 import type { KnowledgeBlockType } from '../memory/blocks/scoped-types.js';
 
 const MEMORY_ROOT = process.env.MEMORY_PATH ?? '/memory';
@@ -134,6 +135,61 @@ export function createMemoryRouter(memoryManager: MemoryManager) {
       const { agentId } = req.params;
       const result = await MemoryCompactionService.getInstance().triggerCompaction(agentId);
       res.json(result);
+    } catch (err: unknown) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  // ── Knowledge Links (Obsidian-style wiki-links in markdown content) ─────
+
+  /** GET /api/memory/:agentId/links — extract all links from all blocks */
+  router.get('/:agentId/links', async (req, res) => {
+    try {
+      const { agentId } = req.params;
+      const entryId = req.query.entryId as string | undefined;
+      const blocks = await scopedStore.list(agentId);
+      const allLinks: Array<{
+        sourceId: string;
+        sourceTitle: string;
+        target: string;
+        relationship: string;
+      }> = [];
+
+      for (const block of blocks) {
+        const links = extractLinks(block.content);
+        for (const link of links) {
+          if (!entryId || block.id === entryId || link.target === entryId) {
+            allLinks.push({
+              sourceId: block.id,
+              sourceTitle: block.title,
+              target: link.target,
+              relationship: link.relationship,
+            });
+          }
+        }
+      }
+      res.json(allLinks);
+    } catch (err: unknown) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  /** GET /api/memory/:agentId/graph — build a link graph from all blocks */
+  router.get('/:agentId/graph', async (req, res) => {
+    try {
+      const { agentId } = req.params;
+      const blocks = await scopedStore.list(agentId);
+      const nodes: Array<{ id: string; title: string; type: string }> = [];
+      const edges: Array<{ source: string; target: string; relationship: string }> = [];
+
+      for (const block of blocks) {
+        nodes.push({ id: block.id, title: block.title, type: block.type });
+        const links = extractLinks(block.content);
+        for (const link of links) {
+          edges.push({ source: block.id, target: link.target, relationship: link.relationship });
+        }
+      }
+      res.json({ nodes, edges });
     } catch (err: unknown) {
       res.status(500).json({ error: (err as Error).message });
     }


### PR DESCRIPTION
## Summary
- Knowledge entries can link to each other using `[[target-id]]` or `[[target-id|relationship]]` syntax in markdown content
- Links are Obsidian-compatible — files can be opened in Obsidian for graph visualization
- Relationship types: relatedTo, expandsOn, contradicts, supersedes, references, derivedFrom
- New API: `GET /api/memory/:agentId/links` and `GET /api/memory/:agentId/graph`
- Links live in content (not separate storage), so they're git-versioned

## Test plan
- [ ] CI passes
- [ ] `GET /api/memory/:agentId/graph` returns nodes and edges
- [ ] Wiki-links in block content are correctly extracted

Closes #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)