### PR TITLE
Reduce aggressive polling intervals on web dashboard hooks

### DIFF
--- a/web/src/hooks/useAgents.ts
+++ b/web/src/hooks/useAgents.ts
@@ -47,7 +47,7 @@ export function useAgentLogs(id: string) {
     queryKey: agentsKeys.logs(id),
     queryFn: () => agentsApi.getAgentLogs(id),
     enabled: id.length > 0,
-    refetchInterval: 3000,
+    refetchInterval: 15000,
   });
 }
 
@@ -205,7 +205,7 @@ export function usePermissionRequests(agentId?: string) {
   return useQuery({
     queryKey: agentsKeys.permissionRequests(agentId),
     queryFn: () => agentsApi.listPermissionRequests(agentId),
-    refetchInterval: 5000,
+    refetchInterval: 15000,
   });
 }
 

--- a/web/src/hooks/useProviders.ts
+++ b/web/src/hooks/useProviders.ts
@@ -44,7 +44,7 @@ export function useDynamicProviderStatuses() {
   return useQuery({
     queryKey: providersKeys.dynamicProviderStatuses,
     queryFn: getDynamicProviderStatuses,
-    refetchInterval: 10000, // Refresh statuses every 10s
+    refetchInterval: 15000, // Refresh statuses every 15s
   });
 }
 

--- a/web/src/lib/query-client.ts
+++ b/web/src/lib/query-client.ts
@@ -5,7 +5,7 @@ export const queryClient = new QueryClient({
     queries: {
       staleTime: 30_000,
       retry: 2,
-      refetchOnWindowFocus: true,
+      refetchOnWindowFocus: false,
     },
     mutations: {
       retry: 0,


### PR DESCRIPTION
I have optimized the performance of the web dashboard by reducing the frequency of background data fetching.

Key changes:
- **Global Query Configuration:** In `web/src/lib/query-client.ts`, I've set `refetchOnWindowFocus` to `false`. This prevents the application from automatically refetching all active queries every time the user switches back to the dashboard tab, which is particularly useful for reducing sudden spikes in API requests.
- **Hook-specific Optimizations:**
    - `useAgentLogs` (in `web/src/hooks/useAgents.ts`): Increased `refetchInterval` from 3 seconds to 15 seconds.
    - `usePermissionRequests` (in `web/src/hooks/useAgents.ts`): Increased `refetchInterval` from 5 seconds to 15 seconds.
    - `useDynamicProviderStatuses` (in `web/src/hooks/useProviders.ts`): Increased `refetchInterval` from 10 seconds to 15 seconds.

These changes significantly reduce the cumulative request volume when multiple dashboard pages are open, while still maintaining a reasonable level of freshness for the user interface. I've verified the changes by running type checking, linting, and the existing test suite in the web workspace, all of which passed.

Fixes #496

---
*PR created automatically by Jules for task [5338720204517879288](https://jules.google.com/task/5338720204517879288) started by @TKCen*