### PR TITLE
feat(agent-runtime): context budget guard + parallel tool execution + pre-compaction save hook

### DIFF
--- a/core/agent-runtime/src/__tests__/preCompactionHook.test.ts
+++ b/core/agent-runtime/src/__tests__/preCompactionHook.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Tests for the pre-compaction memory save hook in ReasoningLoop.
+ *
+ * When the context window is nearly full and the agent has the knowledge-store
+ * tool, the loop injects a save-reminder before compacting — giving the agent
+ * one iteration to persist important findings.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ReasoningLoop } from '../loop.js';
+import type { LLMResponse, ToolDefinition, ChatMessage } from '../llmClient.js';
+import type { RuntimeManifest } from '../manifest.js';
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockChat = vi.fn<(messages: ChatMessage[], tools?: ToolDefinition[], temperature?: number) => Promise<LLMResponse>>();
+const mockPublishThought = vi.fn();
+const mockPublishStreamToken = vi.fn();
+const mockGetToolDefinitions = vi.fn();
+const mockExecuteToolCalls = vi.fn();
+
+const mockLlm = { chat: mockChat } as any;
+const mockCentrifugo = {
+  publishThought: mockPublishThought,
+  publishStreamToken: mockPublishStreamToken,
+} as any;
+const mockTools = {
+  getToolDefinitions: mockGetToolDefinitions,
+  executeToolCalls: mockExecuteToolCalls,
+} as any;
+
+const manifest: RuntimeManifest = {
+  apiVersion: 'v1',
+  kind: 'Agent',
+  metadata: { name: 'test-agent', displayName: 'Test', icon: 'bot', circle: 'system', tier: 1 },
+  identity: { role: 'tester', description: 'Test agent' },
+  model: { provider: 'openai', name: 'gpt-4o-mini' },
+};
+
+function successResponse(content: string): LLMResponse {
+  return { content, usage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 } };
+}
+
+// ── Setup ────────────────────────────────────────────────────────────────────
+
+let savedEnv: Record<string, string | undefined>;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  mockPublishThought.mockResolvedValue(undefined);
+  mockPublishStreamToken.mockResolvedValue(undefined);
+  mockExecuteToolCalls.mockResolvedValue([]);
+
+  savedEnv = {
+    CONTEXT_WINDOW: process.env['CONTEXT_WINDOW'],
+    MAX_CONTEXT_TOKENS: process.env['MAX_CONTEXT_TOKENS'],
+  };
+});
+
+afterEach(() => {
+  for (const [k, v] of Object.entries(savedEnv)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+});
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('ReasoningLoop — pre-compaction memory save hook', () => {
+  it('injects save-reminder when knowledge-store is available and context is near limit', async () => {
+    // Small context window → isNearLimit triggers immediately
+    process.env['CONTEXT_WINDOW'] = '100';
+    delete process.env['MAX_CONTEXT_TOKENS'];
+
+    // Include knowledge-store in tool definitions
+    const knowledgeStoreDef: ToolDefinition = {
+      type: 'function',
+      function: { name: 'knowledge-store', description: 'Store knowledge', parameters: {} },
+    };
+    mockGetToolDefinitions.mockReturnValue([knowledgeStoreDef]);
+
+    // First LLM call: agent responds to the save reminder
+    // Second LLM call: after compaction, agent produces final answer
+    mockChat
+      .mockResolvedValueOnce(successResponse('I will save my findings now'))
+      .mockResolvedValueOnce(successResponse('Final answer'));
+
+    const loop = new ReasoningLoop(mockLlm, mockTools, mockCentrifugo, manifest);
+    const longTask = 'Analyze this data: ' + 'word '.repeat(20);
+    const result = await loop.run({ taskId: 'task-1', task: longTask });
+
+    expect(result.exitReason).toBe('success');
+
+    // Verify the save-reminder system message was injected
+    const saveThoughts = result.thoughtStream.filter(
+      (t) => t.step === 'reflect' && t.content.includes('save-reminder'),
+    );
+    expect(saveThoughts.length).toBeGreaterThan(0);
+  });
+
+  it('skips hook when knowledge-store is NOT in tool definitions', async () => {
+    process.env['CONTEXT_WINDOW'] = '100';
+    delete process.env['MAX_CONTEXT_TOKENS'];
+
+    // No knowledge-store tool
+    mockGetToolDefinitions.mockReturnValue([]);
+
+    mockChat.mockResolvedValueOnce(successResponse('Done'));
+
+    const loop = new ReasoningLoop(mockLlm, mockTools, mockCentrifugo, manifest);
+    const longTask = 'Analyze this data: ' + 'word '.repeat(20);
+    const result = await loop.run({ taskId: 'task-1', task: longTask });
+
+    expect(result.exitReason).toBe('success');
+
+    // No save-reminder thoughts
+    const saveThoughts = result.thoughtStream.filter(
+      (t) => t.step === 'reflect' && t.content.includes('save-reminder'),
+    );
+    expect(saveThoughts).toHaveLength(0);
+  });
+
+  it('hook fires at most once per run', async () => {
+    process.env['CONTEXT_WINDOW'] = '100';
+    delete process.env['MAX_CONTEXT_TOKENS'];
+
+    const knowledgeStoreDef: ToolDefinition = {
+      type: 'function',
+      function: { name: 'knowledge-store', description: 'Store knowledge', parameters: {} },
+    };
+    mockGetToolDefinitions.mockReturnValue([knowledgeStoreDef]);
+
+    // Multiple iterations — each will trigger isNearLimit
+    mockChat
+      .mockResolvedValueOnce(successResponse('Saving context...'))
+      .mockResolvedValueOnce(successResponse('Still working...'))
+      .mockResolvedValueOnce(successResponse('Done'));
+
+    const loop = new ReasoningLoop(mockLlm, mockTools, mockCentrifugo, manifest);
+    const longTask = 'Big task: ' + 'word '.repeat(20);
+    const result = await loop.run({ taskId: 'task-1', task: longTask });
+
+    // Save-reminder should appear exactly once
+    const saveThoughts = result.thoughtStream.filter(
+      (t) => t.step === 'reflect' && t.content.includes('save-reminder'),
+    );
+    expect(saveThoughts).toHaveLength(1);
+  });
+
+  it('emits reflect thought for the hook', async () => {
+    process.env['CONTEXT_WINDOW'] = '100';
+    delete process.env['MAX_CONTEXT_TOKENS'];
+
+    const knowledgeStoreDef: ToolDefinition = {
+      type: 'function',
+      function: { name: 'knowledge-store', description: 'Store knowledge', parameters: {} },
+    };
+    mockGetToolDefinitions.mockReturnValue([knowledgeStoreDef]);
+
+    mockChat
+      .mockResolvedValueOnce(successResponse('Saving...'))
+      .mockResolvedValueOnce(successResponse('Done'));
+
+    const loop = new ReasoningLoop(mockLlm, mockTools, mockCentrifugo, manifest);
+    const result = await loop.run({ taskId: 'task-1', task: 'Big task: ' + 'word '.repeat(20) });
+
+    // publishThought should have been called with the save-reminder reflect
+    const publishCalls = mockPublishThought.mock.calls;
+    const hookCall = publishCalls.find(
+      (c: unknown[]) => c[0] === 'reflect' && (c[1] as string).includes('save-reminder'),
+    );
+    expect(hookCall).toBeDefined();
+  });
+});

--- a/core/agent-runtime/src/__tests__/tools.test.ts
+++ b/core/agent-runtime/src/__tests__/tools.test.ts
@@ -238,6 +238,63 @@ describe('RuntimeToolExecutor', () => {
     });
   });
 
