### PR TITLE
fix(core): bridge sera-core MCP tools into SkillRegistry at startup

### DIFF
--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -542,11 +542,8 @@ const startServer = async () => {
   mcpRegistry.setIntercom(intercomService);
 
   const { SeraMCPServer } = await import('./mcp/SeraMCPServer.js');
-  const seraMcpServer = new SeraMCPServer(orchestrator);
-  // For simplicity in this story, we bridge it directly since it's in-process.
-  // In a full implementation, we'd use a local transport.
-  await mcpRegistry.registerSeraCoreTools(seraMcpServer);
-
+  // Set up MCP ↔ SkillRegistry bridge hooks BEFORE registering any servers,
+  // so that sera-core tools (and any loaded from disk) are automatically bridged.
   mcpRegistry.onRegister((name) => {
     skillRegistry
       .bridgeMCPToolsForServer(name, mcpRegistry)
@@ -560,6 +557,9 @@ const startServer = async () => {
     skillRegistry.unregisterByPrefix(`${name}/`);
     logger.info(`Removed bridged skills for MCP server "${name}"`);
   });
+
+  const seraMcpServer = new SeraMCPServer(orchestrator);
+  await mcpRegistry.registerSeraCoreTools(seraMcpServer);
 
   await mcpRegistry
     .loadFromDirectory(mcpServersDir)


### PR DESCRIPTION
Closes #299

## Summary
- The `onRegister` hook was set up **after** `registerSeraCoreTools()`, so the hook never fired for `sera-core` — its 21 MCP tools were registered in the MCPRegistry but never bridged into the SkillRegistry
- Agents could see the tools in their system prompt (via `tools.allowed`) but ToolExecutor couldn't resolve them, causing tool-not-found errors at runtime
- **Fix:** Move the `onRegister`/`onUnregister` hooks before any server registration (5 lines moved up)

## Test plan
- [x] Typecheck, lint, format clean
- [x] Web tests: 41/41 passed
- [x] Change is a pure ordering fix — no new code, no API changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)