### PR TITLE
feat: composable multi-section system prompt builder

### DIFF
--- a/core/agent-runtime/src/__tests__/manifest.test.ts
+++ b/core/agent-runtime/src/__tests__/manifest.test.ts
@@ -95,5 +95,94 @@ model:
       expect(prompt).toContain('Role: Helpful Assistant');
       expect(prompt).toContain('Description: A test agent.');
     });
+
+    it('includes all sections when fully configured', () => {
+      const manifest: RuntimeManifest = {
+        apiVersion: 'v1',
+        kind: 'Agent',
+        metadata: {
+          name: 'test-agent',
+          displayName: 'Test Agent',
+          icon: 'robot',
+          circle: 'default',
+          tier: 1,
+        },
+        identity: {
+          role: 'Helpful Assistant',
+          description: 'A test agent.',
+          principles: ['Always honest'],
+          communicationStyle: 'Brief',
+          notes: 'Agent notes here.',
+        },
+        model: {
+          provider: 'openai',
+          name: 'gpt-4',
+        },
+        contextFiles: ['README.md'],
+        outputFormat: 'Markdown',
+      };
+
+      const prompt = generateSystemPrompt(manifest, {
+        tools: [
+          {
+            type: 'function',
+            function: {
+              name: 'test-tool',
+              description: 'A test tool.',
+              parameters: { type: 'object', properties: {} },
+            },
+          },
+        ],
+        circleName: 'Engineering',
+        circleMembers: ['alice', 'bob'],
+        availableAgents: [{ name: 'sub-agent', role: 'Support' }],
+      });
+
+      expect(prompt).toContain('You are Test Agent, a SERA AI agent.');
+      expect(prompt).toContain('## Principles');
+      expect(prompt).toContain('Always honest');
+      expect(prompt).toContain('## Communication Style');
+      expect(prompt).toContain('Brief');
+      expect(prompt).toContain('## Available Tools');
+      expect(prompt).toContain('test-tool');
+      expect(prompt).toContain('## System Context');
+      expect(prompt).toContain('## Circle: Engineering');
+      expect(prompt).toContain('## Delegation');
+      expect(prompt).toContain('## Agent Notes');
+      expect(prompt).toContain('Agent notes here.');
+      expect(prompt).toContain('## Workspace Context');
+      expect(prompt).toContain('README.md');
+      expect(prompt).toContain('## System Constraints');
+      expect(prompt).toContain('## Output Format');
+    });
+
+    it('respects the token budget', () => {
+      const manifest: RuntimeManifest = {
+        apiVersion: 'v1',
+        kind: 'Agent',
+        metadata: {
+          name: 'test-agent',
+          displayName: 'Test Agent',
+          icon: 'robot',
+          circle: 'default',
+          tier: 1,
+        },
+        identity: {
+          role: 'Helpful Assistant',
+          description: 'A test agent.',
+          principles: ['A very long principle that will definitely add many tokens to the prompt to make sure budget is exceeded'],
+        },
+        model: {
+          provider: 'openai',
+          name: 'gpt-4',
+        },
+      };
+
+      // Set a tiny budget to force dropping optional sections
+      const prompt = generateSystemPrompt(manifest, { tokenBudget: 20 });
+      expect(prompt).toContain('You are Test Agent');
+      // identity (required) should be there, but principles (optional) should be dropped
+      expect(prompt).not.toContain('## Principles');
+    });
   });
 });