+  describe('executeToolCalls() — parallel execution', () => {
+    it('executes multiple read tools and preserves result order', async () => {
+      // Create 3 files and read them all in one batch
+      fs.writeFileSync(path.join(tempDir, 'a.txt'), 'content-a');
+      fs.writeFileSync(path.join(tempDir, 'b.txt'), 'content-b');
+      fs.writeFileSync(path.join(tempDir, 'c.txt'), 'content-c');
+
+      const calls = [
+        makeCallWithId('call_1', 'file-read', { path: 'a.txt' }),
+        makeCallWithId('call_2', 'file-read', { path: 'b.txt' }),
+        makeCallWithId('call_3', 'file-read', { path: 'c.txt' }),
+      ];
+
+      const results = await executor.executeToolCalls(calls);
+      expect(results).toHaveLength(3);
+      expect(results[0]!.message.content).toBe('content-a');
+      expect(results[1]!.message.content).toBe('content-b');
+      expect(results[2]!.message.content).toBe('content-c');
+    });
+
+    it('write tools complete without data races', async () => {
+      const calls = [
+        makeCallWithId('call_1', 'file-write', { path: 'out1.txt', content: 'data1' }),
+        makeCallWithId('call_2', 'file-write', { path: 'out2.txt', content: 'data2' }),
+      ];
+
+      const results = await executor.executeToolCalls(calls);
+      expect(results).toHaveLength(2);
+      expect(results[0]!.message.content).toContain('File written');
+      expect(results[1]!.message.content).toContain('File written');
+      expect(fs.readFileSync(path.join(tempDir, 'out1.txt'), 'utf-8')).toBe('data1');
+      expect(fs.readFileSync(path.join(tempDir, 'out2.txt'), 'utf-8')).toBe('data2');
+    });
+
+    it('individual failure does not block other tools', async () => {
+      fs.writeFileSync(path.join(tempDir, 'good.txt'), 'ok');
+      const calls = [
+        makeCallWithId('call_1', 'file-read', { path: 'nonexistent.txt' }),
+        makeCallWithId('call_2', 'file-read', { path: 'good.txt' }),
+      ];
+
+      const results = await executor.executeToolCalls(calls);
+      expect(results).toHaveLength(2);
+      expect(results[0]!.message.content).toContain('Error');
+      expect(results[1]!.message.content).toBe('ok');
+    });
+
+    it('single call takes fast path', async () => {
+      fs.writeFileSync(path.join(tempDir, 'solo.txt'), 'alone');
+      const results = await executor.executeToolCalls([
+        makeCallWithId('call_1', 'file-read', { path: 'solo.txt' }),
+      ]);
+      expect(results).toHaveLength(1);
+      expect(results[0]!.message.content).toBe('alone');
+    });
+  });
+
   describe('getToolDefinitions()', () => {
     it('returns all 7 built-in tools when no filter given', () => {
       const tools = executor.getToolDefinitions();
@@ -257,6 +314,14 @@ describe('RuntimeToolExecutor', () => {
 function makeCall(name: string, args: Record<string, unknown>): ToolCall {
   return {
     id: 'call_test',
+    type: 'function',
+    function: { name, arguments: JSON.stringify(args) },
+  };
+}
+
+function makeCallWithId(id: string, name: string, args: Record<string, unknown>): ToolCall {
+  return {
+    id,
     type: 'function',
     function: { name, arguments: JSON.stringify(args) },
   };

--- a/core/agent-runtime/src/contextManager.test.ts
+++ b/core/agent-runtime/src/contextManager.test.ts
@@ -186,6 +186,84 @@ describe('ContextManager', () => {
     });
   });
 
+  describe('getAvailableBudget()', () => {
+    it('returns positive value when under limit', () => {
+      const messages: ChatMessage[] = [
+        { role: 'system', content: 'System.' },
+        { role: 'user', content: 'Hello' },
+      ];
+      const budget = mgr.getAvailableBudget(messages);
+      expect(budget).toBeGreaterThan(0);
+    });
+
+    it('returns 0 when at or over high-water mark', () => {
+      // Use a tiny window so a few messages exceed it
+      process.env['CONTEXT_WINDOW'] = '30';
+      delete process.env['MAX_CONTEXT_TOKENS'];
+      const tinyMgr = new ContextManager('gpt-4o-mini');
+      const messages: ChatMessage[] = [
+        { role: 'system', content: 'System prompt with enough words to fill the window.' },
+        { role: 'user', content: 'User message with additional words to exceed budget.' },
+      ];
+      expect(tinyMgr.getAvailableBudget(messages)).toBe(0);
+      tinyMgr.free();
+      delete process.env['CONTEXT_WINDOW'];
+    });
+
+    it('respects custom responseReserve', () => {
+      const messages: ChatMessage[] = [{ role: 'user', content: 'Hi' }];
+      const withDefault = mgr.getAvailableBudget(messages);
+      const withLarger = mgr.getAvailableBudget(messages, 8192);
+      expect(withLarger).toBeLessThan(withDefault);
+    });
+  });
+
+  describe('truncateToContextBudget()', () => {
+    it('returns content unchanged when budget is sufficient', () => {
+      const messages: ChatMessage[] = [{ role: 'user', content: 'Hi' }];
+      const result = mgr.truncateToContextBudget('Short result', messages);
+      expect(result.content).toBe('Short result');
+      expect(result.budgetExceeded).toBe(false);
+      expect(result.compactionNeeded).toBe(false);
+    });
+
+    it('truncates content when it exceeds available budget', () => {
+      // Window of 500 tokens, high-water 400. Short messages ~30 tokens + 4096 reserve
+      // won't fit, so use a small responseReserve to leave some budget for the content.
+      process.env['CONTEXT_WINDOW'] = '500';
+      delete process.env['MAX_CONTEXT_TOKENS'];
+      const smallMgr = new ContextManager('gpt-4o-mini');
+      const messages: ChatMessage[] = [
+        { role: 'system', content: 'System.' },
+        { role: 'user', content: 'Hi' },
+      ];
+      const longContent = 'word '.repeat(500);
+      // Use responseReserve=0 so the budget is highWaterMark(400) - messageTokens(~15) ≈ 385
+      const result = smallMgr.truncateToContextBudget(longContent, messages, 0);
+      expect(result.budgetExceeded).toBe(true);
+      expect(result.compactionNeeded).toBe(false);
+      expect(result.content).toContain('[SERA: tool result truncated to fit context budget');
+      expect(result.content.length).toBeLessThan(longContent.length);
+      smallMgr.free();
+      delete process.env['CONTEXT_WINDOW'];
+    });
+
+    it('returns compactionNeeded when budget is zero', () => {
+      process.env['CONTEXT_WINDOW'] = '30';
+      delete process.env['MAX_CONTEXT_TOKENS'];
+      const tinyMgr = new ContextManager('gpt-4o-mini');
+      const messages: ChatMessage[] = [
+        { role: 'system', content: 'System prompt with enough words to completely fill the window and more.' },
+        { role: 'user', content: 'User message that pushes well over the tiny limit we set.' },
+      ];
+      const result = tinyMgr.truncateToContextBudget('any content', messages);
+      expect(result.compactionNeeded).toBe(true);
+      expect(result.budgetExceeded).toBe(true);
+      tinyMgr.free();
+      delete process.env['CONTEXT_WINDOW'];
+    });
+  });
+
   describe('compact() — sliding-window', () => {
     it('always preserves system message', () => {
       process.env['MAX_CONTEXT_TOKENS'] = '50';

--- a/core/agent-runtime/src/contextManager.ts
+++ b/core/agent-runtime/src/contextManager.ts
@@ -39,6 +39,7 @@ const DEFAULT_CONTEXT_WINDOW = 32_768;
 const DEFAULT_HIGH_WATER_PCT = 0.80;
 const AGGRESSIVE_COMPACT_PCT = 0.50;
 const DEFAULT_TOOL_OUTPUT_MAX_TOKENS = 4_000;
+const DEFAULT_RESPONSE_RESERVE = 4_096;
 const DEFAULT_EMERGENCY_TOOL_TOKENS = 500;
 
 export type CompactionStrategy = 'sliding-window' | 'summarise';
@@ -279,6 +280,44 @@ export class ContextManager {
       log('info', `ContextManager: retroactively truncated ${truncatedCount} tool result(s) to ${maxTokens} tokens`);
     }
     return truncatedCount;
+  }
+
+  /**
+   * Returns how many tokens remain before hitting the high-water mark,
+   * minus a reserve for the LLM's response. Clamped to 0.
+   */
+  getAvailableBudget(messages: ChatMessage[], responseReserve: number = DEFAULT_RESPONSE_RESERVE): number {
+    return Math.max(0, this.highWaterMark - this.countMessageTokens(messages) - responseReserve);
+  }
+
+  /**
+   * Context-aware truncation: ensures a tool result fits within the remaining
+   * context budget. Applied after the per-result TOOL_OUTPUT_MAX_TOKENS cap.
+   *
+   * @returns The (possibly truncated) content, whether the budget was exceeded,
+   *          and whether compaction is needed before adding the result.
+   */
+  truncateToContextBudget(
+    content: string,
+    messages: ChatMessage[],
+    responseReserve: number = DEFAULT_RESPONSE_RESERVE,
+  ): { content: string; budgetExceeded: boolean; compactionNeeded: boolean } {
+    const budget = this.getAvailableBudget(messages, responseReserve);
+
+    if (budget === 0) {
+      return { content, budgetExceeded: true, compactionNeeded: true };
+    }
+
+    const tokens = this.countTokens(content);
+    if (tokens <= budget) {
+      return { content, budgetExceeded: false, compactionNeeded: false };
+    }
+
+    const notice = `\n\n[SERA: tool result truncated to fit context budget — ${tokens} → ${budget} tokens]`;
+    const noticeTokens = this.countTokens(notice);
+    const truncated = this.truncateToFit(content, Math.max(1, budget - noticeTokens)) + notice;
+
+    return { content: truncated, budgetExceeded: true, compactionNeeded: false };
   }
 
   /** Release the tiktoken encoding (no-op for js-tiktoken, kept for API compatibility). */

--- a/core/agent-runtime/src/loop.ts
+++ b/core/agent-runtime/src/loop.ts
@@ -133,6 +133,10 @@ export class ReasoningLoop {
     const loopDetector = new ToolLoopDetector();
     let forceTextNext = false;
 
+    // ── Pre-compaction memory save hook (fires at most once per run) ───────
+    let preCompactionHookFired = false;
+    const hasKnowledgeStore = this.toolDefs.some((t) => t.function.name === 'knowledge-store');
+
     // ── Retry state machine (per-run, reset on each invocation) ───────────
     const retryState: RetryState = {
       overflowCompactionAttempts: 0,
@@ -169,6 +173,22 @@ export class ReasoningLoop {
 
         // Context window management — compact before each LLM call
         if (this.contextManager.isNearLimit(messages)) {
+          // Pre-compaction memory save hook (#506): give the agent one iteration
+          // to save important context before it's compacted away.
+          if (hasKnowledgeStore && !preCompactionHookFired) {
+            preCompactionHookFired = true;
+            await think('reflect', 'Context window nearly full — injecting save-reminder before compaction', iteration);
+            messages.push({
+              role: 'system',
+              content:
+                'IMPORTANT: Your context window is nearly full and compaction will occur shortly. ' +
+                'If there is any critical information from this conversation that you want to ' +
+                'preserve long-term, call the knowledge-store tool NOW to save it. ' +
+                'After this turn, older messages will be dropped.',
+            });
+            continue; // Let the next iteration handle the save, then compact
+          }
+
           const compaction = this.contextManager.compact(messages);
           await think('reflect', compaction.reflectMessage, iteration);
         }
@@ -303,8 +323,20 @@ export class ReasoningLoop {
           // Execute tools and add results
           const toolResults = await this.tools.executeToolCalls(response.toolCalls);
           for (const result of toolResults) {
-            // Pre-truncate tool output before adding to history
+            // 1. Per-result absolute cap (TOOL_OUTPUT_MAX_TOKENS)
             result.message.content = this.contextManager.truncateToolOutput(result.message.content);
+
+            // 2. Context-aware budget guard — truncate further if remaining budget is tight
+            const budgetCheck = this.contextManager.truncateToContextBudget(result.message.content, messages);
+            if (budgetCheck.compactionNeeded) {
+              const compaction = this.contextManager.compact(messages);
+              await think('reflect', `Pre-result compaction: ${compaction.reflectMessage}`, iteration);
+              const recheck = this.contextManager.truncateToContextBudget(result.message.content, messages);
+              result.message.content = recheck.content;
+            } else {
+              result.message.content = budgetCheck.content;
+            }
+
             messages.push(result.message);
 
             // Emit reflect thought for argument repair

--- a/core/agent-runtime/src/tools/executor.ts
+++ b/core/agent-runtime/src/tools/executor.ts
@@ -29,15 +29,42 @@ const LOCAL_TOOLS = new Set([
   'shell-exec', 'spawn-subagent', 'run-tool',
 ]);
 
+/** Tools that modify state — executed with mutual exclusion to prevent races. */
+export const WRITE_TOOLS = new Set(['file-write', 'file-delete', 'shell-exec']);
+
+const DEFAULT_MAX_TOOL_CONCURRENCY = 4;
+
+// ── Semaphore for concurrency control ────────────────────────────────────────
+
+class Semaphore {
+  private permits: number;
+  private queue: Array<() => void> = [];
+  constructor(permits: number) { this.permits = permits; }
+  async acquire(): Promise<void> {
+    if (this.permits > 0) { this.permits--; return; }
+    return new Promise<void>((resolve) => { this.queue.push(resolve); });
+  }
+  release(): void {
+    const next = this.queue.shift();
+    if (next) { next(); } else { this.permits++; }
+  }
+}
+
 export class RuntimeToolExecutor {
   private workspacePath: string;
   private tier: number;
   /** Remote tools fetched from core's catalog. */
   private remoteCatalog: ToolDefinition[] = [];
+  /** Mutex for write tools — at most 1 write tool at a time. */
+  private writeMutex = new Semaphore(1);
+  /** Max concurrent tool executions. */
+  private concurrency: number;
 
   constructor(workspacePath: string = '/workspace', tier?: number) {
     this.workspacePath = workspacePath;
     this.tier = tier ?? (process.env['AGENT_TIER'] ? parseInt(process.env['AGENT_TIER'], 10) : 2);
+    const envConcurrency = process.env['MAX_TOOL_CONCURRENCY'];
+    this.concurrency = envConcurrency ? parseInt(envConcurrency, 10) : DEFAULT_MAX_TOOL_CONCURRENCY;
   }
 
   /**
@@ -198,12 +225,41 @@ export class RuntimeToolExecutor {
     }
   }
 
-  /** Execute multiple tool calls sequentially (order matters for state). */
+  /**
+   * Execute tool calls with concurrency. Write tools are serialized via a mutex;
+   * read-only tools run in parallel up to the configured concurrency limit.
+   * Results maintain the same order as the input tool calls.
+   */
   async executeToolCalls(toolCalls: ToolCall[]): Promise<ToolExecutionResult[]> {
-    const results: ToolExecutionResult[] = [];
-    for (const tc of toolCalls) {
-      results.push(await this.executeTool(tc));
+    // Fast path: single call, no concurrency overhead
+    if (toolCalls.length <= 1) {
+      const results: ToolExecutionResult[] = [];
+      for (const tc of toolCalls) {
+        results.push(await this.executeTool(tc));
+      }
+      return results;
     }
+
+    const concurrencySem = new Semaphore(this.concurrency);
+    const results = new Array<ToolExecutionResult>(toolCalls.length);
+
+    const tasks = toolCalls.map(async (tc, index) => {
+      await concurrencySem.acquire();
+      try {
+        const toolName = sanitizeToolName(tc.function.name);
+        const isWrite = WRITE_TOOLS.has(toolName);
+        if (isWrite) await this.writeMutex.acquire();
+        try {
+          results[index] = await this.executeTool(tc);
+        } finally {
+          if (isWrite) this.writeMutex.release();
+        }
+      } finally {
+        concurrencySem.release();
+      }
+    });
+
+    await Promise.all(tasks);
     return results;
   }
 


### PR DESCRIPTION
## Summary
- **#507 Context-aware tool result guard**: `getAvailableBudget()` and `truncateToContextBudget()` ensure tool results fit within remaining context budget before adding to history. Triggers compaction when budget is exhausted. Effective limit: `min(TOOL_OUTPUT_MAX_TOKENS, contextBudget)`.
- **#503 Parallel tool execution**: `executeToolCalls()` runs read-only tools concurrently (up to `MAX_TOOL_CONCURRENCY`, default 4) while serializing write tools (`file-write`, `file-delete`, `shell-exec`) via a mutex. Results preserve input ordering. Individual failures don't block others.
- **#506 Pre-compaction memory save hook**: When context is nearly full and `knowledge-store` tool is available, injects a save-reminder system message and gives the agent one iteration to persist important findings before compaction drops older messages. Fires at most once per task.

## Test plan
- [x] 6 new tests for getAvailableBudget + truncateToContextBudget (budget sufficient, exceeded, compaction needed)
- [x] 4 new tests for parallel execution (concurrent reads, write serialization, failure isolation, fast path)
- [x] 4 new tests for pre-compaction hook (fires with knowledge-store, skips without, fires once, emits thought)
- [x] All 130 agent-runtime tests pass
- [x] Full CI: 770+ tests, typecheck, lint, format, build all green

Closes #507, closes #503, closes #506

🤖 Generated with [Claude Code](https://claude.com/claude-code)