### PR TITLE
feat(web): add recent sessions to dashboard

### DIFF
--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -9,11 +9,28 @@ import {
   CheckCircle,
   XCircle,
 } from 'lucide-react';
+import { useQuery } from '@tanstack/react-query';
 import { useAgents } from '@/hooks/useAgents';
 import { useHealthDetail } from '@/hooks/useHealth';
 import { useCircles } from '@/hooks/useCircles';
 import { useSchedules } from '@/hooks/useSchedules';
-import { cn } from '@/lib/utils';
+import { request } from '@/lib/api/client';
+import { cn, formatDistanceToNow } from '@/lib/utils';
+
+interface SessionSummary {
+  id: string;
+  agentName: string;
+  title: string;
+  messageCount: number;
+  updatedAt: string;
+}
+
+function useSessions() {
+  return useQuery({
+    queryKey: ['sessions-recent'],
+    queryFn: () => request<SessionSummary[]>('/sessions'),
+  });
+}
 
 function StatCard({
   label,
@@ -67,6 +84,47 @@ function HealthBanner({ status }: { status: 'healthy' | 'degraded' | 'unhealthy'
     <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-sera-error/10 border border-sera-error/20 text-xs text-sera-error">
       <XCircle size={14} /> System unhealthy
     </div>
+  );
+}
+
+function RecentSessions() {
+  const { data: sessions } = useSessions();
+  const recent = (sessions ?? [])
+    .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
+    .slice(0, 5);
+
+  if (!recent.length) return null;
+
+  return (
+    <section className="sera-card-static p-4">
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="text-xs font-semibold text-sera-text-dim uppercase tracking-wider">
+          Recent Sessions
+        </h2>
+        <Link to="/chat" className="text-[11px] text-sera-accent hover:underline">
+          View all
+        </Link>
+      </div>
+      <div className="space-y-1.5">
+        {recent.map((s) => (
+          <Link
+            key={s.id}
+            to="/chat"
+            className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-sera-surface-hover transition-colors"
+          >
+            <MessageSquare size={13} className="text-sera-text-muted flex-shrink-0" />
+            <span className="text-sm text-sera-text flex-1 truncate">{s.title}</span>
+            <span className="text-[10px] text-sera-text-dim">{s.agentName}</span>
+            <span className="text-[10px] text-sera-text-dim">
+              {s.messageCount} msg{s.messageCount !== 1 ? 's' : ''}
+            </span>
+            <span className="text-[10px] text-sera-text-dim">
+              {formatDistanceToNow(s.updatedAt)}
+            </span>
+          </Link>
+        ))}
+      </div>
+    </section>
   );
 }
 
@@ -149,6 +207,9 @@ export default function DashboardPage() {
           </div>
         </section>
       )}
+
+      {/* Recent sessions */}
+      <RecentSessions />
 
       {/* Quick actions */}
       <div className="flex items-center gap-3 flex-wrap">


### PR DESCRIPTION
## Summary
- Dashboard now shows 5 most recently updated chat sessions
- Displays title, agent name, message count, and relative time
- Links to chat page for quick access

## Test plan
- [x] Typecheck, lint, format clean
- [x] Web tests: 41/41 passed
- [ ] Manual: verify sessions appear on dashboard, sorted by recency

🤖 Generated with [Claude Code](https://claude.com/claude-code)