--- a/core/agent-runtime/src/__tests__/systemPromptBuilder.test.ts
+++ b/core/agent-runtime/src/__tests__/systemPromptBuilder.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest';
+import { SystemPromptBuilder } from '../systemPromptBuilder.js';
+import type { RuntimeManifest } from '../manifest.js';
+import type { ToolDefinition } from '../llmClient.js';
+
+describe('SystemPromptBuilder', () => {
+  const mockManifest: RuntimeManifest = {
+    apiVersion: 'v1',
+    kind: 'Agent',
+    metadata: {
+      name: 'test-agent',
+      displayName: 'Test Agent',
+      icon: 'robot',
+      circle: 'default',
+      tier: 1,
+    },
+    identity: {
+      role: 'Test Assistant',
+      description: 'A test agent for unit tests.',
+      principles: ['Be helpful', 'Be concise'],
+      communicationStyle: 'Professional',
+      notes: 'Some internal notes.',
+    },
+    model: {
+      provider: 'openai',
+      name: 'gpt-4',
+    },
+    contextFiles: ['README.md'],
+    outputFormat: 'Markdown',
+  };
+
+  const mockTools: ToolDefinition[] = [
+    {
+      type: 'function',
+      function: {
+        name: 'test-tool',
+        description: 'A test tool description.',
+        parameters: { type: 'object', properties: {} },
+      },
+    },
+  ];
+
+  it('builds a full system prompt with all sections', () => {
+    const builder = new SystemPromptBuilder();
+    builder
+      .addIdentity(mockManifest)
+      .addPrinciples(mockManifest)
+      .addCommunicationStyle(mockManifest)
+      .addAvailableTools(mockTools)
+      .addToolUsageGuidelines()
+      .addMemoryInstructions()
+      .addTimeContext()
+      .addCircleContext('default', ['user1'])
+      .addDelegationContext([{ name: 'sub-agent', role: 'Sub-agent role' }])
+      .addAgentNotes(mockManifest)
+      .addWorkspaceContext(mockManifest)
+      .addReasoningHints('gpt-4-thinking')
+      .addConstraints(1)
+      .addOutputFormat(mockManifest.outputFormat);
+
+    const prompt = builder.build();
+
+    expect(prompt).toContain('You are Test Agent, a SERA AI agent.');
+    expect(prompt).toContain('Role: Test Assistant');
+    expect(prompt).toContain('## Principles');
+    expect(prompt).toContain('- Be helpful');
+    expect(prompt).toContain('## Communication Style');
+    expect(prompt).toContain('Professional');
+    expect(prompt).toContain('## Available Tools');
+    expect(prompt).toContain('- **test-tool**: A test tool description.');
+    expect(prompt).toContain('## Tool Usage Guidelines');
+    expect(prompt).toContain('## Memory & Knowledge');
+    expect(prompt).toContain('## System Context');
+    expect(prompt).toContain('## Circle: default');
+    expect(prompt).toContain('## Delegation');
+    expect(prompt).toContain('## Agent Notes');
+    expect(prompt).toContain('Some internal notes.');
+    expect(prompt).toContain('## Workspace Context');
+    expect(prompt).toContain('- README.md');
+    expect(prompt).toContain('## Reasoning Instructions');
+    expect(prompt).toContain('## System Constraints');
+    expect(prompt).toContain('## Output Format');
+    expect(prompt).toContain('Markdown');
+  });
+
+  it('respects token budget by dropping optional sections', () => {
+    const builder = new SystemPromptBuilder();
+    // Required: identity (approx 20 tokens), constraints (approx 15 tokens)
+    // Optional: principles (approx 15 tokens)
+    builder
+      .addIdentity(mockManifest)
+      .addPrinciples(mockManifest)
+      .addConstraints(1);
+
+    // Total should be around 50 tokens. Set budget to 35.
+    // Principles (priority 10) should be dropped. Identity and Constraints are required.
+    const prompt = builder.build(35);
+
+    expect(prompt).toContain('You are Test Agent');
+    expect(prompt).toContain('## System Constraints');
+    expect(prompt).not.toContain('## Principles');
+  });
+
+  it('keeps all required sections even if over budget', () => {
+    const builder = new SystemPromptBuilder();
+    builder
+      .addIdentity(mockManifest)
+      .addConstraints(1);
+
+    // Total approx 35 tokens. Set budget to 10.
+    const prompt = builder.build(10);
+
+    expect(prompt).toContain('You are Test Agent');
+    expect(prompt).toContain('## System Constraints');
+  });
+
+  it('handles empty optional fields gracefully', () => {
+    const minimalManifest: RuntimeManifest = {
+      apiVersion: 'v1',
+      kind: 'Agent',
+      metadata: {
+        name: 'minimal',
+        displayName: 'Minimal',
+        icon: 'robot',
+        circle: 'default',
+        tier: 1,
+      },
+      identity: {
+        role: 'Minimalist',
+        description: 'Less is more.',
+      },
+      model: {
+        provider: 'openai',
+        name: 'gpt-4',
+      },
+    };
+
+    const builder = new SystemPromptBuilder();
+    builder
+      .addIdentity(minimalManifest)
+      .addPrinciples(minimalManifest)
+      .addAgentNotes(minimalManifest)
+      .addWorkspaceContext(minimalManifest);
+
+    const prompt = builder.build();
+    expect(prompt).toContain('You are Minimal, a SERA AI agent.');
+    expect(prompt).not.toContain('## Principles');
+    expect(prompt).not.toContain('## Agent Notes');
+    expect(prompt).not.toContain('## Workspace Context');
+  });
+});

