### PR TITLE
fix(web): memory page routing and navigation

### DIFF
--- a/web/src/components/AgentDetailMemoryTab.tsx
+++ b/web/src/components/AgentDetailMemoryTab.tsx
@@ -29,12 +29,20 @@ export function MemoryTab({ id }: { id: string }) {
             </button>
           ))}
         </div>
-        <Link
-          to={`/agents/${id}/memory-graph`}
-          className="flex items-center gap-1 text-xs text-sera-accent hover:underline"
-        >
-          <ExternalLink size={11} /> View graph
-        </Link>
+        <div className="flex items-center gap-3">
+          <Link
+            to={`/memory/${id}`}
+            className="flex items-center gap-1 text-xs text-sera-accent hover:underline"
+          >
+            <ExternalLink size={11} /> Browse all
+          </Link>
+          <Link
+            to={`/agents/${id}/memory-graph`}
+            className="flex items-center gap-1 text-xs text-sera-accent hover:underline"
+          >
+            <ExternalLink size={11} /> Graph view
+          </Link>
+        </div>
       </div>
 
       {isLoading ? (
@@ -44,11 +52,7 @@ export function MemoryTab({ id }: { id: string }) {
       ) : (
         <div className="space-y-2">
           {blocks.map((block) => (
-            <Link
-              key={block.id}
-              to={`/memory/${block.id}`}
-              className="sera-card flex items-start gap-3 p-3 block"
-            >
+            <div key={block.id} className="sera-card flex items-start gap-3 p-3">
               <div className="flex-1 min-w-0">
                 <div className="flex items-center gap-2 mb-0.5">
                   <span className="text-sm font-medium text-sera-text truncate">{block.title}</span>
@@ -73,7 +77,7 @@ export function MemoryTab({ id }: { id: string }) {
                   <Clock size={9} /> {new Date(block.updatedAt).toLocaleDateString()}
                 </span>
               )}
-            </Link>
+            </div>
           ))}
         </div>
       )}

--- a/web/src/pages/MemoryDetailPage.tsx
+++ b/web/src/pages/MemoryDetailPage.tsx
@@ -146,17 +146,25 @@ export default function MemoryDetailPage() {
         </div>
       </div>
 
-      {/* Stats */}
-      {stats && (
-        <div className="flex items-center gap-6 text-xs text-sera-text-muted">
-          <span className="flex items-center gap-1.5">
-            <FileText size={12} /> {stats.blockCount} blocks
-          </span>
-          <span className="flex items-center gap-1.5">
-            <Search size={12} /> {stats.vectorCount} vectors indexed
-          </span>
-        </div>
-      )}
+      {/* Stats + Graph link */}
+      <div className="flex items-center gap-6 text-xs text-sera-text-muted">
+        {stats && (
+          <>
+            <span className="flex items-center gap-1.5">
+              <FileText size={12} /> {stats.blockCount} blocks
+            </span>
+            <span className="flex items-center gap-1.5">
+              <Search size={12} /> {stats.vectorCount} vectors indexed
+            </span>
+          </>
+        )}
+        <Link
+          to={`/agents/${agentId}/memory-graph`}
+          className="flex items-center gap-1.5 text-sera-accent hover:underline ml-auto"
+        >
+          <Link2 size={12} /> Graph view
+        </Link>
+      </div>
 
       {/* Filters */}
       <div className="flex items-center gap-3 flex-wrap">


### PR DESCRIPTION
## Summary
- Fix: Memory tab blocks were linking to `/memory/:blockId` (using block ID as agent ID → empty results)
- Blocks now display inline in the agent detail Memory tab
- Added "Browse all" link from Memory tab → `/memory/:agentId` (full block browser)
- Added "Graph view" link from MemoryDetailPage → memory-graph page

## Test plan
- [ ] CI passes
- [ ] `/memory/<agentId>` shows blocks correctly
- [ ] Agent detail Memory tab shows blocks inline
- [ ] "Browse all" and "Graph view" links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)