### PR TITLE
fix(core): add schedules to AgentTemplate Zod schema

### DIFF
--- a/core/src/agents/schemas.ts
+++ b/core/src/agents/schemas.ts
@@ -81,6 +81,19 @@ export const AgentTemplateSchema = z.object({
       .optional(),
     workspace: z.record(z.any()).optional(),
     memory: z.record(z.any()).optional(),
+    schedules: z
+      .array(
+        z.object({
+          name: z.string(),
+          description: z.string().optional(),
+          type: z.enum(['cron', 'once']),
+          expression: z.string(),
+          task: z.string(),
+          status: z.enum(['active', 'paused']).optional(),
+          category: z.string().optional(),
+        })
+      )
+      .optional(),
   }),
 });
 


### PR DESCRIPTION
## Summary

- Fix: Zod schema for `AgentTemplate.spec` was missing `schedules` field
- Zod strips unknown fields by default, so template-declared schedules were silently dropped during YAML import
- Root cause of inner-life schedules not appearing on existing instances after #600/#601/#602

## Test plan

- [ ] Restart core — Sera's template now includes schedules in DB
- [ ] Inner-life schedules appear on Sera's instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)