### PR TITLE
Add DELETE endpoint for memory blocks

### DIFF
--- a/core/src/memory/blocks/ScopedMemoryBlockStore.ts
+++ b/core/src/memory/blocks/ScopedMemoryBlockStore.ts
@@ -300,6 +300,29 @@ export class ScopedMemoryBlockStore {
     return results;
   }
 
+  /** Delete a block from the archive directory. */
+  async deleteArchive(agentId: string, id: string): Promise<boolean> {
+    const archiveDir = path.join(this.memoryRoot, agentId, 'archive');
+    let files: string[];
+    try {
+      files = await fs.readdir(archiveDir);
+    } catch {
+      return false;
+    }
+    for (const file of files) {
+      if (!file.endsWith('.md') || !file.includes(id)) continue;
+      const filePath = path.join(archiveDir, file);
+      const raw = await fs.readFile(filePath, 'utf8').catch(() => null);
+      if (!raw) continue;
+      const block = this.parse(raw, filePath);
+      if (block?.id === id) {
+        await fs.unlink(filePath);
+        return true;
+      }
+    }
+    return false;
+  }
+
   /** List all agent IDs that have memory directories. */
   async listAgentIds(): Promise<string[]> {
     let entries: string[];

--- a/core/src/routes/memory.test.ts
+++ b/core/src/routes/memory.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+import { createMemoryRouter } from './memory.js';
+
+// Mock dependencies
+const mockMemoryManager = {
+  deleteEntry: vi.fn(),
+};
+
+const mockScopedStore = {
+  delete: vi.fn(),
+  deleteArchive: vi.fn(),
+  listAgentIds: vi.fn().mockResolvedValue([]),
+};
+
+const mockVectorService = {
+  delete: vi.fn(),
+};
+
+// We need to mock the constructor of ScopedMemoryBlockStore and VectorService inside the router file
+// or just mock the entire modules if we want to control the instances created inside createMemoryRouter.
+// Since createMemoryRouter instantiates them internally, we'll mock the modules.
+
+vi.mock('../memory/blocks/ScopedMemoryBlockStore.js', () => {
+  return {
+    ScopedMemoryBlockStore: vi.fn().mockImplementation(function() {
+      return mockScopedStore;
+    }),
+  };
+});
+
+vi.mock('../services/vector.service.js', () => {
+  return {
+    VectorService: vi.fn().mockImplementation(function() {
+      return mockVectorService;
+    }),
+  };
+});
+
+describe('Memory Routes DELETE', () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = express();
+    app.use(express.json());
+    app.use('/api/memory', createMemoryRouter(mockMemoryManager as any));
+  });
+
+  describe('DELETE /api/memory/entries/:id', () => {
+    it('returns 204 on successful deletion', async () => {
+      mockMemoryManager.deleteEntry.mockResolvedValue(true);
+      const res = await request(app).delete('/api/memory/entries/entry-123');
+      expect(res.status).toBe(204);
+      expect(mockMemoryManager.deleteEntry).toHaveBeenCalledWith('entry-123');
+    });
+
+    it('returns 404 when entry not found', async () => {
+      mockMemoryManager.deleteEntry.mockResolvedValue(false);
+      const res = await request(app).delete('/api/memory/entries/non-existent');
+      expect(res.status).toBe(404);
+    });
+
+    it('returns 500 on error', async () => {
+      mockMemoryManager.deleteEntry.mockRejectedValue(new Error('Store error'));
+      const res = await request(app).delete('/api/memory/entries/error-id');
+      expect(res.status).toBe(500);
+      expect(res.body.error).toBe('Store error');
+    });
+  });
+
+  describe('DELETE /api/memory/:agentId/blocks/:id', () => {
+    const agentId = 'agent-456';
+    const blockId = 'block-789';
+
+    it('returns 204 when deleted from active store', async () => {
+      mockScopedStore.delete.mockResolvedValue(true);
+      const res = await request(app).delete(`/api/memory/${agentId}/blocks/${blockId}`);
+
+      expect(res.status).toBe(204);
+      expect(mockScopedStore.delete).toHaveBeenCalledWith(agentId, blockId);
+      expect(mockVectorService.delete).toHaveBeenCalledWith(blockId, `personal:${agentId}`);
+    });
+
+    it('returns 204 when deleted from archive store', async () => {
+      mockScopedStore.delete.mockResolvedValue(false);
+      mockScopedStore.deleteArchive.mockResolvedValue(true);
+      const res = await request(app).delete(`/api/memory/${agentId}/blocks/${blockId}`);
+
+      expect(res.status).toBe(204);
+      expect(mockScopedStore.delete).toHaveBeenCalledWith(agentId, blockId);
+      expect(mockScopedStore.deleteArchive).toHaveBeenCalledWith(agentId, blockId);
+      expect(mockVectorService.delete).toHaveBeenCalledWith(blockId, `personal:${agentId}`);
+    });
+
+    it('handles global namespace correctly', async () => {
+      mockScopedStore.delete.mockResolvedValue(true);
+      const res = await request(app).delete(`/api/memory/global/blocks/${blockId}`);
+
+      expect(res.status).toBe(204);
+      expect(mockVectorService.delete).toHaveBeenCalledWith(blockId, 'global');
+    });
+
+    it('handles circle namespace correctly', async () => {
+      const circleId = 'circle:123';
+      mockScopedStore.delete.mockResolvedValue(true);
+      const res = await request(app).delete(`/api/memory/${circleId}/blocks/${blockId}`);
+
+      expect(res.status).toBe(204);
+      expect(mockVectorService.delete).toHaveBeenCalledWith(blockId, circleId);
+    });
+
+    it('returns 404 when not found in active or archive', async () => {
+      mockScopedStore.delete.mockResolvedValue(false);
+      mockScopedStore.deleteArchive.mockResolvedValue(false);
+      const res = await request(app).delete(`/api/memory/${agentId}/blocks/${blockId}`);
+
+      expect(res.status).toBe(404);
+      expect(mockVectorService.delete).not.toHaveBeenCalled();
+    });
+
+    it('returns 500 on error', async () => {
+      mockScopedStore.delete.mockRejectedValue(new Error('File system error'));
+      const res = await request(app).delete(`/api/memory/${agentId}/blocks/${blockId}`);
+      expect(res.status).toBe(500);
+    });
+  });
+});

