### PR TITLE
feat(core): exclude sera-core MCP from internal agent tool registry

### DIFF
--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -550,8 +550,11 @@ const startServer = async () => {
 
   const { SeraMCPServer } = await import('./mcp/SeraMCPServer.js');
   // Set up MCP ↔ SkillRegistry bridge hooks BEFORE registering any servers,
-  // so that sera-core tools (and any loaded from disk) are automatically bridged.
+  // so that external MCP tools (loaded from disk) are automatically bridged.
+  // The sera-core MCP server is NOT bridged — it's designed for external
+  // integrations (Claude Code, IDE). Agents use native built-in skills instead. (#535)
   mcpRegistry.onRegister((name) => {
+    if (name === 'sera-core') return; // External-only MCP server
     skillRegistry
       .bridgeMCPToolsForServer(name, mcpRegistry)
       .then((count) => {

--- a/templates/builtin/sera.template.yaml
+++ b/templates/builtin/sera.template.yaml
@@ -168,23 +168,8 @@ spec:
       - shell-exec
       # Scheduling
       - schedule-task
-      # SERA platform management (via sera-core MCP)
-      - sera-core/list_agents
-      - sera-core/agent_status
-      - sera-core/agent_capabilities
-      - sera-core/start_agent
-      - sera-core/stop_agent
-      - sera-core/restart_agent
-      - sera-core/create_agent
-      - sera-core/agents.spawn_subagent
-      - sera-core/circles.*
-      - sera-core/orchestration.*
-      - sera-core/chat
-      - sera-core/list_sessions
-      - sera-core/chat_history
-      - sera-core/circle.broadcast
-      - sera-core/delegate_task
-      - sera-core/memory_blocks
+      # Delegation & agent management (native built-in skills)
+      - delegate-task
     denied:
       - file-write   # requires explicit permission request per session
 


### PR DESCRIPTION
## Summary
- Skip sera-core MCP server in the SkillRegistry bridge hook — it's designed for external integrations (Claude Code, IDE), not internal agents
- Remove sera-core/* tool patterns from sera.template.yaml — agents use native built-in skills instead
- **Tool count: 35 → ~15 per agent** — massive context window savings

Partial fix for #535 (Phase 1: deduplication). Phase 2 (semantic tool retrieval) is separate.

## Test plan
- [x] Full CI passes (797 tests)
- [ ] Restart sera-core, verify tool catalog count drops
- [ ] E2E: ask Sera to delegate — verify she now selects delegate-task from the smaller set

🤖 Generated with [Claude Code](https://claude.com/claude-code)