### PR TITLE
feat(core): context assembly event logging and debug endpoint

### DIFF
--- a/core/src/intercom/types.ts
+++ b/core/src/intercom/types.ts
@@ -24,7 +24,8 @@ export type ThoughtStepType =
   | 'reflect'
   | 'tool-call'
   | 'tool-result'
-  | 'reasoning';
+  | 'reasoning'
+  | 'context-assembly';
 
 // ── Message Envelope ────────────────────────────────────────────────────────────
 

--- a/core/src/llm/ContextAssembler.ts
+++ b/core/src/llm/ContextAssembler.ts
@@ -14,6 +14,16 @@ const logger = new Logger('ContextAssembler');
 const DEFAULT_MEMORY_CHAR_BUDGET = 16_000; // ~4000 tokens
 const DEFAULT_TOP_K = 8;
 
+/** Structured event emitted during context assembly for debugging/introspection. */
+export interface ContextAssemblyEvent {
+  stage: string;
+  detail: Record<string, unknown>;
+  durationMs?: number;
+}
+
+/** Callback for receiving context assembly events (published as thoughts). */
+export type ContextEventListener = (event: ContextAssemblyEvent) => void;
+
 export class ContextAssembler {
   private skillInjector: SkillInjector;
   private vectorService = new VectorService('_ctx_assembler_unused');
@@ -31,18 +41,48 @@ export class ContextAssembler {
    * 1. Skill injection
    * 2. RAG — embed current message, search all accessible namespaces,
    *    inject top-K memory blocks into the system prompt.
+   *
+   * @param onEvent - Optional callback for context assembly events (for thought stream)
    */
-  async assemble(agentId: string, messages: ChatMessage[]): Promise<ChatMessage[]> {
+  async assemble(
+    agentId: string,
+    messages: ChatMessage[],
+    onEvent?: ContextEventListener
+  ): Promise<ChatMessage[]> {
+    const assemblyStart = Date.now();
+    const emit = onEvent ?? (() => {});
+
     const systemMessage = messages.find((m) => m.role === 'system');
     if (!systemMessage) return messages;
 
     const manifest =
       this.orchestrator.getManifestByInstanceId(agentId) || this.orchestrator.getManifest(agentId);
 
-    if (!manifest) return messages;
+    if (!manifest) {
+      emit({ stage: 'assembly.skipped', detail: { reason: 'manifest not found', agentId } });
+      return messages;
+    }
+
+    emit({
+      stage: 'assembly.started',
+      detail: {
+        agentId,
+        agentName: manifest.metadata.name,
+        hasMemoryConfig: !!manifest.memory,
+        skillCount: (manifest.skills ?? []).length,
+        messageCount: messages.length,
+      },
+    });
 
     // Skip assembly if agent has no memory configuration
-    if (!manifest.memory) return messages;
+    if (!manifest.memory) {
+      emit({
+        stage: 'assembly.skipped',
+        detail: { reason: 'no memory configuration' },
+        durationMs: Date.now() - assemblyStart,
+      });
+      return messages;
+    }
 
     const lastUserMessage = [...messages].reverse().find((m) => m.role === 'user');
     const currentMessage = lastUserMessage?.content ?? '';
@@ -51,6 +91,7 @@ export class ContextAssembler {
     const instance = await AgentFactory.getInstance(agentId);
 
     // 1. Inject skills (and constitution)
+    const skillsStart = Date.now();
     const skillsPrompt = await this.skillInjector.inject(
       systemMessage.content ?? '',
       manifest.skills ?? [],
@@ -58,11 +99,31 @@ export class ContextAssembler {
       currentMessage,
       instance?.circle_id
     );
+    emit({
+      stage: 'skills.injected',
+      detail: {
+        skillNames: manifest.skills ?? [],
+        skillPackages: manifest.skillPackages ?? [],
+        circleId: instance?.circle_id ?? null,
+        promptLengthChars: skillsPrompt.length,
+      },
+      durationMs: Date.now() - skillsStart,
+    });
 
     // 2. RAG memory retrieval
-    const memoryContext = await this.retrieveMemoryContext(agentId, manifest, currentMessage);
+    const memoryContext = await this.retrieveMemoryContext(agentId, manifest, currentMessage, emit);
 
     const newSystemContent = memoryContext ? `${skillsPrompt}\n\n${memoryContext}` : skillsPrompt;
+
+    emit({
+      stage: 'assembly.completed',
+      detail: {
+        finalPromptLengthChars: newSystemContent.length,
+        estimatedTokens: Math.ceil(newSystemContent.length / 4),
+        memoryInjected: !!memoryContext,
+      },
+      durationMs: Date.now() - assemblyStart,
+    });
 
     return messages.map((m) => (m.role === 'system' ? { ...m, content: newSystemContent } : m));
   }
@@ -70,13 +131,24 @@ export class ContextAssembler {
   private async retrieveMemoryContext(
     agentId: string,
     manifest: import('../agents/manifest/types.js').AgentManifest,
-    currentMessage: string
+    currentMessage: string,
+    emit: ContextEventListener
   ): Promise<string | null> {
     if (!this.embeddingService.isAvailable()) {
+      emit({
+        stage: 'memory.skipped',
+        detail: { reason: 'embedding service unavailable' },
+      });
       logger.debug(`ContextAssembler: embedding unavailable for agent ${agentId}, skipping RAG`);
       return null;
     }
-    if (!currentMessage.trim()) return null;
+    if (!currentMessage.trim()) {
+      emit({
+        stage: 'memory.skipped',
+        detail: { reason: 'empty user message' },
+      });
+      return null;
+    }
 
     const start = Date.now();
 
@@ -103,6 +175,10 @@ export class ContextAssembler {
     try {
       queryVector = await this.embeddingService.embed(currentMessage);
     } catch (err) {
+      emit({
+        stage: 'memory.skipped',
+        detail: { reason: 'embedding failed', error: (err as Error).message },
+      });
       logger.debug('ContextAssembler: failed to embed message, skipping RAG', err);
       return null;
     }
@@ -112,15 +188,31 @@ export class ContextAssembler {
     try {
       results = await this.vectorService.search(namespaces, queryVector, DEFAULT_TOP_K, filter);
     } catch (err) {
+      emit({
+        stage: 'memory.skipped',
+        detail: { reason: 'vector search failed', error: (err as Error).message },
+      });
       logger.debug('ContextAssembler: vector search failed, skipping RAG', err);
       return null;
     }
 
-    if (results.length === 0) return null;
+    if (results.length === 0) {
+      emit({
+        stage: 'memory.retrieved',
+        detail: {
+          namespaces,
+          blockCount: 0,
+          topK: DEFAULT_TOP_K,
+        },
+        durationMs: Date.now() - start,
+      });
+      return null;
+    }
 
     // Build <memory> block, respect token budget (trim lowest-score blocks first)
     const charBudget = DEFAULT_MEMORY_CHAR_BUDGET;
     const blocks: string[] = [];
+    const scores: number[] = [];
     let charCount = 0;
 
     for (const r of results) {
@@ -128,15 +220,31 @@ export class ContextAssembler {
       const blockXml = `<block id="${r.id}" type="${r.payload.type ?? ''}" scope="${r.namespace}" author="${r.payload.agent_id ?? ''}" timestamp="${r.payload.created_at ?? ''}">${content}</block>`;
       if (charCount + blockXml.length > charBudget) break;
       blocks.push(blockXml);
+      scores.push(r.score);
       charCount += blockXml.length;
       logger.debug(
         `ContextAssembler: retrieved block ${r.id} from ${r.namespace} (score=${r.score.toFixed(3)})`
       );
     }
 
+    const elapsed = Date.now() - start;
+
+    emit({
+      stage: 'memory.retrieved',
+      detail: {
+        namespaces,
+        searchResultCount: results.length,
+        injectedBlockCount: blocks.length,
+        charBudget,
+        charsUsed: charCount,
+        topK: DEFAULT_TOP_K,
+        scores: scores.map((s) => Math.round(s * 1000) / 1000),
+      },
+      durationMs: elapsed,
+    });
+
     if (blocks.length === 0) return null;
 
-    const elapsed = Date.now() - start;
     if (elapsed > 200) {
       logger.warn(`ContextAssembler: memory retrieval took ${elapsed}ms (>200ms budget)`);
     }

--- a/core/src/routes/agents.ts
+++ b/core/src/routes/agents.ts
@@ -11,6 +11,8 @@ import type { AgentRegistry } from '../agents/registry.service.js';
 import { AgentManifestLoader } from '../agents/manifest/AgentManifestLoader.js';
 import { AgentFactory } from '../agents/AgentFactory.js';
 import { IdentityService } from '../agents/identity/IdentityService.js';
+import { ContextAssembler, type ContextAssemblyEvent } from '../llm/ContextAssembler.js';
+import { pool as dbPool } from '../lib/database.js';
 import { Logger } from '../lib/logger.js';
 
 const logger = new Logger('AgentRouter');
@@ -521,6 +523,62 @@ export function createAgentRouter(orchestrator: Orchestrator, agentRegistry: Age
         agentName: instance.name,
         overallStatus,
         checks,
+      });
+    })
+  );
+
+  // ── Context Debug (#305) ─────────────────────────────────────────────────
+  /**
+   * GET /api/agents/:id/context-debug?message=...
+   * Dry-runs context assembly and returns structured events showing what
+   * would be injected into the LLM call (skills, memory, token budget).
+   */
+  router.get(
+    '/:id/context-debug',
+    asyncHandler(async (req, res) => {
+      const instanceId = String(req.params['id']);
+      const testMessage = (req.query['message'] as string) || 'Hello';
+
+      const instance = await agentRegistry.getInstance(instanceId);
+      if (!instance) {
+        res.status(404).json({ error: 'Agent not found' });
+        return;
+      }
+
+      const manifest = orchestrator.getManifest(instance.name);
+      if (!manifest) {
+        res.status(404).json({ error: 'Agent manifest not found' });
+        return;
+      }
+
+      // Build minimal message array for assembly
+      const systemPrompt = IdentityService.generateSystemPrompt(manifest);
+
+      const messages = [
+        { role: 'system' as const, content: systemPrompt },
+        { role: 'user' as const, content: testMessage },
+      ];
+
+      const assembler = new ContextAssembler(dbPool, orchestrator);
+
+      const events: ContextAssemblyEvent[] = [];
+      try {
+        await assembler.assemble(instanceId, messages, (event) => {
+          events.push(event);
+        });
+      } catch (err) {
+        events.push({
+          stage: 'assembly.error',
+          detail: { error: (err as Error).message },
+        });
+      }
+
+      res.json({
+        agentId: instanceId,
+        agentName: instance.name,
+        testMessage,
+        systemPromptLength: systemPrompt.length,
+        events,
       });
     })
   );

--- a/core/src/routes/llmProxy.ts
+++ b/core/src/routes/llmProxy.ts
@@ -126,12 +126,18 @@ export function createLlmProxyRouter(
         return;
       }
 
-      // ── 2.1 Context Assembly (Story 6.3 / 8.4) ─────────────────────────────
+      // ── 2.1 Context Assembly (Story 6.3 / 8.4 / #308) ────────────────────
       try {
         if (messages) {
           messages = (await contextAssembler.assemble(
             agentId,
-            messages as unknown as import('../llm/LlmRouter.js').ChatMessage[]
+            messages as unknown as import('../llm/LlmRouter.js').ChatMessage[],
+            (event) => {
+              logger.info(`[context-assembly] ${event.stage}`, {
+                ...event.detail,
+                ...(event.durationMs !== undefined ? { durationMs: event.durationMs } : {}),
+              });
+            }
           )) as unknown as import('../agents/types.js').ChatMessage[];
         }
       } catch (err) {


### PR DESCRIPTION
Partial fix for #308, #305

## Summary
### Context Assembly Events (#308)
ContextAssembler now emits structured events during each assembly phase:
- `assembly.started` — agent info, skill count, message count
- `skills.injected` — skill names, packages, prompt length, duration
- `memory.retrieved` — namespaces searched, block count, similarity scores, duration
- `memory.skipped` — reason (embedding unavailable, empty query, vector search failed)
- `assembly.completed` — final prompt length, estimated tokens, total duration

Events are logged via the LLM proxy route and available programmatically.

### Context Debug Endpoint (#305)
New `GET /api/agents/:id/context-debug?message=...` endpoint that:
- Dry-runs context assembly with a test message
- Returns all structured events without making an LLM call
- Shows what skills, memory blocks, and token budgets would be injected

### New ThoughtStepType
Added `context-assembly` to ThoughtStepType for future thought stream integration.

## Test plan
- [x] Typecheck, lint, format clean
- [x] Web tests: 41/41 passed
- [ ] Manual: `curl -H "Authorization: Bearer sera_bootstrap_dev_123" "http://localhost:3001/api/agents/<id>/context-debug?message=hello"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)