### PR TITLE
chore(core): remove unused type aliases in lifecycle router

### DIFF
--- a/core/src/routes/lifecycle.ts
+++ b/core/src/routes/lifecycle.ts
@@ -29,12 +29,6 @@ import type { SandboxManager } from '../sandbox/SandboxManager.js';
 import { PermissionRequestService } from '../sandbox/PermissionRequestService.js';
 import type { PermissionDecision } from '../sandbox/PermissionRequestService.js';
 
-// Typed param shapes
-
-type IdParam = { id: string };
-type RequestIdParam = { requestId: string };
-type IdGrantParam = { id: string; grantId: string };
-
 export function createLifecycleRouter(
   registry: AgentRegistry,
   orchestrator: Orchestrator,


### PR DESCRIPTION
## Summary
Remove 3 unused type aliases (`IdParam`, `RequestIdParam`, `IdGrantParam`) from lifecycle.ts that caused lint warnings on every CI run.

## Test plan
- [x] Lint now reports 0 warnings (was 3)
- [x] Typecheck, tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)