### PR TITLE
feat(agent-runtime): Interface-based agent loop for testability

### DIFF
--- a/core/agent-runtime/src/__tests__/loop.test.ts
+++ b/core/agent-runtime/src/__tests__/loop.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ReasoningLoop } from '../loop.js';
+import { ScriptedLLMClient, StaticToolExecutor, createMockPublisher } from './testHelpers.js';
+import type { RuntimeManifest } from '../manifest.js';
+import type { ToolDefinition } from '../llmClient.js';
+
+describe('ReasoningLoop E2E', () => {
+  const mockManifest: RuntimeManifest = {
+    apiVersion: 'sera.io/v1',
+    kind: 'Agent',
+    metadata: {
+      name: 'test-agent',
+      displayName: 'Test Agent',
+      icon: 'bot',
+      circle: 'test',
+      tier: 2,
+    },
+    identity: {
+      role: 'Tester',
+      description: 'An agent for testing',
+    },
+    model: {
+      provider: 'openai',
+      name: 'gpt-4o',
+      temperature: 0,
+    },
+    tools: { allowed: ['echo'] },
+  };
+
+  const echoTool: ToolDefinition = {
+    type: 'function',
+    function: {
+      name: 'echo',
+      description: 'Echo back input',
+      parameters: {
+        type: 'object',
+        properties: { text: { type: 'string' } },
+        required: ['text'],
+      },
+    },
+  };
+
+  it('completes basic turn with text response', async () => {
+    const llm = new ScriptedLLMClient([
+      { content: 'Hello, how can I help you today?' },
+    ]);
+    const tools = new StaticToolExecutor();
+    const publisher = createMockPublisher();
+    const loop = new ReasoningLoop(llm, tools, publisher, mockManifest);
+
+    const output = await loop.run({
+      taskId: 'task-1',
+      task: 'Say hello',
+    });
+
+    expect(output.result).toBe('Hello, how can I help you today?');
+    expect(output.exitReason).toBe('success');
+    expect(llm.getCallCount()).toBe(1);
+    expect(publisher.publishThought).toHaveBeenCalledWith('observe', expect.stringContaining('Received task'), 0, undefined);
+  });
+
+  it('handles tool call cycle', async () => {
+    const llm = new ScriptedLLMClient([
+      {
+        content: 'I will echo that.',
+        toolCalls: [
+          { id: 'call_1', type: 'function', function: { name: 'echo', arguments: '{"text": "hello"}' } },
+        ],
+      },
+      { content: 'Echoed: hello' },
+    ]);
+    const tools = new StaticToolExecutor().register(echoTool, (args) => {
+      const parsed = JSON.parse(args);
+      return parsed.text;
+    });
+    const publisher = createMockPublisher();
+    const loop = new ReasoningLoop(llm, tools, publisher, mockManifest);
+
+    const output = await loop.run({
+      taskId: 'task-2',
+      task: 'Echo hello',
+    });
+
+    expect(output.result).toBe('Echoed: hello');
+    expect(output.exitReason).toBe('success');
+    expect(llm.getCallCount()).toBe(2);
+    expect(publisher.publishThought).toHaveBeenCalledWith('act', expect.stringContaining('Calling tool: echo'), 1, expect.any(Object));
+    expect(publisher.publishThought).toHaveBeenCalledWith('reflect', expect.stringContaining('Tool result: hello'), 1, undefined);
+  });
+
+  it('handles unknown tool call by returning error to LLM', async () => {
+    const llm = new ScriptedLLMClient([
+      {
+        content: 'Trying unknown tool.',
+        toolCalls: [
+          { id: 'call_2', type: 'function', function: { name: 'unknown', arguments: '{}' } },
+        ],
+      },
+      { content: 'It failed as expected.' },
+    ]);
+    const tools = new StaticToolExecutor();
+    const publisher = createMockPublisher();
+    const loop = new ReasoningLoop(llm, tools, publisher, mockManifest);
+
+    const output = await loop.run({
+      taskId: 'task-3',
+      task: 'Call unknown tool',
+    });
+
+    expect(output.result).toBe('It failed as expected.');
+    expect(llm.getCallCount()).toBe(2);
+    expect(publisher.publishThought).toHaveBeenCalledWith('reflect', expect.stringContaining('Tool result: Error: Unknown tool "unknown"'), 1, undefined);
+  });
+});

