### PR TITLE
feat: capabilities prompt, cache-aware usage, configurable thinking levels

### DIFF
--- a/core/agent-runtime/src/__tests__/preCompactionHook.test.ts
+++ b/core/agent-runtime/src/__tests__/preCompactionHook.test.ts
@@ -38,7 +38,7 @@ const manifest: RuntimeManifest = {
 };
 
 function successResponse(content: string): LLMResponse {
-  return { content, usage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 } };
+  return { content, usage: { promptTokens: 10, completionTokens: 5, cacheCreationTokens: 0, cacheReadTokens: 0, totalTokens: 15 } };
 }
 
 // ── Setup ────────────────────────────────────────────────────────────────────

--- a/core/agent-runtime/src/__tests__/retryStateMachine.test.ts
+++ b/core/agent-runtime/src/__tests__/retryStateMachine.test.ts
@@ -38,7 +38,7 @@ const manifest: RuntimeManifest = {
 };
 
 function successResponse(content: string): LLMResponse {
-  return { content, usage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 } };
+  return { content, usage: { promptTokens: 10, completionTokens: 5, cacheCreationTokens: 0, cacheReadTokens: 0, totalTokens: 15 } };
 }
 
 // ── Setup ────────────────────────────────────────────────────────────────────

--- a/core/agent-runtime/src/index.ts
+++ b/core/agent-runtime/src/index.ts
@@ -193,7 +193,7 @@ async function main(): Promise<void> {
         error: 'shutdown',
         exitReason: 'shutdown',
         completedAt: new Date().toISOString(),
-        usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+        usage: { promptTokens: 0, completionTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0, totalTokens: 0, turns: 0 },
         thoughtStream: [],
       };
       writeResultFile(partial);

--- a/core/agent-runtime/src/llmClient.ts
+++ b/core/agent-runtime/src/llmClient.ts
@@ -76,6 +76,8 @@ export interface ChatMessage {
   tool_call_id?: string;
 }
 
