### PR TITLE
fix(web): resolve hooks crash, circles TypeError, and insights request spam

### DIFF
--- a/web/src/app/agents/_id/page.tsx
+++ b/web/src/app/agents/_id/page.tsx
@@ -60,6 +60,34 @@ export default function AgentDetailPage() {
   const restartAgent = useRestartAgent();
   const deleteAgent = useDeleteAgent();
 
+  const initialValues: AgentFormInitialValues | undefined = useMemo(() => {
+    if (!agent) return undefined;
+    const overrides = (agent.overrides ?? {}) as Record<string, unknown>;
+    const modelOv = overrides.model as Record<string, unknown> | undefined;
+    const resourcesOv = overrides.resources as Record<string, unknown> | undefined;
+    const permissionsOv = overrides.permissions as Record<string, unknown> | undefined;
+    const toolsOv = overrides.tools as Record<string, unknown> | undefined;
+
+    return {
+      templateRef: agent.template_ref,
+      name: agent.name,
+      displayName: agent.display_name ?? '',
+      circle: agent.circle ?? '',
+      lifecycleMode: (agent.lifecycle_mode as 'persistent' | 'ephemeral') ?? 'persistent',
+      modelName: (modelOv?.name as string) ?? '',
+      modelProvider: (modelOv?.provider as string) ?? '',
+      temperature: (modelOv?.temperature as number) ?? 0.7,
+      sandboxBoundary: (overrides.sandboxBoundary as string) ?? 'tier-2',
+      tokensPerHour: (resourcesOv?.maxLlmTokensPerHour as number) ?? 100000,
+      tokensPerDay: (resourcesOv?.maxLlmTokensPerDay as number) ?? 1000000,
+      canExec: (permissionsOv?.canExec as boolean) ?? false,
+      canSpawnSubagents: (permissionsOv?.canSpawnSubagents as boolean) ?? false,
+      toolsAllowed: Array.isArray(toolsOv?.allowed) ? (toolsOv.allowed as string[]) : [],
+      toolsDenied: Array.isArray(toolsOv?.denied) ? (toolsOv.denied as string[]) : [],
+      skills: Array.isArray(overrides.skills) ? (overrides.skills as string[]) : [],
+    };
+  }, [agent]);
+
   async function handleLifecycle(action: 'start' | 'stop' | 'restart') {
     try {
       if (action === 'start') {
@@ -89,34 +117,6 @@ export default function AgentDetailPage() {
   }
 
   const displayName = agent?.display_name ?? agent?.name ?? id;
-
-  const initialValues: AgentFormInitialValues | undefined = useMemo(() => {
-    if (!agent) return undefined;
-    const overrides = (agent.overrides ?? {}) as Record<string, unknown>;
-    const modelOv = overrides.model as Record<string, unknown> | undefined;
-    const resourcesOv = overrides.resources as Record<string, unknown> | undefined;
-    const permissionsOv = overrides.permissions as Record<string, unknown> | undefined;
-    const toolsOv = overrides.tools as Record<string, unknown> | undefined;
-
-    return {
-      templateRef: agent.template_ref,
-      name: agent.name,
-      displayName: agent.display_name ?? '',
-      circle: agent.circle ?? '',
-      lifecycleMode: (agent.lifecycle_mode as 'persistent' | 'ephemeral') ?? 'persistent',
-      modelName: (modelOv?.name as string) ?? '',
-      modelProvider: (modelOv?.provider as string) ?? '',
-      temperature: (modelOv?.temperature as number) ?? 0.7,
-      sandboxBoundary: (overrides.sandboxBoundary as string) ?? 'tier-2',
-      tokensPerHour: (resourcesOv?.maxLlmTokensPerHour as number) ?? 100000,
-      tokensPerDay: (resourcesOv?.maxLlmTokensPerDay as number) ?? 1000000,
-      canExec: (permissionsOv?.canExec as boolean) ?? false,
-      canSpawnSubagents: (permissionsOv?.canSpawnSubagents as boolean) ?? false,
-      toolsAllowed: Array.isArray(toolsOv?.allowed) ? (toolsOv.allowed as string[]) : [],
-      toolsDenied: Array.isArray(toolsOv?.denied) ? (toolsOv.denied as string[]) : [],
-      skills: Array.isArray(overrides.skills) ? (overrides.skills as string[]) : [],
-    };
-  }, [agent]);
 
   return (
     <div className="flex flex-col h-full">

--- a/web/src/app/circles/page.tsx
+++ b/web/src/app/circles/page.tsx
@@ -144,10 +144,10 @@ export default function CirclesPage() {
               )}
 
               {/* Agent membership ring */}
-              {circle.agents.length > 0 && (
+              {(circle.agents?.length ?? 0) > 0 && (
                 <div className="flex items-center gap-2">
                   <div className="flex -space-x-2">
-                    {circle.agents.slice(0, 5).map((agent) => (
+                    {circle.agents!.slice(0, 5).map((agent) => (
                       <div
                         key={agent}
                         className="h-7 w-7 rounded-full bg-sera-surface-active border-2 border-sera-bg flex items-center justify-center"
@@ -156,23 +156,23 @@ export default function CirclesPage() {
                         <Bot size={12} className="text-sera-text-muted" />
                       </div>
                     ))}
-                    {circle.agents.length > 5 && (
+                    {circle.agents!.length > 5 && (
                       <div className="h-7 w-7 rounded-full bg-sera-surface-active border-2 border-sera-bg flex items-center justify-center">
                         <span className="text-[10px] font-medium text-sera-text-muted">
-                          +{circle.agents.length - 5}
+                          +{circle.agents!.length - 5}
                         </span>
                       </div>
                     )}
                   </div>
                   <span className="text-xs text-sera-text-dim">
-                    {circle.agents.length} agent{circle.agents.length !== 1 ? 's' : ''}
+                    {circle.agents!.length} agent{circle.agents!.length !== 1 ? 's' : ''}
                   </span>
                 </div>
               )}
 
               {/* Stats row */}
               <div className="flex items-center gap-3 flex-wrap mt-auto">
-                {circle.channelCount > 0 && (
+                {(circle.channelCount ?? 0) > 0 && (
                   <Badge variant="default" className="gap-1">
                     <Radio size={10} />
                     {circle.channelCount} channel{circle.channelCount !== 1 ? 's' : ''}

--- a/web/src/app/insights/page.tsx
+++ b/web/src/app/insights/page.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 import {
   AreaChart,
   Area,
@@ -23,11 +23,15 @@ function rangeToFromTo(
   customFrom?: string,
   customTo?: string
 ): { from: string; to: string } {
-  const now = new Date();
-  const to = now.toISOString();
   if (range === 'custom') {
-    return { from: customFrom ?? to, to: customTo ?? to };
+    const now = new Date().toISOString();
+    return { from: customFrom ?? now, to: customTo ?? now };
   }
+  // Truncate to the start of the current minute so the value stays stable within
+  // the same minute and doesn't cause query key churn on every render.
+  const now = new Date();
+  now.setSeconds(0, 0);
+  const to = now.toISOString();
   const ms = range === '24h' ? 86400_000 : range === '7d' ? 7 * 86400_000 : 30 * 86400_000;
   return { from: new Date(now.getTime() - ms).toISOString(), to };
 }
@@ -58,7 +62,10 @@ function InsightsPageContent() {
   const [sortKey, setSortKey] = useState<SortKey>('totalTokens');
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>('desc');
 
-  const { from, to } = rangeToFromTo(range, customFrom, customTo);
+  const { from, to } = useMemo(
+    () => rangeToFromTo(range, customFrom, customTo),
+    [range, customFrom, customTo]
+  );
   const { data, isLoading, refetch, isFetching } = useUsage({ groupBy: 'agent', from, to });
 
   const toggleSort = useCallback(

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -81,9 +81,9 @@ export interface CircleSummary {
   name: string;
   displayName: string;
   description?: string;
-  agents: string[];
-  hasProjectContext: boolean;
-  channelCount: number;
+  agents?: string[];
+  hasProjectContext?: boolean;
+  channelCount?: number;
 }
 
 export interface CircleChannelConfig {


### PR DESCRIPTION
## Summary
- **#586**: Move `useMemo` before early return in AgentDetailPage to fix React hooks ordering crash
- **#587**: Make `CircleSummary.agents/channelCount/hasProjectContext` optional to match actual API response; guard `.length` access
- **#589**: Memoize `rangeToFromTo` output and truncate timestamps to minute precision to stop query key churn causing infinite refetches

Closes #586, closes #587, closes #589

## Test plan
- [x] Typecheck passes
- [x] All 66 web tests pass
- [ ] Verify agent detail page loads without crash
- [ ] Verify circles page loads without TypeError
- [ ] Verify insights page makes ~1 request per minute, not dozens per second

🤖 Generated with [Claude Code](https://claude.com/claude-code)