### PR TITLE
fix(channels): process channel messages sequentially per user

### DIFF
--- a/core/src/channels/ChannelAdapter.test.ts
+++ b/core/src/channels/ChannelAdapter.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from 'vitest';
+import { ChannelAdapter } from './ChannelAdapter.js';
+
+// Concrete test subclass to access protected methods
+class TestAdapter extends ChannelAdapter {
+  public sentMessages: Array<{ chatId: string; text: string }> = [];
+
+  constructor(options?: { messageTimeoutMs?: number }) {
+    super('Test', options);
+  }
+
+  async start() {}
+  async stop() {
+    await this.shutdownBase();
+  }
+
+  async sendMessage(chatId: string, text: string) {
+    this.sentMessages.push({ chatId, text });
+  }
+
+  // Expose protected method for testing
+  public testEnqueue(key: string, task: () => Promise<void>) {
+    this.enqueueMessage(key, task);
+  }
+
+  public testIsRateLimited(userId: string) {
+    return this.isRateLimited(userId);
+  }
+}
+
+describe('ChannelAdapter', () => {
+  describe('message queue', () => {
+    it('should process messages sequentially for the same key', async () => {
+      const adapter = new TestAdapter();
+      const order: number[] = [];
+
+      const task1Done = new Promise<void>((resolve) => {
+        adapter.testEnqueue('user:1', async () => {
+          order.push(1);
+          // Simulate slow processing
+          await new Promise((r) => setTimeout(r, 50));
+          order.push(2);
+          resolve();
+        });
+      });
+
+      const task2Done = new Promise<void>((resolve) => {
+        adapter.testEnqueue('user:1', async () => {
+          order.push(3);
+          resolve();
+        });
+      });
+
+      await Promise.all([task1Done, task2Done]);
+
+      // Task 2 should only start after task 1 finishes
+      expect(order).toEqual([1, 2, 3]);
+    });
+
+    it('should process messages in parallel for different keys', async () => {
+      const adapter = new TestAdapter();
+      const order: string[] = [];
+
+      const task1Done = new Promise<void>((resolve) => {
+        adapter.testEnqueue('user:A', async () => {
+          order.push('A-start');
+          await new Promise((r) => setTimeout(r, 50));
+          order.push('A-end');
+          resolve();
+        });
+      });
+
+      const task2Done = new Promise<void>((resolve) => {
+        adapter.testEnqueue('user:B', async () => {
+          order.push('B-start');
+          await new Promise((r) => setTimeout(r, 10));
+          order.push('B-end');
+          resolve();
+        });
+      });
+
+      await Promise.all([task1Done, task2Done]);
+
+      // B should start before A ends (parallel for different keys)
+      const aEndIdx = order.indexOf('A-end');
+      const bStartIdx = order.indexOf('B-start');
+      expect(bStartIdx).toBeLessThan(aEndIdx);
+    });
+
+    it('should handle task errors without blocking the queue', async () => {
+      const adapter = new TestAdapter();
+      const results: string[] = [];
+
+      adapter.testEnqueue('user:1', async () => {
+        throw new Error('Task 1 failed');
+      });
+
+      const task2Done = new Promise<void>((resolve) => {
+        adapter.testEnqueue('user:1', async () => {
+          results.push('task2-ok');
+          resolve();
+        });
+      });
+
+      await task2Done;
+      expect(results).toEqual(['task2-ok']);
+    });
+
+    it('should timeout tasks that run too long', async () => {
+      const adapter = new TestAdapter({ messageTimeoutMs: 50 });
+      const results: string[] = [];
+
+      adapter.testEnqueue('user:1', async () => {
+        // This task takes too long and should be timed out
+        await new Promise((r) => setTimeout(r, 200));
+        results.push('slow-task');
+      });
+
+      const task2Done = new Promise<void>((resolve) => {
+        adapter.testEnqueue('user:1', async () => {
+          results.push('fast-task');
+          resolve();
+        });
+      });
+
+      await task2Done;
+
+      // The fast task should complete, slow task was timed out
+      expect(results).toContain('fast-task');
+    });
+  });
+
+  describe('rate limiting', () => {
+    it('should rate limit after maxMessagesPerWindow', () => {
+      const adapter = new TestAdapter();
+      // Default is 20 messages per window
+      for (let i = 0; i < 20; i++) {
+        expect(adapter.testIsRateLimited('user1')).toBe(false);
+      }
+      expect(adapter.testIsRateLimited('user1')).toBe(true);
+    });
+
+    it('should not rate limit different users', () => {
+      const adapter = new TestAdapter();
+      for (let i = 0; i < 20; i++) {
+        adapter.testIsRateLimited('user1');
+      }
+      expect(adapter.testIsRateLimited('user1')).toBe(true);
+      expect(adapter.testIsRateLimited('user2')).toBe(false);
+    });
+  });
+});

