### PR TITLE
feat(web): show auth status badge on providers page

### DIFF
--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -262,6 +262,7 @@ export interface ProviderConfig {
   baseUrl?: string;
   description?: string;
   dynamicProviderId?: string;
+  authStatus?: string;
 }
 
 export interface ProvidersResponse {

--- a/web/src/pages/ProvidersPage.tsx
+++ b/web/src/pages/ProvidersPage.tsx
@@ -139,6 +139,20 @@ export default function ProvidersPage() {
                             {m.baseUrl}
                           </span>
                         )}
+                        {m.authStatus && (
+                          <Badge
+                            variant={
+                              m.authStatus === 'configured'
+                                ? 'success'
+                                : m.authStatus === 'not-required'
+                                  ? 'default'
+                                  : 'warning'
+                            }
+                            className="text-[9px]"
+                          >
+                            {m.authStatus}
+                          </Badge>
+                        )}
                         {dpStatus && (
                           <span className="flex items-center gap-1 text-[10px]">
                             {dpStatus === 'connected' ? (


### PR DESCRIPTION
Partial fix for #286

## Summary
- Added `authStatus` field to `ProviderConfig` type
- Display color-coded auth status badge per model (configured/not-required/missing)

## Test plan
- [x] Typecheck, lint, format clean
- [x] Web tests: 41/41 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)