### PR TITLE
Implement memory flush before context compaction

### DIFF
--- a/core/agent-runtime/src/__tests__/memoryFlush.test.ts
+++ b/core/agent-runtime/src/__tests__/memoryFlush.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Tests for the memory flush logic in ReasoningLoop (Story 5.12).
+ *
+ * Before context compaction, if enabled, the agent gets one internal turn
+ * restricted to memory tools to persist important context.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ReasoningLoop } from '../loop.js';
+import type { LLMResponse, ToolDefinition, ChatMessage } from '../llmClient.js';
+import type { RuntimeManifest } from '../manifest.js';
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockChat = vi.fn<(messages: ChatMessage[], tools?: ToolDefinition[], temperature?: number) => Promise<LLMResponse>>();
+const mockPublishThought = vi.fn();
+const mockPublishStreamToken = vi.fn();
+const mockGetToolDefinitions = vi.fn();
+const mockExecuteToolCalls = vi.fn();
+
+const mockLlm = { chat: mockChat } as any;
+const mockCentrifugo = {
+  publishThought: mockPublishThought,
+  publishStreamToken: mockPublishStreamToken,
+  publishStreamError: vi.fn().mockResolvedValue(undefined),
+} as any;
+const mockTools = {
+  getToolDefinitions: mockGetToolDefinitions,
+  executeToolCalls: mockExecuteToolCalls,
+} as any;
+
+const manifest: RuntimeManifest = {
+  apiVersion: 'v1',
+  kind: 'Agent',
+  metadata: { name: 'test-agent', displayName: 'Test', icon: 'bot', circle: 'system', tier: 1 },
+  identity: { role: 'tester', description: 'Test agent' },
+  model: { provider: 'openai', name: 'gpt-4o-mini' },
+};
+
+function successResponse(content: string, toolCalls?: any[]): LLMResponse {
+  return {
+    content,
+    toolCalls,
+    usage: { promptTokens: 10, completionTokens: 5, cacheCreationTokens: 0, cacheReadTokens: 0, totalTokens: 15 },
+  };
+}
+
+// ── Setup ────────────────────────────────────────────────────────────────────
+
+let savedEnv: Record<string, string | undefined>;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  mockPublishThought.mockResolvedValue(undefined);
+  mockPublishStreamToken.mockResolvedValue(undefined);
+  mockExecuteToolCalls.mockResolvedValue([]);
+
+  savedEnv = {
+    CONTEXT_WINDOW: process.env['CONTEXT_WINDOW'],
+    MAX_CONTEXT_TOKENS: process.env['MAX_CONTEXT_TOKENS'],
+    MEMORY_FLUSH_BEFORE_COMPACTION: process.env['MEMORY_FLUSH_BEFORE_COMPACTION'],
+      CONTEXT_COMPACTION_THRESHOLD: process.env['CONTEXT_COMPACTION_THRESHOLD'],
+  };
+});
+
+afterEach(() => {
+  for (const [k, v] of Object.entries(savedEnv)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+});
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('ReasoningLoop — memory flush', () => {
+  it('triggers memory flush when near limit and knowledge-store is available', async () => {
+    process.env['CONTEXT_WINDOW'] = '100';
+    delete process.env['MAX_CONTEXT_TOKENS'];
+
+    const ksTool: ToolDefinition = {
+      type: 'function',
+      function: { name: 'knowledge-store', description: 'Store knowledge', parameters: {} },
+    };
+    mockGetToolDefinitions.mockReturnValue([ksTool]);
+
+    // 1st call: Flush turn - agent calls knowledge-store
+    // 2nd call: Main loop turn - agent finishes task
+    mockChat
+      .mockResolvedValueOnce(successResponse('', [{ id: 'call_1', type: 'function', function: { name: 'knowledge-store', arguments: '{"content":"important"}' } }]))
+      .mockResolvedValueOnce(successResponse('Done'));
+
+    mockExecuteToolCalls.mockResolvedValueOnce([{
+      message: { role: 'tool', tool_call_id: 'call_1', content: 'Success' },
+      toolName: 'knowledge-store',
+      argRepaired: false,
+      repairStrategy: null,
+    }]);
+
+    const loop = new ReasoningLoop(mockLlm, mockTools, mockCentrifugo, manifest);
+    const result = await loop.run({ taskId: 't1', task: 'long task '.repeat(10) });
+
+    expect(result.exitReason).toBe('success');
+
+    // Verify flush turn restricted tools
+    const flushCallTools = mockChat.mock.calls[0][1];
+    expect(flushCallTools).toHaveLength(1);
+    expect(flushCallTools![0].function.name).toBe('knowledge-store');
+
+    // Verify 30s timeout was passed
+    const flushCallTimeout = mockChat.mock.calls[0][4];
+    expect(flushCallTimeout).toBe(30_000);
+
+    // Verify internal thoughts
+    const internalThoughts = mockPublishThought.mock.calls.filter(c => c[3]?.internal === true);
+    expect(internalThoughts.length).toBeGreaterThan(0);
+    expect(internalThoughts.some(c => c[1].includes('triggering memory flush'))).toBe(true);
+
+    // Verify usage stats exclude flush turn
+    // Total calls = 2. Each successResponse returns usage with 15 tokens.
+    // Loop increments turnCount for each turn that has usage.
+    // BUT we need to ensure the flush turn doesn't increment the usage returned in result.
+    // In current implementation, LLM responses are accumulated.
+    // Wait, the requirement said "Turn not counted against token budget".
+    // I need to check how to implement this.
+    // Re-reading code:
+    // response = await this.llm.chat(...)
+    // if (response.usage) { totalPromptTokens += ... }
+    // My implementation of flush uses this.llm.chat but DOES NOT accumulate usage if I'm careful.
+    // Looking at my loop.ts changes... Oh, I called this.llm.chat directly and didn't accumulate usage!
+
+    expect(result.usage.turns).toBe(1); // Only the "Done" turn
+    expect(result.usage.totalTokens).toBe(15);
+  });
+
+  it('skips flush when MEMORY_FLUSH_BEFORE_COMPACTION=false', async () => {
+    process.env['CONTEXT_WINDOW'] = '100';
+    process.env['MEMORY_FLUSH_BEFORE_COMPACTION'] = 'false';
+
+    const ksTool: ToolDefinition = {
+      type: 'function',
+      function: { name: 'knowledge-store', description: 'Store knowledge', parameters: {} },
+    };
+    mockGetToolDefinitions.mockReturnValue([ksTool]);
+
+    mockChat.mockResolvedValueOnce(successResponse('Done'));
+
+    const loop = new ReasoningLoop(mockLlm, mockTools, mockCentrifugo, manifest);
+    await loop.run({ taskId: 't1', task: 'long task '.repeat(10) });
+
+    // Should only be one chat call (no flush)
+    expect(mockChat).toHaveBeenCalledTimes(1);
+    const thoughts = mockPublishThought.mock.calls.map(c => c[1]);
+    expect(thoughts.some(t => t.includes('triggering memory flush'))).toBe(false);
+  });
+
+  it('handles flush turn timeout or error gracefully', async () => {
+    process.env['CONTEXT_WINDOW'] = '100';
+
+    const ksTool: ToolDefinition = {
+      type: 'function',
+      function: { name: 'knowledge-store', description: 'Store knowledge', parameters: {} },
+    };
+    mockGetToolDefinitions.mockReturnValue([ksTool]);
+
+    // Flush turn throws
+    mockChat
+      .mockRejectedValueOnce(new Error('LLM Timeout'))
+      .mockResolvedValueOnce(successResponse('Done'));
+
+    const loop = new ReasoningLoop(mockLlm, mockTools, mockCentrifugo, manifest);
+    const result = await loop.run({ taskId: 't1', task: 'long task '.repeat(10) });
+
+    expect(result.exitReason).toBe('success');
+    expect(mockChat).toHaveBeenCalledTimes(2); // 1 failed flush + 1 successful main
+  });
+
+  it('triggers memory flush with multiple memory tools available', async () => {
+    process.env['CONTEXT_WINDOW'] = '100';
+
+    const ksTool: ToolDefinition = {
+      type: 'function',
+      function: { name: 'knowledge-store', description: 'Store knowledge', parameters: {} },
+    };
+    const storeMemoryTool: ToolDefinition = {
+      type: 'function',
+      function: { name: 'store-memory', description: 'Store memory', parameters: {} },
+    };
+    const otherTool: ToolDefinition = {
+      type: 'function',
+      function: { name: 'file-read', description: 'Read file', parameters: {} },
+    };
+    mockGetToolDefinitions.mockReturnValue([ksTool, storeMemoryTool, otherTool]);
+
+    mockChat
+      .mockResolvedValueOnce(successResponse('Saving...'))
+      .mockResolvedValueOnce(successResponse('Done'));
+
+    const loop = new ReasoningLoop(mockLlm, mockTools, mockCentrifugo, manifest);
+    await loop.run({ taskId: 't1', task: 'long task '.repeat(10) });
+
+    // Verify flush turn restricted tools to memory tools only
+    const flushCallTools = mockChat.mock.calls[0][1];
+    expect(flushCallTools).toHaveLength(2);
+    expect(flushCallTools!.some(t => t.function.name === 'knowledge-store')).toBe(true);
+    expect(flushCallTools!.some(t => t.function.name === 'store-memory')).toBe(true);
+    expect(flushCallTools!.some(t => t.function.name === 'file-read')).toBe(false);
+  });
+
+  it('respects CONTEXT_COMPACTION_THRESHOLD env var', async () => {
+    process.env['CONTEXT_WINDOW'] = '1000';
+    process.env['CONTEXT_COMPACTION_THRESHOLD'] = '0.2'; // 200 token threshold
+
+    const ksTool: ToolDefinition = {
+      type: 'function',
+      function: { name: 'knowledge-store', description: 'Store knowledge', parameters: {} },
+    };
+    mockGetToolDefinitions.mockReturnValue([ksTool]);
+
+    mockChat.mockResolvedValue(successResponse('Done'));
+
+    const loop = new ReasoningLoop(mockLlm, mockTools, mockCentrifugo, manifest);
+
+    // 1. Under threshold
+    await loop.run({ taskId: 't1', task: 'tiny' });
+    expect(mockChat).toHaveBeenCalledTimes(1);
+
+    mockChat.mockClear();
+
+    // 2. Over threshold (task content ~400 tokens)
+    await loop.run({ taskId: 't2', task: 'word '.repeat(200) });
+    expect(mockChat).toHaveBeenCalledTimes(2);
+  });
+});

--- a/core/agent-runtime/src/__tests__/preCompactionHook.test.ts
+++ b/core/agent-runtime/src/__tests__/preCompactionHook.test.ts
@@ -66,8 +66,8 @@ afterEach(() => {
 
 // ── Tests ────────────────────────────────────────────────────────────────────
 
-describe('ReasoningLoop — pre-compaction memory save hook', () => {
-  it('injects save-reminder when knowledge-store is available and context is near limit', async () => {
+describe('ReasoningLoop — memory flush (formerly pre-compaction memory save hook)', () => {
+  it('injects memory flush turn when knowledge-store is available and context is near limit', async () => {
     // Small context window → isNearLimit triggers immediately
     process.env['CONTEXT_WINDOW'] = '100';
     delete process.env['MAX_CONTEXT_TOKENS'];
@@ -79,10 +79,10 @@ describe('ReasoningLoop — pre-compaction memory save hook', () => {
     };
     mockGetToolDefinitions.mockReturnValue([knowledgeStoreDef]);
 
-    // First LLM call: agent responds to the save reminder
+    // First LLM call: Flush turn
     // Second LLM call: after compaction, agent produces final answer
     mockChat
-      .mockResolvedValueOnce(successResponse('I will save my findings now'))
+      .mockResolvedValueOnce(successResponse('Saving...'))
       .mockResolvedValueOnce(successResponse('Final answer'));
 
     const loop = new ReasoningLoop(mockLlm, mockTools, mockCentrifugo, manifest);
@@ -91,11 +91,11 @@ describe('ReasoningLoop — pre-compaction memory save hook', () => {
 
     expect(result.exitReason).toBe('success');
 
-    // Verify the save-reminder system message was injected
-    const saveThoughts = result.thoughtStream.filter(
-      (t) => t.step === 'reflect' && t.content.includes('save-reminder'),
+    // Verify the memory flush reflect thought was emitted
+    const flushThoughts = result.thoughtStream.filter(
+      (t) => t.step === 'reflect' && t.content.includes('triggering memory flush'),
     );
-    expect(saveThoughts.length).toBeGreaterThan(0);
+    expect(flushThoughts.length).toBeGreaterThan(0);
   });
 
   it('skips hook when knowledge-store is NOT in tool definitions', async () => {
@@ -120,7 +120,7 @@ describe('ReasoningLoop — pre-compaction memory save hook', () => {
     expect(saveThoughts).toHaveLength(0);
   });
 
-  it('hook fires at most once per run', async () => {
+  it('flush fires at most once per run', async () => {
     process.env['CONTEXT_WINDOW'] = '100';
     delete process.env['MAX_CONTEXT_TOKENS'];
 
@@ -140,14 +140,14 @@ describe('ReasoningLoop — pre-compaction memory save hook', () => {
     const longTask = 'Big task: ' + 'word '.repeat(20);
     const result = await loop.run({ taskId: 'task-1', task: longTask });
 
-    // Save-reminder should appear exactly once
-    const saveThoughts = result.thoughtStream.filter(
-      (t) => t.step === 'reflect' && t.content.includes('save-reminder'),
+    // Flush should appear exactly once
+    const flushThoughts = result.thoughtStream.filter(
+      (t) => t.step === 'reflect' && t.content.includes('triggering memory flush'),
     );
-    expect(saveThoughts).toHaveLength(1);
+    expect(flushThoughts).toHaveLength(1);
   });
 
-  it('emits reflect thought for the hook', async () => {
+  it('emits internal reflect thought for the flush', async () => {
     process.env['CONTEXT_WINDOW'] = '100';
     delete process.env['MAX_CONTEXT_TOKENS'];
 
@@ -162,13 +162,14 @@ describe('ReasoningLoop — pre-compaction memory save hook', () => {
       .mockResolvedValueOnce(successResponse('Done'));
 
     const loop = new ReasoningLoop(mockLlm, mockTools, mockCentrifugo, manifest);
-    const result = await loop.run({ taskId: 'task-1', task: 'Big task: ' + 'word '.repeat(20) });
+    await loop.run({ taskId: 'task-1', task: 'Big task: ' + 'word '.repeat(20) });
 
-    // publishThought should have been called with the save-reminder reflect
+    // publishThought should have been called with the triggering memory flush reflect
     const publishCalls = mockPublishThought.mock.calls;
-    const hookCall = publishCalls.find(
-      (c: unknown[]) => c[0] === 'reflect' && (c[1] as string).includes('save-reminder'),
+    const flushCall = publishCalls.find(
+      (c: unknown[]) => c[0] === 'reflect' && (c[1] as string).includes('triggering memory flush'),
     );
-    expect(hookCall).toBeDefined();
+    expect(flushCall).toBeDefined();
+    expect(flushCall[3]?.internal).toBe(true);
   });
 });

--- a/core/agent-runtime/src/__tests__/testHelpers.ts
+++ b/core/agent-runtime/src/__tests__/testHelpers.ts
@@ -15,6 +15,7 @@ export class ScriptedLLMClient implements ILLMClient {
     _tools?: ToolDefinition[],
     _temperature?: number,
     _thinkingLevel?: ThinkingLevel,
+    _timeoutMs?: number,
   ): Promise<LLMResponse> {
     const response = this.responses[this.callCount];
     if (!response) {

--- a/core/agent-runtime/src/centrifugo.ts
+++ b/core/agent-runtime/src/centrifugo.ts
@@ -39,6 +39,7 @@ export interface ThoughtEvent {
   toolName?: string;
   toolArgs?: Record<string, unknown>;
   anomaly?: boolean;
+  internal?: boolean;
 }
 
 export interface StreamToken {
@@ -93,6 +94,7 @@ export class CentrifugoPublisher {
       toolName?: string;
       toolArgs?: Record<string, unknown>;
       anomaly?: boolean;
+      internal?: boolean;
     },
   ): Promise<void> {
     const canonical = this.toCanonicalStep(step);
@@ -108,6 +110,7 @@ export class CentrifugoPublisher {
       ...(opts?.toolName !== undefined ? { toolName: opts.toolName } : {}),
       ...(opts?.toolArgs !== undefined ? { toolArgs: opts.toolArgs } : {}),
       ...(opts?.anomaly !== undefined ? { anomaly: opts.anomaly } : {}),
+      ...(opts?.internal !== undefined ? { internal: opts.internal } : {}),
     };
 
     await this.publish(channel, event);

--- a/core/agent-runtime/src/contextManager.ts
+++ b/core/agent-runtime/src/contextManager.ts
@@ -63,6 +63,7 @@ export class ContextManager {
   private strategy: CompactionStrategy;
   private toolOutputMaxTokens: number;
   private preserveRecentMessages: number;
+  private memoryFlushEnabled: boolean;
 
   constructor(modelName: string, contextWindowOverride?: number) {
     this.modelName = modelName;
@@ -73,10 +74,13 @@ export class ContextManager {
       (envContextWindow ? parseInt(envContextWindow, 10) : undefined) ??
       this.resolveContextWindow(modelName);
 
+    const thresholdPctEnv = process.env['CONTEXT_COMPACTION_THRESHOLD'];
+    const highWaterPct = thresholdPctEnv ? parseFloat(thresholdPctEnv) : DEFAULT_HIGH_WATER_PCT;
+
     const maxTokensEnv = process.env['MAX_CONTEXT_TOKENS'];
     this.highWaterMark = maxTokensEnv
       ? parseInt(maxTokensEnv, 10)
-      : Math.floor(this.contextWindow * DEFAULT_HIGH_WATER_PCT);
+      : Math.floor(this.contextWindow * highWaterPct);
 
     const strategyEnv = process.env['CONTEXT_COMPACTION_STRATEGY'] as CompactionStrategy | undefined;
     this.strategy = strategyEnv === 'summarise' ? 'summarise' : 'sliding-window';
@@ -90,6 +94,9 @@ export class ContextManager {
     this.preserveRecentMessages = preserveEnv
       ? parseInt(preserveEnv, 10)
       : DEFAULT_PRESERVE_RECENT_MESSAGES;
+
+    const flushEnabledEnv = process.env['MEMORY_FLUSH_BEFORE_COMPACTION'];
+    this.memoryFlushEnabled = flushEnabledEnv !== 'false';
 
     // Use cl100k_base encoding as a universal approximation for any model.
     // 5-10% error is acceptable per the spec.
@@ -153,6 +160,10 @@ export class ContextManager {
    */
   isNearLimit(messages: ChatMessage[]): boolean {
     return this.countMessageTokens(messages) >= this.highWaterMark;
+  }
+
+  isMemoryFlushEnabled(): boolean {
+    return this.memoryFlushEnabled;
   }
 
   /**

--- a/core/agent-runtime/src/llmClient.ts
+++ b/core/agent-runtime/src/llmClient.ts
@@ -74,6 +74,8 @@ export interface ChatMessage {
   content: string;
   tool_calls?: ToolCall[];
   tool_call_id?: string;
+  /** Internal messages are hidden from the chat UI (Story 5.12). */
+  internal?: boolean;
 }
 
 export type ThinkingLevel = 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'max';
@@ -100,6 +102,7 @@ export interface ILLMClient {
     tools?: ToolDefinition[],
     temperature?: number,
     thinkingLevel?: ThinkingLevel,
+    timeoutMs?: number,
   ): Promise<LLMResponse>;
 }
 
@@ -141,6 +144,7 @@ export class LLMClient implements ILLMClient {
     tools?: ToolDefinition[],
     temperature?: number,
     thinkingLevel?: ThinkingLevel,
+    timeoutMs?: number,
   ): Promise<LLMResponse> {
     const body: Record<string, unknown> = {
       model: this.model,
@@ -171,7 +175,9 @@ export class LLMClient implements ILLMClient {
     }
 
     try {
-      const res = await this.http.post('/chat/completions', body);
+      const res = await this.http.post('/chat/completions', body, {
+        ...(timeoutMs ? { timeout: timeoutMs } : {}),
+      });
       const data = res.data as Record<string, unknown>;
 
       const choices = data['choices'] as Array<Record<string, unknown>> | undefined;

--- a/core/agent-runtime/src/loop.ts
+++ b/core/agent-runtime/src/loop.ts
@@ -210,9 +210,10 @@ export class ReasoningLoop {
     const loopDetector = new ToolLoopDetector();
     let forceTextNext = false;
 
-    // ── Pre-compaction memory save hook (fires at most once per run) ───────
-    let preCompactionHookFired = false;
-    const hasKnowledgeStore = this.toolDefs.some((t) => t.function.name === 'knowledge-store');
+    // ── Pre-compaction memory flush (fires at most once per run) ───────
+    let memoryFlushFired = false;
+    const MEMORY_TOOLS = ['knowledge-store', 'store-memory', 'update-memory'];
+    const flushTools = this.allToolDefs.filter((t) => MEMORY_TOOLS.includes(t.function.name));
 
     // ── Retry state machine (per-run, reset on each invocation) ───────────
     const retryState: RetryState = {
@@ -257,24 +258,69 @@ export class ReasoningLoop {
 
         // Context window management — compact before each LLM call
         if (this.contextManager.isNearLimit(messages)) {
-          // Pre-compaction memory save hook (#506): give the agent one iteration
-          // to save important context before it's compacted away.
-          if (hasKnowledgeStore && !preCompactionHookFired) {
-            preCompactionHookFired = true;
-            await think(
-              'reflect',
-              'Context window nearly full — injecting save-reminder before compaction',
-              iteration
-            );
+          // Pre-compaction memory flush (Story 5.12): allow one turn with only
+          // memory tools before compaction.
+          if (
+            this.contextManager.isMemoryFlushEnabled() &&
+            flushTools.length > 0 &&
+            !memoryFlushFired
+          ) {
+            memoryFlushFired = true;
+            await think('reflect', 'Context window approaching limit — triggering memory flush', iteration, {
+              internal: true,
+            });
+
             messages.push({
               role: 'system',
               content:
-                'IMPORTANT: Your context window is nearly full and compaction will occur shortly. ' +
-                'If there is any critical information from this conversation that you want to ' +
-                'preserve long-term, call the knowledge-store tool NOW to save it. ' +
-                'After this turn, older messages will be dropped.',
+                'Your context window is about to be compacted. Before this happens, use your memory tools ' +
+                'to save any important information from the current conversation that you want to remember. ' +
+                'This is your last chance to persist this context.',
+              internal: true,
             });
-            continue; // Let the next iteration handle the save, then compact
+
+            // Execute one reasoning turn restricted to memory tools only (30s timeout)
+            try {
+              const flushResponse = await this.llm.chat(
+                messages,
+                flushTools,
+                this.manifest.model.temperature,
+                this.manifest.model.thinkingLevel as ThinkingLevel | undefined,
+                30_000
+              );
+
+              if (flushResponse.toolCalls && flushResponse.toolCalls.length > 0) {
+                messages.push({
+                  role: 'assistant',
+                  content: flushResponse.content || '',
+                  tool_calls: flushResponse.toolCalls,
+                  internal: true,
+                });
+
+                const toolResults = await this.tools.executeToolCalls(flushResponse.toolCalls);
+                let savedCount = 0;
+                for (const tr of toolResults) {
+                  tr.message.internal = true;
+                  messages.push(tr.message);
+                  if (MEMORY_TOOLS.includes(tr.toolName) && !tr.message.content.includes('Error:')) {
+                    savedCount++;
+                  }
+                  await think('reflect', `Flush tool result: ${tr.message.content.substring(0, 100)}`, iteration, {
+                    internal: true,
+                  });
+                }
+
+                log('info', `memory.flush: saved ${savedCount} block(s) before compaction`);
+              } else {
+                messages.push({
+                  role: 'assistant',
+                  content: flushResponse.content || '',
+                  internal: true,
+                });
+              }
+            } catch (flushErr) {
+              log('warn', `Memory flush failed: ${flushErr instanceof Error ? flushErr.message : String(flushErr)}`);
+            }
           }
 
           const compaction = this.contextManager.compact(messages);


### PR DESCRIPTION
Introduces a "memory flush" feature in the agent reasoning loop. When an agent's context window approaches the compaction threshold (default 80%), the loop now injects a synthetic system message and allows the agent one "internal" turn to save important information using its memory tools. This turn is hidden from the UI, has a 30s timeout, and is not counted against the user's token budget.

Key changes:
- `ContextManager`: Added `MEMORY_FLUSH_BEFORE_COMPACTION` toggle and `CONTEXT_COMPACTION_THRESHOLD` configurability.
- `ReasoningLoop`: Implemented the flush turn logic, tool filtering, and internal state management.
- `LLMClient`: Added support for per-request `timeoutMs`.
- `CentrifugoPublisher`: Propagates the `internal` flag to thoughts.
- `Types`: Added `internal` flag to `ChatMessage` and `ThoughtEvent`.
- `Tests`: Added `memoryFlush.test.ts` and updated `preCompactionHook.test.ts`.

Fixes #619

---
*PR created automatically by Jules for task [5308237530361703831](https://jules.google.com/task/5308237530361703831) started by @TKCen*