--- a/core/src/channels/ChannelAdapter.ts
+++ b/core/src/channels/ChannelAdapter.ts
@@ -9,6 +9,9 @@ export interface IncomingMessage {
   metadata?: Record<string, unknown>;
 }
 
+/** Default per-message processing timeout (2 minutes). */
+const DEFAULT_MESSAGE_TIMEOUT_MS = 120_000;
+
 export abstract class ChannelAdapter {
   protected logger: Logger;
   protected userRateLimits: Map<string, { count: number; lastReset: number }> = new Map();
@@ -16,13 +19,27 @@ export abstract class ChannelAdapter {
   protected maxMessagesPerWindow: number;
   private cleanupInterval: NodeJS.Timeout | null = null;
 
+  /**
+   * Per-key FIFO message queue.
+   * Each key (e.g. `{channelId}:{userId}`) has an array of pending tasks
+   * and a flag indicating whether the queue is currently draining.
+   */
+  private messageQueues: Map<string, { tasks: Array<() => Promise<void>>; draining: boolean }> =
+    new Map();
+  protected messageTimeoutMs: number;
+
   constructor(
     public readonly platform: string,
-    options?: { rateLimitWindow?: number; maxMessagesPerWindow?: number }
+    options?: {
+      rateLimitWindow?: number;
+      maxMessagesPerWindow?: number;
+      messageTimeoutMs?: number;
+    }
   ) {
     this.logger = new Logger(`Channel:${platform}`);
     this.rateLimitWindow = options?.rateLimitWindow || 60 * 1000;
     this.maxMessagesPerWindow = options?.maxMessagesPerWindow || 20;
+    this.messageTimeoutMs = options?.messageTimeoutMs || DEFAULT_MESSAGE_TIMEOUT_MS;
 
     // Periodic cleanup to avoid memory leak
     this.cleanupInterval = setInterval(() => this.cleanupRateLimits(), this.rateLimitWindow * 2);
@@ -60,6 +77,50 @@ export abstract class ChannelAdapter {
     }
   }
 
+  /**
+   * Enqueue a message-processing task for sequential execution.
+   * Messages with the same key are processed one at a time in FIFO order.
+   * @param key Unique queue key (e.g. `{channelId}:{userId}`)
+   * @param task Async function that processes the message
+   */
+  protected enqueueMessage(key: string, task: () => Promise<void>): void {
+    let queue = this.messageQueues.get(key);
+    if (!queue) {
+      queue = { tasks: [], draining: false };
+      this.messageQueues.set(key, queue);
+    }
+    queue.tasks.push(task);
+
+    if (!queue.draining) {
+      this.drainQueue(key);
+    }
+  }
+
+  private drainQueue(key: string): void {
+    const queue = this.messageQueues.get(key);
+    if (!queue || queue.tasks.length === 0) {
+      if (queue) {
+        queue.draining = false;
+      }
+      return;
+    }
+
+    queue.draining = true;
+    const task = queue.tasks.shift()!;
+
+    const timeoutPromise = new Promise<void>((_, reject) =>
+      setTimeout(() => reject(new Error('Message processing timeout')), this.messageTimeoutMs)
+    );
+
+    Promise.race([task(), timeoutPromise])
+      .catch((err) => {
+        this.logger.error(`Message queue error for key "${key}":`, (err as Error).message);
+      })
+      .finally(() => {
+        this.drainQueue(key);
+      });
+  }
+
   abstract start(): Promise<void>;
   abstract stop(): Promise<void>;
   abstract sendMessage(chatId: string, text: string): Promise<void>;
@@ -69,5 +130,6 @@ export abstract class ChannelAdapter {
       clearInterval(this.cleanupInterval);
       this.cleanupInterval = null;
     }
+    this.messageQueues.clear();
   }
 }

