### PR TITLE
fix(core,web): reimport templates on startup + fix agent schedules route

### DIFF
--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -602,6 +602,18 @@ const startServer = async () => {
     await initDb();
   }
 
+  // Re-import templates and resources from filesystem on every startup.
+  // This ensures template changes (new schedules, updated capabilities, etc.)
+  // are synced to the DB and propagated to existing instances.
+  await resourceImporter
+    .importAll()
+    .then((r) =>
+      logger.info(
+        `Resource import: ${r.added.length} added, ${r.updated.length} updated, ${r.errors.length} errors`
+      )
+    )
+    .catch((err) => logger.error('Failed to import resources on startup:', err));
+
   // Hydrate provider API keys from encrypted secrets store (if SECRETS_MASTER_KEY is set)
   await providerRegistry.hydrateSecrets().catch((err) => {
     logger.warn('Could not hydrate provider secrets (SECRETS_MASTER_KEY may not be set):', err);

--- a/web/src/lib/api/agents.ts
+++ b/web/src/lib/api/agents.ts
@@ -5,6 +5,7 @@ import type {
   AgentInfo,
   AgentTask,
   AgentSchedule,
+  Schedule,
   AgentMemoryBlock,
   ThoughtEvent,
   CreateAgentInstanceParams,
@@ -90,8 +91,20 @@ export function getAgentMemory(id: string, scope?: string): Promise<AgentMemoryB
   return request<AgentMemoryBlock[]>(`/memory/${encodeURIComponent(id)}/blocks${params}`);
 }
 
-export function getAgentSchedules(id: string): Promise<AgentSchedule[]> {
-  return request<AgentSchedule[]>(`/agents/${encodeURIComponent(id)}/schedules`);
+export async function getAgentSchedules(id: string): Promise<AgentSchedule[]> {
+  // The schedule list endpoint is /api/schedules?agentId=:id (not /api/agents/:id/schedules)
+  const schedules = await request<Schedule[]>(`/schedules?agentId=${encodeURIComponent(id)}`);
+  return schedules.map((s) => ({
+    id: s.id,
+    agentName: s.agentName,
+    cron: s.expression,
+    description: s.name,
+    category: s.category,
+    lastRunAt: s.lastRunAt,
+    lastRunStatus: s.lastRunStatus as AgentSchedule['lastRunStatus'],
+    nextRunAt: s.nextRunAt,
+    enabled: s.status === 'active',
+  }));
 }
 
 export function getAgentTasks(id: string, type?: string): Promise<AgentTask[]> {


### PR DESCRIPTION
## Summary

- Fix: templates are now reimported from filesystem on every startup (not just first boot)
- Fix: 404 on `GET /api/agents/:id/schedules` — route never existed; frontend now uses `GET /api/schedules?agentId=:id` with response mapping
- Combined with #601, inner-life schedules now appear on existing Sera instances after stack update

## Test plan

- [ ] Restart core — templates reimported, inner-life schedules synced to existing Sera instance
- [ ] Agent detail Schedules tab loads without 404
- [ ] Schedules display correctly with cron, status, category badges

🤖 Generated with [Claude Code](https://claude.com/claude-code)