### PR TITLE
fix(infra): squid stale PID on restart, web healthcheck localhost resolution

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -53,7 +53,7 @@ services:
     entrypoint: ["/bin/sh", "/app/docker-entrypoint.dev.sh"]
     command: ["bun", "run", "dev", "--", "--host", "0.0.0.0"]
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO /dev/null http://localhost:5173/ || exit 1"]
+      test: ["CMD-SHELL", "wget -qO /dev/null http://127.0.0.1:5173/ || exit 1"]
     environment:
       - NODE_ENV=development
       - VITE_API_URL=http://sera-core:3001

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -80,7 +80,7 @@ services:
       - sera_net
       - agent_net
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO /dev/null http://localhost/ || exit 1"]
+      test: ["CMD-SHELL", "wget -qO /dev/null http://127.0.0.1/ || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 5

--- a/egress-proxy/entrypoint.sh
+++ b/egress-proxy/entrypoint.sh
@@ -14,4 +14,8 @@ fi
 # Ensure log directory is writable
 chown -R proxy:proxy /var/log/squid
 
+# Remove stale PID file from previous run — prevents "Squid is already running"
+# on container restart (#363)
+rm -f /var/run/squid/squid.pid
+
 exec squid --foreground -f /etc/squid/squid.conf


### PR DESCRIPTION
Closes #363, closes #364

## Summary
- **Squid egress proxy (#363)**: Remove stale PID file in entrypoint before starting squid — prevents `FATAL: Squid is already running` on `docker restart`
- **Web healthcheck (#364)**: Use `http://127.0.0.1` instead of `http://localhost` in healthcheck — `wget` inside the node-slim container can't resolve `localhost` but `127.0.0.1` works

## Test plan
- [x] CI clean (typecheck, lint, format, 41/41 web tests)
- [x] Both fixes are 1-line changes in infrastructure files
- [ ] Rebuild egress-proxy image and verify `docker restart sera-egress-proxy` works
- [ ] Rebuild sera-web and verify healthcheck reports `healthy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)