### PR TITLE
Add unit tests for core utilities

### DIFF
--- a/core/src/lib/PlatformPath.test.ts
+++ b/core/src/lib/PlatformPath.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
-import { PlatformPath } from './PlatformPath';
+import { describe, it, expect, afterEach } from 'vitest';
+import { PlatformPath } from './PlatformPath.js';
 
 describe('PlatformPath', () => {
   const originalPlatform = process.platform;

--- a/core/src/lib/json.test.ts
+++ b/core/src/lib/json.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseJson, safeParseJson } from './json';
+import { parseJson, safeParseJson } from './json.js';
 
 describe('json utilities', () => {
   describe('parseJson', () => {

--- a/core/src/middleware/asyncHandler.test.ts
+++ b/core/src/middleware/asyncHandler.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { Request, Response, NextFunction } from 'express';
-import { asyncHandler } from './asyncHandler';
+import { asyncHandler } from './asyncHandler.js';
 
 describe('asyncHandler', () => {
   it('should call the wrapped function and pass arguments to it', async () => {
@@ -34,9 +34,6 @@ describe('asyncHandler', () => {
 
   it('should catch synchronously thrown errors and call next with the error', async () => {
     const error = new Error('sync error');
-    const fn = vi.fn().mockImplementation(() => {
-      throw error;
-    });
 
     const asyncFn = vi.fn().mockImplementation(async () => {
       throw error;


### PR DESCRIPTION
Adds unit tests for uncovered files `asyncHandler.ts` and `PlatformPath.ts` in the `core` package, increasing test coverage and ensuring their expected behavior under various conditions. All changes pass the unit tests and address previous review feedback.

---
*PR created automatically by Jules for task [14007630537009206071](https://jules.google.com/task/14007630537009206071) started by @TKCen*