### PR TITLE
fix(core): sync manifest schedules on template upsert

### DIFF
--- a/core/src/agents/registry.service.ts
+++ b/core/src/agents/registry.service.ts
@@ -28,6 +28,20 @@ export class AgentRegistry {
       RETURNING *;
     `;
     const res = await this.pool.query(query, [name, displayName, builtin, category, template.spec]);
+
+    // Sync manifest schedules to all existing instances of this template.
+    // New schedules are created; duplicates are silently skipped (unique constraint).
+    const spec = template.spec as Record<string, unknown> | undefined;
+    if ((spec?.schedules as unknown[] | undefined)?.length) {
+      const instances = await this.pool.query(
+        'SELECT id FROM agent_instances WHERE template_ref = $1',
+        [name]
+      );
+      for (const inst of instances.rows) {
+        await this.syncManifestSchedules(inst.id as string, name);
+      }
+    }
+
     return {
       status: existing ? 'updated' : 'added',
       name: res.rows[0].name,


### PR DESCRIPTION
## Summary

- Fix: manifest-declared schedules were only synced on instance creation, not on template update
- Now `upsertTemplate()` syncs schedules to all existing instances of the updated template
- Duplicates silently skipped via existing unique constraint handler
- This ensures inner-life schedules (from #600) appear on existing Sera instances after a stack update

## Test plan

- [ ] Update sera template with new schedules, restart core — existing Sera instance receives them
- [ ] Schedules with same name are not duplicated (unique constraint)
- [ ] New schedules inherit `status: paused` from template

🤖 Generated with [Claude Code](https://claude.com/claude-code)