### PR TITLE
chore: public release readiness — LICENSE, SECURITY.md, secret cleanup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,19 +13,20 @@ JWT_SECRET=sera-ephemeral-secret-change-me # Secret for JWT signing
 SERA_BOOTSTRAP_API_KEY= # Random string, e.g. sera_bootstrap_123
 SECRETS_MASTER_KEY= # 32-byte hex string (64 characters)
 
-# ── LiteLLM Gateway ──
-LITELLM_MASTER_KEY=sk-sera-master-key-change-me
-LLM_BASE_URL=http://litellm:4000/v1
-LLM_API_KEY=sk-sera-master-key-change-me # Should match LITELLM_MASTER_KEY
+# ── LLM Providers ──
+# Default local provider (LM Studio, Ollama, etc.)
+# LLM_BASE_URL=http://host.docker.internal:1234/v1
+# LLM_MODEL=qwen3.5-35b-a3b
 
-# ── Upstream LLM Providers (Optional) ──
-# LiteLLM will ignore these if left blank.
-OPENAI_API_KEY=
-ANTHROPIC_API_KEY=
+# ── Cloud LLM Providers (Optional) ──
+# Add via Settings UI or set env vars here.
+# OPENAI_API_KEY=
+# ANTHROPIC_API_KEY=
+# GOOGLE_API_KEY=
 
 # ── Web (sera-web) ──
-NEXT_PUBLIC_CENTRIFUGO_URL=ws://localhost:10001/connection/websocket
-CORE_API_URL=http://localhost:3001
+# Vite dev server proxies /api to sera-core automatically.
+# VITE_API_URL=http://sera-core:3001
 
 # ── Database (sera-db) ──
 POSTGRES_USER=sera_user

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Sebastian Hänisch
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,47 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in SERA, please report it responsibly:
+
+1. **Do not** open a public GitHub issue for security vulnerabilities
+2. Email: [Create a private security advisory](https://github.com/TKCen/sera/security/advisories/new)
+3. Include: description, reproduction steps, and potential impact
+
+We will acknowledge receipt within 48 hours and aim to provide a fix within 7 days for critical issues.
+
+## Secrets Management
+
+SERA uses environment variables for all secrets. **Never commit real credentials to the repository.**
+
+### Required secrets for production:
+
+| Variable | Purpose |
+|---|---|
+| `SECRETS_MASTER_KEY` | AES-256-GCM encryption key for stored secrets (64 hex chars) |
+| `SERA_BOOTSTRAP_API_KEY` | Initial API key for operator authentication |
+| `DATABASE_URL` | PostgreSQL connection string |
+
+### Optional secrets:
+
+| Variable | Purpose |
+|---|---|
+| `OPENAI_API_KEY` | OpenAI API access |
+| `ANTHROPIC_API_KEY` | Anthropic API access |
+| `GOOGLE_API_KEY` | Google AI Studio access |
+| `CENTRIFUGO_API_KEY` | Centrifugo server-to-server auth |
+
+### Setup
+
+1. Copy `.env.example` to `.env`
+2. Generate a strong `SECRETS_MASTER_KEY`: `openssl rand -hex 32`
+3. Generate a strong `SERA_BOOTSTRAP_API_KEY`: `openssl rand -base64 32`
+4. Never use the default development values in production
+
+## Architecture Security
+
+- **Agent sandboxing**: Each agent runs in an isolated Docker container with resource limits
+- **Capability-based access**: Agents only access what their policy permits
+- **Egress filtering**: Outbound network traffic filtered by Squid proxy with per-agent ACLs
+- **Audit trail**: All agent actions are recorded with Merkle hash-chain integrity
+- **Delegation tokens**: Operator-to-agent trust with scope intersection validation

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -28,8 +28,8 @@ services:
       - HOST_MEMORY_DIR=${PWD}/memory
       - NODE_ENV=development
       - PORT=3001
-      - SERA_BOOTSTRAP_API_KEY=sera_bootstrap_dev_123
-      - SECRETS_MASTER_KEY=f6e5d4c3b2a1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7
+      - SERA_BOOTSTRAP_API_KEY=${SERA_BOOTSTRAP_API_KEY:-sera-dev-key-change-me}
+      - SECRETS_MASTER_KEY=${SECRETS_MASTER_KEY:-0000000000000000000000000000000000000000000000000000000000000000}
       - DATABASE_URL=postgresql://sera_user:sera_pass@sera-db:5432/sera_db
       - EGRESS_PROXY_URL=http://sera-egress-proxy:3128
       # Uncomment to enable local embeddings (Ollama on host):
@@ -57,7 +57,7 @@ services:
     environment:
       - NODE_ENV=development
       - VITE_API_URL=http://sera-core:3001
-      - VITE_DEV_API_KEY=sera_bootstrap_dev_123
+      - VITE_DEV_API_KEY=${SERA_BOOTSTRAP_API_KEY:-sera-dev-key-change-me}
 
   # Egress proxy — no dev overrides, uses base definition from docker-compose.yaml
   sera-egress-proxy: {}


### PR DESCRIPTION
## Summary
Prepares the repository for public release on GitHub:

- **MIT License** — Copyright 2026 Sebastian Hänisch
- **SECURITY.md** — vulnerability reporting, secrets guide, architecture security overview
- **docker-compose.dev.yaml** — replaced hardcoded dev secrets with env var references
- **.env.example** — updated for current architecture (removed LiteLLM, added Google)

## Test plan
- [ ] CI passes
- [ ] `docker compose -f docker-compose.yaml -f docker-compose.dev.yaml config` validates
- [ ] No hardcoded secrets in committed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)