--- a/core/agent-runtime/src/__tests__/testHelpers.ts
+++ b/core/agent-runtime/src/__tests__/testHelpers.ts
@@ -1,0 +1,89 @@
+import { vi } from 'vitest';
+import type { ILLMClient, ChatMessage, ToolDefinition, LLMResponse, ThinkingLevel } from '../llmClient.js';
+import type { IToolExecutor, ToolExecutionResult } from '../tools/executor.js';
+import type { CentrifugoPublisher } from '../centrifugo.js';
+
+/**
+ * ScriptedLLMClient returns a sequence of pre-defined responses.
+ */
+export class ScriptedLLMClient implements ILLMClient {
+  private callCount = 0;
+  constructor(private responses: LLMResponse[]) {}
+
+  async chat(
+    _messages: ChatMessage[],
+    _tools?: ToolDefinition[],
+    _temperature?: number,
+    _thinkingLevel?: ThinkingLevel,
+  ): Promise<LLMResponse> {
+    const response = this.responses[this.callCount];
+    if (!response) {
+      throw new Error(`ScriptedLLMClient: No more responses defined (call count: ${this.callCount})`);
+    }
+    this.callCount++;
+    return response;
+  }
+
+  getCallCount(): number {
+    return this.callCount;
+  }
+}
+
+/**
+ * StaticToolExecutor allows registering manual handlers for specific tool names.
+ */
+export class StaticToolExecutor implements IToolExecutor {
+  private handlers = new Map<string, (args: string) => string | Promise<string>>();
+  private toolDefinitions: ToolDefinition[] = [];
+
+  register(
+    definition: ToolDefinition,
+    handler: (args: string) => string | Promise<string>
+  ): this {
+    this.toolDefinitions.push(definition);
+    this.handlers.set(definition.function.name, handler);
+    return this;
+  }
+
+  getToolDefinitions(allowedTools?: string[]): ToolDefinition[] {
+    if (!allowedTools || allowedTools.length === 0) {
+      return this.toolDefinitions;
+    }
+    return this.toolDefinitions.filter((t) => allowedTools.includes(t.function.name));
+  }
+
+  async executeToolCalls(toolCalls: ToolCall[]): Promise<ToolExecutionResult[]> {
+    const results: ToolExecutionResult[] = [];
+    for (const tc of toolCalls) {
+      const handler = this.handlers.get(tc.function.name);
+      let content: string;
+      if (!handler) {
+        content = `Error: Unknown tool "${tc.function.name}"`;
+      } else {
+        try {
+          content = await handler(tc.function.arguments);
+        } catch (err) {
+          content = `Error: ${err instanceof Error ? err.message : String(err)}`;
+        }
+      }
+      results.push({
+        message: { role: 'tool', tool_call_id: tc.id, content },
+        toolName: tc.function.name,
+        argRepaired: false,
+        repairStrategy: null,
+      });
+    }
+    return results;
+  }
+}
+
+/**
+ * Minimal mock for CentrifugoPublisher.
+ */
+export function createMockPublisher(): CentrifugoPublisher {
+  return {
+    publish: vi.fn().mockResolvedValue(undefined),
+    publishThought: vi.fn().mockResolvedValue(undefined),
+    publishStreamToken: vi.fn().mockResolvedValue(undefined),
+  } as unknown as CentrifugoPublisher;
+}

--- a/core/agent-runtime/src/llmClient.ts
+++ b/core/agent-runtime/src/llmClient.ts
@@ -92,9 +92,20 @@ export interface LLMResponse {
   };
 }
 
+// ── Interface ─────────────────────────────────────────────────────────────────
+
+export interface ILLMClient {
+  chat(
+    messages: ChatMessage[],
+    tools?: ToolDefinition[],
+    temperature?: number,
+    thinkingLevel?: ThinkingLevel,
+  ): Promise<LLMResponse>;
+}
+
 // ── Client ────────────────────────────────────────────────────────────────────
 
