### PR TITLE
chore(core): remove unused pool property from ContextAssembler

### DIFF
--- a/core/src/llm/ContextAssembler.ts
+++ b/core/src/llm/ContextAssembler.ts
@@ -30,7 +30,7 @@ export class ContextAssembler {
   private embeddingService = EmbeddingService.getInstance();
 
   constructor(
-    private pool: Pool,
+    pool: Pool,
     private orchestrator: Orchestrator
   ) {
     this.skillInjector = new SkillInjector(pool);


### PR DESCRIPTION
## Summary
Remove `private` modifier from `pool` constructor parameter — it was stored as a property but never read directly (only passed to `SkillInjector`). Clears the unused-property diagnostic.

## Test plan
- [x] Typecheck, lint, tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)