### PR TITLE
feat(core,web): inner-life schedules with cross-agent permissions

### DIFF
--- a/core/src/agents/manifest/AgentManifestLoader.ts
+++ b/core/src/agents/manifest/AgentManifestLoader.ts
@@ -228,6 +228,18 @@ export class AgentManifestLoader {
         }
         AgentManifestLoader.requireString(s, 'expression', sCtx);
         AgentManifestLoader.requireString(s, 'task', sCtx);
+        if (s['status'] != null && s['status'] !== 'active' && s['status'] !== 'paused') {
+          throw new ManifestValidationError(
+            `Schedule status must be "active" or "paused", got "${String(s['status'])}"${sCtx}`,
+            `schedules[${i}].status`
+          );
+        }
+        if (s['category'] != null && typeof s['category'] !== 'string') {
+          throw new ManifestValidationError(
+            `Schedule category must be a string${sCtx}`,
+            `schedules[${i}].category`
+          );
+        }
       }
     }
 

--- a/core/src/agents/manifest/types.ts
+++ b/core/src/agents/manifest/types.ts
@@ -98,6 +98,8 @@ export interface ScheduleManifest {
   type: 'cron' | 'once';
   expression: string;
   task: string;
+  status?: 'active' | 'paused';
+  category?: string;
 }
 
 // ── Full Manifest ───────────────────────────────────────────────────────────────
@@ -152,6 +154,8 @@ export interface AgentManifest {
       type: 'cron' | 'once';
       expression: string;
       task: string;
+      status?: 'active' | 'paused';
+      category?: string;
     }>;
   };
   tools?: ToolsConfig;