-export class LLMClient {
+export class LLMClient implements ILLMClient {
   private http: AxiosInstance;
   private model: string;
 

--- a/core/agent-runtime/src/loop.ts
+++ b/core/agent-runtime/src/loop.ts
@@ -5,9 +5,9 @@
  * and returns a structured result with usage stats.
  */
 
-import type { LLMClient, ChatMessage, ToolDefinition, LLMResponse, ThinkingLevel } from './llmClient.js';
+import type { ILLMClient, ChatMessage, ToolDefinition, LLMResponse, ThinkingLevel } from './llmClient.js';
 import { BudgetExceededError, ProviderUnavailableError, ContextOverflowError, LLMTimeoutError } from './llmClient.js';
-import type { RuntimeToolExecutor } from './tools/index.js';
+import type { IToolExecutor } from './tools/index.js';
 import type { CentrifugoPublisher } from './centrifugo.js';
 import type { RuntimeManifest } from './manifest.js';
 import { generateSystemPrompt } from './manifest.js';
@@ -57,8 +57,8 @@ interface RetryState {
 // ── ReasoningLoop ─────────────────────────────────────────────────────────────
 
 export class ReasoningLoop {
-  private llm: LLMClient;
-  private tools: RuntimeToolExecutor;
+  private llm: ILLMClient;
+  private tools: IToolExecutor;
   private centrifugo: CentrifugoPublisher;
   private manifest: RuntimeManifest;
   private systemPrompt: string;
@@ -69,8 +69,8 @@ export class ReasoningLoop {
   shutdownRequested = false;
 
   constructor(
-    llm: LLMClient,
-    tools: RuntimeToolExecutor,
+    llm: ILLMClient,
+    tools: IToolExecutor,
     centrifugo: CentrifugoPublisher,
     manifest: RuntimeManifest,
   ) {

--- a/core/agent-runtime/src/tools/executor.ts
+++ b/core/agent-runtime/src/tools/executor.ts
@@ -34,6 +34,13 @@ export const WRITE_TOOLS = new Set(['file-write', 'file-delete', 'shell-exec']);
 
 const DEFAULT_MAX_TOOL_CONCURRENCY = 4;
 
+// ── Interface ─────────────────────────────────────────────────────────────────
+
+export interface IToolExecutor {
+  getToolDefinitions(allowedTools?: string[]): ToolDefinition[];
+  executeToolCalls(toolCalls: ToolCall[]): Promise<ToolExecutionResult[]>;
+}
+
 // ── Semaphore for concurrency control ────────────────────────────────────────
 
 class Semaphore {
@@ -50,7 +57,7 @@ class Semaphore {
   }
 }
 
-export class RuntimeToolExecutor {
+export class RuntimeToolExecutor implements IToolExecutor {
   private workspacePath: string;
   private tier: number;
   /** Remote tools fetched from core's catalog. */

--- a/core/agent-runtime/src/tools/index.ts
+++ b/core/agent-runtime/src/tools/index.ts
@@ -5,6 +5,6 @@
  */
 
 export { RuntimeToolExecutor } from './executor.js';
-export type { ToolExecutionResult } from './executor.js';
+export type { ToolExecutionResult, IToolExecutor } from './executor.js';
 export { BUILTIN_TOOLS } from './definitions.js';
 export { PermissionDeniedError, NotPermittedError } from './types.js';


### PR DESCRIPTION
This PR refactors the agent's reasoning loop in `core/agent-runtime` to use an interface-based approach, greatly improving testability. 

Key changes:
- **Interfaces**: `ILLMClient` (in `llmClient.ts`) and `IToolExecutor` (in `executor.ts`) now define the contracts for the LLM and tool execution.
- **Dependency Injection**: `ReasoningLoop` now accepts these interfaces in its constructor, allowing for easy mocking/stubbing in tests.
- **Test Helpers**: New `ScriptedLLMClient` and `StaticToolExecutor` classes in `src/__tests__/testHelpers.ts` allow for precise, turn-by-turn control of LLM responses and tool results during testing.
- **Verification**: New E2E tests in `src/__tests__/loop.test.ts` demonstrate and verify the loop's behavior in various scenarios (basic turns, tool calls, and error cases).

These changes follow the trait-based pattern observed in related projects and unlock robust unit testing for the agent's core reasoning logic.

Fixes #543

---
*PR created automatically by Jules for task [2188998567120810415](https://jules.google.com/task/2188998567120810415) started by @TKCen*