--- a/core/src/routes/memory.ts
+++ b/core/src/routes/memory.ts
@@ -63,6 +63,16 @@ export function createMemoryRouter(memoryManager: MemoryManager) {
     }
   });
 
+  router.delete('/entries/:id', async (req, res) => {
+    try {
+      const deleted = await memoryManager.deleteEntry(req.params.id);
+      if (!deleted) return res.status(404).json({ error: 'Entry not found' });
+      res.status(204).end();
+    } catch (err: unknown) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
   router.get('/graph', async (_req, res) => {
     try {
       // Build graph from Epic 8 scoped blocks instead of legacy Letta-style graph
@@ -455,6 +465,36 @@ export function createMemoryRouter(memoryManager: MemoryManager) {
         }
       }
       res.json(backlinks);
+    } catch (err: unknown) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  /** DELETE /api/memory/:agentId/blocks/:id — delete a block */
+  router.delete('/:agentId/blocks/:id', async (req, res) => {
+    try {
+      const { agentId, id } = req.params;
+      let deleted = await scopedStore.delete(agentId, id);
+      if (!deleted) {
+        deleted = await scopedStore.deleteArchive(agentId, id);
+      }
+
+      if (!deleted) {
+        res.status(404).json({ error: 'Block not found' });
+        return;
+      }
+
+      // Cleanup vector store
+      const namespace: MemoryNamespace =
+        agentId === 'global'
+          ? 'global'
+          : agentId.startsWith('circle:')
+            ? (agentId as MemoryNamespace)
+            : (`personal:${agentId}` as MemoryNamespace);
+
+      await vectorService.delete(id, namespace);
+
+      res.status(204).end();
     } catch (err: unknown) {
       res.status(500).json({ error: (err as Error).message });
     }


### PR DESCRIPTION
Added DELETE endpoints for legacy and scoped memory blocks, including vector store cleanup and archive deletion support.

Fixes #465

---
*PR created automatically by Jules for task [2088777842681199683](https://jules.google.com/task/2088777842681199683) started by @TKCen*