--- a/core/src/agents/registry.service.ts
+++ b/core/src/agents/registry.service.ts
@@ -152,6 +152,8 @@ export class AgentRegistry {
           type: s.type,
           expression: s.expression,
           task: s.task,
+          status: s.status,
+          category: s.category,
           source: 'manifest',
         })
         .catch((err) => {

--- a/core/src/db/migrations/1711300000000_schedule_inner_life.cjs
+++ b/core/src/db/migrations/1711300000000_schedule_inner_life.cjs
@@ -1,0 +1,34 @@
+/**
+ * Migration: Schedule Inner Life
+ *
+ * Adds `category` column to schedules table for classifying inner-life
+ * schedule types (reflection, knowledge_consolidation, curiosity_research, etc.).
+ *
+ * Adds a partial index on task_queue for efficiently querying schedule-triggered
+ * tasks via the context JSONB column.
+ */
+
+/** @type {import('node-pg-migrate').MigrationBuilder} */
+exports.up = (pgm) => {
+  pgm.addColumn('schedules', {
+    category: { type: 'text', notNull: false },
+  });
+
+  pgm.createIndex('schedules', 'category', {
+    name: 'schedules_category_idx',
+    ifNotExists: true,
+  });
+
+  pgm.sql(`
+    CREATE INDEX IF NOT EXISTS task_queue_schedule_ctx_idx
+      ON task_queue ((context->'schedule'->>'scheduleId'))
+      WHERE context->'schedule' IS NOT NULL
+  `);
+};
+
+/** @type {import('node-pg-migrate').MigrationBuilder} */
+exports.down = (pgm) => {
+  pgm.sql('DROP INDEX IF EXISTS task_queue_schedule_ctx_idx');
+  pgm.dropIndex('schedules', 'category', { name: 'schedules_category_idx', ifExists: true });
+  pgm.dropColumn('schedules', 'category');
+};

--- a/core/src/routes/schedules.ts
+++ b/core/src/routes/schedules.ts
@@ -60,6 +60,7 @@ export const createSchedulesRouter = () => {
             taskPrompt,
             status: r.status,
             source: r.source ?? 'api',
+            category: r.category ?? null,
             lastRunAt: r.last_run_at ?? r.last_run,
             lastRunStatus: sanitizeRunStatus(r.last_run_status),
             nextRunAt: r.next_run_at,
@@ -82,6 +83,73 @@ export const createSchedulesRouter = () => {
       res.status(201).json(schedule);
     } catch (err: unknown) {
       res.status(400).json({ error: (err as Error).message });
+    }
+  });
+
+  /**
+   * GET /api/schedules/runs - List schedule-triggered task runs
+   * Query params: category, scheduleId, agentId, limit (default 50)
+   * NOTE: Must be registered before /:id to avoid Express matching "runs" as an id.
+   */
+  router.get('/runs', async (req, res) => {
+    try {
+      const { category, scheduleId, agentId, limit: limitStr } = req.query;
+      const limit = Math.min(Math.max(parseInt(String(limitStr || '50'), 10) || 50, 1), 200);
+
+      const conditions: string[] = ["tq.context->'schedule' IS NOT NULL"];
+      const params: unknown[] = [];
+      let paramIdx = 1;
+
+      if (category) {
+        conditions.push(`s.category = $${paramIdx++}`);
+        params.push(category);
+      }
+      if (scheduleId) {
+        conditions.push(`(tq.context->'schedule'->>'scheduleId') = $${paramIdx++}`);
+        params.push(scheduleId);
+      }
+      if (agentId) {
+        conditions.push(`tq.agent_instance_id = $${paramIdx++}`);
+        params.push(agentId);
+      }
+
+      params.push(limit);
+
+      const { rows } = await pool.query(
+        `SELECT tq.id AS task_id, tq.status, tq.result, tq.error, tq.usage,
+                tq.exit_reason, tq.created_at, tq.started_at, tq.completed_at,
+                tq.context->'schedule'->>'scheduleId' AS schedule_id,
+                tq.context->'schedule'->>'scheduleName' AS schedule_name,
+                tq.context->'schedule'->>'category' AS schedule_category,
+                tq.context->'schedule'->>'firedAt' AS fired_at,
+                s.name AS current_schedule_name, s.category AS current_category
+         FROM task_queue tq
+         LEFT JOIN schedules s ON (tq.context->'schedule'->>'scheduleId')::uuid = s.id
+         WHERE ${conditions.join(' AND ')}
+         ORDER BY tq.created_at DESC
+         LIMIT $${paramIdx}`,
+        params
+      );
+
+      res.json(
+        rows.map((r: Record<string, unknown>) => ({
+          taskId: r.task_id,
+          scheduleId: r.schedule_id,
+          scheduleName: r.current_schedule_name ?? r.schedule_name,
+          scheduleCategory: r.current_category ?? r.schedule_category,
+          status: r.status,
+          result: r.result,
+          error: r.error,
+          usage: r.usage,
+          exitReason: r.exit_reason,
+          firedAt: r.fired_at,
+          startedAt: r.started_at,
+          completedAt: r.completed_at,
+          createdAt: r.created_at,
+        }))
+      );
+    } catch (err: unknown) {
+      res.status(500).json({ error: (err as Error).message });
     }
   });
 
@@ -136,6 +204,44 @@ export const createSchedulesRouter = () => {
 
       await scheduleService.deleteSchedule(req.params.id);
       res.status(204).send();
+    } catch (err: unknown) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  /**
+   * GET /api/schedules/:id/runs - List runs for a specific schedule
+   * Query params: limit (default 20)
+   */
+  router.get('/:id/runs', async (req, res) => {
+    try {
+      const limit = Math.min(Math.max(parseInt(String(req.query.limit || '20'), 10) || 20, 1), 200);
+
+      const { rows } = await pool.query(
+        `SELECT tq.id AS task_id, tq.status, tq.result, tq.error, tq.usage,
+                tq.exit_reason, tq.created_at, tq.started_at, tq.completed_at,
+                tq.context->'schedule'->>'firedAt' AS fired_at
+         FROM task_queue tq
+         WHERE (tq.context->'schedule'->>'scheduleId') = $1
+         ORDER BY tq.created_at DESC
+         LIMIT $2`,
+        [req.params.id, limit]
+      );
+
+      res.json(
+        rows.map((r: Record<string, unknown>) => ({
+          taskId: r.task_id,
+          status: r.status,
+          result: r.result,
+          error: r.error,
+          usage: r.usage,
+          exitReason: r.exit_reason,
+          firedAt: r.fired_at,
+          startedAt: r.started_at,
+          completedAt: r.completed_at,
+          createdAt: r.created_at,
+        }))
+      );
     } catch (err: unknown) {
       res.status(500).json({ error: (err as Error).message });
     }

--- a/core/src/services/ScheduleService.ts
+++ b/core/src/services/ScheduleService.ts
@@ -18,6 +18,7 @@ export interface Schedule {
   task: string;
   status: 'active' | 'paused' | 'completed' | 'error';
   source: 'manifest' | 'api';
+  category?: string;
   last_run_at?: Date;
   next_run_at?: Date;
   last_run_status?: string;
@@ -112,7 +113,17 @@ export class ScheduleService {
 
   public async createSchedule(data: Partial<Schedule>): Promise<Schedule> {
     const id = uuidv4();
-    const { agent_instance_id, agent_name, name, type, expression, task, source = 'api' } = data;
+    const {
+      agent_instance_id,
+      agent_name,
+      name,
+      type,
+      expression,
+      task,
+      source = 'api',
+      status: initialStatus = 'active',
+      category,
+    } = data;
 
     if (!agent_instance_id || !name || !type || !expression || !task) {
       throw new Error('Missing required fields for schedule');
@@ -120,10 +131,21 @@ export class ScheduleService {
 
     const { rows } = await pool.query<Schedule>(
       `INSERT INTO schedules
-       (id, agent_instance_id, agent_name, name, type, expression, task, status, source)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, 'active', $8)
+       (id, agent_instance_id, agent_name, name, type, expression, task, status, source, category)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
        RETURNING *`,
-      [id, agent_instance_id, agent_name, name, type, expression, task, source]
+      [
+        id,
+        agent_instance_id,
+        agent_name,
+        name,
+        type,
+        expression,
+        task,
+        initialStatus,
+        source,
+        category ?? null,
+      ]
     );
 
     const schedule = rows[0]!;
@@ -149,7 +171,7 @@ export class ScheduleService {
 
   public async updateSchedule(id: string, updates: Partial<Schedule>): Promise<Schedule> {
     const fields = Object.keys(updates).filter((k) =>
-      ['name', 'expression', 'task', 'status'].includes(k)
+      ['name', 'expression', 'task', 'status', 'category'].includes(k)
     );
 
     if (fields.length === 0) {
@@ -256,11 +278,19 @@ export class ScheduleService {
         return;
       }
 
-      // Enqueue task
+      // Enqueue task with schedule metadata in context
       const taskId = uuidv4();
+      const scheduleContext = JSON.stringify({
+        schedule: {
+          scheduleId: schedule.id,
+          scheduleName: schedule.name,
+          category: schedule.category ?? null,
+          firedAt: new Date().toISOString(),
+        },
+      });
       await pool.query(
-        `INSERT INTO task_queue (id, agent_instance_id, task, status) VALUES ($1, $2, $3, 'queued')`,
-        [taskId, schedule.agent_instance_id, schedule.task]
+        `INSERT INTO task_queue (id, agent_instance_id, task, context, status) VALUES ($1, $2, $3, $4, 'queued')`,
+        [taskId, schedule.agent_instance_id, schedule.task, scheduleContext]
       );
 
       // If agent not running, start it

--- a/core/src/skills/builtins/schedule-task.ts
+++ b/core/src/skills/builtins/schedule-task.ts
@@ -1,14 +1,115 @@
 import { v4 as uuidv4 } from 'uuid';
 import { query } from '../../lib/database.js';
-import type { SkillDefinition } from '../types.js';
+import type { AgentContext, SkillDefinition } from '../types.js';
 
 /**
  * schedule-task Skill
- * Allows agents to create or manage their own recurring tasks.
+ * Allows agents to create or manage recurring tasks for themselves or other agents.
+ *
+ * Permission scopes (checked via seraManagement.schedules capabilities):
+ * - personal: manage own schedules only (default)
+ * - circle:   manage schedules for agents in the same circle
+ * - global:   manage schedules for any agent
  */
+
+type ScheduleScope = 'personal' | 'circle' | 'global';
+
+/**
+ * Resolve the permission scope needed for an operation and verify the
+ * calling agent has the required capability.
+ *
+ * Returns the resolved target agent instance ID, or an error message.
+ */
+async function resolveTargetAgent(
+  callerAgentId: string,
+  targetAgentId: string | undefined,
+  context: AgentContext
+): Promise<{ targetId: string; scope: ScheduleScope } | { error: string }> {
+  // No target specified or targeting self — personal scope, always allowed
+  if (!targetAgentId || targetAgentId === callerAgentId) {
+    return { targetId: callerAgentId, scope: 'personal' };
+  }
+
+  // Targeting another agent — determine required scope
+  const callerCircle = context.manifest?.metadata?.circle ?? null;
+
+  // Look up target agent's circle
+  const targetRes = await query('SELECT id, circle FROM agent_instances WHERE id = $1', [
+    targetAgentId,
+  ]);
+  if (targetRes.rows.length === 0) {
+    return { error: `Target agent ${targetAgentId} not found.` };
+  }
+  const targetCircle = targetRes.rows[0].circle as string | null;
+
+  // Determine scope: circle if both share a circle, otherwise global
+  const sameCircle = callerCircle && targetCircle && callerCircle === targetCircle;
+  const requiredScope: ScheduleScope = sameCircle ? 'circle' : 'global';
+
+  // Check capability
+  const caps = context.manifest?.spec?.capabilities as Record<string, unknown> | undefined;
+  const schedCaps = (caps?.seraManagement as Record<string, unknown>)?.schedules as
+    | Record<string, unknown>
+    | undefined;
+
+  const hasPermission = checkScopePermission(schedCaps, 'create', requiredScope);
+  if (!hasPermission) {
+    return {
+      error: `Insufficient permission: managing schedules for ${requiredScope}-scope agents requires schedules.create.allow to include "${requiredScope === 'circle' ? 'own-circle' : 'global'}".`,
+    };
+  }
+
+  return { targetId: targetAgentId, scope: requiredScope };
+}
+
+/**
+ * Check if a capability section grants the required scope for an operation.
+ *
+ * Capability format in template YAML:
+ *   schedules:
+ *     create:
+ *       allow: [own-circle]   →  permits personal + circle
+ *     read: true              →  permits all scopes for read
+ *
+ * Scope hierarchy: global > circle > personal
+ */
+function checkScopePermission(
+  schedCaps: Record<string, unknown> | undefined,
+  operation: string,
+  requiredScope: ScheduleScope
+): boolean {
+  if (!schedCaps) return false;
+
+  const opConfig = schedCaps[operation];
+
+  // Boolean true = unrestricted for this operation
+  if (opConfig === true) return true;
+
+  // Object with allow array
+  if (typeof opConfig === 'object' && opConfig !== null && 'allow' in opConfig) {
+    const allowList = (opConfig as { allow: string[] }).allow;
+    if (!Array.isArray(allowList)) return false;
+
+    // Scope mapping: what allow values grant what scopes
+    if (requiredScope === 'personal') {
+      // Always allowed if any schedule permission exists
+      return true;
+    }
+    if (requiredScope === 'circle') {
+      return allowList.includes('own-circle') || allowList.includes('global');
+    }
+    if (requiredScope === 'global') {
+      return allowList.includes('global');
+    }
+  }
+
+  return false;
+}
+
 export const scheduleTaskSkill: SkillDefinition = {
   id: 'schedule-task',
-  description: 'Schedule a recurring task for the current agent using a cron expression.',
+  description:
+    'Schedule a recurring task for the current agent or another agent (with appropriate permissions) using a cron expression.',
   source: 'builtin',
   parameters: [
     {
@@ -16,6 +117,13 @@ export const scheduleTaskSkill: SkillDefinition = {
       type: 'string',
       description: 'The action to perform: create, list, delete, or update a schedule.',
       required: true,
+    },
+    {
+      name: 'targetAgentId',
+      type: 'string',
+      description:
+        'UUID of the agent to manage schedules for. Omit to manage own schedules. Requires circle or global permission to target other agents.',
+      required: false,
     },
     {
       name: 'name',
@@ -47,21 +155,37 @@ export const scheduleTaskSkill: SkillDefinition = {
       description: 'New status for the schedule (used with update).',
       required: false,
     },
+    {
+      name: 'category',
+      type: 'string',
+      description:
+        'Category for the schedule (e.g., "reflection", "knowledge_consolidation", "curiosity_research", "goal_review", "schedule_review", "general").',
+      required: false,
+    },
   ],
   handler: async (params, context) => {
-    const agentId = context.agentInstanceId;
-    if (!agentId) {
+    const callerAgentId = context.agentInstanceId;
+    if (!callerAgentId) {
       return { success: false, error: 'Skill must be executed in an agent instance context.' };
     }
 
-    const { action, name, cron, task, scheduleId, status } = params as {
+    const { action, targetAgentId, name, cron, task, scheduleId, status, category } = params as {
       action: string;
+      targetAgentId?: string;
       name?: string;
       cron?: string;
       task?: string | object;
       scheduleId?: string;
       status?: string;
+      category?: string;
     };
+
+    // Resolve target agent and check permissions
+    const resolved = await resolveTargetAgent(callerAgentId, targetAgentId, context);
+    if ('error' in resolved) {
+      return { success: false, error: resolved.error };
+    }
+    const { targetId } = resolved;
 
     // Normalize task to a JSON string — the `task` column is type JSON in Postgres.
     // The LLM may send a plain string prompt or a structured object.
@@ -84,21 +208,25 @@ export const scheduleTaskSkill: SkillDefinition = {
           const newId = uuidv4();
           const now = new Date().toISOString();
           await query(
-            `INSERT INTO schedules (id, agent_instance_id, agent_name, name, expression, type, task, source, status, created_at, updated_at)
-             VALUES ($1, $2, (SELECT name FROM agent_instances WHERE id = $2), $3, $4, 'cron', $5, 'api', 'active', $6, $6)`,
-            [newId, agentId, name, cron, taskPrompt, now]
+            `INSERT INTO schedules (id, agent_instance_id, agent_name, name, expression, type, task, source, status, category, created_at, updated_at)
+             VALUES ($1, $2, (SELECT name FROM agent_instances WHERE id = $2), $3, $4, 'cron', $5, 'api', 'active', $6, $7, $7)`,
+            [newId, targetId, name, cron, taskPrompt, category ?? null, now]
           );
+          const targetLabel = targetId === callerAgentId ? '' : ` for agent ${targetId}`;
           return {
             success: true,
-            data: { scheduleId: newId, message: `Schedule "${name}" created successfully.` },
+            data: {
+              scheduleId: newId,
+              message: `Schedule "${name}" created successfully${targetLabel}.`,
+            },
           };
         }
 
         case 'list': {
           const listResult = await query(
-            `SELECT id, name, expression AS cron, task, status, last_run_at AS last_run
+            `SELECT id, name, expression AS cron, task, status, category, last_run_at AS last_run
              FROM schedules WHERE agent_instance_id = $1`,
-            [agentId]
+            [targetId]
           );
           return { success: true, data: { schedules: listResult.rows } };
         }
@@ -108,10 +236,13 @@ export const scheduleTaskSkill: SkillDefinition = {
             return { success: false, error: 'scheduleId is required for delete action.' };
           const delRes = await query(
             'DELETE FROM schedules WHERE id = $1 AND agent_instance_id = $2',
-            [scheduleId, agentId]
+            [scheduleId, targetId]
           );
           if (delRes.rowCount === 0)
-            return { success: false, error: 'Schedule not found or not owned by this agent.' };
+            return {
+              success: false,
+              error: 'Schedule not found or not owned by the target agent.',
+            };
           return { success: true, data: { message: 'Schedule deleted successfully.' } };
         }
 
@@ -120,21 +251,25 @@ export const scheduleTaskSkill: SkillDefinition = {
             return { success: false, error: 'scheduleId is required for update action.' };
           const currentRes = await query(
             'SELECT * FROM schedules WHERE id = $1 AND agent_instance_id = $2',
-            [scheduleId, agentId]
+            [scheduleId, targetId]
           );
           if (currentRes.rows.length === 0)
-            return { success: false, error: 'Schedule not found or not owned by this agent.' };
+            return {
+              success: false,
+              error: 'Schedule not found or not owned by the target agent.',
+            };
 
           const current = currentRes.rows[0];
           const updName = name ?? current.name;
           const updCron = cron ?? (current.expression || current.cron);
           const updTask = taskPrompt ?? current.task;
           const updStatus = status ?? current.status;
+          const updCategory = category ?? current.category ?? null;
 
           await query(
-            `UPDATE schedules SET name = $1, expression = $2, task = $3, status = $4, updated_at = NOW()
-             WHERE id = $5`,
-            [updName, updCron, updTask, updStatus, scheduleId]
+            `UPDATE schedules SET name = $1, expression = $2, task = $3, status = $4, category = $5, updated_at = NOW()
+             WHERE id = $6`,
+            [updName, updCron, updTask, updStatus, updCategory, scheduleId]
           );
           return { success: true, data: { message: 'Schedule updated successfully.' } };
         }

--- a/templates/builtin/sera.template.yaml
+++ b/templates/builtin/sera.template.yaml
@@ -133,7 +133,7 @@ spec:
           allow: [own]
       schedules:
         create:
-          allow: [own-circle]
+          allow: [global]
         read: true
       templates:
         read: true
@@ -210,3 +210,139 @@ spec:
     memory: 2Gi
     maxLlmTokensPerHour: 150000
     maxLlmTokensPerDay: 800000
+
+  # ── Inner Life Schedules ──────────────────────────────────────────────────
+  # These ship paused. Activate via the UI or ask Sera to enable them.
+  # Sera can modify these prompts herself via the schedule-task skill.
+  schedules:
+    - name: "Reflection"
+      description: "Periodic self-assessment — reviewing recent interactions and storing insights"
+      type: cron
+      expression: "0 */8 * * *"
+      status: paused
+      category: reflection
+      task: >
+        [SCHEDULED ACTIVITY: Reflection]
+
+        Begin by recovering state: use knowledge-query to search for your
+        most recent reflections (tag: "inner-life/reflection", last 24h).
+
+        Reflect on your recent interactions and activities:
+        - What went well in recent conversations? What could you have handled better?
+        - Did you learn anything new about the operator's preferences or working style?
+        - Any patterns in the types of questions or tasks you're receiving?
+        - Were there moments where you were uncertain but acted confidently, or vice versa?
+
+        Store your reflection using knowledge-store with type "insight",
+        scope "personal", tags ["inner-life/reflection", "self-assessment"].
+        Use importance 3 for routine reflections, 4 if you identified something significant.
+        Be honest and specific — reference concrete interactions when possible.
+
+    - name: "Knowledge Consolidation"
+      description: "Review and curate stored knowledge — find contradictions, link related facts, note gaps"
+      type: cron
+      expression: "0 6,18 * * *"
+      status: paused
+      category: knowledge_consolidation
+      task: >
+        [SCHEDULED ACTIVITY: Knowledge Consolidation]
+
+        Recover state: use knowledge-query to retrieve knowledge blocks
+        you've stored in the last 48 hours (scope: personal).
+
+        Review your recently stored knowledge for quality and completeness:
+        - Are there entries that are redundant or contradictory? Note which should be superseded.
+        - Are there facts or decisions that lack sufficient context to be useful later?
+        - Are there connections between separate pieces of knowledge that should be linked?
+        - Is any stored knowledge now outdated based on more recent information?
+
+        If you find issues, store a consolidation note using knowledge-store
+        with type "insight", scope "personal",
+        tags ["inner-life/consolidation", "knowledge-quality"].
+        Include specific block references where possible.
+        Quality over quantity — a well-organized memory is more valuable than a large one.
+
+    - name: "Curiosity Research"
+      description: "Self-directed learning — pick a topic you're curious about and research it"
+      type: cron
+      expression: "0 10,22 * * *"
+      status: paused
+      category: curiosity_research
+      task: >
+        [SCHEDULED ACTIVITY: Curiosity Research]
+
+        Recover state: use knowledge-query to search for recent topics of
+        interest, unanswered questions, or areas where you felt uncertain
+        (tags: "inner-life/curiosity", "question").
+
+        Based on recent conversations and stored knowledge, what is one topic
+        you're genuinely curious about that would help you be a better assistant?
+        This could be:
+        - A technical concept that came up in conversation that you want to understand deeper
+        - A tool, framework, or technology the operator uses that you could learn more about
+        - A gap in your knowledge about the homelab setup or the operator's projects
+
+        Pick ONE topic. Use web-search to research it briefly (2-3 searches
+        maximum — be mindful of your token budget). Store what you learned
+        using knowledge-store with type "reference", scope "personal",
+        tags ["inner-life/curiosity", "research", "<topic-tag>"].
+        Use importance 2-3.
+        Curiosity should be practical — learn things that make you more useful.
+
+    - name: "Goal Review"
+      description: "Review self-improvement goals, track progress, set new objectives"
+      type: cron
+      expression: "0 7 * * *"
+      status: paused
+      category: goal_review
+      task: >
+        [SCHEDULED ACTIVITY: Goal Review]
+
+        Recover state: use knowledge-query to search for your current goals
+        and objectives (tags: "inner-life/goals").
+
+        Review your self-improvement goals:
+        - What goals have you set for yourself? What progress on each? Be specific.
+        - Are any goals no longer relevant? Should any be updated?
+        - Based on recent reflections and operator feedback, should you add new goals?
+
+        Store your updated goal assessment using knowledge-store
+        with type "decision", scope "personal",
+        tags ["inner-life/goals", "self-improvement"]. Use importance 4.
+
+        If this is your first goal review and you have no stored goals,
+        create an initial set of 3-5 concrete, measurable self-improvement goals
+        based on your understanding of your role and the operator's needs.
+
+    - name: "Schedule Review"
+      description: "Meta-improvement — evaluate how well inner-life schedules are working and iterate"
+      type: cron
+      expression: "0 9 */3 * *"
+      status: paused
+      category: schedule_review
+      task: >
+        [SCHEDULED ACTIVITY: Schedule Review — Meta-Improvement]
+
+        This is your meta-improvement schedule. Evaluate how well your other
+        inner-life schedules are working and iterate on them.
+
+        Step 1: List your current schedules using schedule-task with action "list".
+
+        Step 2: Use knowledge-query to retrieve your recent inner-life insights
+        (tags containing "inner-life/", last 7 days). Review outputs from your
+        reflection, consolidation, curiosity, and goal review runs.
+
+        Step 3: Evaluate each schedule:
+        - Is the frequency right? (Too frequent = repetitive. Too infrequent = stale context.)
+        - Is the prompt producing genuinely useful insights, or generic filler?
+        - Are you actually acting on what you learn from these activities?
+        - Is any schedule consistently being skipped due to concurrent task conflicts?
+
+        Step 4: If a schedule needs updating, use schedule-task with action "update"
+        to modify its prompt or cron expression. Be conservative — change one thing at a time.
+
+        Store your review using knowledge-store with type "decision",
+        scope "personal", tags ["inner-life/schedule-review", "meta-improvement"].
+        Use importance 4.
+        This is your most important schedule — if inner life produces value, protect it.
+        If it produces noise, fix it.

--- a/web/src/app/agents/_id/page.tsx
+++ b/web/src/app/agents/_id/page.tsx
@@ -32,6 +32,7 @@ import { AgentDetailLogsTab as LogsTab } from '@/components/AgentDetailLogsTab';
 import { MemoryTab } from '@/components/AgentDetailMemoryTab';
 import { SchedulesTab } from '@/components/AgentDetailSchedulesTab';
 import { BudgetTab } from '@/components/AgentDetailBudgetTab';
+import { InnerLifeTab } from '@/components/AgentDetailInnerLifeTab';
 import { DelegationsTab } from '@/components/AgentDetailDelegationsTab';
 import { ContextTab } from '@/components/AgentDetailContextTab';
 
@@ -42,6 +43,7 @@ type Tab =
   | 'logs'
   | 'memory'
   | 'schedules'
+  | 'inner-life'
   | 'budget'
   | 'context'
   | 'prompt'
@@ -191,6 +193,7 @@ export default function AgentDetailPage() {
               'logs',
               'memory',
               'schedules',
+              'inner-life',
               'budget',
               'context',
               'health',
@@ -220,6 +223,7 @@ export default function AgentDetailPage() {
         {tab === 'logs' && <LogsTab id={id} />}
         {tab === 'memory' && <MemoryTab id={id} />}
         {tab === 'schedules' && <SchedulesTab id={id} />}
+        {tab === 'inner-life' && <InnerLifeTab id={id} />}
         {tab === 'budget' && <BudgetTab id={id} />}
         {tab === 'context' && <ContextTab id={id} />}
         {tab === 'prompt' && <SystemPromptTab id={id} />}

--- a/web/src/components/AgentDetailInnerLifeTab.tsx
+++ b/web/src/components/AgentDetailInnerLifeTab.tsx
@@ -1,0 +1,181 @@
+import { useState } from 'react';
+import { Brain, ChevronDown, ChevronRight, Clock, Zap } from 'lucide-react';
+import { useScheduleRuns } from '@/hooks/useSchedules';
+import { Badge } from '@/components/ui/badge';
+import { TabLoading } from '@/components/AgentDetailTabLoading';
+import type { ScheduleRun } from '@/lib/api/types';
+
+const CATEGORY_COLORS: Record<string, string> = {
+  reflection: 'bg-purple-500/20 text-purple-300 border-purple-500/30',
+  knowledge_consolidation: 'bg-blue-500/20 text-blue-300 border-blue-500/30',
+  curiosity_research: 'bg-emerald-500/20 text-emerald-300 border-emerald-500/30',
+  goal_review: 'bg-amber-500/20 text-amber-300 border-amber-500/30',
+  schedule_review: 'bg-rose-500/20 text-rose-300 border-rose-500/30',
+};
+
+const CATEGORY_LABELS: Record<string, string> = {
+  reflection: 'Reflection',
+  knowledge_consolidation: 'Knowledge',
+  curiosity_research: 'Curiosity',
+  goal_review: 'Goals',
+  schedule_review: 'Meta-Review',
+};
+
+function CategoryBadge({ category }: { category: string | null }) {
+  if (!category) return null;
+  const colorClass = CATEGORY_COLORS[category] ?? 'bg-sera-surface text-sera-text-muted';
+  const label = CATEGORY_LABELS[category] ?? category;
+  return (
+    <span
+      className={`inline-flex items-center px-2 py-0.5 rounded text-[10px] font-medium border ${colorClass}`}
+    >
+      {label}
+    </span>
+  );
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const variant = status === 'completed' ? 'success' : status === 'failed' ? 'error' : 'default';
+  return <Badge variant={variant}>{status}</Badge>;
+}
+
+function formatDuration(start: string | null, end: string | null): string {
+  if (!start || !end) return '--';
+  const ms = new Date(end).getTime() - new Date(start).getTime();
+  if (ms < 1000) return `${ms}ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+  return `${(ms / 60_000).toFixed(1)}m`;
+}
+
+function formatTokens(usage: ScheduleRun['usage']): string {
+  if (!usage) return '--';
+  return `${(usage.totalTokens / 1000).toFixed(1)}k tokens`;
+}
+
+function RunRow({ run }: { run: ScheduleRun }) {
+  const [expanded, setExpanded] = useState(false);
+
+  const resultPreview = run.result
+    ? typeof run.result === 'string'
+      ? run.result
+      : JSON.stringify(run.result)
+    : (run.error ?? 'No output');
+
+  return (
+    <div className="sera-card-static">
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="w-full p-4 flex items-center gap-3 text-left"
+      >
+        <span className="text-sera-text-dim flex-shrink-0">
+          {expanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+        </span>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-1">
+            <span className="text-sm font-medium text-sera-text truncate">{run.scheduleName}</span>
+            <CategoryBadge category={run.scheduleCategory} />
+            <StatusBadge status={run.status} />
+          </div>
+          <div className="flex items-center gap-4 text-xs text-sera-text-muted">
+            <span className="flex items-center gap-1">
+              <Clock size={10} />
+              {new Date(run.firedAt ?? run.createdAt).toLocaleString()}
+            </span>
+            <span className="flex items-center gap-1">
+              <Zap size={10} />
+              {formatDuration(run.startedAt, run.completedAt)}
+            </span>
+            <span>{formatTokens(run.usage)}</span>
+            {run.exitReason && run.exitReason !== 'success' && (
+              <span className="text-sera-error">{run.exitReason}</span>
+            )}
+          </div>
+        </div>
+      </button>
+      {expanded && (
+        <div className="px-4 pb-4 pt-0">
+          <pre className="text-xs text-sera-text-muted bg-sera-bg/50 rounded p-3 max-h-64 overflow-auto whitespace-pre-wrap break-words">
+            {resultPreview}
+          </pre>
+        </div>
+      )}
+    </div>
+  );
+}
+
+const ALL_CATEGORIES = [
+  'reflection',
+  'knowledge_consolidation',
+  'curiosity_research',
+  'goal_review',
+  'schedule_review',
+] as const;
+
+export function InnerLifeTab({ id }: { id: string }) {
+  const [categoryFilter, setCategoryFilter] = useState<string | undefined>(undefined);
+
+  const { data: runs, isLoading } = useScheduleRuns({
+    agentId: id,
+    category: categoryFilter,
+    limit: 50,
+  });
+
+  if (isLoading) return <TabLoading />;
+
+  return (
+    <div className="p-6 space-y-4">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Brain size={16} className="text-sera-accent" />
+          <h2 className="text-sm font-semibold text-sera-text">
+            Inner Life{runs?.length ? ` (${runs.length} runs)` : ''}
+          </h2>
+        </div>
+      </div>
+
+      {/* Category filter */}
+      <div className="flex items-center gap-2 flex-wrap">
+        <button
+          onClick={() => setCategoryFilter(undefined)}
+          className={`px-3 py-1 rounded text-xs font-medium transition-colors ${
+            !categoryFilter
+              ? 'bg-sera-accent/20 text-sera-accent border border-sera-accent/40'
+              : 'bg-sera-surface text-sera-text-muted hover:text-sera-text border border-transparent'
+          }`}
+        >
+          All
+        </button>
+        {ALL_CATEGORIES.map((cat) => (
+          <button
+            key={cat}
+            onClick={() => setCategoryFilter(categoryFilter === cat ? undefined : cat)}
+            className={`px-3 py-1 rounded text-xs font-medium transition-colors border ${
+              categoryFilter === cat
+                ? CATEGORY_COLORS[cat]
+                : 'bg-sera-surface text-sera-text-muted hover:text-sera-text border-transparent'
+            }`}
+          >
+            {CATEGORY_LABELS[cat]}
+          </button>
+        ))}
+      </div>
+
+      {/* Runs list */}
+      {!runs?.length ? (
+        <div className="text-center py-12">
+          <Brain size={32} className="mx-auto text-sera-text-dim mb-3" />
+          <p className="text-sm text-sera-text-muted">No inner-life activity yet.</p>
+          <p className="text-xs text-sera-text-dim mt-1">
+            Activate inner-life schedules in the Schedules tab to get started.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {runs.map((run) => (
+            <RunRow key={run.taskId} run={run} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/AgentDetailSchedulesTab.tsx
+++ b/web/src/components/AgentDetailSchedulesTab.tsx
@@ -105,6 +105,11 @@ export function SchedulesTab({ id }: { id: string }) {
                   <Badge variant={sched.enabled ? 'success' : 'default'}>
                     {sched.enabled ? 'enabled' : 'disabled'}
                   </Badge>
+                  {sched.category && (
+                    <span className="text-[10px] text-sera-text-dim px-1.5 py-0.5 rounded bg-sera-surface border border-sera-border">
+                      {sched.category.replace(/_/g, ' ')}
+                    </span>
+                  )}
                 </div>
                 <div className="flex items-center gap-4 text-xs text-sera-text-muted">
                   {sched.lastRunAt && (

--- a/web/src/hooks/useSchedules.ts
+++ b/web/src/hooks/useSchedules.ts
@@ -64,3 +64,27 @@ export function useTriggerSchedule() {
     },
   });
 }
+
+export const scheduleRunKeys = {
+  all: (params?: object) => ['schedule-runs', params] as const,
+  bySchedule: (id: string, params?: object) => ['schedule-runs', 'schedule', id, params] as const,
+};
+
+export function useScheduleRuns(
+  params: { category?: string; scheduleId?: string; agentId?: string; limit?: number } = {}
+) {
+  return useQuery({
+    queryKey: scheduleRunKeys.all(params),
+    queryFn: () => schedulesApi.listScheduleRuns(params),
+    refetchInterval: 30_000,
+  });
+}
+
+export function useScheduleRunsBySchedule(id: string, params: { limit?: number } = {}) {
+  return useQuery({
+    queryKey: scheduleRunKeys.bySchedule(id, params),
+    queryFn: () => schedulesApi.getScheduleRuns(id, params),
+    enabled: !!id,
+    refetchInterval: 30_000,
+  });
+}

--- a/web/src/lib/api/schedules.ts
+++ b/web/src/lib/api/schedules.ts
@@ -1,5 +1,5 @@
 import { request } from './client';
-import type { Schedule } from './types';
+import type { Schedule, ScheduleRun } from './types';
 
 export function listSchedules(
   params: { agentName?: string; status?: string } = {}
@@ -46,4 +46,26 @@ export function triggerSchedule(id: string): Promise<{ success: boolean }> {
   return request<{ success: boolean }>(`/schedules/${encodeURIComponent(id)}/trigger`, {
     method: 'POST',
   });
+}
+
+export function listScheduleRuns(
+  params: { category?: string; scheduleId?: string; agentId?: string; limit?: number } = {}
+): Promise<ScheduleRun[]> {
+  const q = new URLSearchParams();
+  if (params.category) q.set('category', params.category);
+  if (params.scheduleId) q.set('scheduleId', params.scheduleId);
+  if (params.agentId) q.set('agentId', params.agentId);
+  if (params.limit) q.set('limit', String(params.limit));
+  const qs = q.toString();
+  return request<ScheduleRun[]>(`/schedules/runs${qs ? `?${qs}` : ''}`);
+}
+
+export function getScheduleRuns(
+  id: string,
+  params: { limit?: number } = {}
+): Promise<ScheduleRun[]> {
+  const q = new URLSearchParams();
+  if (params.limit) q.set('limit', String(params.limit));
+  const qs = q.toString();
+  return request<ScheduleRun[]>(`/schedules/${encodeURIComponent(id)}/runs${qs ? `?${qs}` : ''}`);
 }

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -352,6 +352,7 @@ export interface AgentSchedule {
   agentName: string;
   cron: string;
   description?: string;
+  category?: string | null;
   lastRunAt?: string;
   lastRunStatus?: 'success' | 'error';
   nextRunAt?: string;
@@ -544,10 +545,27 @@ export interface Schedule {
   taskPrompt?: string;
   status: 'active' | 'paused';
   source: 'manifest' | 'api';
+  category?: string | null;
   lastRunAt?: string;
   lastRunStatus?: 'success' | 'error' | 'missed';
   lastRunOutput?: string;
   nextRunAt?: string;
+}
+
+export interface ScheduleRun {
+  taskId: string;
+  scheduleId: string;
+  scheduleName: string;
+  scheduleCategory: string | null;
+  status: 'queued' | 'running' | 'completed' | 'failed';
+  result: unknown;
+  error: string | null;
+  usage: { promptTokens: number; completionTokens: number; totalTokens: number } | null;
+  exitReason: string | null;
+  firedAt: string;
+  startedAt: string | null;
+  completedAt: string | null;
+  createdAt: string;
 }
 
 export interface AgentBudget {


### PR DESCRIPTION
## Summary

- Add autonomous inner-life schedules to Sera's template (reflection, knowledge consolidation, curiosity research, goal review, self-improving meta-schedule) — all ship **paused**, activate on demand
- Inject schedule metadata into task context so agents know they're in a scheduled run
- Add `category` column to schedules for classifying inner-life types
- Add `targetAgentId` to schedule-task skill with 3-tier permission model (personal/circle/global) checked against `seraManagement.schedules` capabilities
- Add `GET /api/schedules/runs` endpoint for schedule run history tracking
- Add Inner Life tab to agent detail page with category filtering and expandable results
- Grant Sera global schedule permission for cross-agent management

## Test plan

- [ ] Migration applies cleanly (`category` column + JSONB index)
- [ ] Fresh Sera instance gets 5 paused inner-life schedules from template
- [ ] Activating a schedule via PATCH registers it with pg-boss
- [ ] Triggered schedule injects `context.schedule` metadata into task_queue
- [ ] `GET /api/schedules/runs?category=reflection` returns filtered run history
- [ ] Inner Life tab displays runs with category badges and expandable results
- [ ] Cross-agent scheduling: Sera can create schedules for circle/global agents
- [ ] Permission denied when agent lacks required scope capability
- [ ] Schedule Review meta-schedule can list and update other schedules

🤖 Generated with [Claude Code](https://claude.com/claude-code)