### PR TITLE
fix: schedule SQL error in UI, UUID in chat sidebar

### DIFF
--- a/core/src/routes/schedules.ts
+++ b/core/src/routes/schedules.ts
@@ -12,20 +12,22 @@ export const createSchedulesRouter = () => {
   router.get('/', async (req, res) => {
     try {
       const { agentId } = req.query;
-      let query = 'SELECT * FROM schedules';
+      let query = `SELECT s.*, ai.name AS resolved_agent_name
+        FROM schedules s
+        LEFT JOIN agent_instances ai ON s.agent_instance_id = ai.id::text`;
       const params = [];
       if (agentId) {
-        query += ' WHERE agent_instance_id = $1';
+        query += ' WHERE s.agent_instance_id = $1';
         params.push(agentId);
       }
-      query += ' ORDER BY created_at DESC';
+      query += ' ORDER BY s.created_at DESC';
 
       const { rows } = await pool.query(query, params);
       // Map snake_case DB columns to camelCase for the frontend
       res.json(
         rows.map((r: Record<string, unknown>) => ({
           id: r.id,
-          agentName: r.agent_name ?? r.agent_instance_id,
+          agentName: (r.resolved_agent_name as string) ?? r.agent_name ?? r.agent_instance_id,
           agentInstanceId: r.agent_instance_id,
           name: r.name,
           type: r.type ?? 'cron',

--- a/web/src/components/ChatSidebar.tsx
+++ b/web/src/components/ChatSidebar.tsx
@@ -262,8 +262,20 @@ export function ChatSidebar({
   onRenameSession,
   onRefetchAgents,
 }: ChatSidebarProps) {
+  // Resolve agent UUIDs to display names when possible
+  const resolveAgentName = (session: SessionInfo): string => {
+    const raw = session.agentName || 'Unknown Agent';
+    // If it looks like a UUID, try to resolve via the agents list
+    if (/^[0-9a-f-]{36}$/i.test(raw) && agents) {
+      const match =
+        agents.find((a) => a.id === raw) ?? agents.find((a) => a.id === session.agentInstanceId);
+      if (match) return match.display_name ?? match.name;
+    }
+    return raw;
+  };
+
   const groupedSessions = sessions.reduce<Record<string, SessionInfo[]>>((acc, s) => {
-    const key = s.agentName || 'Unknown Agent';
+    const key = resolveAgentName(s);
     if (!acc[key]) acc[key] = [];
     acc[key]!.push(s);
     return acc;

--- a/web/src/pages/SchedulesPage.tsx
+++ b/web/src/pages/SchedulesPage.tsx
@@ -255,7 +255,11 @@ function ScheduleRow({ sched }: { sched: Schedule }) {
         <tr className="border-b border-sera-border/50 bg-sera-bg/50">
           <td colSpan={8} className="px-8 py-3">
             <pre className="text-xs font-mono text-sera-text-muted leading-relaxed whitespace-pre-wrap">
-              {sched.lastRunOutput}
+              {/VIOLATES NOT NULL CONSTRAINT|syntax error|column .* does not exist/i.test(
+                sched.lastRunOutput
+              )
+                ? 'Internal error: schedule configuration is invalid. Check agent logs for details.'
+                : sched.lastRunOutput}
             </pre>
           </td>
         </tr>


### PR DESCRIPTION
Closes #407, closes #409

## Summary
- **Schedules (#407)**: JOIN agent_instances to resolve agent name; sanitize raw SQL errors in lastRunOutput
- **Chat sidebar (#409)**: Resolve UUID-based session agentName to display name via agents list

## Test plan
- [x] Typecheck, lint, tests pass (41/41)
- [ ] Manual: verify schedule page shows agent name and friendly error
- [ ] Manual: verify chat sidebar doesn't show UUIDs as group headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)