### PR TITLE
fix(web): map taskPrompt to task in schedule update

### DIFF
--- a/web/src/lib/api/schedules.ts
+++ b/web/src/lib/api/schedules.ts
@@ -27,9 +27,12 @@ export function updateSchedule(
   id: string,
   data: Partial<Pick<Schedule, 'expression' | 'taskPrompt' | 'status' | 'name'>>
 ): Promise<Schedule> {
+  // Backend expects 'task' not 'taskPrompt'
+  const { taskPrompt, ...rest } = data;
+  const payload = taskPrompt !== undefined ? { ...rest, task: taskPrompt } : rest;
   return request<Schedule>(`/schedules/${encodeURIComponent(id)}`, {
     method: 'PATCH',
-    body: JSON.stringify(data),
+    body: JSON.stringify(payload),
   });
 }
 


### PR DESCRIPTION
## Summary
Backend PATCH `/api/schedules/:id` accepts `task` but frontend sent `taskPrompt` (camelCase from the Schedule type). The field was silently filtered out by the backend's whitelist, making updates appear to fail.

Closes #588

## Test plan
- [x] Typecheck passes
- [ ] Edit schedule expression + task prompt, verify both persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)