### PR TITLE
feat(core): expand MCP server tools — agent lifecycle, chat history, memory blocks, A2A delegation

### DIFF
--- a/core/src/mcp/SeraMCPServer.ts
+++ b/core/src/mcp/SeraMCPServer.ts
@@ -31,261 +31,380 @@ export class SeraMCPServer {
     this.setupHandlers();
   }
 
+  public getToolDefinitions() {
+    return [
+      {
+        name: 'list_agents',
+        description: 'List all active agents and their status.',
+        inputSchema: { type: 'object', properties: {} },
+      },
+      {
+        name: 'restart_agent',
+        description: 'Restart a specific agent by ID.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            agentId: { type: 'string' },
+          },
+          required: ['agentId'],
+        },
+      },
+      // ── Circle Management (Story 10.1) ──────────────────────────────────
+      {
+        name: 'circles.create',
+        description: 'Create a new circle.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            name: { type: 'string', description: "Slug name (e.g. 'security-council')" },
+            displayName: { type: 'string' },
+            description: { type: 'string' },
+            constitution: { type: 'string', description: 'Markdown constitution' },
+          },
+          required: ['name', 'displayName'],
+        },
+      },
+      {
+        name: 'circles.list',
+        description: 'List all circles.',
+        inputSchema: { type: 'object', properties: {} },
+      },
+      {
+        name: 'circles.add_member',
+        description: 'Add an agent instance to a circle.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            circleId: { type: 'string' },
+            agentId: { type: 'string' },
+          },
+          required: ['circleId', 'agentId'],
+        },
+      },
+      // ── Coordination (Story 10.3) ───────────────────────────────────────
+      {
+        name: 'orchestration.sequential',
+        description: 'Run tasks in sequence across agents.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            tasks: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  id: { type: 'string' },
+                  description: { type: 'string' },
+                  assignedAgent: { type: 'string' },
+                },
+                required: ['id', 'description'],
+              },
+            },
+          },
+          required: ['tasks'],
+        },
+      },
+      {
+        name: 'orchestration.parallel',
+        description: 'Run multiple tasks in parallel across agents.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            tasks: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  id: { type: 'string' },
+                  description: { type: 'string' },
+                  assignedAgent: { type: 'string' },
+                },
+                required: ['id', 'description'],
+              },
+            },
+          },
+          required: ['tasks'],
+        },
+      },
+      {
+        name: 'orchestration.hierarchical',
+        description: 'Run tasks with a manager agent overseeing and validating results.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            managerAgent: { type: 'string', description: 'Name of the manager agent' },
+            tasks: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  id: { type: 'string' },
+                  description: { type: 'string' },
+                  assignedAgent: { type: 'string' },
+                },
+                required: ['id', 'description'],
+              },
+            },
+          },
+          required: ['managerAgent', 'tasks'],
+        },
+      },
+      // ── Party Mode (Story 10.5) ─────────────────────────────────────────
+      {
+        name: 'circle.broadcast',
+        description: 'Broadcast a message to all members of a circle.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            circleId: { type: 'string' },
+            payload: { type: 'object' },
+          },
+          required: ['circleId', 'payload'],
+        },
+      },
+      // ── Chat ─────────────────────────────────────────────────────────────
+      {
+        name: 'chat',
+        description: 'Send a message to a SERA agent and get a response. Returns the agent reply.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            agentName: {
+              type: 'string',
+              description: 'Name of the agent to chat with (e.g. "sera")',
+            },
+            message: { type: 'string', description: 'The message to send' },
+            sessionId: {
+              type: 'string',
+              description: 'Optional session ID for continuing a conversation',
+            },
+          },
+          required: ['agentName', 'message'],
+        },
+      },
+      {
+        name: 'list_sessions',
+        description: 'List chat sessions for an agent.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            agentInstanceId: { type: 'string', description: 'Agent instance ID' },
+          },
+          required: ['agentInstanceId'],
+        },
+      },
+      {
+        name: 'knowledge_query',
+        description: "Semantic search across an agent's knowledge. Returns relevant entries.",
+        inputSchema: {
+          type: 'object',
+          properties: {
+            agentId: { type: 'string', description: 'Agent instance ID' },
+            query: { type: 'string', description: 'Search query text' },
+            tags: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'Optional tag filter',
+            },
+            topK: { type: 'number', description: 'Max results (default 10)' },
+          },
+          required: ['agentId', 'query'],
+        },
+      },
+      {
+        name: 'knowledge_store',
+        description: 'Store a knowledge entry for an agent.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            agentId: { type: 'string', description: 'Agent instance ID' },
+            content: { type: 'string', description: 'Content to store' },
+            type: {
+              type: 'string',
+              description:
+                'Block type: fact, context, memory, insight, reference, observation, decision',
+            },
+            title: { type: 'string', description: 'Title for the entry' },
+            tags: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'Tags for the entry',
+            },
+            importance: { type: 'number', description: 'Importance 1-5 (default 3)' },
+          },
+          required: ['agentId', 'content', 'type'],
+        },
+      },
+      // ── Extended Agent Management ────────────────────────────────────
+      {
+        name: 'agent_status',
+        description: 'Get detailed status and info for a specific agent by instance ID or name.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            agentId: { type: 'string', description: 'Agent instance ID or name' },
+          },
+          required: ['agentId'],
+        },
+      },
+      {
+        name: 'start_agent',
+        description: 'Start an existing agent instance by ID.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            agentId: { type: 'string', description: 'Agent instance ID' },
+            task: { type: 'string', description: 'Optional initial task description' },
+          },
+          required: ['agentId'],
+        },
+      },
+      {
+        name: 'stop_agent',
+        description: 'Stop a running agent instance by ID.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            agentId: { type: 'string', description: 'Agent instance ID' },
+          },
+          required: ['agentId'],
+        },
+      },
+      {
+        name: 'create_agent',
+        description: 'Create a new agent instance from an existing template.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            templateName: { type: 'string', description: 'Template name to create from' },
+            name: { type: 'string', description: 'Name for the new instance' },
+            circleId: { type: 'string', description: 'Optional circle ID to join' },
+            task: { type: 'string', description: 'Optional initial task to start with' },
+          },
+          required: ['templateName', 'name'],
+        },
+      },
+      {
+        name: 'agent_capabilities',
+        description: "Query an agent's manifest capabilities before delegating or interacting.",
+        inputSchema: {
+          type: 'object',
+          properties: {
+            agentName: { type: 'string', description: 'Agent name or instance ID' },
+          },
+          required: ['agentName'],
+        },
+      },
+      // ── Chat History ─────────────────────────────────────────────────────
+      {
+        name: 'chat_history',
+        description: 'Retrieve the message history for a specific chat session.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            sessionId: { type: 'string', description: 'Session ID' },
+            limit: { type: 'number', description: 'Max messages to return (default 50)' },
+          },
+          required: ['sessionId'],
+        },
+      },
+      // ── Memory Blocks ────────────────────────────────────────────────────
+      {
+        name: 'memory_blocks',
+        description: "List an agent's memory blocks with optional tag and importance filtering.",
+        inputSchema: {
+          type: 'object',
+          properties: {
+            agentId: { type: 'string', description: 'Agent instance ID' },
+            type: {
+              type: 'string',
+              description:
+                'Filter by block type: fact, context, memory, insight, reference, observation, decision',
+            },
+            tags: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'Filter blocks that have any of these tags',
+            },
+            minImportance: {
+              type: 'number',
+              description: 'Filter by minimum importance (1-5)',
+            },
+            limit: { type: 'number', description: 'Max blocks to return (default 50)' },
+          },
+          required: ['agentId'],
+        },
+      },
+      // ── A2A Delegation ───────────────────────────────────────────────────
+      {
+        name: 'delegate_task',
+        description:
+          'Delegate a task to a Sera agent and get the result. Creates a new session for each call.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            agentName: { type: 'string', description: 'Name of the agent to delegate to' },
+            task: { type: 'string', description: 'Task description to send to the agent' },
+            context: {
+              type: 'string',
+              description: 'Optional additional context for the agent',
+            },
+          },
+          required: ['agentName', 'task'],
+        },
+      },
+      // ── Subagent Spawning (Story 10.5 / 10.4 / 17.4) ──────────────────
+      {
+        name: 'agents.spawn_subagent',
+        description:
+          'Spawn a subagent to handle a delegated subtask. Only available to agents with permissions.canSpawnSubagents.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            role: {
+              type: 'string',
+              description: 'Subagent role (must be in manifest subagents.allowed)',
+            },
+            task: { type: 'string', description: 'Task description for the subagent' },
+            circle: {
+              type: 'string',
+              description: "Circle to join. Pass 'none' to skip circle inheritance.",
+            },
+            parentAgentId: {
+              type: 'string',
+              description: "Calling agent's instance ID (required for delegation passthrough)",
+            },
+            delegations: {
+              type: 'array',
+              description:
+                "Delegation tokens to pass to the subagent. Each token must be owned by the calling agent. Child scope may be narrower but not broader than the parent token's scope.",
+              items: {
+                type: 'object',
+                properties: {
+                  delegationTokenId: { type: 'string' },
+                  narrowedScope: {
+                    type: 'object',
+                    properties: {
+                      service: { type: 'string' },
+                      permissions: { type: 'array', items: { type: 'string' } },
+                      resourceConstraints: { type: 'object' },
+                    },
+                    required: ['service', 'permissions'],
+                  },
+                },
+                required: ['delegationTokenId'],
+              },
+            },
+          },
+          required: ['role', 'task'],
+        },
+      },
+    ];
+  }
+
   private setupHandlers() {
     this.server.setRequestHandler(ListToolsRequestSchema, async () => {
-      return {
-        tools: [
-          {
-            name: 'list_agents',
-            description: 'List all active agents and their status.',
-            inputSchema: { type: 'object', properties: {} },
-          },
-          {
-            name: 'restart_agent',
-            description: 'Restart a specific agent by ID.',
-            inputSchema: {
-              type: 'object',
-              properties: {
-                agentId: { type: 'string' },
-              },
-              required: ['agentId'],
-            },
-          },
-          // ── Circle Management (Story 10.1) ──────────────────────────────────
-          {
-            name: 'circles.create',
-            description: 'Create a new circle.',
-            inputSchema: {
-              type: 'object',
-              properties: {
-                name: { type: 'string', description: "Slug name (e.g. 'security-council')" },
-                displayName: { type: 'string' },
-                description: { type: 'string' },
-                constitution: { type: 'string', description: 'Markdown constitution' },
-              },
-              required: ['name', 'displayName'],
-            },
-          },
-          {
-            name: 'circles.list',
-            description: 'List all circles.',
-            inputSchema: { type: 'object', properties: {} },
-          },
-          {
-            name: 'circles.add_member',
-            description: 'Add an agent instance to a circle.',
-            inputSchema: {
-              type: 'object',
-              properties: {
-                circleId: { type: 'string' },
-                agentId: { type: 'string' },
-              },
-              required: ['circleId', 'agentId'],
-            },
-          },
-          // ── Coordination (Story 10.3) ───────────────────────────────────────
-          {
-            name: 'orchestration.sequential',
-            description: 'Run tasks in sequence across agents.',
-            inputSchema: {
-              type: 'object',
-              properties: {
-                tasks: {
-                  type: 'array',
-                  items: {
-                    type: 'object',
-                    properties: {
-                      id: { type: 'string' },
-                      description: { type: 'string' },
-                      assignedAgent: { type: 'string' },
-                    },
-                    required: ['id', 'description'],
-                  },
-                },
-              },
-              required: ['tasks'],
-            },
-          },
-          {
-            name: 'orchestration.parallel',
-            description: 'Run multiple tasks in parallel across agents.',
-            inputSchema: {
-              type: 'object',
-              properties: {
-                tasks: {
-                  type: 'array',
-                  items: {
-                    type: 'object',
-                    properties: {
-                      id: { type: 'string' },
-                      description: { type: 'string' },
-                      assignedAgent: { type: 'string' },
-                    },
-                    required: ['id', 'description'],
-                  },
-                },
-              },
-              required: ['tasks'],
-            },
-          },
-          {
-            name: 'orchestration.hierarchical',
-            description: 'Run tasks with a manager agent overseeing and validating results.',
-            inputSchema: {
-              type: 'object',
-              properties: {
-                managerAgent: { type: 'string', description: 'Name of the manager agent' },
-                tasks: {
-                  type: 'array',
-                  items: {
-                    type: 'object',
-                    properties: {
-                      id: { type: 'string' },
-                      description: { type: 'string' },
-                      assignedAgent: { type: 'string' },
-                    },
-                    required: ['id', 'description'],
-                  },
-                },
-              },
-              required: ['managerAgent', 'tasks'],
-            },
-          },
-          // ── Party Mode (Story 10.5) ─────────────────────────────────────────
-          {
-            name: 'circle.broadcast',
-            description: 'Broadcast a message to all members of a circle.',
-            inputSchema: {
-              type: 'object',
-              properties: {
-                circleId: { type: 'string' },
-                payload: { type: 'object' },
-              },
-              required: ['circleId', 'payload'],
-            },
-          },
-          // ── Chat ─────────────────────────────────────────────────────────────
-          {
-            name: 'chat',
-            description:
-              'Send a message to a SERA agent and get a response. Returns the agent reply.',
-            inputSchema: {
-              type: 'object',
-              properties: {
-                agentName: {
-                  type: 'string',
-                  description: 'Name of the agent to chat with (e.g. "sera")',
-                },
-                message: { type: 'string', description: 'The message to send' },
-                sessionId: {
-                  type: 'string',
-                  description: 'Optional session ID for continuing a conversation',
-                },
-              },
-              required: ['agentName', 'message'],
-            },
-          },
-          {
-            name: 'list_sessions',
-            description: 'List chat sessions for an agent.',
-            inputSchema: {
-              type: 'object',
-              properties: {
-                agentInstanceId: { type: 'string', description: 'Agent instance ID' },
-              },
-              required: ['agentInstanceId'],
-            },
-          },
-          {
-            name: 'knowledge_query',
-            description: "Semantic search across an agent's knowledge. Returns relevant entries.",
-            inputSchema: {
-              type: 'object',
-              properties: {
-                agentId: { type: 'string', description: 'Agent instance ID' },
-                query: { type: 'string', description: 'Search query text' },
-                tags: {
-                  type: 'array',
-                  items: { type: 'string' },
-                  description: 'Optional tag filter',
-                },
-                topK: { type: 'number', description: 'Max results (default 10)' },
-              },
-              required: ['agentId', 'query'],
-            },
-          },
-          {
-            name: 'knowledge_store',
-            description: 'Store a knowledge entry for an agent.',
-            inputSchema: {
-              type: 'object',
-              properties: {
-                agentId: { type: 'string', description: 'Agent instance ID' },
-                content: { type: 'string', description: 'Content to store' },
-                type: {
-                  type: 'string',
-                  description:
-                    'Block type: fact, context, memory, insight, reference, observation, decision',
-                },
-                title: { type: 'string', description: 'Title for the entry' },
-                tags: {
-                  type: 'array',
-                  items: { type: 'string' },
-                  description: 'Tags for the entry',
-                },
-                importance: { type: 'number', description: 'Importance 1-5 (default 3)' },
-              },
-              required: ['agentId', 'content', 'type'],
-            },
-          },
-          // ── Subagent Spawning (Story 10.5 / 10.4 / 17.4) ──────────────────
-          {
-            name: 'agents.spawn_subagent',
-            description:
-              'Spawn a subagent to handle a delegated subtask. Only available to agents with permissions.canSpawnSubagents.',
-            inputSchema: {
-              type: 'object',
-              properties: {
-                role: {
-                  type: 'string',
-                  description: 'Subagent role (must be in manifest subagents.allowed)',
-                },
-                task: { type: 'string', description: 'Task description for the subagent' },
-                circle: {
-                  type: 'string',
-                  description: "Circle to join. Pass 'none' to skip circle inheritance.",
-                },
-                parentAgentId: {
-                  type: 'string',
-                  description: "Calling agent's instance ID (required for delegation passthrough)",
-                },
-                delegations: {
-                  type: 'array',
-                  description:
-                    "Delegation tokens to pass to the subagent. Each token must be owned by the calling agent. Child scope may be narrower but not broader than the parent token's scope.",
-                  items: {
-                    type: 'object',
-                    properties: {
-                      delegationTokenId: { type: 'string' },
-                      narrowedScope: {
-                        type: 'object',
-                        properties: {
-                          service: { type: 'string' },
-                          permissions: { type: 'array', items: { type: 'string' } },
-                          resourceConstraints: { type: 'object' },
-                        },
-                        required: ['service', 'permissions'],
-                      },
-                    },
-                    required: ['delegationTokenId'],
-                  },
-                },
-              },
-              required: ['role', 'task'],
-            },
-          },
-        ],
-      };
+      return { tools: this.getToolDefinitions() };
     });
 
     this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
@@ -345,6 +464,43 @@ export class SeraMCPServer {
             toolArgs['title'] as string | undefined,
             toolArgs['tags'] as string[] | undefined,
             toolArgs['importance'] as number | undefined
+          );
+        case 'agent_status':
+          return this.handleAgentStatus(toolArgs['agentId'] as string);
+        case 'start_agent':
+          return this.handleStartAgent(
+            toolArgs['agentId'] as string,
+            toolArgs['task'] as string | undefined
+          );
+        case 'stop_agent':
+          return this.handleStopAgent(toolArgs['agentId'] as string);
+        case 'create_agent':
+          return this.handleCreateAgent(
+            toolArgs['templateName'] as string,
+            toolArgs['name'] as string,
+            toolArgs['circleId'] as string | undefined,
+            toolArgs['task'] as string | undefined
+          );
+        case 'agent_capabilities':
+          return this.handleAgentCapabilities(toolArgs['agentName'] as string);
+        case 'chat_history':
+          return this.handleChatHistory(
+            toolArgs['sessionId'] as string,
+            toolArgs['limit'] as number | undefined
+          );
+        case 'memory_blocks':
+          return this.handleMemoryBlocks(
+            toolArgs['agentId'] as string,
+            toolArgs['type'] as string | undefined,
+            toolArgs['tags'] as string[] | undefined,
+            toolArgs['minImportance'] as number | undefined,
+            toolArgs['limit'] as number | undefined
+          );
+        case 'delegate_task':
+          return this.handleDelegateTask(
+            toolArgs['agentName'] as string,
+            toolArgs['task'] as string,
+            toolArgs['context'] as string | undefined
           );
         case 'agents.spawn_subagent':
           return this.handleSpawnSubagent(
@@ -721,5 +877,179 @@ export class SeraMCPServer {
         },
       ],
     };
