### PR TITLE
fix(core): normalize schedule task to valid JSON before JSONB insert

### DIFF
--- a/core/src/services/ScheduleService.ts
+++ b/core/src/services/ScheduleService.ts
@@ -129,6 +129,20 @@ export class ScheduleService {
       throw new Error('Missing required fields for schedule');
     }
 
+    // Normalize task to valid JSON for the JSONB column.
+    // Plain strings (e.g. from template YAML) are wrapped as { prompt: "..." }.
+    let taskJson: string;
+    if (typeof task === 'string') {
+      try {
+        JSON.parse(task);
+        taskJson = task; // Already valid JSON
+      } catch {
+        taskJson = JSON.stringify({ prompt: task }); // Wrap plain string
+      }
+    } else {
+      taskJson = JSON.stringify(task);
+    }
+
     const { rows } = await pool.query<Schedule>(
       `INSERT INTO schedules
        (id, agent_instance_id, agent_name, name, type, expression, task, status, source, category)
@@ -141,7 +155,7 @@ export class ScheduleService {
         name,
         type,
         expression,
-        task,
+        taskJson,
         initialStatus,
         source,
         category ?? null,


### PR DESCRIPTION
## Summary

- Fix: template-declared schedule tasks are plain strings but `task` column is JSONB
- `createSchedule()` now normalizes: wraps plain strings as `{"prompt": "..."}`, passes valid JSON through
- This was the root cause of inner-life schedules failing to sync from template to instances

## Test plan

- [ ] Restart core — inner-life schedules sync without JSON parse errors
- [ ] Sera's instance shows 5 paused inner-life schedules

🤖 Generated with [Claude Code](https://claude.com/claude-code)