### PR TITLE
Enhanced usage tracking with cache awareness

### DIFF
--- a/core/agent-runtime/src/__tests__/usage.test.ts
+++ b/core/agent-runtime/src/__tests__/usage.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import { UsageTracker, type TokenUsage } from '../usage.js';
+
+describe('UsageTracker', () => {
+  it('should start with zero usage', () => {
+    const tracker = new UsageTracker();
+    expect(tracker.turns()).toBe(0);
+    expect(tracker.totalTokens()).toBe(0);
+    expect(tracker.cumulativeUsage()).toEqual({
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheCreationInputTokens: 0,
+      cacheReadInputTokens: 0,
+    });
+  });
+
+  it('should record usage correctly', () => {
+    const tracker = new UsageTracker();
+    const usage: TokenUsage = {
+      inputTokens: 100,
+      outputTokens: 50,
+      cacheCreationInputTokens: 20,
+      cacheReadInputTokens: 10,
+    };
+
+    tracker.record(usage);
+    expect(tracker.turns()).toBe(1);
+    expect(tracker.totalTokens()).toBe(180);
+    expect(tracker.cumulativeUsage()).toEqual(usage);
+
+    tracker.record(usage);
+    expect(tracker.turns()).toBe(2);
+    expect(tracker.totalTokens()).toBe(360);
+    expect(tracker.cumulativeUsage()).toEqual({
+      inputTokens: 200,
+      outputTokens: 100,
+      cacheCreationInputTokens: 40,
+      cacheReadInputTokens: 20,
+    });
+  });
+
+  it('should estimate cost for known models', () => {
+    const tracker = new UsageTracker();
+    // 1M input, 1M output, 1M cacheRead
+    tracker.record({
+      inputTokens: 1_000_000,
+      outputTokens: 1_000_000,
+      cacheCreationInputTokens: 0,
+      cacheReadInputTokens: 1_000_000,
+    });
+
+    // GPT-4o: $2.50 (in) + $10.00 (out) + $1.25 (cacheRead) = $13.75
+    expect(tracker.estimatedCostUsd('gpt-4o')).toBeCloseTo(13.75, 2);
+
+    // Claude 3.5 Sonnet: $3.00 (in) + $15.00 (out) + $0.30 (cacheRead) = $18.30
+    expect(tracker.estimatedCostUsd('claude-3-5-sonnet')).toBeCloseTo(18.30, 2);
+  });
+
+  it('should return 0 cost for unknown models', () => {
+    const tracker = new UsageTracker();
+    tracker.record({
+      inputTokens: 1000,
+      outputTokens: 1000,
+      cacheCreationInputTokens: 0,
+      cacheReadInputTokens: 0,
+    });
+    expect(tracker.estimatedCostUsd('local-model')).toBe(0);
+  });
+
+  it('should reconstruct from messages', () => {
+    const messages = [
+      { content: 'hi' },
+      {
+        content: 'hello',
+        usage: {
+          inputTokens: 10,
+          outputTokens: 5,
+          cacheCreationInputTokens: 0,
+          cacheReadInputTokens: 0,
+        },
+      },
+      {
+        content: 'bye',
+        usage: {
+          inputTokens: 20,
+          outputTokens: 10,
+          cacheCreationInputTokens: 5,
+          cacheReadInputTokens: 5,
+        },
+      },
+    ];
+
+    const tracker = UsageTracker.fromMessages(messages as any);
+    expect(tracker.turns()).toBe(2);
+    expect(tracker.cumulativeUsage()).toEqual({
+      inputTokens: 30,
+      outputTokens: 15,
+      cacheCreationInputTokens: 5,
+      cacheReadInputTokens: 5,
+    });
+  });
+});

--- a/core/agent-runtime/src/centrifugo.ts
+++ b/core/agent-runtime/src/centrifugo.ts
@@ -6,6 +6,7 @@
 import axios, { type AxiosInstance, AxiosError } from 'axios';
 import { Centrifuge } from 'centrifuge';
 import { log } from './logger.js';