+  }
+
+  // ── Extended Agent Management ─────────────────────────────────────────────
+
+  private handleAgentStatus(agentId: string) {
+    if (!agentId) throw new Error('agentId is required');
+
+    // Try running agents first (by ID or name)
+    const running = this.orchestrator.getAgent(agentId);
+    if (running) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(
+              {
+                id: running.agentInstanceId,
+                name: running.name,
+                status: running.status,
+                startTime: running.startTime,
+              },
+              null,
+              2
+            ),
+          },
+        ],
+      };
+    }
+
+    // Fall back to manifest info (template / stopped instance)
+    const info = this.orchestrator.getAgentInfo(agentId);
+    if (info) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(
+              { name: info.name, status: 'stopped', manifest: info.manifest.metadata },
+              null,
+              2
+            ),
+          },
+        ],
+      };
+    }
+
+    throw new Error(`Agent "${agentId}" not found`);
+  }
+
+  private async handleStartAgent(agentId: string, task?: string) {
+    if (!agentId) throw new Error('agentId is required');
+    await this.orchestrator.startInstance(agentId, undefined, task);
+    return {
+      content: [{ type: 'text', text: `Agent "${agentId}" started.` }],
+    };
+  }
+
+  private async handleStopAgent(agentId: string) {
+    if (!agentId) throw new Error('agentId is required');
+    await this.orchestrator.stopInstance(agentId);
+    return {
+      content: [{ type: 'text', text: `Agent "${agentId}" stopped.` }],
+    };
+  }
+
+  private async handleCreateAgent(
+    templateName: string,
+    name: string,
+    circleId?: string,
+    task?: string
+  ) {
+    if (!templateName || !name) throw new Error('templateName and name are required');
+    const { AgentFactory } = await import('../agents/AgentFactory.js');
+    const instance = await AgentFactory.createInstance(templateName, name, '', circleId);
+    if (task) {
+      await this.orchestrator.startInstance(instance.id, undefined, task);
+    }
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(
+            { instanceId: instance.id, name: instance.name, templateName },
+            null,
+            2
+          ),
+        },
+      ],
+    };
+  }
+
+  private handleAgentCapabilities(agentName: string) {
+    if (!agentName) throw new Error('agentName is required');
+
+    const info = this.orchestrator.getAgentInfo(agentName);
+    if (!info) throw new Error(`Agent "${agentName}" not found`);
+
+    const { manifest } = info;
+    const m = manifest as unknown as Record<string, unknown>;
+    const spec = m['spec'] as Record<string, unknown> | undefined;
+    const capabilities = spec?.['capabilities'] ?? m['capabilities'];
+    const identity = spec?.['identity'] ?? m['identity'];
+    const model = spec?.['model'] ?? m['model'];
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({ name: agentName, identity, model, capabilities }, null, 2),
+        },
+      ],
+    };
+  }
+
+  // ── Chat History ──────────────────────────────────────────────────────────
+
+  private async handleChatHistory(sessionId: string, limit?: number) {
+    if (!sessionId) throw new Error('sessionId is required');
+    const { rows } = await pool.query(
+      `SELECT id, role, content, created_at, metadata
+       FROM session_messages
+       WHERE session_id = $1
+       ORDER BY created_at ASC
+       LIMIT $2`,
+      [sessionId, limit ?? 50]
+    );
+    return {
+      content: [{ type: 'text', text: JSON.stringify(rows, null, 2) }],
+    };
+  }
+
+  // ── Memory Blocks ─────────────────────────────────────────────────────────
+
+  private async handleMemoryBlocks(
+    agentId: string,
+    type?: string,
+    tags?: string[],
+    minImportance?: number,
+    limit?: number
+  ) {
+    if (!agentId) throw new Error('agentId is required');
+    const { ScopedMemoryBlockStore } = await import('../memory/blocks/ScopedMemoryBlockStore.js');
+    const store = new ScopedMemoryBlockStore(process.env.MEMORY_PATH ?? '/memory');
+
+    const { KNOWLEDGE_BLOCK_TYPES } = await import('../memory/blocks/scoped-types.js');
+    const blocks = await store.list(agentId, {
+      ...(type && (KNOWLEDGE_BLOCK_TYPES as readonly string[]).includes(type)
+        ? { type: type as (typeof KNOWLEDGE_BLOCK_TYPES)[number] }
+        : {}),
+      ...(tags && tags.length > 0 ? { tags } : {}),
+      ...(minImportance !== undefined ? { minImportance } : {}),
+    });
+
+    const results = blocks.slice(0, limit ?? 50).map((b) => ({
+      id: b.id,
+      type: b.type,
+      title: b.title,
+      content: b.content,
+      tags: b.tags,
+      importance: b.importance,
+      timestamp: b.timestamp,
+    }));
+
+    return {
+      content: [{ type: 'text', text: JSON.stringify(results, null, 2) }],
+    };
+  }
+
+  // ── A2A Delegation ────────────────────────────────────────────────────────
+
+  private async handleDelegateTask(agentName: string, task: string, context?: string) {
+    if (!agentName || !task) throw new Error('agentName and task are required');
+    const message = context ? `${task}\n\nContext:\n${context}` : task;
+    return this.handleChat(agentName, message, undefined);
   }
 }

