### PR TITLE
fix(core): serialize schedule task prompt as JSON for JSONB column

### DIFF
--- a/core/src/skills/builtins/schedule-task.ts
+++ b/core/src/skills/builtins/schedule-task.ts
@@ -63,9 +63,14 @@ export const scheduleTaskSkill: SkillDefinition = {
       status?: string;
     };
 
-    // Normalize task to a string prompt — the LLM may send a string or an object
+    // Normalize task to a JSON string — the `task` column is type JSON in Postgres.
+    // The LLM may send a plain string prompt or a structured object.
     const taskPrompt =
-      task == null ? undefined : typeof task === 'string' ? task : JSON.stringify(task);
+      task == null
+        ? undefined
+        : typeof task === 'string'
+          ? JSON.stringify({ prompt: task })
+          : JSON.stringify(task);
 
     try {
       switch (action) {


### PR DESCRIPTION
## Summary
The `schedule-task` skill handler passed a plain string to the `task` column (JSONB), causing Postgres to reject with "invalid input syntax for type json". Now wraps string prompts as `{ "prompt": "..." }`.

This was the root cause of Sera's inability to create schedules autonomously — the executor reported success but the DB error was swallowed in the response body.

Closes #598

## Test plan
- [x] Core typecheck passes
- [ ] Ask Sera to create a schedule — verify it persists in DB
- [ ] Verify schedule-task list returns the new schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)