### PR TITLE
feat(web): chat message queue — allow sending while agent is streaming

### DIFF
--- a/web/src/components/ChatInputBar.tsx
+++ b/web/src/components/ChatInputBar.tsx
@@ -10,6 +10,7 @@ interface ChatInputBarProps {
   selectedAgent: string;
   handleSend: () => void;
   onCancel?: () => void;
+  queueCount?: number;
 }
 
 export function ChatInputBar({
@@ -21,31 +22,39 @@ export function ChatInputBar({
   selectedAgent,
   handleSend,
   onCancel,
+  queueCount = 0,
 }: ChatInputBarProps) {
   return (
     <div className="flex items-end gap-2">
-      <textarea
-        ref={inputRef}
-        value={input}
-        onChange={(e) => setInput(e.target.value)}
-        onKeyDown={handleKeyDown}
-        disabled={streaming || !selectedAgent}
-        placeholder={
-          streaming
-            ? 'Agent is responding…'
-            : selectedAgent
-              ? 'Message agent… (Enter to send, Shift+Enter for newline)'
-              : 'Select an agent above'
-        }
-        rows={1}
-        className="sera-input flex-1 resize-none min-h-[38px] max-h-32 overflow-y-auto"
-        style={{ height: 'auto' }}
-        onInput={(e) => {
-          const el = e.currentTarget;
-          el.style.height = 'auto';
-          el.style.height = `${Math.min(el.scrollHeight, 128)}px`;
-        }}
-      />
+      <div className="relative flex-1">
+        <textarea
+          ref={inputRef}
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={handleKeyDown}
+          disabled={!selectedAgent}
+          placeholder={
+            streaming
+              ? 'Type next message… (queued until response completes)'
+              : selectedAgent
+                ? 'Message agent… (Enter to send, Shift+Enter for newline)'
+                : 'Select an agent above'
+          }
+          rows={1}
+          className="sera-input w-full resize-none min-h-[38px] max-h-32 overflow-y-auto"
+          style={{ height: 'auto' }}
+          onInput={(e) => {
+            const el = e.currentTarget;
+            el.style.height = 'auto';
+            el.style.height = `${Math.min(el.scrollHeight, 128)}px`;
+          }}
+        />
+        {queueCount > 0 && (
+          <span className="absolute right-2 top-1 text-[10px] font-medium text-sera-accent bg-sera-accent/15 rounded-full px-1.5 py-0.5">
+            {queueCount} queued
+          </span>
+        )}
+      </div>
       {streaming && onCancel ? (
         <button
           onClick={onCancel}
@@ -54,15 +63,14 @@ export function ChatInputBar({
         >
           <StopCircle size={14} />
         </button>
-      ) : (
-        <button
-          onClick={() => void handleSend()}
-          disabled={streaming || !input.trim() || !selectedAgent}
-          className="flex-shrink-0 h-[38px] w-[38px] rounded-lg bg-sera-accent text-sera-bg flex items-center justify-center disabled:opacity-40 disabled:cursor-not-allowed hover:brightness-110 transition-all"
-        >
-          {streaming ? <Loader2 size={14} className="animate-spin" /> : <Send size={14} />}
-        </button>
-      )}
+      ) : null}
+      <button
+        onClick={() => void handleSend()}
+        disabled={!input.trim() || !selectedAgent}
+        className="flex-shrink-0 h-[38px] w-[38px] rounded-lg bg-sera-accent text-sera-bg flex items-center justify-center disabled:opacity-40 disabled:cursor-not-allowed hover:brightness-110 transition-all"
+      >
+        {streaming ? <Loader2 size={14} className="animate-spin" /> : <Send size={14} />}
+      </button>
     </div>
   );
 }

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -127,6 +127,8 @@ function ChatPageContent() {
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const streamingMsgId = useRef<string | null>(null);
   const messageIdRef = useRef<string | null>(null);
+  const messageQueue = useRef<string[]>([]);
+  const [queueCount, setQueueCount] = useState(0);
 
   // ── Auto-scroll ─────────────────────────────────────────────────────────────
   useEffect(() => {
@@ -311,6 +313,8 @@ function ChatPageContent() {
     setStreaming(false);
     streamingMsgId.current = null;
     messageIdRef.current = null;
+    messageQueue.current = [];
+    setQueueCount(0);
     setExpandedThoughts(new Set());
     inputRef.current?.focus();
   }, []);
@@ -342,60 +346,71 @@ function ChatPageContent() {
 
   // ── Send message ─────────────────────────────────────────────────────────────
 
-  const handleSend = useCallback(async () => {
-    const text = input.trim();
-    if (!text || !selectedAgent || streaming) return;
+  const handleSend = useCallback(
+    async (overrideText?: string) => {
+      const text = (overrideText ?? input).trim();
+      if (!text || !selectedAgent) return;
 
-    const userMsgId = crypto.randomUUID();
-    const agentMsgId = crypto.randomUUID();
+      // Queue the message if the agent is still streaming
+      if (streaming) {
+        messageQueue.current.push(text);
+        setQueueCount(messageQueue.current.length);
+        setInput('');
+        return;
+      }
 
-    const userMsg: Message = {
-      id: userMsgId,
-      role: 'user',
-      content: text,
-      thoughts: [],
-      streaming: false,
-      createdAt: new Date(),
-    };
-    const agentMsg: Message = {
-      id: agentMsgId,
-      role: 'agent',
-      content: '',
-      thoughts: [],
-      streaming: true,
-      createdAt: new Date(),
-    };
+      const userMsgId = crypto.randomUUID();
+      const agentMsgId = crypto.randomUUID();
 
-    setMessages((prev) => [...prev, userMsg, agentMsg]);
-    setInput('');
-    setStreaming(true);
-    setExpandedThoughts((prev) => new Set(prev).add(agentMsgId));
-    streamingMsgId.current = agentMsgId;
+      const userMsg: Message = {
+        id: userMsgId,
+        role: 'user',
+        content: text,
+        thoughts: [],
+        streaming: false,
+        createdAt: new Date(),
+      };
+      const agentMsg: Message = {
+        id: agentMsgId,
+        role: 'agent',
+        content: '',
+        thoughts: [],
+        streaming: true,
+        createdAt: new Date(),
+      };
 
-    try {
-      const { sessionId: newSessionId, messageId } = await sendChatStream(
-        selectedAgent,
-        text,
-        sessionId ?? undefined,
-        selectedAgentId || undefined
-      );
-      setSessionId(newSessionId);
-      messageIdRef.current = messageId;
-      // Refresh the session list so the sidebar shows the new/updated session
-      void fetchSessions();
-    } catch (err) {
-      const errMsg = err instanceof Error ? err.message : 'Failed to send message';
-      toast.error(errMsg);
-      setMessages((prev) =>
-        prev.map((m) =>
-          m.id === agentMsgId ? { ...m, content: `Error: ${errMsg}`, streaming: false } : m
-        )
-      );
-      setStreaming(false);
-      streamingMsgId.current = null;
-      messageIdRef.current = null;
-    }
-  }, [input, selectedAgent, selectedAgentId, streaming, sessionId, fetchSessions]);
+      setMessages((prev) => [...prev, userMsg, agentMsg]);
+      setInput('');
+      setStreaming(true);
+      setExpandedThoughts((prev) => new Set(prev).add(agentMsgId));
+      streamingMsgId.current = agentMsgId;
+
+      try {
+        const { sessionId: newSessionId, messageId } = await sendChatStream(
+          selectedAgent,
+          text,
+          sessionId ?? undefined,
+          selectedAgentId || undefined
+        );
+        setSessionId(newSessionId);
+        messageIdRef.current = messageId;
+        // Refresh the session list so the sidebar shows the new/updated session
+        void fetchSessions();
+      } catch (err) {
+        const errMsg = err instanceof Error ? err.message : 'Failed to send message';
+        toast.error(errMsg);
+        setMessages((prev) =>
+          prev.map((m) =>
+            m.id === agentMsgId ? { ...m, content: `Error: ${errMsg}`, streaming: false } : m
+          )
+        );
+        setStreaming(false);
+        streamingMsgId.current = null;
+        messageIdRef.current = null;
+      }
+    },
+    [input, selectedAgent, selectedAgentId, streaming, sessionId, fetchSessions]
+  );
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === 'Enter' && !e.shiftKey) {
@@ -430,6 +445,18 @@ function ChatPageContent() {
     streamingMsgId.current = null;
     messageIdRef.current = null;
   }, [streaming]);
+
+  // ── Drain message queue when streaming finishes ──────────────────────────────
+  const prevStreaming = useRef(false);
+  useEffect(() => {
+    // Fire when streaming transitions from true → false
+    if (prevStreaming.current && !streaming && messageQueue.current.length > 0) {
+      const next = messageQueue.current.shift()!;
+      setQueueCount(messageQueue.current.length);
+      void handleSend(next);
+    }
+    prevStreaming.current = streaming;
+  }, [streaming, handleSend]);
 
   // ── Selected agent status ────────────────────────────────────────────────────
   const selectedAgentData = agents?.find((a) => a.name === selectedAgent);
@@ -499,6 +526,7 @@ function ChatPageContent() {
               selectedAgent={selectedAgent}
               handleSend={() => void handleSend()}
               onCancel={handleCancel}
+              queueCount={queueCount}
             />
           </div>
         </div>
@@ -645,6 +673,7 @@ function ChatPageContent() {
               selectedAgent={selectedAgent}
               handleSend={() => void handleSend()}
               onCancel={handleCancel}
+              queueCount={queueCount}
             />
           </div>
         </div>


### PR DESCRIPTION
Closes #333

## Summary
- Input field stays enabled during streaming — users can type and send messages while the agent responds
- Messages are queued client-side and sent sequentially when the current response completes
- Queue count badge shows "N queued" in the input bar
- Placeholder text updates to indicate queuing behavior
- Queue is cleared on new session or agent change

## Test plan
- [x] Typecheck, lint, format clean
- [x] Web tests: 41/41 passed
- [ ] Manual: send message, while streaming type another and press Enter — verify it queues and sends after response completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)