### PR TITLE
refactor(web): extract chat components

### DIFF
--- a/web/src/app/chat/page.tsx
+++ b/web/src/app/chat/page.tsx
@@ -1,16 +1,10 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
 import {
-  Loader2,
   Bot,
-  User,
   Brain,
   PanelLeftClose,
   PanelLeftOpen,
-  Copy,
-  Check,
 } from 'lucide-react';
-import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
 import type { PublicationContext } from 'centrifuge';
 import { useAgents } from '@/hooks/useAgents';
 import { useCentrifugoContext } from '@/hooks/useCentrifugo';
@@ -21,9 +15,24 @@ import { toast } from '@/lib/toast';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { ChatSidebar } from '@/components/ChatSidebar';
 import { ChatInputBar } from '@/components/ChatInputBar';
-import { ChatThoughtPanel } from '@/components/ChatThoughtPanel';
+import { ChatMessageBubble } from '@/components/ChatMessageBubble';
 
 // ── Types ────────────────────────────────────────────────────────────────────
+
+export interface MessageThought {
+  timestamp: string;
+  stepType: string;
+  content: string;
+}
+
+export interface Message {
+  id: string;
+  role: 'user' | 'agent';
+  content: string;
+  thoughts: MessageThought[];
+  streaming: boolean;
+  createdAt: Date;
+}
 
 interface SessionInfo {
   id: string;
@@ -48,12 +57,6 @@ interface SessionMessage {
   createdAt: string;
 }
 
-interface MessageThought {
-  timestamp: string;
-  stepType: string;
-  content: string;
-}
-
 interface TokenPayload {
   token: string;
   done: boolean;
@@ -66,66 +69,6 @@ interface ThoughtPayload {
   content: string;
   agentId: string;
   agentDisplayName: string;
-}
-
-interface Message {
-  id: string;
-  role: 'user' | 'agent';
-  content: string;
-  thoughts: MessageThought[];
-  streaming: boolean;
-  createdAt: Date;
-}
-
-// ── Code block with copy button ───────────────────────────────────────────────
-
-function CodeBlock({ children, className }: { children?: React.ReactNode; className?: string }) {
-  const [copied, setCopied] = useState(false);
-  const code = String(children ?? '').trim();
-
-  function handleCopy() {
-    void navigator.clipboard.writeText(code).then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1500);
-    });
-  }
-
-  return (
-    <div className="relative group my-2">
-      <pre
-        className={cn(
-          'bg-sera-bg border border-sera-border rounded-lg px-4 py-3 overflow-x-auto text-[0.8em] leading-relaxed',
-          className
-        )}
-      >
-        <code>{children}</code>
-      </pre>
-      <button
-        onClick={handleCopy}
-        className="absolute top-2 right-2 px-2 py-0.5 rounded text-[10px] bg-sera-surface text-sera-text-muted opacity-0 group-hover:opacity-100 transition-opacity hover:text-sera-text"
-      >
-        {copied ? 'Copied!' : 'Copy'}
-      </button>
-    </div>
-  );
-}
-
-function MessageCopyButton({ text }: { text: string }) {
-  const [copied, setCopied] = useState(false);
-  return (
-    <button
-      onClick={() => {
-        void navigator.clipboard.writeText(text).then(() => {
-          setCopied(true);
-          setTimeout(() => setCopied(false), 1500);
-        });
-      }}
-      className="p-1 rounded text-sera-text-dim hover:text-sera-text transition-colors"
-      title="Copy message"
-    >
-      {copied ? <Check size={12} className="text-sera-success" /> : <Copy size={12} />}
-    </button>
-  );
 }
 
 // ── ChatPage ──────────────────────────────────────────────────────────────────
