### PR TITLE
fix(mcp): add auth header to embedded MCP chat call

### DIFF
--- a/core/src/mcp/SeraMCPServer.ts
+++ b/core/src/mcp/SeraMCPServer.ts
@@ -731,12 +731,17 @@ export class SeraMCPServer {
 
     // Call the internal HTTP API directly
     const port = process.env.PORT ?? '3001';
+    const apiKey =
+      process.env.SERA_BOOTSTRAP_API_KEY ?? process.env.SERA_API_KEY ?? 'sera_bootstrap_dev_123';
     const body: Record<string, string> = { agentName, message };
     if (sessionId) body.sessionId = sessionId;
 
     const res = await fetch(`http://localhost:${port}/api/chat`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
       body: JSON.stringify(body),
       signal: AbortSignal.timeout(120_000),
     });


### PR DESCRIPTION
Closes #411

## Summary
The embedded `SeraMCPServer.handleChat()` was calling `/api/chat` without an `Authorization` header. Since the chat route sits behind `authMiddleware`, this caused auth failures that prevented session continuity.

**Fix:** Include `Authorization: Bearer <apiKey>` using the bootstrap API key from env vars.

## Test plan
- [x] Typecheck, lint, tests pass
- [ ] Manual: call `sera_chat` via MCP, pass back `sessionId` — verify multi-turn works

🤖 Generated with [Claude Code](https://claude.com/claude-code)