--- a/core/src/mcp/registry.ts
+++ b/core/src/mcp/registry.ts
@@ -243,30 +243,13 @@ export class MCPRegistry {
   ): Promise<void> {
     const name = 'sera-core';
 
-    // Create a shim that matches the MCPClient interface.
-    // Since this is in-process, we bypass the real transport-based MCPClient
-    // and call the server instance (or its wrapper) directly.
+    // In-process shim — bypasses transport and delegates directly to the server instance.
+    // listTools reads the tool definitions from the server so the list stays in sync.
     const mockClient: Partial<MCPClient> = {
       listTools: async () => {
         return {
-          tools: [
-            {
-              name: 'list_agents',
-              description: 'List all active agents and their status.',
-              inputSchema: { type: 'object', properties: {} },
-            },
-            {
-              name: 'restart_agent',
-              description: 'Restart a specific agent by ID.',
-              inputSchema: {
-                type: 'object',
-                properties: {
-                  agentId: { type: 'string' },
-                },
-                required: ['agentId'],
-              },
-            },
-          ],
+          tools:
+            seraMcp.getToolDefinitions() as import('@modelcontextprotocol/sdk/types.js').Tool[],
         };
       },
       callTool: async (
@@ -274,8 +257,6 @@ export class MCPRegistry {
         args: Record<string, unknown>,
         _meta?: Record<string, unknown>
       ) => {
-        // callTool typically expects CallToolResult from the MCP sdk.
-        // We cast the output if needed since seraMcp returns a simpler object.
         const result = await seraMcp.callTool(toolName, args);
         return result as import('@modelcontextprotocol/sdk/types.js').CallToolResult;
       },


### PR DESCRIPTION
Closes #346

## Summary
Expands the Sera MCP server from 14 tools to 21, covering all the gaps identified in #346.

**New tools:**
- `agent_status` — detailed status for a single agent by ID or name
- `start_agent` / `stop_agent` — lifecycle control (complements existing `restart_agent`)
- `create_agent` — create a new instance from a template, with optional initial task
- `agent_capabilities` — query agent manifest (identity, model, capabilities) before delegating
- `chat_history` — retrieve messages for a session with a `limit` param
- `memory_blocks` — list an agent's knowledge blocks with `type`/`tags`/`minImportance` filters
- `delegate_task` — A2A delegation: send a task to a named agent and get its reply

**Registry fix:**
- `MCPRegistry.registerSeraCoreTools` previously hardcoded only `list_agents` + `restart_agent` in its `listTools` shim, making 12 tools invisible to agents using the in-process registry
- Refactored `SeraMCPServer.getToolDefinitions()` as a public method; both the transport handler and the in-process shim now call it — the tool list stays in sync automatically

## Test plan
- [x] `tsc --noEmit` passes (0 errors)
- [x] Format + lint clean
- [x] Web tests: 41/41 passed
- [x] No breaking changes to existing tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)