### PR TITLE
feat(web): session rename via double-click or pencil icon

### DIFF
--- a/web/src/components/ChatSidebar.tsx
+++ b/web/src/components/ChatSidebar.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react';
-import { Plus, Bot, MessageSquare, Trash2, ChevronDown } from 'lucide-react';
+import { Plus, Bot, MessageSquare, Trash2, ChevronDown, Pencil, Check, X } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 export interface SessionInfo {
@@ -31,6 +31,7 @@ interface ChatSidebarProps {
   onStartNewSession: () => void;
   onLoadSession: (id: string) => void;
   onDeleteSession: (id: string, e: React.MouseEvent) => void;
+  onRenameSession: (id: string, title: string) => void;
   onRefetchAgents: () => void;
 }
 
@@ -114,6 +115,138 @@ function AgentDropdown({
   );
 }
 
+function SessionItem({
+  session,
+  isActive,
+  onLoad,
+  onDelete,
+  onRename,
+}: {
+  session: SessionInfo;
+  isActive: boolean;
+  onLoad: () => void;
+  onDelete: (e: React.MouseEvent) => void;
+  onRename: (title: string) => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [editValue, setEditValue] = useState(session.title);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (editing) {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }
+  }, [editing]);
+
+  const commitRename = () => {
+    const trimmed = editValue.trim();
+    if (trimmed && trimmed !== session.title) {
+      onRename(trimmed);
+    }
+    setEditing(false);
+  };
+
+  const cancelRename = () => {
+    setEditValue(session.title);
+    setEditing(false);
+  };
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={() => !editing && onLoad()}
+      onKeyDown={(e) => {
+        if (!editing && (e.key === 'Enter' || e.key === ' ')) {
+          e.preventDefault();
+          onLoad();
+        }
+      }}
+      onDoubleClick={(e) => {
+        e.stopPropagation();
+        setEditValue(session.title);
+        setEditing(true);
+      }}
+      className={cn(
+        'w-full text-left px-3 py-2 flex items-start gap-2 group transition-colors border-l-2 cursor-pointer',
+        isActive
+          ? 'bg-sera-accent-soft border-sera-accent'
+          : 'hover:bg-sera-surface border-transparent'
+      )}
+    >
+      <MessageSquare size={13} className="text-sera-text-muted mt-0.5 flex-shrink-0" />
+      <div className="flex-1 min-w-0">
+        {editing ? (
+          <div className="flex items-center gap-1">
+            <input
+              ref={inputRef}
+              value={editValue}
+              onChange={(e) => setEditValue(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') commitRename();
+                if (e.key === 'Escape') cancelRename();
+                e.stopPropagation();
+              }}
+              onClick={(e) => e.stopPropagation()}
+              className="text-xs bg-sera-surface border border-sera-border rounded px-1 py-0.5 w-full text-sera-text outline-none focus:border-sera-accent"
+            />
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                commitRename();
+              }}
+              className="p-0.5 text-sera-success hover:text-green-400"
+              title="Save"
+            >
+              <Check size={11} />
+            </button>
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                cancelRename();
+              }}
+              className="p-0.5 text-sera-text-muted hover:text-red-400"
+              title="Cancel"
+            >
+              <X size={11} />
+            </button>
+          </div>
+        ) : (
+          <>
+            <p className="text-xs text-sera-text truncate">{session.title}</p>
+            <p className="text-[10px] text-sera-text-muted mt-0.5">
+              {session.messageCount} messages · {new Date(session.updatedAt).toLocaleDateString()}
+            </p>
+          </>
+        )}
+      </div>
+      {!editing && (
+        <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-all">
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              setEditValue(session.title);
+              setEditing(true);
+            }}
+            className="p-0.5 rounded text-sera-text-muted hover:text-sera-accent"
+            title="Rename session"
+          >
+            <Pencil size={11} />
+          </button>
+          <button
+            onClick={onDelete}
+            className="p-0.5 rounded text-sera-text-muted hover:text-red-400"
+            title="Delete session"
+          >
+            <Trash2 size={12} />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
 export function ChatSidebar({
   sessions,
   agents,
@@ -126,6 +259,7 @@ export function ChatSidebar({
   onStartNewSession,
   onLoadSession,
   onDeleteSession,
+  onRenameSession,
   onRefetchAgents,
 }: ChatSidebarProps) {
   const groupedSessions = sessions.reduce<Record<string, SessionInfo[]>>((acc, s) => {
@@ -198,42 +332,14 @@ export function ChatSidebar({
                 </div>
                 <div className="space-y-0.5">
                   {agentSessions.map((s) => (
-                    <div
+                    <SessionItem
                       key={s.id}
-                      role="button"
-                      tabIndex={0}
-                      onClick={() => onLoadSession(s.id)}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter' || e.key === ' ') {
-                          e.preventDefault();
-                          onLoadSession(s.id);
-                        }
-                      }}
-                      className={cn(
-                        'w-full text-left px-3 py-2 flex items-start gap-2 group transition-colors border-l-2 cursor-pointer',
-                        sessionId === s.id
-                          ? 'bg-sera-accent-soft border-sera-accent'
-                          : 'hover:bg-sera-surface border-transparent'
-                      )}
-                    >
-                      <MessageSquare
-                        size={13}
-                        className="text-sera-text-muted mt-0.5 flex-shrink-0"
-                      />
-                      <div className="flex-1 min-w-0">
-                        <p className="text-xs text-sera-text truncate">{s.title}</p>
-                        <p className="text-[10px] text-sera-text-muted mt-0.5">
-                          {s.messageCount} messages · {new Date(s.updatedAt).toLocaleDateString()}
-                        </p>
-                      </div>
-                      <button
-                        onClick={(e) => onDeleteSession(s.id, e)}
-                        className="opacity-0 group-hover:opacity-100 p-0.5 rounded text-sera-text-muted hover:text-red-400 transition-all"
-                        title="Delete session"
-                      >
-                        <Trash2 size={12} />
-                      </button>
-                    </div>
+                      session={s}
+                      isActive={sessionId === s.id}
+                      onLoad={() => onLoadSession(s.id)}
+                      onDelete={(e) => onDeleteSession(s.id, e)}
+                      onRename={(title) => onRenameSession(s.id, title)}
+                    />
                   ))}
                 </div>
               </div>

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -335,6 +335,20 @@ function ChatPageContent() {
     [sessionId, startNewSession]
   );
 
+  const renameSession = useCallback(async (id: string, title: string) => {
+    try {
+      await request(`/sessions/${id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title }),
+      });
+      setSessions((prev) => prev.map((s) => (s.id === id ? { ...s, title } : s)));
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : 'Failed to rename session';
+      toast.error(errMsg);
+    }
+  }, []);
+
   const toggleThoughts = useCallback((msgId: string) => {
     setExpandedThoughts((prev) => {
       const next = new Set(prev);
@@ -494,6 +508,7 @@ function ChatPageContent() {
           onStartNewSession={startNewSession}
           onLoadSession={(id) => void loadSession(id)}
           onDeleteSession={(id, e) => void deleteSession(id, e)}
+          onRenameSession={(id, title) => void renameSession(id, title)}
           onRefetchAgents={() => void refetchAgents()}
         />
         <div className="flex-1 flex flex-col items-center justify-center px-8 relative">
@@ -550,6 +565,7 @@ function ChatPageContent() {
         onStartNewSession={startNewSession}
         onLoadSession={(id) => void loadSession(id)}
         onDeleteSession={(id, e) => void deleteSession(id, e)}
+        onRenameSession={(id, title) => void renameSession(id, title)}
         onRefetchAgents={() => void refetchAgents()}
       />
 


### PR DESCRIPTION
Partial fix for #317

## Summary
- Double-click a session title in the sidebar to rename inline
- Pencil icon appears on hover as alternative rename trigger
- Enter saves, Escape cancels
- Calls `PUT /api/sessions/:id` to persist
- Extracted `SessionItem` into its own component for cleaner state

## Test plan
- [x] Typecheck, lint, format clean
- [x] Web tests: 41/41 passed
- [ ] Manual: double-click session title, rename, verify persistence across reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)