### PR TITLE
fix(core): schedule dedup guard — enqueue instead of skipping

### DIFF
--- a/core/src/services/ScheduleService.ts
+++ b/core/src/services/ScheduleService.ts
@@ -314,18 +314,22 @@ export class ScheduleService {
 
     const { lifecycle_mode, status } = agentInstance.rows[0];
 
-    // Concurrent execution guard
-    // For persistent agents, check task_queue
+    // Dedup guard for persistent agents: skip only if THIS schedule already has a pending task.
+    // Other schedules can enqueue freely — the agent processes them sequentially.
     if (lifecycle_mode === 'persistent') {
-      const runningTask = await pool.query(
-        "SELECT id FROM task_queue WHERE agent_instance_id = $1 AND status = 'running' LIMIT 1",
-        [schedule.agent_instance_id]
+      const existingTask = await pool.query(
+        `SELECT id FROM task_queue
+         WHERE agent_instance_id = $1
+           AND status IN ('queued', 'running')
+           AND context->'schedule'->>'scheduleId' = $2
+         LIMIT 1`,
+        [schedule.agent_instance_id, schedule.id]
       );
-      if (runningTask.rows.length > 0) {
-        logger.warn(
-          `Skipping scheduled task for ${schedule.agent_name}: agent is already running a task.`
+      if (existingTask.rows.length > 0) {
+        logger.info(
+          `Schedule ${schedule.name} already has a queued/running task — skipping duplicate`
         );
-        await this.updateRunStatus(id, 'skipped', 'Agent already running a task');
+        await this.updateRunStatus(id, 'skipped', 'Schedule already has a pending task');
         return;
       }
 


### PR DESCRIPTION
## Summary

Replace the overly broad concurrent execution guard with a narrow dedup check. Scheduled tasks now **enqueue** instead of being **skipped** when the agent is busy.

**Before:** Reflection running → Goal Review fires → **SKIPPED** (work lost)  
**After:** Reflection running → Goal Review fires → **QUEUED** (processed next)

The dedup guard only prevents the *same* schedule from queueing twice (e.g., if Reflection fires again before the previous Reflection completes). Different schedules queue independently.

## Why this is safe

- The agent runtime processes tasks sequentially via `pollTaskQueue` — no concurrent execution risk
- The task queue already supports multiple queued tasks per agent
- The `/tasks/next` endpoint handles `queued → running` transitions atomically with `FOR UPDATE SKIP LOCKED`
- Ephemeral agent guard is unchanged (they can only run one task)

## Test plan

- [x] `tsc --noEmit` passes
- [x] 9 ScheduleService tests pass
- [x] Pre-commit hooks pass (typecheck, lint, web tests)
- [ ] Manual: trigger two different schedules while agent is busy, verify both enqueue
- [ ] Manual: trigger same schedule twice, verify dedup prevents double-queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)