+import { type TokenUsage } from './usage.js';
 
 export interface IntercomMessage {
   id: string;
@@ -45,6 +46,13 @@ export interface StreamToken {
   token: string;
   done: boolean;
   messageId: string;
+}
+
+export interface UsageEvent {
+  agentId: string;
+  usage: TokenUsage;
+  costUsd: number;
+  timestamp: string;
 }
 
 // ── Publisher ─────────────────────────────────────────────────────────────────
@@ -120,6 +128,20 @@ export class CentrifugoPublisher {
     const channel = `tokens:${this.agentId}`;
     const data: StreamToken = { token, done, messageId };
     await this.publish(channel, data);
+  }
+
+  async publishUsage(
+    usage: TokenUsage,
+    costUsd: number,
+  ): Promise<void> {
+    const channel = `usage:${this.agentId}`;
+    const event: UsageEvent = {
+      agentId: this.agentId,
+      usage,
+      costUsd,
+      timestamp: new Date().toISOString(),
+    };
+    await this.publish(channel, event);
   }
 
   private toCanonicalStep(step: ThoughtType | InternalStepType): ThoughtType {

--- a/core/agent-runtime/src/llmClient.ts
+++ b/core/agent-runtime/src/llmClient.ts
@@ -7,6 +7,7 @@
 
 import axios, { type AxiosInstance, AxiosError } from 'axios';
 import { log } from './logger.js';
+import { type TokenUsage } from './usage.js';
 
 // ── Error Types ───────────────────────────────────────────────────────────────
 
@@ -74,6 +75,7 @@ export interface ChatMessage {
   content: string;
   tool_calls?: ToolCall[];
   tool_call_id?: string;
+  usage?: TokenUsage;
 }
 
 export type ThinkingLevel = 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'max';
@@ -83,13 +85,7 @@ export interface LLMResponse {
   /** Chain-of-thought text, e.g. Qwen / DeepSeek reasoning_content. */
   reasoning?: string;
   toolCalls?: ToolCall[];
-  usage?: {
-    promptTokens: number;
-    completionTokens: number;
-    cacheCreationTokens: number;
-    cacheReadTokens: number;
-    totalTokens: number;
-  };
+  usage?: TokenUsage;
 }
 
 // ── Client ────────────────────────────────────────────────────────────────────
@@ -192,11 +188,10 @@ export class LLMClient {
       const rawUsage = data['usage'] as Record<string, number> | undefined;
       const usage = rawUsage
         ? {
-            promptTokens: rawUsage['prompt_tokens'] ?? 0,
-            completionTokens: rawUsage['completion_tokens'] ?? 0,
-            cacheCreationTokens: rawUsage['cache_creation_input_tokens'] ?? 0,
-            cacheReadTokens: rawUsage['cache_read_input_tokens'] ?? 0,
-            totalTokens: rawUsage['total_tokens'] ?? 0,
+            inputTokens: rawUsage['prompt_tokens'] ?? 0,
+            outputTokens: rawUsage['completion_tokens'] ?? 0,
+            cacheCreationInputTokens: rawUsage['cache_creation_input_tokens'] ?? 0,
+            cacheReadInputTokens: rawUsage['cache_read_input_tokens'] ?? 0,
           }
         : undefined;
 

--- a/core/agent-runtime/src/loop.ts
+++ b/core/agent-runtime/src/loop.ts
@@ -14,6 +14,7 @@ import { generateSystemPrompt } from './manifest.js';
 import { ContextManager } from './contextManager.js';
 import { ToolLoopDetector } from './toolLoopDetector.js';
 import { log } from './logger.js';
+import { UsageTracker, type TokenUsage } from './usage.js';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -28,11 +29,7 @@ export interface TaskOutput {
   taskId: string;
   result: string | null;
   error?: string;
-  usage: {
-    promptTokens: number;
-    completionTokens: number;
-    cacheCreationTokens: number;
-    cacheReadTokens: number;
+  usage: TokenUsage & {
     totalTokens: number;
     turns: number;
   };
@@ -105,19 +102,12 @@ export class ReasoningLoop {
     const thoughtStream: TaskOutput['thoughtStream'] = [];
 
     // ── Usage tracking with cache awareness (#547) ────────────────────────
-    let totalPromptTokens = 0;
-    let totalCompletionTokens = 0;
-    let totalCacheCreationTokens = 0;
-    let totalCacheReadTokens = 0;
-    let turnCount = 0;
+    const usageTracker = UsageTracker.fromMessages(history);
 
     const buildUsage = () => ({
-      promptTokens: totalPromptTokens,
-      completionTokens: totalCompletionTokens,
-      cacheCreationTokens: totalCacheCreationTokens,
-      cacheReadTokens: totalCacheReadTokens,
-      totalTokens: totalPromptTokens + totalCompletionTokens,
-      turns: turnCount,
+      ...usageTracker.cumulativeUsage(),
+      totalTokens: usageTracker.totalTokens(),
+      turns: usageTracker.turns(),
     });
 
     // Helper to emit and record a thought
@@ -283,12 +273,14 @@ export class ReasoningLoop {
 
         // Accumulate usage (including cache tokens)
         if (response.usage) {
-          totalPromptTokens += response.usage.promptTokens;
-          totalCompletionTokens += response.usage.completionTokens;
-          totalCacheCreationTokens += response.usage.cacheCreationTokens;
-          totalCacheReadTokens += response.usage.cacheReadTokens;
-          turnCount++;
-          log('debug', `Iteration ${iteration} usage: prompt=${response.usage.promptTokens} completion=${response.usage.completionTokens} cacheRead=${response.usage.cacheReadTokens} turn=${turnCount}`);
+          usageTracker.record(response.usage);
+          const cumulative = usageTracker.cumulativeUsage();
+          const costUsd = usageTracker.estimatedCostUsd(this.manifest.model.name);
+
+          // Publish real-time usage to dashboard
+          await this.centrifugo.publishUsage(cumulative, costUsd);
+
+          log('debug', `Iteration ${iteration} usage: input=${response.usage.inputTokens} output=${response.usage.outputTokens} cacheRead=${response.usage.cacheReadInputTokens} turn=${usageTracker.turns()}`);
         }
 
         // Emit chain-of-thought reasoning if present (e.g. Qwen / DeepSeek)
@@ -332,11 +324,12 @@ export class ReasoningLoop {
             });
           }
 
-          // Add assistant turn with tool_calls
+          // Add assistant turn with tool_calls and usage
           messages.push({
             role: 'assistant',
             content: response.content || '',
             tool_calls: response.toolCalls,
+            usage: response.usage,
           });
 
           // Execute tools and add results

--- a/core/agent-runtime/src/usage.ts
+++ b/core/agent-runtime/src/usage.ts
@@ -1,0 +1,93 @@
+/**
+ * Usage tracking with cache awareness and cost estimation.
+ * Follows claw-code's usage tracker pattern.
+ */
+
+export interface TokenUsage {
+  inputTokens: number;
+  outputTokens: number;
+  cacheCreationInputTokens: number;
+  cacheReadInputTokens: number;
+}
+
+export class UsageTracker {
+  private _turns: number = 0;
+  private _cumulative: TokenUsage = {
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheCreationInputTokens: 0,
+    cacheReadInputTokens: 0,
+  };
+
+  /** Record a single LLM response's token usage. */
+  record(usage: TokenUsage): void {
+    this._turns++;
+    this._cumulative.inputTokens += usage.inputTokens || 0;
+    this._cumulative.outputTokens += usage.outputTokens || 0;
+    this._cumulative.cacheCreationInputTokens += usage.cacheCreationInputTokens || 0;
+    this._cumulative.cacheReadInputTokens += usage.cacheReadInputTokens || 0;
+  }
+
+  /** Total number of LLM turns recorded. */
+  turns(): number {
+    return this._turns;
+  }
+
+  /** Cumulative token usage across all turns. */
+  cumulativeUsage(): TokenUsage {
+    return { ...this._cumulative };
+  }
+
+  /** Total tokens (sum of all input and output types). */
+  totalTokens(): number {
+    return (
+      this._cumulative.inputTokens +
+      this._cumulative.outputTokens +
+      this._cumulative.cacheCreationInputTokens +
+      this._cumulative.cacheReadInputTokens
+    );
+  }
+
+  /**
+   * Estimate the cost of cumulative usage in USD based on the model.
+   * Uses placeholder pricing for common frontier models and $0 for local/unknown.
+   */
+  estimatedCostUsd(model: string): number {
+    // Pricing per 1M tokens (Input, Output, CacheRead, CacheCreation)
+    // Values are placeholders for standard frontier model rates.
+    const pricing: Record<string, { input: number; output: number; cacheRead?: number; cacheCreation?: number }> = {
+      'gpt-4o': { input: 2.50, output: 10.00, cacheRead: 1.25 },
+      'claude-3-5-sonnet': { input: 3.00, output: 15.00, cacheRead: 0.30, cacheCreation: 3.75 },
+      'deepseek-chat': { input: 0.14, output: 0.28, cacheRead: 0.014 },
+      'deepseek-reasoner': { input: 0.55, output: 2.19, cacheRead: 0.14 },
+    };
+
+    const modelLower = model.toLowerCase();
+    const key = Object.keys(pricing).find((k) => modelLower.includes(k));
+
+    if (!key) {
+      return 0;
+    }
+
+    const p = pricing[key]!;
+    const u = this._cumulative;
+
+    const inputCost = (u.inputTokens / 1_000_000) * p.input;
+    const outputCost = (u.outputTokens / 1_000_000) * p.output;
+    const cacheReadCost = (u.cacheReadInputTokens / 1_000_000) * (p.cacheRead ?? p.input);
+    const cacheCreationCost = (u.cacheCreationInputTokens / 1_000_000) * (p.cacheCreation ?? p.input);
+
+    return inputCost + outputCost + cacheReadCost + cacheCreationCost;
+  }
+
+  /** Reconstruct a UsageTracker from saved message history. */
+  static fromMessages(messages: Array<{ usage?: TokenUsage }>): UsageTracker {
+    const tracker = new UsageTracker();
+    for (const msg of messages) {
+      if (msg.usage) {
+        tracker.record(msg.usage);
+      }
+    }
+    return tracker;
+  }
+}

--- a/core/src/intercom/ChannelNamespace.ts
+++ b/core/src/intercom/ChannelNamespace.ts
@@ -52,6 +52,11 @@ export class ChannelNamespace {
     return `tokens:${agentId}`;
   }
 
+  /** Agent usage and cost channel. */
+  static usage(agentId: string): string {
+    return `usage:${agentId}`;
+  }
+
   /**
    * Bridge channel for cross-instance communication.
    * bridge:dm:{circleA}:{circleB}:{agentA}:{agentB}
@@ -100,6 +105,10 @@ export class ChannelNamespace {
 
       case 'tokens':
         // tokens:{agentId}
+        return parts.length === 2 ? prefix : null;
+
+      case 'usage':
+        // usage:{agentId}
         return parts.length === 2 ? prefix : null;
 
       case 'agent':

--- a/core/src/intercom/types.ts
+++ b/core/src/intercom/types.ts
@@ -13,7 +13,8 @@ export type IntercomMessageType =
   | 'task'
   | 'status'
   | 'approval-request'
-  | 'thought';
+  | 'thought'
+  | 'usage';
 
 // ── Thought Step Types ──────────────────────────────────────────────────────────
 
@@ -87,6 +88,7 @@ export const CHANNEL_PREFIXES = [
   'system',
   'bridge',
   'federation',
+  'usage',
 ] as const;
 
 export type ChannelPrefix = (typeof CHANNEL_PREFIXES)[number];

--- a/core/src/llm/LlmRouter.ts
+++ b/core/src/llm/LlmRouter.ts
@@ -67,6 +67,8 @@ export interface ChatCompletionRequest {
 export interface ChatCompletionUsage {
   prompt_tokens: number;
   completion_tokens: number;
+  cache_creation_input_tokens?: number;
+  cache_read_input_tokens?: number;
   total_tokens: number;
 }
 
@@ -258,6 +260,8 @@ function toCompletionResponse(msg: AssistantMessage, modelName: string): ChatCom
     usage: {
       prompt_tokens: msg.usage.input,
       completion_tokens: msg.usage.output,
+      cache_creation_input_tokens: msg.usage.cacheWrite,
+      cache_read_input_tokens: msg.usage.cacheRead,
       total_tokens: msg.usage.totalTokens,
     },
   };


### PR DESCRIPTION
Extended usage tracking to include prompt cache tokens (creation and read), per-turn breakdown, and cost estimation, following the pattern in claw-code.

Key changes:
1. **New `usage.ts`**: Core tracking logic and cost estimation.
2. **`LlmRouter.ts` & `llmClient.ts`**: Updated to handle cache token fields in API responses and internal types.
3. **`centrifugo.ts`**: Added support for publishing usage events.
4. **`loop.ts`**: Integrated `UsageTracker` into the reasoning cycle, enabling real-time dashboard updates and persistent usage awareness across turns.
5. **Intercom**: Extended `CHANNEL_PREFIXES` and `ChannelNamespace` to include the `usage` namespace.

Verified with new unit tests in `core/agent-runtime/src/__tests__/usage.test.ts`.

Fixes #547

---
*PR created automatically by Jules for task [5053397761476584105](https://jules.google.com/task/5053397761476584105) started by @TKCen*