+export type ThinkingLevel = 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'max';
+
 export interface LLMResponse {
   content: string;
   /** Chain-of-thought text, e.g. Qwen / DeepSeek reasoning_content. */
@@ -84,6 +86,8 @@ export interface LLMResponse {
   usage?: {
     promptTokens: number;
     completionTokens: number;
+    cacheCreationTokens: number;
+    cacheReadTokens: number;
     totalTokens: number;
   };
 }
@@ -125,6 +129,7 @@ export class LLMClient {
     messages: ChatMessage[],
     tools?: ToolDefinition[],
     temperature?: number,
+    thinkingLevel?: ThinkingLevel,
   ): Promise<LLMResponse> {
     const body: Record<string, unknown> = {
       model: this.model,
@@ -142,6 +147,10 @@ export class LLMClient {
 
     if (temperature !== undefined) {
       body['temperature'] = temperature;
+    }
+
+    if (thinkingLevel && thinkingLevel !== 'off') {
+      body['thinking_level'] = thinkingLevel;
     }
 
     // Debug: log tool names and message roles sent to LLM
@@ -185,6 +194,8 @@ export class LLMClient {
         ? {
             promptTokens: rawUsage['prompt_tokens'] ?? 0,
             completionTokens: rawUsage['completion_tokens'] ?? 0,
+            cacheCreationTokens: rawUsage['cache_creation_input_tokens'] ?? 0,
+            cacheReadTokens: rawUsage['cache_read_input_tokens'] ?? 0,
             totalTokens: rawUsage['total_tokens'] ?? 0,
           }
         : undefined;

--- a/core/agent-runtime/src/loop.ts
+++ b/core/agent-runtime/src/loop.ts
@@ -5,7 +5,7 @@
  * and returns a structured result with usage stats.
  */
 
-import type { LLMClient, ChatMessage, ToolDefinition, LLMResponse } from './llmClient.js';
+import type { LLMClient, ChatMessage, ToolDefinition, LLMResponse, ThinkingLevel } from './llmClient.js';
 import { BudgetExceededError, ProviderUnavailableError, ContextOverflowError, LLMTimeoutError } from './llmClient.js';
 import type { RuntimeToolExecutor } from './tools/index.js';
 import type { CentrifugoPublisher } from './centrifugo.js';
@@ -31,7 +31,10 @@ export interface TaskOutput {
   usage: {
     promptTokens: number;
     completionTokens: number;
+    cacheCreationTokens: number;
+    cacheReadTokens: number;
     totalTokens: number;
+    turns: number;
   };
   /** Ordered list of thought events for Story 5.9. */
   thoughtStream: Array<{ step: string; content: string; iteration: number; timestamp: string }>;
@@ -101,8 +104,21 @@ export class ReasoningLoop {
     const hasTools = this.toolDefs.length > 0;
     const thoughtStream: TaskOutput['thoughtStream'] = [];
 
+    // ── Usage tracking with cache awareness (#547) ────────────────────────
     let totalPromptTokens = 0;
     let totalCompletionTokens = 0;
+    let totalCacheCreationTokens = 0;
+    let totalCacheReadTokens = 0;
+    let turnCount = 0;
+
+    const buildUsage = () => ({
+      promptTokens: totalPromptTokens,
+      completionTokens: totalCompletionTokens,
+      cacheCreationTokens: totalCacheCreationTokens,
+      cacheReadTokens: totalCacheReadTokens,
+      totalTokens: totalPromptTokens + totalCompletionTokens,
+      turns: turnCount,
+    });
 
     // Helper to emit and record a thought
     const think = async (
@@ -154,7 +170,7 @@ export class ReasoningLoop {
             taskId,
             result: null,
             error: 'shutdown',
-            usage: { promptTokens: totalPromptTokens, completionTokens: totalCompletionTokens, totalTokens: totalPromptTokens + totalCompletionTokens },
+            usage: buildUsage(),
             thoughtStream,
             exitReason: 'shutdown',
           };
@@ -201,9 +217,9 @@ export class ReasoningLoop {
           const useTools = hasTools && !forceTextNext;
           forceTextNext = false; // reset after use
           if (useTools) {
-            response = await this.llm.chat(messages, this.toolDefs, this.manifest.model.temperature);
+            response = await this.llm.chat(messages, this.toolDefs, this.manifest.model.temperature, this.manifest.model.thinkingLevel as ThinkingLevel | undefined);
           } else {
-            response = await this.llm.chat(messages, undefined, this.manifest.model.temperature);
+            response = await this.llm.chat(messages, undefined, this.manifest.model.temperature, this.manifest.model.thinkingLevel as ThinkingLevel | undefined);
           }
         } catch (llmErr) {
           // ── Context overflow recovery ────────────────────────────────────
@@ -236,7 +252,7 @@ export class ReasoningLoop {
               taskId,
               result: null,
               error: `Context overflow after ${MAX_OVERFLOW_RETRIES} compaction attempts: ${llmErr.message}`,
-              usage: { promptTokens: totalPromptTokens, completionTokens: totalCompletionTokens, totalTokens: totalPromptTokens + totalCompletionTokens },
+              usage: buildUsage(),
               thoughtStream,
               exitReason: 'context_overflow',
             };
@@ -265,11 +281,14 @@ export class ReasoningLoop {
           throw llmErr;
         }
 
-        // Accumulate usage
+        // Accumulate usage (including cache tokens)
         if (response.usage) {
           totalPromptTokens += response.usage.promptTokens;
           totalCompletionTokens += response.usage.completionTokens;
-          log('debug', `Iteration ${iteration} usage: prompt=${response.usage.promptTokens} completion=${response.usage.completionTokens}`);
+          totalCacheCreationTokens += response.usage.cacheCreationTokens;
+          totalCacheReadTokens += response.usage.cacheReadTokens;
+          turnCount++;
+          log('debug', `Iteration ${iteration} usage: prompt=${response.usage.promptTokens} completion=${response.usage.completionTokens} cacheRead=${response.usage.cacheReadTokens} turn=${turnCount}`);
         }
 
         // Emit chain-of-thought reasoning if present (e.g. Qwen / DeepSeek)
@@ -368,11 +387,7 @@ export class ReasoningLoop {
         return {
           taskId,
           result: reply,
-          usage: {
-            promptTokens: totalPromptTokens,
-            completionTokens: totalCompletionTokens,
-            totalTokens: totalPromptTokens + totalCompletionTokens,
-          },
+          usage: buildUsage(),
           thoughtStream,
           exitReason: 'success',
         };
@@ -386,7 +401,7 @@ export class ReasoningLoop {
         taskId,
         result: null,
         error: 'max_iterations_exceeded',
-        usage: { promptTokens: totalPromptTokens, completionTokens: totalCompletionTokens, totalTokens: totalPromptTokens + totalCompletionTokens },
+        usage: buildUsage(),
         thoughtStream,
         exitReason: 'max_iterations_exceeded',
       };
@@ -405,7 +420,7 @@ export class ReasoningLoop {
         taskId,
         result: null,
         error: errMsg,
-        usage: { promptTokens: totalPromptTokens, completionTokens: totalCompletionTokens, totalTokens: totalPromptTokens + totalCompletionTokens },
+        usage: buildUsage(),
         thoughtStream,
         exitReason,
       };

--- a/core/agent-runtime/src/manifest.ts
+++ b/core/agent-runtime/src/manifest.ts
@@ -31,6 +31,7 @@ export interface RuntimeManifest {
     provider: string;
     name: string;
     temperature?: number;
+    thinkingLevel?: string;
   };
   tools?: {
     allowed?: string[];

--- a/core/src/agents/identity/IdentityService.test.ts
+++ b/core/src/agents/identity/IdentityService.test.ts
@@ -196,5 +196,37 @@ describe('IdentityService', () => {
       // LLM from hallucinating tool calls — tools are provided via function-calling API
       expect(streamingPrompt).not.toContain('## Available Tools');
     });
+
+    it('should include Capabilities section with delegation and scheduling tools in streaming prompt', () => {
+      const manifest = {
+        kind: 'Agent',
+        metadata: { name: 'sera' },
+        identity: { role: 'assistant' },
+        tools: { allowed: ['delegate-task', 'schedule-task', 'knowledge-store', 'web-search'] },
+      } as unknown as AgentManifest;
+
+      const streamingPrompt = IdentityService.generateStreamingSystemPrompt(manifest);
+
+      // Available Tools is stripped, but Capabilities survives
+      expect(streamingPrompt).not.toContain('## Available Tools');
+      expect(streamingPrompt).toContain('## Capabilities');
+      expect(streamingPrompt).toContain('`delegate-task`');
+      expect(streamingPrompt).toContain('`schedule-task`');
+      expect(streamingPrompt).toContain('`knowledge-store`');
+      expect(streamingPrompt).toContain('Delegation');
+      expect(streamingPrompt).toContain('Scheduling');
+    });
+
+    it('should not include Capabilities section when no known tools are allowed', () => {
+      const manifest = {
+        kind: 'Agent',
+        metadata: { name: 'test-agent' },
+        identity: { role: 'tester' },
+        tools: { allowed: ['custom-unknown-tool'] },
+      } as unknown as AgentManifest;
+
+      const streamingPrompt = IdentityService.generateStreamingSystemPrompt(manifest);
+      expect(streamingPrompt).not.toContain('## Capabilities');
+    });
   });
 });

--- a/core/src/agents/identity/IdentityService.ts
+++ b/core/src/agents/identity/IdentityService.ts
@@ -85,6 +85,8 @@ export class IdentityService {
     }
 
     // ── Available Tools ───────────────────────────────────────────────────────
+    // Note: In streaming mode, this section is stripped (tools provided via
+    // function-calling API). The Capabilities section below survives.
     if (tools?.allowed && tools.allowed.length > 0) {
       const toolsList = tools.allowed.map((t) => `- ${t}`).join('\n');
       sections.push(`## Available Tools\n${toolsList}`);
@@ -93,6 +95,18 @@ export class IdentityService {
     if (tools?.denied && tools.denied.length > 0) {
       const deniedList = tools.denied.map((t) => `- ${t}`).join('\n');
       sections.push(`## Denied Tools (never use these)\n${deniedList}`);
+    }
+
+    // ── Capabilities (survives streaming-mode tool section stripping) ─────────
+    if (tools?.allowed && tools.allowed.length > 0) {
+      const capabilities = IdentityService.buildCapabilitySummary(tools.allowed);
+      if (capabilities.length > 0) {
+        sections.push(
+          `## Capabilities\n` +
+            `You have these capabilities available as function-calling tools:\n` +
+            capabilities.join('\n')
+        );
+      }
     }
 
     // ── Skills ────────────────────────────────────────────────────────────────
@@ -192,5 +206,67 @@ export class IdentityService {
       `fabricate tool calls in XML, JSON, or any other text format.\n`;
 
     return withFormat + stabilityGuidelines;
+  }
+
+  // ── Capability mapping ─────────────────────────────────────────────────────
+
+  /** Maps tool IDs to human-readable capability descriptions for the system prompt. */
+  private static readonly CAPABILITY_MAP: Record<
+    string,
+    { category: string; description: string }
+  > = {
+    'delegate-task': {
+      category: 'Delegation',
+      description: 'assign work to other agents or spawn ephemeral helpers',
+    },
+    'schedule-task': {
+      category: 'Scheduling',
+      description: 'create reminders, recurring jobs, and scheduled tasks',
+    },
+    'knowledge-store': {
+      category: 'Knowledge',
+      description: 'save important facts, decisions, and context to persistent memory',
+    },
+    'knowledge-query': {
+      category: 'Knowledge',
+      description: 'retrieve relevant context from persistent memory',
+    },
+    'web-search': { category: 'Web', description: 'search the web for current information' },
+    'web-fetch': { category: 'Web', description: 'fetch and read web page content' },
+    'file-read': { category: 'Files', description: 'read file contents from the workspace' },
+    'file-write': { category: 'Files', description: 'create or update files in the workspace' },
+    'file-list': { category: 'Files', description: 'list directory contents' },
+    'file-delete': { category: 'Files', description: 'delete files or directories' },
+    'shell-exec': { category: 'Shell', description: 'execute shell commands in the workspace' },
+    'spawn-subagent': {
+      category: 'Delegation',
+      description: 'spawn a child agent in a separate container',
+    },
+    'run-tool': {
+      category: 'Tools',
+      description: 'run an ephemeral tool in an isolated container',
+    },
+  };
+
+  /**
+   * Build capability summary lines from a list of allowed tool IDs.
+   * Groups by category and deduplicates.
+   */
+  private static buildCapabilitySummary(allowedTools: string[]): string[] {
+    const seen = new Set<string>();
+    const lines: string[] = [];
+
+    for (const toolId of allowedTools) {
+      const mapping = IdentityService.CAPABILITY_MAP[toolId];
+      if (!mapping) continue;
+
+      const key = `${mapping.category}:${toolId}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+
+      lines.push(`- **${mapping.category}**: Use \`${toolId}\` to ${mapping.description}`);
+    }
+
+    return lines;
   }
 }

--- a/core/src/llm/LlmRouter.ts
+++ b/core/src/llm/LlmRouter.ts
@@ -60,6 +60,8 @@ export interface ChatCompletionRequest {
   temperature?: number;
   tools?: unknown[];
   stream?: boolean;
+  /** Thinking/reasoning level for capable models (maps to pi-mono reasoning option). */
+  thinkingLevel?: string;
 }
 
 export interface ChatCompletionUsage {
@@ -396,6 +398,21 @@ export class LlmRouter {
    * Heuristic: detect whether a model name indicates a reasoning/thinking model.
    * These models separate reasoning_content from content in streaming.
    */
+  /**
+   * Map agent-facing thinking level names to pi-mono ThinkingLevel values.
+   * 'off' is handled before this is called (not passed to pi-mono).
+   */
+  private static mapThinkingLevel(level: string): string {
+    const mapping: Record<string, string> = {
+      minimal: 'minimal',
+      low: 'low',
+      medium: 'medium',
+      high: 'high',
+      max: 'xhigh',
+    };
+    return mapping[level] ?? 'medium';
+  }
+
   private static isReasoningModel(modelName: string): boolean {
     const lower = modelName.toLowerCase();
     return (
@@ -470,6 +487,9 @@ export class LlmRouter {
     const context = toContext(request);
     const opts: StreamOptions = {
       ...(request.temperature !== undefined ? { temperature: request.temperature } : {}),
+      ...(request.thinkingLevel
+        ? { reasoning: LlmRouter.mapThinkingLevel(request.thinkingLevel) }
+        : {}),
     };
 
     const eventStream = this.dispatch(config, context, opts);
@@ -494,6 +514,9 @@ export class LlmRouter {
     const context = toContext(request);
     const opts: StreamOptions = {
       ...(request.temperature !== undefined ? { temperature: request.temperature } : {}),
+      ...(request.thinkingLevel
+        ? { reasoning: LlmRouter.mapThinkingLevel(request.thinkingLevel) }
+        : {}),
     };
 
     const eventStream = this.dispatch(config, context, opts);

--- a/core/src/routes/llmProxy.ts
+++ b/core/src/routes/llmProxy.ts
@@ -118,7 +118,7 @@ export function createLlmProxyRouter(
 
       // ── 2. Validate request body ───────────────────────────────────────────
       const body = req.body as Record<string, unknown>;
-      const { model, temperature, tools, stream } = body;
+      const { model, temperature, tools, stream, thinking_level: thinkingLevel } = body;
       let messages = body['messages'] as import('../agents/types.js').ChatMessage[] | undefined;
 
       if (!messages || !Array.isArray(messages) || messages.length === 0) {
@@ -172,6 +172,7 @@ export function createLlmProxyRouter(
         messages: messages as unknown as import('../llm/LlmRouter.js').ChatMessage[],
         ...(temperature !== undefined ? { temperature: temperature as number } : {}),
         ...(Array.isArray(tools) ? { tools: tools as unknown[] } : {}),
+        ...(thinkingLevel ? { thinkingLevel: thinkingLevel as string } : {}),
       };
 
       // ── 3. Streaming path ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- **#533 Fix Sera delegation bug**: Add `## Capabilities` section to IdentityService system prompt that maps tool names to human-readable descriptions (e.g., "Use `delegate-task` to assign work to other agents"). This section survives the streaming-mode stripping of `## Available Tools`, so the LLM knows about delegation/scheduling capabilities even when tools are provided only via function-calling API.
- **#547 Cache-aware usage tracking**: `LLMResponse.usage` now includes `cacheCreationTokens` and `cacheReadTokens` from the OpenAI-compat response. `TaskOutput.usage` extended with cache fields and `turns` count. Per-turn accumulation in loop.ts.
- **#508 Configurable thinking levels**: `manifest.model.thinkingLevel` (off/minimal/low/medium/high/max) flows end-to-end through `llmClient` → `llmProxy` → `LlmRouter` → pi-mono `StreamOptions.reasoning`. Enables per-agent control of extended thinking for Claude, o1/o3, Qwen3, DeepSeek-R1.

## Test plan
- [x] 2 new IdentityService tests: Capabilities section present with known tools, absent for unknown tools
- [x] All 130 agent-runtime tests pass (including updated usage type in test helpers)
- [x] All 22 IdentityService + SkillInjector tests pass
- [x] Full CI: 772 tests, typecheck, lint, format, build all green

Closes #533, closes #547, closes #508

🤖 Generated with [Claude Code](https://claude.com/claude-code)