### PR TITLE
feat(agent-runtime): implement pre/post tool execution hooks

### DIFF
--- a/core/agent-runtime/src/__tests__/hooks.test.ts
+++ b/core/agent-runtime/src/__tests__/hooks.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { HookRunner } from '../hooks.js';
+import { spawnSync } from 'child_process';
+
+vi.mock('child_process', () => ({
+  spawnSync: vi.fn(),
+}));
+
+describe('HookRunner', () => {
+  const runner = new HookRunner('/tmp');
+  const toolName = 'test-tool';
+  const toolInput = JSON.stringify({ arg1: 'val1' });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should allow execution when hook exits 0', async () => {
+    (spawnSync as any).mockReturnValue({
+      status: 0,
+      stdout: 'All good',
+      stderr: '',
+    });
+
+    const result = await runner.runHooks('PreToolUse', ['test-hook'], toolName, toolInput);
+
+    expect(result.allowed).toBe(true);
+    expect(result.feedback).toBe('All good');
+    expect(result.warning).toBeUndefined();
+    expect(spawnSync).toHaveBeenCalledWith('bash', ['-c', 'test-hook'], expect.any(Object));
+  });
+
+  it('should deny execution when hook exits 2', async () => {
+    (spawnSync as any).mockReturnValue({
+      status: 2,
+      stdout: 'Policy violation',
+      stderr: '',
+    });
+
+    const result = await runner.runHooks('PreToolUse', ['test-hook'], toolName, toolInput);
+
+    expect(result.allowed).toBe(false);
+    expect(result.feedback).toBe('Policy violation');
+  });
+
+  it('should treat other non-zero exits as warnings', async () => {
+    (spawnSync as any).mockReturnValue({
+      status: 1,
+      stdout: 'Be careful',
+      stderr: 'Some stderr',
+    });
+
+    const result = await runner.runHooks('PreToolUse', ['test-hook'], toolName, toolInput);
+
+    expect(result.allowed).toBe(true);
+    expect(result.warning).toBe('Be careful');
+    expect(result.feedback).toBeUndefined();
+  });
+
+  it('should combine feedback from multiple hooks', async () => {
+    (spawnSync as any)
+      .mockReturnValueOnce({ status: 0, stdout: 'Feedback 1' })
+      .mockReturnValueOnce({ status: 0, stdout: 'Feedback 2' });
+
+    const result = await runner.runHooks('PostToolUse', ['hook1', 'hook2'], toolName, toolInput, 'output');
+
+    expect(result.allowed).toBe(true);
+    expect(result.feedback).toBe('Feedback 1\nFeedback 2');
+  });
+
+  it('should combine warnings from multiple hooks', async () => {
+    (spawnSync as any)
+      .mockReturnValueOnce({ status: 1, stdout: 'Warning 1' })
+      .mockReturnValueOnce({ status: 3, stdout: 'Warning 2' });
+
+    const result = await runner.runHooks('PreToolUse', ['hook1', 'hook2'], toolName, toolInput);
+
+    expect(result.allowed).toBe(true);
+    expect(result.warning).toBe('Warning 1\nWarning 2');
+  });
+
+  it('should pass correct environment variables and stdin', async () => {
+    (spawnSync as any).mockReturnValue({ status: 0 });
+
+    await runner.runHooks('PostToolUse', ['test-hook'], toolName, toolInput, 'some-output', true);
+
+    expect(spawnSync).toHaveBeenCalledWith(
+      'bash',
+      ['-c', 'test-hook'],
+      expect.objectContaining({
+        input: JSON.stringify({
+          event: 'PostToolUse',
+          toolName,
+          toolInput: { arg1: 'val1' },
+          toolOutput: 'some-output',
+          isError: true,
+        }),
+        env: expect.objectContaining({
+          HOOK_EVENT: 'PostToolUse',
+          HOOK_TOOL_NAME: toolName,
+          HOOK_TOOL_INPUT: toolInput,
+          HOOK_TOOL_OUTPUT: 'some-output',
+          HOOK_TOOL_IS_ERROR: '1',
+        }),
+      })
+    );
+  });
+
+  it('should not crash if hook fails to spawn', async () => {
+    (spawnSync as any).mockImplementation(() => {
+      throw new Error('Spawn failed');
+    });
+
+    const result = await runner.runHooks('PreToolUse', ['test-hook'], toolName, toolInput);
+
+    expect(result.allowed).toBe(true);
+    expect(result.feedback).toBeUndefined();
+  });
+
+  it('should handle JSON in tool output for stdin payload', async () => {
+    (spawnSync as any).mockReturnValue({ status: 0 });
+    const jsonOutput = JSON.stringify({ res: 'ok' });
+
+    await runner.runHooks('PostToolUse', ['test-hook'], toolName, toolInput, jsonOutput);
+
+    const call = (spawnSync as any).mock.calls[0];
+    const payload = JSON.parse(call[2].input);
+    expect(payload.toolOutput).toEqual({ res: 'ok' });
+  });
+});