--- a/core/src/channels/adapters/DiscordAdapter.ts
+++ b/core/src/channels/adapters/DiscordAdapter.ts
@@ -156,12 +156,12 @@ export class DiscordAdapter extends ChannelAdapter {
     }
   }
 
-  private async handleMessage(message: Record<string, unknown>) {
+  private handleMessage(message: Record<string, unknown>) {
     // Ignore bot messages
     if ((message.author as Record<string, unknown>)?.bot) return;
 
     const incoming: IncomingMessage = {
-      platform: 'Discord', // Retained 'Discord' as this is DiscordAdapter
+      platform: 'Discord',
       userId: (message.author as { id?: string })?.id || 'unknown',
       userName: (message.author as { username?: string })?.username || 'unknown',
       chatId: (message.channel_id as string) || 'unknown',
@@ -170,19 +170,13 @@ export class DiscordAdapter extends ChannelAdapter {
 
     if (this.isRateLimited(incoming.userId)) {
       this.logger.warn(`Rate limit exceeded for user ${incoming.userId}`);
-      await this.sendMessage(
-        incoming.chatId,
-        '⚠️ You are sending messages too fast. Please slow down.'
-      );
+      this.sendMessage(incoming.chatId, '⚠️ You are sending messages too fast. Please slow down.');
       return;
     }
 
-    try {
-      // The user's instruction includes a line `const querySpy = vi.spyOn(AuditService.getInstance() as unknown as Record<string, any>, 'query');`
-      // This line is not present in the original code and seems to be related to testing or a different context.
-      // I will not add this line as it's not a direct type replacement and introduces new functionality/dependencies.
-      // If the user intended to add this, it should be a separate instruction.
-
+    // Enqueue for sequential processing per channel+user
+    const queueKey = `${incoming.chatId}:${incoming.userId}`;
+    this.enqueueMessage(queueKey, async () => {
       const agent = this.orchestrator.getPrimaryAgent();
       if (!agent) {
         await this.sendMessage(incoming.chatId, 'Sorry, no agent is currently available.');
@@ -193,9 +187,7 @@ export class DiscordAdapter extends ChannelAdapter {
       const reply = response.finalAnswer || response.thought || 'No response generated.';
 
       await this.sendMessage(incoming.chatId, reply);
-    } catch (err: unknown) {
-      this.logger.error('Error processing Discord message:', (err as Error).message);
-    }
+    });
   }
 
   async sendMessage(chatId: string, text: string): Promise<void> {

--- a/core/src/channels/adapters/WhatsAppAdapter.ts
+++ b/core/src/channels/adapters/WhatsAppAdapter.ts
@@ -58,7 +58,9 @@ export class WhatsAppAdapter extends ChannelAdapter {
       return;
     }
 
-    try {
+    // Enqueue for sequential processing per user
+    const queueKey = `${incoming.chatId}:${incoming.userId}`;
+    this.enqueueMessage(queueKey, async () => {
       const agent = this.orchestrator.getPrimaryAgent();
       if (!agent) {
         await this.sendMessage(incoming.chatId, 'Sorry, no agent is currently available.');
@@ -69,9 +71,7 @@ export class WhatsAppAdapter extends ChannelAdapter {
       const reply = response.finalAnswer || response.thought || 'No response generated.';
 
       await this.sendMessage(incoming.chatId, reply);
-    } catch (err: unknown) {
-      this.logger.error('Error processing WhatsApp message:', (err as Error).message);
-    }
+    });
   }
 
   async sendMessage(chatId: string, text: string): Promise<void> {


### PR DESCRIPTION
## Summary
- Adds per-key FIFO message queue to `ChannelAdapter` base class with timeout protection
- Discord adapter: messages now queued by `{channelId}:{userId}` instead of firing concurrently
- WhatsApp adapter: webhook messages queued by `{chatId}:{userId}` instead of fire-and-forget
- Telegram was already sequential (polling loop with `await`) — unaffected

Fixes #516

## Test plan
- [x] New `ChannelAdapter.test.ts` with 6 tests covering:
  - Sequential processing for same key
  - Parallel processing for different keys
  - Error handling without blocking queue
  - Timeout of slow tasks
  - Rate limiting
- [x] Type check passes
- [x] Full CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)