### PR TITLE
fix(web,core): circle detail crash, budget PATCH, insights data

### DIFF
--- a/core/src/routes/budget.ts
+++ b/core/src/routes/budget.ts
@@ -141,18 +141,19 @@ export function createBudgetRouter(meteringService?: MeteringService): Router {
         maxLlmTokensPerDay?: number | null;
       };
 
-      const hourly = maxLlmTokensPerHour ?? DEFAULT_HOURLY_QUOTA;
-      const daily = maxLlmTokensPerDay ?? DEFAULT_DAILY_QUOTA;
+      // Use provided values, or fall back to existing values, or defaults for new rows
+      const hourly = maxLlmTokensPerHour !== undefined ? maxLlmTokensPerHour : null;
+      const daily = maxLlmTokensPerDay !== undefined ? maxLlmTokensPerDay : null;
 
       await query(
         `INSERT INTO token_quotas (agent_id, max_tokens_per_hour, max_tokens_per_day, updated_at)
-         VALUES ($1, $2, $3, NOW())
+         VALUES ($1, COALESCE($2, $4), COALESCE($3, $5), NOW())
          ON CONFLICT (agent_id)
          DO UPDATE SET
-           max_tokens_per_hour = $2,
-           max_tokens_per_day = $3,
+           max_tokens_per_hour = COALESCE($2, token_quotas.max_tokens_per_hour),
+           max_tokens_per_day = COALESCE($3, token_quotas.max_tokens_per_day),
            updated_at = NOW()`,
-        [agentId, hourly, daily]
+        [agentId, hourly, daily, DEFAULT_HOURLY_QUOTA, DEFAULT_DAILY_QUOTA]
       );
 
       logger.info(`Budget updated for agent=${agentId} hourly=${hourly} daily=${daily}`);

--- a/web/src/app/circles/_id/page.tsx
+++ b/web/src/app/circles/_id/page.tsx
@@ -89,7 +89,9 @@ export default function CircleDetailPage() {
     if (!id) return;
     try {
       await deleteCircle.mutateAsync(id);
-      toast.success(`Deleted circle "${circle?.metadata.displayName ?? id}"`);
+      toast.success(
+        `Deleted circle "${circle?.displayName ?? circle?.metadata?.displayName ?? id}"`
+      );
       void navigate('/circles');
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Failed to delete');
@@ -104,7 +106,8 @@ export default function CircleDetailPage() {
         manifest: {
           ...circle,
           metadata: {
-            ...circle.metadata,
+            name: circle.name ?? circle.metadata?.name ?? id,
+            displayName: circle.displayName ?? circle.metadata?.displayName ?? id,
             description: descDraft.trim() || undefined,
           },
         },
@@ -156,8 +159,12 @@ export default function CircleDetailPage() {
           <Users size={24} className="text-sera-accent" />
         </div>
         <div className="flex-1 min-w-0">
-          <h1 className="text-xl font-bold text-sera-text">{circle.metadata.displayName}</h1>
-          <span className="text-xs text-sera-text-dim font-mono">{circle.metadata.name}</span>
+          <h1 className="text-xl font-bold text-sera-text">
+            {circle.displayName ?? circle.metadata?.displayName}
+          </h1>
+          <span className="text-xs text-sera-text-dim font-mono">
+            {circle.name ?? circle.metadata?.name}
+          </span>
 
           {/* Description — inline editable */}
           <div className="mt-1">
@@ -187,11 +194,11 @@ export default function CircleDetailPage() {
             ) : (
               <div className="flex items-center gap-1.5 group/desc">
                 <p className="text-sm text-sera-text-muted">
-                  {circle.metadata.description || 'No description'}
+                  {circle.description ?? circle.metadata?.description ?? 'No description'}
                 </p>
                 <button
                   onClick={() => {
-                    setDescDraft(circle.metadata.description ?? '');
+                    setDescDraft(circle.description ?? circle.metadata?.description ?? '');
                     setEditingDesc(true);
                   }}
                   className="p-1 rounded text-sera-text-dim opacity-0 group-hover/desc:opacity-100 hover:bg-sera-surface-hover transition-opacity"

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -126,8 +126,18 @@ export interface CircleManifest {
   connections?: CircleConnectionConfig[];
 }
 
-/** Full manifest + resolved project context content from GET /circles/:name */
+/** Full manifest + resolved project context content from GET /circles/:name.
+ *  DB-sourced circles return flat properties; YAML circles use the metadata wrapper. */
 export interface CircleDetails extends CircleManifest {
+  /** Flat DB properties (may not have metadata wrapper) */
+  id?: string;
+  name?: string;
+  displayName?: string;
+  description?: string;
+  constitution?: string;
+  members?: string[];
+  createdAt?: string;
+  updatedAt?: string;
   projectContext?: { path: string; autoLoad?: boolean; content?: string };
 }
 

--- a/web/src/lib/api/usage.ts
+++ b/web/src/lib/api/usage.ts
@@ -3,9 +3,9 @@ import type { UsageResponse } from './types';
 
 interface UsageRow {
   period: string;
-  agent_id?: string;
-  total_tokens: number;
-  cost_usd: number;
+  agentId?: string;
+  totalTokens: number;
+  costUsd: number;
 }
 
 /**
@@ -34,7 +34,7 @@ export async function getUsage(params: {
   const periodMap = new Map<string, { promptTokens: number; completionTokens: number }>();
   for (const row of rows) {
     const existing = periodMap.get(row.period);
-    const tokens = Number(row.total_tokens) || 0;
+    const tokens = Number(row.totalTokens) || 0;
     if (existing) {
       existing.completionTokens += tokens;
     } else {
@@ -51,8 +51,8 @@ export async function getUsage(params: {
   // Build by-agent breakdown
   const agentMap = new Map<string, number>();
   for (const row of rows) {
-    const name = row.agent_id ?? 'unknown';
-    agentMap.set(name, (agentMap.get(name) ?? 0) + (Number(row.total_tokens) || 0));
+    const name = row.agentId ?? 'unknown';
+    agentMap.set(name, (agentMap.get(name) ?? 0) + (Number(row.totalTokens) || 0));
   }
   const grandTotal = [...agentMap.values()].reduce((a, b) => a + b, 0) || 1;
   const byAgent = [...agentMap.entries()].map(([agentName, totalTokens]) => ({
@@ -70,7 +70,7 @@ export async function getUsage(params: {
     summary: {
       totalTokensToday: totalTokens,
       totalTokensMonth: totalTokens,
-      estimatedCost: rows.reduce((s, r) => s + (Number(r.cost_usd) || 0), 0),
+      estimatedCost: rows.reduce((s, r) => s + (Number(r.costUsd) || 0), 0),
       mostActiveAgent: byAgent[0]?.agentName,
     },
     timeSeries: timeSeries.map((t) => ({


### PR DESCRIPTION
## Summary
- **#591**: Circle detail page accessed `circle.metadata.displayName` but DB circles return flat properties. Now checks both shapes.
- **#593**: Budget PATCH endpoint reset the other limit to defaults. Now uses `COALESCE` to preserve existing values.
- **#595**: Insights page mapped `total_tokens`/`agent_id` (snake_case) but API returns `totalTokens`/`agentId` (camelCase). Fixed field names.

Closes #591, closes #593, closes #595

## Test plan
- [x] Typecheck passes
- [x] All 66 web tests pass
- [ ] Verify `/circles/{name}` loads without crash
- [ ] Verify budget PATCH preserves other limit
- [ ] Verify insights page displays charts and tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)