--- a/core/agent-runtime/src/hooks.ts
+++ b/core/agent-runtime/src/hooks.ts
@@ -1,0 +1,113 @@
+/**
+ * HookRunner — executes pre- and post-tool execution hooks.
+ *
+ * Hooks are shell commands defined in the agent manifest that can
+ * deny execution (PreToolUse), warn, or provide additional feedback.
+ */
+
+import { spawnSync } from 'child_process';
+import { log } from './logger.js';
+
+export type HookEvent = 'PreToolUse' | 'PostToolUse';
+
+export interface HookRunResult {
+  allowed: boolean;
+  feedback?: string;
+  warning?: string;
+}
+
+export class HookRunner {
+  private workspacePath: string;
+
+  constructor(workspacePath: string = '/workspace') {
+    this.workspacePath = workspacePath;
+  }
+
+  /**
+   * Execute a set of hooks for a given event.
+   */
+  async runHooks(
+    event: HookEvent,
+    hooks: string[],
+    toolName: string,
+    toolInput: string,
+    toolOutput?: string,
+    isError: boolean = false
+  ): Promise<HookRunResult> {
+    let combinedFeedback = '';
+    let combinedWarning = '';
+
+    for (const hookCmd of hooks) {
+      try {
+        const payload = JSON.stringify({
+          event,
+          toolName,
+          toolInput: JSON.parse(toolInput),
+          toolOutput: toolOutput ? (this.isJson(toolOutput) ? JSON.parse(toolOutput) : toolOutput) : undefined,
+          isError,
+        });
+
+        const env = {
+          ...process.env,
+          HOOK_EVENT: event,
+          HOOK_TOOL_NAME: toolName,
+          HOOK_TOOL_INPUT: toolInput,
+          HOOK_TOOL_OUTPUT: toolOutput || '',
+          HOOK_TOOL_IS_ERROR: isError ? '1' : '0',
+        };
+
+        const result = spawnSync('bash', ['-c', hookCmd], {
+          cwd: this.workspacePath,
+          input: payload,
+          env,
+          encoding: 'utf-8',
+          timeout: 30_000,
+        });
+
+        const stdout = result.stdout?.trim() || '';
+        const stderr = result.stderr?.trim() || '';
+        const exitCode = result.status ?? -1;
+
+        if (exitCode === 2) {
+          // Deny (only relevant for PreToolUse, but we respect it for both)
+          log('info', `Hook ${event} denied by ${hookCmd}: ${stdout || 'No reason provided'}`);
+          return {
+            allowed: false,
+            feedback: stdout || 'Tool execution denied by policy hook.',
+          };
+        }
+
+        if (exitCode !== 0) {
+          // Warning
+          log('warn', `Hook ${event} warning from ${hookCmd} (exit ${exitCode}): ${stdout} ${stderr}`);
+          if (stdout) {
+            combinedWarning += (combinedWarning ? '\n' : '') + stdout;
+          }
+        } else {
+          // Allow / Success
+          if (stdout) {
+            combinedFeedback += (combinedFeedback ? '\n' : '') + stdout;
+          }
+        }
+      } catch (err) {
+        log('error', `Failed to execute hook ${hookCmd}: ${err instanceof Error ? err.message : String(err)}`);
+        // We don't crash the loop if a hook fails to spawn
+      }
+    }
+
+    return {
+      allowed: true,
+      feedback: combinedFeedback || undefined,
+      warning: combinedWarning || undefined,
+    };
+  }
+
+  private isJson(str: string): boolean {
+    try {
+      JSON.parse(str);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/core/agent-runtime/src/loop.ts
+++ b/core/agent-runtime/src/loop.ts
@@ -13,6 +13,7 @@ import type { RuntimeManifest } from './manifest.js';
 import { generateSystemPrompt } from './manifest.js';
 import { ContextManager } from './contextManager.js';
 import { ToolLoopDetector } from './toolLoopDetector.js';
+import { HookRunner } from './hooks.js';
 import { log } from './logger.js';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -64,6 +65,7 @@ export class ReasoningLoop {
   private systemPrompt: string;
   private toolDefs: ToolDefinition[];
   private contextManager: ContextManager;
+  private hookRunner: HookRunner;
 
   /** Set to true when SIGTERM received; loop exits after current step. */
   shutdownRequested = false;
@@ -81,6 +83,7 @@ export class ReasoningLoop {
     this.toolDefs = tools.getToolDefinitions(manifest.tools?.allowed);
     this.systemPrompt = generateSystemPrompt(manifest);
     this.contextManager = new ContextManager(manifest.model.name);
+    this.hookRunner = new HookRunner(process.env['WORKSPACE_PATH'] || '/workspace');
   }
 
   /**
@@ -340,7 +343,74 @@ export class ReasoningLoop {
           });
 
           // Execute tools and add results
-          const toolResults = await this.tools.executeToolCalls(response.toolCalls);
+          const preHooks = this.manifest.hooks?.preToolUse || [];
+          const postHooks = this.manifest.hooks?.postToolUse || [];
+
+          const toolResults: Array<Awaited<ReturnType<typeof this.tools.executeTool>>> = [];
+
+          for (const tc of response.toolCalls) {
+            const toolName = tc.function.name;
+            const toolInput = tc.function.arguments || '{}';
+
+            // 1. PreToolUse hooks
+            if (preHooks.length > 0) {
+              const preResult = await this.hookRunner.runHooks('PreToolUse', preHooks, toolName, toolInput);
+              if (!preResult.allowed) {
+                toolResults.push({
+                  message: {
+                    role: 'tool',
+                    tool_call_id: tc.id,
+                    content: `Error: Tool execution denied by policy hook.\n\n${preResult.feedback || ''}`.trim(),
+                  },
+                  toolName,
+                  argRepaired: false,
+                  repairStrategy: null,
+                });
+                continue;
+              }
+
+              // Pre-hook feedback/warning can be prepended or handled if needed
+              // For now, Claude Code architecture suggests merging into tool result.
+              // If it's a pre-hook allow with feedback, we store it to merge later.
+              (tc as any).hookFeedback = preResult.feedback;
+              (tc as any).hookWarning = preResult.warning;
+            }
+
+            // 2. Execute tool
+            const result = await this.tools.executeTool(tc);
+
+            // 3. PostToolUse hooks
+            if (postHooks.length > 0) {
+              const isError = result.message.content.startsWith('Error:');
+              const postResult = await this.hookRunner.runHooks(
+                'PostToolUse',
+                postHooks,
+                toolName,
+                toolInput,
+                result.message.content,
+                isError
+              );
+
+              // Merge post-hook feedback/warning
+              if (postResult.feedback || postResult.warning) {
+                const parts = [result.message.content];
+                if (postResult.feedback) parts.push(`\nHook feedback:\n${postResult.feedback}`);
+                if (postResult.warning) parts.push(`\nHook warning:\n${postResult.warning}`);
+                result.message.content = parts.join('\n');
+              }
+            }
+
+            // Merge pre-hook feedback/warning if any
+            if ((tc as any).hookFeedback || (tc as any).hookWarning) {
+              const parts = [result.message.content];
+              if ((tc as any).hookFeedback) parts.push(`\nPre-hook feedback:\n${(tc as any).hookFeedback}`);
+              if ((tc as any).hookWarning) parts.push(`\nPre-hook warning:\n${(tc as any).hookWarning}`);
+              result.message.content = parts.join('\n');
+            }
+
+            toolResults.push(result);
+          }
+
           for (const result of toolResults) {
             // 1. Per-result absolute cap (TOOL_OUTPUT_MAX_TOKENS)
             result.message.content = this.contextManager.truncateToolOutput(result.message.content);

--- a/core/agent-runtime/src/manifest.ts
+++ b/core/agent-runtime/src/manifest.ts
@@ -46,6 +46,10 @@ export interface RuntimeManifest {
       subscribe?: string[];
     };
   };
+  hooks?: {
+    preToolUse?: string[];
+    postToolUse?: string[];
+  };
 }
 
 /**
@@ -69,6 +73,7 @@ export function loadManifest(manifestPath: string): RuntimeManifest {
     if (spec['skills'] && !raw['skills']) raw['skills'] = spec['skills'];
     if (spec['memory'] && !raw['memory']) raw['memory'] = spec['memory'];
     if (spec['intercom'] && !raw['intercom']) raw['intercom'] = spec['intercom'];
+    if (spec['hooks'] && !raw['hooks']) raw['hooks'] = spec['hooks'];
   }
 
   const parsed = raw as unknown as RuntimeManifest;

--- a/core/agent-runtime/vitest.config.ts
+++ b/core/agent-runtime/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    exclude: ['node_modules', 'dist'],
+  },
+});


### PR DESCRIPTION
This change adds a hook system to the agent runtime that allows running shell commands before and after tool execution. Hooks can deny execution (exit 2), provide warnings (other non-zero), or allow execution (exit 0). Context is provided via environment variables and JSON on stdin. Hook feedback is merged into tool results. This follows the Claude Code hook architecture.

Fixes #544

---
*PR created automatically by Jules for task [7668830394704992052](https://jules.google.com/task/7668830394704992052) started by @TKCen*