### PR TITLE
fix(core): reasoning model detection for chat streaming

### DIFF
--- a/core/config/providers.json
+++ b/core/config/providers.json
@@ -19,7 +19,8 @@
       "description": "Qwen 3.5 35B A3B via LM Studio",
       "contextWindow": 131072,
       "maxTokens": 8192,
-      "contextStrategy": "sliding-window"
+      "contextStrategy": "sliding-window",
+      "reasoning": true
     },
     {
       "modelName": "ollama-local",

--- a/core/src/agents/BaseAgent.ts
+++ b/core/src/agents/BaseAgent.ts
@@ -471,6 +471,21 @@ export abstract class BaseAgent {
     // Flush any remaining reasoning (e.g. model only reasoned, produced no content)
     if (accumulatedReasoning) {
       await this.publishThought('reasoning', accumulatedReasoning);
+
+      // Fallback: if the model only produced reasoning tokens and no content tokens
+      // (happens when reasoning flag is misconfigured), use the reasoning as the reply.
+      if (!accumulated) {
+        accumulated = accumulatedReasoning;
+        // Also publish the reasoning as token content so the web UI shows it
+        if (this.intercom) {
+          await this.intercom.publishToken(
+            this.agentInstanceId || this.role,
+            accumulated,
+            false,
+            messageId
+          );
+        }
+      }
     }
 
     const reply = accumulated || 'No response generated.';

--- a/core/src/lib/llm/LlmRouterProvider.ts
+++ b/core/src/lib/llm/LlmRouterProvider.ts
@@ -32,11 +32,14 @@ export class LlmRouterProvider implements LLMProvider {
     const msg = await eventStream.result();
 
     let textContent = '';
+    let thinkingContent = '';
     const toolCalls: LLMResponse['toolCalls'] = [];
 
     for (const block of msg.content) {
       if (block.type === 'text') {
         textContent += block.text;
+      } else if (block.type === 'thinking') {
+        thinkingContent += (block as { type: 'thinking'; thinking: string }).thinking;
       } else if (block.type === 'toolCall') {
         toolCalls!.push({
           id: block.id,
@@ -50,6 +53,13 @@ export class LlmRouterProvider implements LLMProvider {
           },
         });
       }
+    }
+
+    // Fallback: if model produced only thinking blocks and no text content,
+    // use the thinking content as the response. This happens when a reasoning
+    // model isn't flagged as reasoning=true in providers.json.
+    if (!textContent && thinkingContent) {
+      textContent = thinkingContent;
     }
 
     const response: LLMResponse = {

--- a/core/src/llm/LlmRouter.ts
+++ b/core/src/llm/LlmRouter.ts
@@ -372,19 +372,40 @@ export class LlmRouter {
         ? { supportsStore: false, supportsDeveloperRole: false }
         : undefined;
 
+    // Auto-detect reasoning/thinking models by name if not explicitly set.
+    // These models emit `reasoning_content` tokens before `content` tokens;
+    // pi-mono needs to know so it correctly separates thinking from answer.
+    const reasoning = config.reasoning ?? LlmRouter.isReasoningModel(config.modelName);
+
     return {
       id: config.modelName,
       name: config.description ?? config.modelName,
       api: config.api as Api,
       provider: (config.provider ?? 'openai') as Provider,
       baseUrl: config.baseUrl ?? '',
-      reasoning: false,
+      reasoning,
       input: ['text'],
       cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
       contextWindow: config.contextWindow ?? 128_000,
       maxTokens: config.maxTokens ?? 4_096,
       ...(compat ? { compat } : {}),
     };
+  }
+
+  /**
+   * Heuristic: detect whether a model name indicates a reasoning/thinking model.
+   * These models separate reasoning_content from content in streaming.
+   */
+  private static isReasoningModel(modelName: string): boolean {
+    const lower = modelName.toLowerCase();
+    return (
+      /qwen3/i.test(lower) ||
+      /deepseek-r1/i.test(lower) ||
+      /\bo[13]-/i.test(lower) || // o1-*, o3-*
+      /\bo[13]$/i.test(lower) || // just "o1" or "o3"
+      /thinking/i.test(lower) ||
+      /reasoner/i.test(lower)
+    );
   }
 
   /**

--- a/core/src/llm/ProviderRegistry.ts
+++ b/core/src/llm/ProviderRegistry.ts
@@ -85,6 +85,15 @@ export interface ProviderConfig {
    * If not set, summarize strategy falls back to sliding-window.
    */
   contextCompactionModel?: string | undefined;
+  /**
+   * Whether this model supports extended thinking / reasoning.
+   * When true, pi-mono separates `reasoning_content` (thinking) from
+   * `content` (answer) in the streaming response. Required for Qwen3
+   * thinking models, o1/o3 series, DeepSeek-R1, etc.
+   *
+   * Default: auto-detected from model name (qwen3*, o1*, o3*, deepseek-r1*).
+   */
+  reasoning?: boolean | undefined;
 }
 
 export interface DynamicProviderConfig {


### PR DESCRIPTION
Closes #406, closes #403

## Summary
Chat responses were empty because pi-mono's Model object had `reasoning: false` hardcoded. Thinking models (Qwen3, DeepSeek-R1, o1/o3) emit `reasoning_content` before `content` in streaming — without the flag, pi-mono can't properly separate them.

**Changes:**
- Add `reasoning` field to `ProviderConfig` for explicit override per model
- Auto-detect reasoning models by name pattern (qwen3*, deepseek-r1*, o1*, o3*, etc.)
- Add fallback in non-streaming path: if no text blocks but thinking blocks exist, use thinking content
- Add fallback in streaming path: if all tokens arrived as reasoning, publish as content

## Test plan
- [x] Typecheck, lint, tests pass (41/41)
- [ ] Manual: chat with Qwen3 model — verify response content appears
- [ ] Manual: verify thinking panel still shows reasoning separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)