### PR TITLE
feat(core): close delegation feedback loop — notifications + waitForResult

### DIFF
--- a/core/agent-runtime/src/index.ts
+++ b/core/agent-runtime/src/index.ts
@@ -145,6 +145,20 @@ async function main(): Promise<void> {
         }
       });
     }
+
+    // Subscribe to delegation completion notifications (Story 17.x / #268)
+    await subscriber.subscribe(`agent:${AGENT_INSTANCE_ID}:status`, (msg) => {
+      const event = msg.payload?.event as string | undefined;
+      if (event === 'delegation.completed') {
+        const p = msg.payload as Record<string, unknown>;
+        const summary = p.resultSummary ? `\nResult: ${String(p.resultSummary).substring(0, 500)}` : '';
+        const errMsg = p.error ? `\nError: ${String(p.error)}` : '';
+        loop.receiveIncomingMessage(
+          'system',
+          `[DELEGATION COMPLETE] Task ${p.taskId} delegated to ${p.targetAgent} finished with status: ${p.status}${summary}${errMsg}`,
+        );
+      }
+    });
   } catch (err) {
     log('warn', `Failed to initialize Centrifugo subscriber: ${err instanceof Error ? err.message : String(err)}`);
   }

--- a/core/src/routes/tasks.ts
+++ b/core/src/routes/tasks.ts
@@ -340,12 +340,15 @@ export function createTasksRouter(intercom: IntercomService): Router {
     const taskContext = row.context as Record<string, unknown> | null;
     const delegation = taskContext?.delegation as { fromInstanceId?: string } | undefined;
     if (delegation?.fromInstanceId) {
+      const resultStr = typeof body.result === 'string' ? body.result : null;
       await intercom
         .publish(`agent:${delegation.fromInstanceId}:status`, {
           event: 'delegation.completed',
           taskId,
           targetAgent: agentId,
           status: newStatus,
+          resultSummary: resultStr ? resultStr.substring(0, 500) : null,
+          error: body.error || null,
           completedAt: new Date().toISOString(),
         })
         .catch(() => {

--- a/core/src/skills/builtins/delegate-task.ts
+++ b/core/src/skills/builtins/delegate-task.ts
@@ -59,6 +59,13 @@ export const delegateTaskSkill: SkillDefinition = {
       description: 'Task ID to check status/result for (required for "check").',
       required: false,
     },
+    {
+      name: 'waitForResult',
+      type: 'boolean',
+      description:
+        'If true, wait for the delegated task to complete and return the result inline (max 2 min). Default: false (fire-and-forget).',
+      required: false,
+    },
   ],
   handler: async (params, agentContext) => {
     const callerInstanceId = agentContext.agentInstanceId;
@@ -68,13 +75,14 @@ export const delegateTaskSkill: SkillDefinition = {
       return { success: false, error: 'delegate-task must run in an agent instance context.' };
     }
 
-    const { action, targetAgent, task, context, priority, taskId } = params as {
+    const { action, targetAgent, task, context, priority, taskId, waitForResult } = params as {
       action: string;
       targetAgent?: string;
       task?: string;
       context?: unknown;
       priority?: number;
       taskId?: string;
+      waitForResult?: boolean;
     };
 
     try {
@@ -158,6 +166,46 @@ export const delegateTaskSkill: SkillDefinition = {
           logger.info(
             `Agent ${callerName} delegated task ${newTaskId} to ${targetAgent} (${target.id})`
           );
+
+          // If waitForResult is set, poll until the task completes or times out
+          if (waitForResult) {
+            const maxWaitMs = 120_000;
+            const pollIntervalMs = 3_000;
+            const deadline = Date.now() + maxWaitMs;
+
+            while (Date.now() < deadline) {
+              await new Promise((r) => setTimeout(r, pollIntervalMs));
+              const { rows } = await pool.query(
+                'SELECT status, result, error, exit_reason FROM task_queue WHERE id = $1',
+                [newTaskId]
+              );
+              const t = rows[0];
+              if (t?.status === 'completed' || t?.status === 'failed') {
+                return {
+                  success: t.status === 'completed',
+                  data: {
+                    taskId: newTaskId,
+                    targetAgent,
+                    status: t.status,
+                    result: t.result,
+                    error: t.error,
+                    exitReason: t.exit_reason,
+                  },
+                };
+              }
+            }
+
+            // Timed out — return what we know
+            const { rows: finalRows } = await pool.query(
+              'SELECT status FROM task_queue WHERE id = $1',
+              [newTaskId]
+            );
+            const finalStatus = finalRows[0]?.status ?? 'unknown';
+            return {
+              success: false,
+              error: `Delegation to ${targetAgent} timed out after ${maxWaitMs / 1000}s. Task ${newTaskId} is still "${finalStatus}". Use action "check" with taskId "${newTaskId}" to poll later.`,
+            };
+          }
 
           return {
             success: true,


### PR DESCRIPTION
## Summary
- Agent-runtime now subscribes to `agent:{id}:status` Centrifugo channel, receiving delegation completion events as observations in the reasoning loop
- `delegate-task` skill gains `waitForResult` boolean parameter — polls task queue inline (3s intervals, 2min timeout) and returns the result without a separate `check` call
- Task completion notification now includes `resultSummary` (first 500 chars) and `error` fields

Partial fix for #268 — closes the notification loop. Delegation tokens/scopes (Epic 17) and chain tracking are separate work.

## Test plan
- [x] Type check passes (core + agent-runtime)
- [x] Full CI passes (797 tests)
- [ ] E2E: rebuild agent-runtime image, start two agents, delegate a task between them, verify completion notification arrives

🤖 Generated with [Claude Code](https://claude.com/claude-code)