--- a/core/agent-runtime/src/contextManager.ts
+++ b/core/agent-runtime/src/contextManager.ts
@@ -98,6 +98,11 @@ export class ContextManager {
     log('info', `ContextManager init: model=${modelName} window=${this.contextWindow} highWater=${this.highWaterMark} strategy=${this.strategy}`);
   }
 
+  /** Get the configured context window size. */
+  getContextWindow(): number {
+    return this.contextWindow;
+  }
+
   /** Count tokens in a string. */
   countTokens(text: string): number {
     if (!text) return 0;

--- a/core/agent-runtime/src/loop.ts
+++ b/core/agent-runtime/src/loop.ts
@@ -105,8 +105,10 @@ export class ReasoningLoop {
     this.centrifugo = centrifugo;
     this.manifest = manifest;
     this.allToolDefs = tools.getToolDefinitions(manifest.tools?.allowed);
-    this.systemPrompt = generateSystemPrompt(manifest);
     this.contextManager = new ContextManager(manifest.model.name);
+
+    // Initial system prompt — will be refreshed per task with current time/tools
+    this.systemPrompt = this.refreshSystemPrompt();
 
     // Dynamic tool exposure (#535): if tool count exceeds CORE_TOOL_LIMIT,
     // defer the excess tools and keep tool-search in the core set.
@@ -153,11 +155,32 @@ export class ReasoningLoop {
     this.incomingMessages.push({ source: from, content, channel });
   }
 
+  /** Refresh the system prompt with current runtime state. */
+  private refreshSystemPrompt(): string {
+    const availableAgents = this.manifest.subagents?.allowed?.map((sa) => ({
+      name: sa.role, // In this context, name/role are interchangeable for fallback
+      role: sa.role,
+    }));
+
+    return generateSystemPrompt(this.manifest, {
+      tools: this.toolDefs,
+      timezone: process.env['TZ'] || 'UTC',
+      circleName: this.manifest.metadata.circle,
+      availableAgents,
+      // Budget: 15% of context window per requirement
+      tokenBudget: Math.floor(this.contextManager.getContextWindow() * 0.15),
+    });
+  }
+
   /**
    * Run the reasoning loop for the given task.
    */
   async run(input: TaskInput): Promise<TaskOutput> {
     const { taskId, task, context, history = [] } = input;
+
+    // Refresh prompt to get current UTC time and current tool set
+    this.systemPrompt = this.refreshSystemPrompt();
+
     const hasTools = this.toolDefs.length > 0;
     const thoughtStream: TaskOutput['thoughtStream'] = [];
 

--- a/core/agent-runtime/src/manifest.ts
+++ b/core/agent-runtime/src/manifest.ts
@@ -7,6 +7,8 @@
 
 import fs from 'fs';
 import yaml from 'js-yaml';
+import type { ToolDefinition } from './llmClient.js';
+import { SystemPromptBuilder } from './systemPromptBuilder.js';
 
 // ── Minimal Manifest Types (mirrors Core's AgentManifest) ───────────────────
 
@@ -26,7 +28,9 @@ export interface RuntimeManifest {
     description: string;
     communicationStyle?: string;
     principles?: string[];
+    notes?: string;
   };
+  notes?: string;
   model: {
     provider: string;
     name: string;
@@ -48,6 +52,14 @@ export interface RuntimeManifest {
       subscribe?: string[];
     };
   };
+  subagents?: {
+    allowed?: Array<{
+      role: string;
+      templateRef?: string;
+    }>;
+  };
+  contextFiles?: string[];
+  outputFormat?: string;
 }
 
 /**
@@ -71,6 +83,10 @@ export function loadManifest(manifestPath: string): RuntimeManifest {
     if (spec['skills'] && !raw['skills']) raw['skills'] = spec['skills'];
     if (spec['memory'] && !raw['memory']) raw['memory'] = spec['memory'];
     if (spec['intercom'] && !raw['intercom']) raw['intercom'] = spec['intercom'];
+    if (spec['subagents'] && !raw['subagents']) raw['subagents'] = spec['subagents'];
+    if (spec['contextFiles'] && !raw['contextFiles']) raw['contextFiles'] = spec['contextFiles'];
+    if (spec['outputFormat'] && !raw['outputFormat']) raw['outputFormat'] = spec['outputFormat'];
+    if (spec['notes'] && !raw['notes']) raw['notes'] = spec['notes'];
   }
 
   const parsed = raw as unknown as RuntimeManifest;
@@ -87,39 +103,73 @@ export function loadManifest(manifestPath: string): RuntimeManifest {
 }
 
 /**
- * Generate a bootstrap system prompt from a manifest.
- *
- * This is a lightweight fallback prompt. In the primary chat path, ContextAssembler
- * on the Core side replaces this with the full IdentityService-generated prompt
- * (which includes stability guidelines, response format, subagents, circle context,
- * and memory). Tools are provided via the function-calling API — listing them in the
- * system prompt causes models to hallucinate XML-style tool calls.
+ * Context for generating the system prompt.
  */
-export function generateSystemPrompt(manifest: RuntimeManifest): string {
-  const lines: string[] = [
-    `You are ${manifest.metadata.displayName}, a SERA AI agent.`,
-    `Role: ${manifest.identity.role}`,
-    `Description: ${manifest.identity.description}`,
-  ];
+export interface SystemPromptContext {
+  tools?: ToolDefinition[];
+  timezone?: string;
+  circleName?: string;
+  circleMembers?: string[];
+  circleConstitution?: string;
+  availableAgents?: Array<{ name: string; role: string }>;
+  tokenBudget?: number;
+}
 
-  if (manifest.identity.communicationStyle) {
-    lines.push(`Communication Style: ${manifest.identity.communicationStyle}`);
+/**
+ * Generate a rich, composable system prompt from a manifest and runtime context.
+ */
+export function generateSystemPrompt(manifest: RuntimeManifest, context: SystemPromptContext = {}): string {
+  const builder = new SystemPromptBuilder();
+
+  // 1. Identity (Priority 0, Required)
+  builder.addIdentity(manifest);
+
+  // 2. Principles (Priority 10)
+  builder.addPrinciples(manifest);
+
+  // 3. Communication Style (Priority 20)
+  builder.addCommunicationStyle(manifest);
+
+  // 4. Available Tools (Priority 30, Required)
+  builder.addAvailableTools(context.tools || []);
+
+  // 5. Tool Usage Guidelines (Priority 40, Required)
+  builder.addToolUsageGuidelines();
+
+  // 6. Memory Instructions (Priority 50, Required)
+  builder.addMemoryInstructions();
+
+  // 7. Time & Context (Priority 60, Required)
+  builder.addTimeContext(context.timezone);
+
+  // 8. Circle Context (Priority 70)
+  if (context.circleName) {
+    builder.addCircleContext(
+      context.circleName,
+      context.circleMembers || [],
+      context.circleConstitution
+    );
   }
 
-  if (manifest.identity.principles?.length) {
-    lines.push('Principles:');
-    for (const p of manifest.identity.principles) {
-      lines.push(`  - ${p}`);
-    }
+  // 9. Delegation Context (Priority 80)
+  if (context.availableAgents) {
+    builder.addDelegationContext(context.availableAgents);
   }
 
-  lines.push('');
-  lines.push('## Tool Usage Guidelines');
-  lines.push('- When you need to accomplish a task, USE the available tools via function calls.');
-  lines.push('- Report results clearly. If a tool errors, explain what happened.');
-  lines.push('- Do not call the same tool with identical arguments repeatedly.');
-  lines.push('- If you cannot accomplish a task with the tools available, say so.');
-  lines.push('- Only use tools provided via function calling. Do NOT fabricate tool calls in XML, JSON, or any other text format.');
+  // 10. Agent Notes (Priority 90)
+  builder.addAgentNotes(manifest);
 
-  return lines.join('\n');
+  // 11. Workspace Context (Priority 100)
+  builder.addWorkspaceContext(manifest);
+
+  // 12. Reasoning Hints (Priority 110)
+  builder.addReasoningHints(manifest.model.name);
+
+  // 13. Constraints (Priority 120, Required)
+  builder.addConstraints(manifest.metadata.tier || 2);
+
+  // 14. Output Format (Priority 130)
+  builder.addOutputFormat(manifest.outputFormat);
+
+  return builder.build(context.tokenBudget);
 }

--- a/core/agent-runtime/src/systemPromptBuilder.ts
+++ b/core/agent-runtime/src/systemPromptBuilder.ts
@@ -1,0 +1,295 @@
+import { getEncoding } from 'js-tiktoken';
+import type { RuntimeManifest } from './manifest.js';
+import type { ToolDefinition } from './llmClient.js';
+
+export interface PromptSection {
+  id: string;
+  priority: number;        // Lower = more important, kept when truncating
+  content: string;
+  required: boolean;       // If true, never truncated
+}
+
+export class SystemPromptBuilder {
+  private sections: PromptSection[] = [];
+  private enc = getEncoding('cl100k_base');
+
+  /** Add a section to the system prompt. */
+  addSection(section: PromptSection): this {
+    // Replace if ID already exists, otherwise add
+    const index = this.sections.findIndex((s) => s.id === section.id);
+    if (index !== -1) {
+      this.sections[index] = section;
+    } else {
+      this.sections.push(section);
+    }
+    return this;
+  }
+
+  /** Build the final system prompt string, respecting the token budget if provided. */
+  build(tokenBudget?: number): string {
+    // Sort sections by priority (ASC: 0 is highest)
+    const sorted = [...this.sections].sort((a, b) => a.priority - b.priority);
+
+    if (!tokenBudget) {
+      return sorted.map((s) => s.content).join('\n\n').trim();
+    }
+
+    const requiredSections = sorted.filter((s) => s.required);
+    const optionalSections = sorted.filter((s) => !s.required);
+
+    // Initial check: if all required sections exceed budget, we keep them anyway
+    // (spec says required sections are never truncated)
+    let currentContent = this.assemble(requiredSections);
+    let currentTokens = this.countTokens(currentContent);
+
+    if (currentTokens >= tokenBudget) {
+      return currentContent;
+    }
+
+    // Add optional sections one by one until budget reached
+    const toKeep = [...requiredSections];
+    for (const section of optionalSections) {
+      const nextContent = this.assemble([...toKeep, section]);
+      const nextTokens = this.countTokens(nextContent);
+
+      if (nextTokens <= tokenBudget) {
+        toKeep.push(section);
+        currentContent = nextContent;
+        currentTokens = nextTokens;
+      } else {
+        // Budget exceeded, stop adding optional sections
+        break;
+      }
+    }
+
+    // Final assembly — we re-sort by the original priority to maintain logical order
+    // even if we dropped some sections in between.
+    return this.assemble(toKeep.sort((a, b) => a.priority - b.priority));
+  }
+
+  private assemble(sections: PromptSection[]): string {
+    return sections.map((s) => s.content).join('\n\n').trim();
+  }
+
+  private countTokens(text: string): number {
+    return this.enc.encode(text).length;
+  }
+
+  // ── Manifest-based Sections ──────────────────────────────────────────────────
+
+  /** Identity: name, role, description (Required, Priority 0) */
+  addIdentity(manifest: RuntimeManifest): this {
+    const lines = [
+      `You are ${manifest.metadata.displayName}, a SERA AI agent.`,
+      `Role: ${manifest.identity.role}`,
+      `Description: ${manifest.identity.description}`,
+    ];
+    return this.addSection({
+      id: 'identity',
+      priority: 0,
+      content: lines.join('\n'),
+      required: true,
+    });
+  }
+
+  /** Principles: bullets (Optional, Priority 10) */
+  addPrinciples(manifest: RuntimeManifest): this {
+    if (!manifest.identity.principles?.length) return this;
+    const lines = ['## Principles', ...manifest.identity.principles.map((p) => `- ${p}`)];
+    return this.addSection({
+      id: 'principles',
+      priority: 10,
+      content: lines.join('\n'),
+      required: false,
+    });
+  }
+
+  /** Communication Style: free-form text (Optional, Priority 20) */
+  addCommunicationStyle(manifest: RuntimeManifest): this {
+    if (!manifest.identity.communicationStyle) return this;
+    const lines = ['## Communication Style', manifest.identity.communicationStyle];
+    return this.addSection({
+      id: 'communication-style',
+      priority: 20,
+      content: lines.join('\n'),
+      required: false,
+    });
+  }
+
+  /** Agent Notes: manifest-level notes (Optional, Priority 90) */
+  addAgentNotes(manifest: RuntimeManifest): this {
+    const notes = manifest.identity.notes || manifest.notes;
+    if (!notes) return this;
+    const lines = ['## Agent Notes', notes];
+    return this.addSection({
+      id: 'agent-notes',
+      priority: 90,
+      content: lines.join('\n'),
+      required: false,
+    });
+  }
+
+  /** Workspace Context: injected files (Optional, Priority 200) */
+  addWorkspaceContext(manifest: RuntimeManifest): this {
+    if (!manifest.contextFiles?.length) return this;
+    const lines = ['## Workspace Context', 'The following files are available for reference in the workspace:'];
+    for (const file of manifest.contextFiles) {
+      lines.push(`- ${file}`);
+    }
+    return this.addSection({
+      id: 'workspace-context',
+      priority: 200, // Lowest priority, first to be truncated
+      content: lines.join('\n'),
+      required: false,
+    });
+  }
+
+  // ── Runtime & Context Sections ───────────────────────────────────────────────
+
+  /** Available Tools: summary list (Required, Priority 30) */
+  addAvailableTools(tools: ToolDefinition[]): this {
+    if (!tools.length) return this;
+    const lines = ['## Available Tools'];
+    for (const t of tools) {
+      const desc = t.function.description.split('.')[0]; // First sentence only
+      lines.push(`- **${t.function.name}**: ${desc}.`);
+    }
+    return this.addSection({
+      id: 'available-tools',
+      priority: 30,
+      content: lines.join('\n'),
+      required: true,
+    });
+  }
+
+  /** Tool Usage Guidelines: common hints (Required, Priority 40) */
+  addToolUsageGuidelines(): this {
+    const lines = [
+      '## Tool Usage Guidelines',
+      '- When you need to accomplish a task, USE the available tools via function calls.',
+      '- Report results clearly. If a tool errors, explain what happened.',
+      '- Do not call the same tool with identical arguments repeatedly.',
+      '- If you cannot accomplish a task with the tools available, say so.',
+      '- Only use tools provided via function calling. Do NOT fabricate tool calls in XML, JSON, or any other text format.',
+      '- Use knowledge-store to save important findings for long-term memory.',
+    ];
+    return this.addSection({
+      id: 'tool-usage-guidelines',
+      priority: 40,
+      content: lines.join('\n'),
+      required: true,
+    });
+  }
+
+  /** Memory Instructions: RAG & saving (Required, Priority 50) */
+  addMemoryInstructions(): this {
+    const lines = [
+      '## Memory & Knowledge',
+      '- Use `knowledge-store` to save important facts, decisions, or results of complex analysis.',
+      '- Use `knowledge-query` to search your long-term memory when you need context from past interactions.',
+      '- When citing information from memory, use the format [Memory: <id>] if an ID is available.',
+      '- Be proactive: if you learn something the user is likely to ask about later, save it.',
+    ];
+    return this.addSection({
+      id: 'memory-instructions',
+      priority: 50,
+      content: lines.join('\n'),
+      required: true,
+    });
+  }
+
+  /** Time & Context: current time/date (Required, Priority 60) */
+  addTimeContext(timezone: string = 'UTC'): this {
+    const now = new Date();
+    const lines = [
+      '## System Context',
+      `- Current UTC Time: ${now.toISOString()}`,
+      `- Local Timezone: ${timezone}`,
+      `- Current Date: ${now.toISOString().split('T')[0]}`,
+    ];
+    return this.addSection({
+      id: 'time-context',
+      priority: 60,
+      content: lines.join('\n'),
+      required: true,
+    });
+  }
+
+  /** Circle Context: team info (Optional, Priority 70) */
+  addCircleContext(circleName: string, members: string[], constitution?: string): this {
+    const lines = [`## Circle: ${circleName}`, `You are a member of the "${circleName}" circle.`];
+    if (members.length) {
+      lines.push(`Fellow members: ${members.join(', ')}`);
+    }
+    if (constitution) {
+      lines.push('', 'Circle Constitution:', constitution);
+    }
+    return this.addSection({
+      id: 'circle-context',
+      priority: 70,
+      content: lines.join('\n'),
+      required: false,
+    });
+  }
+
+  /** Delegation Context: for orchestrators (Optional, Priority 80) */
+  addDelegationContext(availableAgents: Array<{ name: string; role: string }>): this {
+    if (!availableAgents.length) return this;
+    const lines = [
+      '## Delegation',
+      'You can delegate tasks to the following specialized agents using `spawn-subagent`:',
+    ];
+    for (const agent of availableAgents) {
+      lines.push(`- **${agent.name}**: ${agent.role}`);
+    }
+    return this.addSection({
+      id: 'delegation-context',
+      priority: 80,
+      content: lines.join('\n'),
+      required: false,
+    });
+  }
+
+  /** Reasoning Hints: for thinking models (Optional, Priority 110) */
+  addReasoningHints(modelName: string): this {
+    const isReasoningModel = modelName.includes('thinking') || modelName.includes('r1') || modelName.includes('o1') || modelName.includes('o3');
+    if (!isReasoningModel) return this;
+    const lines = [
+      '## Reasoning Instructions',
+      'This model supports internal reasoning. You should use your internal thinking process to decompose complex problems before providing a final answer.',
+    ];
+    return this.addSection({
+      id: 'reasoning-hints',
+      priority: 110,
+      content: lines.join('\n'),
+      required: false,
+    });
+  }
+
+  /** Constraints: sandbox limits (Required, Priority 120) */
+  addConstraints(tier: number): this {
+    const lines = ['## System Constraints', `- Security Tier: ${tier}`];
+    if (tier >= 2) {
+      lines.push('- Network access is restricted to approved domains.');
+      lines.push('- Filesystem access is limited to the `/workspace` directory.');
+    }
+    return this.addSection({
+      id: 'constraints',
+      priority: 120,
+      content: lines.join('\n'),
+      required: true,
+    });
+  }
+
+  /** Output Format: preferences (Optional, Priority 130) */
+  addOutputFormat(format?: string): this {
+    if (!format) return this;
+    const lines = ['## Output Format', format];
+    return this.addSection({
+      id: 'output-format',
+      priority: 130,
+      content: lines.join('\n'),
+      required: false,
+    });
+  }
+}


### PR DESCRIPTION
This PR introduces a `SystemPromptBuilder` that replaces the previous minimal system prompt generation. The builder assembles prompts from discrete, testable sections including identity, principles, tools, memory instructions, time, and more. It implements a priority-based truncation strategy to ensure the system prompt stays within a configurable token budget (defaulting to 15% of the context window), dropping lower-priority optional sections like workspace context files first. The `ReasoningLoop` has been updated to refresh the prompt at each turn to ensure data like the current time is always accurate. Unit tests and integration-style tests have been added to verify the builder's logic and the rich prompt assembly.

Fixes #500

---
*PR created automatically by Jules for task [16945677189764983349](https://jules.google.com/task/16945677189764983349) started by @TKCen*