@@ -624,92 +567,13 @@ function ChatPageContent() {
         {/* Messages */}
         <div className="flex-1 overflow-y-auto px-6 py-6 space-y-5 min-h-0">
           {messages.map((msg) => (
-            <div
+            <ChatMessageBubble
               key={msg.id}
-              className={cn(
-                'flex gap-3 group',
-                msg.role === 'user' ? 'justify-end' : 'justify-start'
-              )}
-            >
-              {msg.role === 'agent' && (
-                <div className="w-8 h-8 rounded-lg bg-sera-accent-soft flex items-center justify-center flex-shrink-0 mt-0.5">
-                  <Bot size={16} className="text-sera-accent" />
-                </div>
-              )}
-              <div
-                className={cn(
-                  'max-w-[72%] rounded-xl px-4 py-3',
-                  msg.role === 'user'
-                    ? 'bg-sera-accent text-sera-bg'
-                    : 'bg-sera-surface border border-sera-border text-sera-text'
-                )}
-              >
-                {/* Inline thinking block */}
-                <ChatThoughtPanel
-                  msg={msg}
-                  showThinking={showThinking}
-                  isExpanded={expandedThoughts.has(msg.id)}
-                  onToggleThoughts={toggleThoughts}
-                />
-
-                {/* Message content */}
-                <div
-                  className={cn(
-                    'text-sm break-words leading-relaxed max-w-none',
-                    msg.role === 'user' ? 'text-sera-bg' : 'chat-prose'
-                  )}
-                >
-                  {msg.role === 'user' ? (
-                    <p className="whitespace-pre-wrap m-0">{msg.content}</p>
-                  ) : msg.streaming && !msg.content ? (
-                    <div className="flex items-center gap-2">
-                      <Loader2 size={14} className="animate-spin text-sera-accent" />
-                      <span className="text-xs text-sera-text-muted">Generating…</span>
-                    </div>
-                  ) : (
-                    <ReactMarkdown
-                      remarkPlugins={[remarkGfm]}
-                      components={{
-                        code({ className, children, ...props }) {
-                          const isBlock = /language-/.test(className ?? '');
-                          return isBlock ? (
-                            <CodeBlock className={className}>{children}</CodeBlock>
-                          ) : (
-                            <code
-                              className="text-sera-accent bg-sera-surface-active rounded px-1 py-0.5 font-mono text-[0.82em]"
-                              {...props}
-                            >
-                              {children}
-                            </code>
-                          );
-                        },
-                      }}
-                    >
-                      {msg.content}
-                    </ReactMarkdown>
-                  )}
-                  {msg.streaming && msg.content && (
-                    <span className="inline-block w-1.5 h-4 bg-sera-accent rounded-sm ml-0.5 animate-pulse align-text-bottom" />
-                  )}
-                </div>
-
-                <div className="flex items-center gap-1.5 mt-1.5">
-                  <span className="text-[10px] opacity-40">
-                    {msg.createdAt.toLocaleTimeString()}
-                  </span>
-                  {msg.role === 'agent' && msg.content && !msg.streaming && (
-                    <span className="opacity-0 group-hover:opacity-100 transition-opacity">
-                      <MessageCopyButton text={msg.content} />
-                    </span>
-                  )}
-                </div>
-              </div>
-              {msg.role === 'user' && (
-                <div className="w-8 h-8 rounded-lg bg-sera-surface border border-sera-border flex items-center justify-center flex-shrink-0 mt-0.5">
-                  <User size={16} className="text-sera-text-muted" />
-                </div>
-              )}
-            </div>
+              msg={msg}
+              showThinking={showThinking}
+              isExpanded={expandedThoughts.has(msg.id)}
+              onToggleThoughts={toggleThoughts}
+            />
           ))}
           <div ref={messagesEndRef} />
         </div>

--- a/web/src/components/ChatMessageBubble.tsx
+++ b/web/src/components/ChatMessageBubble.tsx
@@ -1,0 +1,110 @@
+import { Bot, User, Loader2 } from 'lucide-react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { cn } from '@/lib/utils';
+import { ChatThoughtPanel } from '@/components/ChatThoughtPanel';
+import { CodeBlock } from '@/components/CodeBlock';
+import { MessageCopyButton } from '@/components/MessageCopyButton';
+import type { Message } from '@/app/chat/page';
+
+export interface ChatMessageBubbleProps {
+  msg: Message;
+  showThinking: boolean;
+  isExpanded: boolean;
+  onToggleThoughts: (id: string) => void;
+}
+
+export function ChatMessageBubble({
+  msg,
+  showThinking,
+  isExpanded,
+  onToggleThoughts,
+}: ChatMessageBubbleProps) {
+  return (
+    <div
+      className={cn(
+        'flex gap-3 group',
+        msg.role === 'user' ? 'justify-end' : 'justify-start'
+      )}
+    >
+      {msg.role === 'agent' && (
+        <div className="w-8 h-8 rounded-lg bg-sera-accent-soft flex items-center justify-center flex-shrink-0 mt-0.5">
+          <Bot size={16} className="text-sera-accent" />
+        </div>
+      )}
+      <div
+        className={cn(
+          'max-w-[72%] rounded-xl px-4 py-3',
+          msg.role === 'user'
+            ? 'bg-sera-accent text-sera-bg'
+            : 'bg-sera-surface border border-sera-border text-sera-text'
+        )}
+      >
+        {/* Inline thinking block */}
+        <ChatThoughtPanel
+          msg={msg}
+          showThinking={showThinking}
+          isExpanded={isExpanded}
+          onToggleThoughts={onToggleThoughts}
+        />
+
+        {/* Message content */}
+        <div
+          className={cn(
+            'text-sm break-words leading-relaxed max-w-none',
+            msg.role === 'user' ? 'text-sera-bg' : 'chat-prose'
+          )}
+        >
+          {msg.role === 'user' ? (
+            <p className="whitespace-pre-wrap m-0">{msg.content}</p>
+          ) : msg.streaming && !msg.content ? (
+            <div className="flex items-center gap-2">
+              <Loader2 size={14} className="animate-spin text-sera-accent" />
+              <span className="text-xs text-sera-text-muted">Generating…</span>
+            </div>
+          ) : (
+            <ReactMarkdown
+              remarkPlugins={[remarkGfm]}
+              components={{
+                code({ className, children, ...props }) {
+                  const isBlock = /language-/.test(className ?? '');
+                  return isBlock ? (
+                    <CodeBlock className={className}>{children}</CodeBlock>
+                  ) : (
+                    <code
+                      className="text-sera-accent bg-sera-surface-active rounded px-1 py-0.5 font-mono text-[0.82em]"
+                      {...props}
+                    >
+                      {children}
+                    </code>
+                  );
+                },
+              }}
+            >
+              {msg.content}
+            </ReactMarkdown>
+          )}
+          {msg.streaming && msg.content && (
+            <span className="inline-block w-1.5 h-4 bg-sera-accent rounded-sm ml-0.5 animate-pulse align-text-bottom" />
+          )}
+        </div>
+
+        <div className="flex items-center gap-1.5 mt-1.5">
+          <span className="text-[10px] opacity-40">
+            {msg.createdAt.toLocaleTimeString()}
+          </span>
+          {msg.role === 'agent' && msg.content && !msg.streaming && (
+            <span className="opacity-0 group-hover:opacity-100 transition-opacity">
+              <MessageCopyButton text={msg.content} />
+            </span>
+          )}
+        </div>
+      </div>
+      {msg.role === 'user' && (
+        <div className="w-8 h-8 rounded-lg bg-sera-surface border border-sera-border flex items-center justify-center flex-shrink-0 mt-0.5">
+          <User size={16} className="text-sera-text-muted" />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/CodeBlock.tsx
+++ b/web/src/components/CodeBlock.tsx
@@ -1,0 +1,38 @@
+import { useState } from 'react';
+import { cn } from '@/lib/utils';
+
+interface CodeBlockProps {
+  children?: React.ReactNode;
+  className?: string;
+}
+
+export function CodeBlock({ children, className }: CodeBlockProps) {
+  const [copied, setCopied] = useState(false);
+  const code = String(children ?? '').trim();
+
+  function handleCopy() {
+    void navigator.clipboard.writeText(code).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    });
+  }
+
+  return (
+    <div className="relative group my-2">
+      <pre
+        className={cn(
+          'bg-sera-bg border border-sera-border rounded-lg px-4 py-3 overflow-x-auto text-[0.8em] leading-relaxed',
+          className
+        )}
+      >
+        <code>{children}</code>
+      </pre>
+      <button
+        onClick={handleCopy}
+        className="absolute top-2 right-2 px-2 py-0.5 rounded text-[10px] bg-sera-surface text-sera-text-muted opacity-0 group-hover:opacity-100 transition-opacity hover:text-sera-text"
+      >
+        {copied ? 'Copied!' : 'Copy'}
+      </button>
+    </div>
+  );
+}

--- a/web/src/components/MessageCopyButton.tsx
+++ b/web/src/components/MessageCopyButton.tsx
@@ -1,0 +1,24 @@
+import { useState } from 'react';
+import { Check, Copy } from 'lucide-react';
+
+interface MessageCopyButtonProps {
+  text: string;
+}
+
+export function MessageCopyButton({ text }: MessageCopyButtonProps) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <button
+      onClick={() => {
+        void navigator.clipboard.writeText(text).then(() => {
+          setCopied(true);
+          setTimeout(() => setCopied(false), 1500);
+        });
+      }}
+      className="p-1 rounded text-sera-text-dim hover:text-sera-text transition-colors"
+      title="Copy message"
+    >
+      {copied ? <Check size={12} className="text-sera-success" /> : <Copy size={12} />}
+    </button>
+  );
+}


### PR DESCRIPTION
Extract reusable components from `web/src/app/chat/page.tsx` to reduce file size.
- `CodeBlock`
- `MessageCopyButton`
- `ChatMessageBubble`

Validated UI and tests successfully.

---
*PR created automatically by Jules for task [17499005958674244220](https://jules.google.com/task/17499005958674244220) started by @TKCen*