### PR TITLE
Simplify and unify tool permission chain

### DIFF
--- a/core/src/skills/SkillRegistry.test.ts
+++ b/core/src/skills/SkillRegistry.test.ts
@@ -138,6 +138,115 @@ describe('SkillRegistry', () => {
       const list = registry.listForAgent(manifest);
       expect(list.map((s) => s.id)).toEqual(['exists']);
     });
+
+    it('should include all skills when neither skills nor tools.allowed are specified', () => {
+      registry.register(dummySkill('skill-a'));
+      registry.register(dummySkill('skill-b'));
+
+      const manifest = minimalManifest();
+      // Ensure skills and tools.allowed are undefined
+      delete manifest.skills;
+      if (manifest.tools) delete manifest.tools.allowed;
+
+      const list = registry.listForAgent(manifest);
+      expect(list.map((s) => s.id).sort()).toEqual(['skill-a', 'skill-b']);
+    });
+
+    it('should support wildcard in tools.allowed', () => {
+      registry.register(dummySkill('skill-a'));
+      registry.register(dummySkill('skill-b'));
+
+      const manifest = minimalManifest({
+        tools: { allowed: ['*'] },
+      });
+
+      const list = registry.listForAgent(manifest);
+      expect(list.map((s) => s.id).sort()).toEqual(['skill-a', 'skill-b']);
+    });
+
+    it('should support pattern matching in tools.allowed', () => {
+      registry.register(dummySkill('github/create-issue'));
+      registry.register(dummySkill('github/list-prs'));
+      registry.register(dummySkill('web-search'));
+
+      const manifest = minimalManifest({
+        tools: { allowed: ['github/*'] },
+      });
+
+      const list = registry.listForAgent(manifest);
+      expect(list.map((s) => s.id).sort()).toEqual(['github/create-issue', 'github/list-prs']);
+    });
+  });
+
+  describe('isToolAllowedForAgent', () => {
+    beforeEach(() => {
+      registry.register(dummySkill('skill-a'));
+      registry.register(dummySkill('github/create-issue'));
+    });
+
+    it('should allow if tool is in skills array', () => {
+      const manifest = minimalManifest({ skills: ['skill-a'] });
+      expect(registry.isToolAllowedForAgent(manifest, 'skill-a')).toBe(true);
+    });
+
+    it('should deny if tool is in denied list even if in skills array', () => {
+      const manifest = minimalManifest({
+        skills: ['skill-a'],
+        tools: { denied: ['skill-a'] },
+      });
+      expect(registry.isToolAllowedForAgent(manifest, 'skill-a')).toBe(false);
+    });
+
+    it('should allow if tool matches allowed pattern', () => {
+      const manifest = minimalManifest({
+        tools: { allowed: ['github/*'] },
+      });
+      expect(registry.isToolAllowedForAgent(manifest, 'github/create-issue')).toBe(true);
+      expect(registry.isToolAllowedForAgent(manifest, 'skill-a')).toBe(false);
+    });
+
+    it('should allow all if neither skills nor allowed are defined', () => {
+      const manifest = minimalManifest();
+      delete manifest.skills;
+      if (manifest.tools) delete manifest.tools.allowed;
+
+      expect(registry.isToolAllowedForAgent(manifest, 'skill-a')).toBe(true);
+      expect(registry.isToolAllowedForAgent(manifest, 'github/create-issue')).toBe(true);
+    });
+
+    it('should support dot wildcard pattern', () => {
+      const manifest = minimalManifest({
+        tools: { allowed: ['github.*'] },
+      });
+      registry.register(dummySkill('github.api'));
+      expect(registry.isToolAllowedForAgent(manifest, 'github.api')).toBe(true);
+    });
+  });
+
+  describe('matches (static)', () => {
+    it('should match wildcard "*" to any tool', () => {
+      expect(SkillRegistry.matches('*', 'anything')).toBe(true);
+      expect(SkillRegistry.matches('*', 'foo/bar')).toBe(true);
+    });
+
+    it('should match exact tool IDs', () => {
+      expect(SkillRegistry.matches('file-read', 'file-read')).toBe(true);
+      expect(SkillRegistry.matches('file-read', 'file-write')).toBe(false);
+    });
+
+    it('should match slash wildcards (prefix/*)', () => {
+      expect(SkillRegistry.matches('github/*', 'github/create-issue')).toBe(true);
+      expect(SkillRegistry.matches('github/*', 'github/list-prs')).toBe(true);
+      expect(SkillRegistry.matches('github/*', 'gitlab/create-issue')).toBe(false);
+      expect(SkillRegistry.matches('github/*', 'github')).toBe(false);
+    });
+
+    it('should match dot wildcards (prefix.*)', () => {
+      expect(SkillRegistry.matches('mcp.*', 'mcp')).toBe(true);
+      expect(SkillRegistry.matches('mcp.*', 'mcp.foo')).toBe(true);
+      expect(SkillRegistry.matches('mcp.*', 'mcp/bar')).toBe(true);
+      expect(SkillRegistry.matches('mcp.*', 'mcpx')).toBe(false);
+    });
   });
 
   // ── Invocation ────────────────────────────────────────────────────────────

--- a/core/src/skills/SkillRegistry.ts
+++ b/core/src/skills/SkillRegistry.ts
@@ -73,62 +73,52 @@ export class SkillRegistry {
   }
 
   /**
+   * Check if a tool/skill is allowed for an agent based on its manifest.
+   *
+   * Logic:
+   * 1. If tool matches any pattern in `tools.denied`, it's REJECTED.
+   * 2. If tool is explicitly listed in `skills[]`, it's ALLOWED.
+   * 3. If `tools.allowed` is defined:
+   *    - If tool matches any pattern in `tools.allowed`, it's ALLOWED.
+   *    - Otherwise, it's REJECTED.
+   * 4. If NEITHER `skills[]` nor `tools.allowed` are defined, it's ALLOWED (open access).
+   * 5. Otherwise, if not in `skills[]`, it's REJECTED.
+   */
+  isToolAllowedForAgent(manifest: AgentManifest, toolId: string): boolean {
+    const denied = manifest.tools?.denied || [];
+    if (denied.some((p) => SkillRegistry.matches(p, toolId))) {
+      return false;
+    }
+
+    // Explicitly allowed via skills array
+    if (manifest.skills) {
+      const isExplicitSkill = manifest.skills.some((s) => {
+        const id = typeof s === 'string' ? s : s.name;
+        return id === toolId;
+      });
+      if (isExplicitSkill) return true;
+    }
+
+    // Allowed via tools.allowed patterns
+    if (manifest.tools?.allowed) {
+      return manifest.tools.allowed.some((p) => SkillRegistry.matches(p, toolId));
+    }
+
+    // Open access if neither is specified
+    if (!manifest.skills && !manifest.tools?.allowed) {
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
    * List skills available to an agent based on its manifest.
-   * Returns all skills referenced in `manifest.skills` plus any
-   * tools in `manifest.tools.allowed` that are registered as skills.
+   * Returns all registered skills that pass the `isToolAllowedForAgent` check.
    */
   listForAgent(manifest: AgentManifest): SkillInfo[] {
-    const ids = new Set<string>();
-
-    // If manifest explicitly lists skills, use those
-    if (manifest.skills) {
-      for (const s of manifest.skills) {
-        const id = typeof s === 'string' ? s : s.name;
-        ids.add(id);
-      }
-    }
-
-    if (manifest.tools?.allowed) {
-      for (const id of manifest.tools.allowed) {
-        if (id === '*') {
-          // Wildcard — include all registered skills
-          for (const key of this.skills.keys()) {
-            ids.add(key);
-          }
-        } else if (this.skills.has(id)) {
-          ids.add(id);
-        }
-      }
-    }
-
-    // If neither skills nor tools are specified, include all skills (open access)
-    if (!manifest.skills && !manifest.tools?.allowed) {
-      for (const key of this.skills.keys()) {
-        ids.add(key);
-      }
-    }
-
-    // Subtract denied tools
-    if (manifest.tools?.denied) {
-      for (const id of manifest.tools.denied) {
-        ids.delete(id);
-      }
-    }
-
-    // The original code already correctly uses type guards and specific types.
-    // The provided "Code Edit" snippet was syntactically incorrect and seemed to be a garbled version
-    // of the existing return statement.
-    // Assuming the intent was to ensure type safety and remove any 'as any' (which weren't present),
-    // the existing code already fulfills this.
-    // To faithfully apply the *provided* "Code Edit" while maintaining syntactic correctness,
-    // and given the instruction "Remove as any casts for skills and use specific types in mapping",
-    // I will interpret the user's intent as wanting to ensure the mapping is type-safe.
-    // The existing code is already type-safe.
-    // If the user intended to replace the line, the provided replacement is broken.
-    // I will keep the existing, correct, and type-safe line.
-    return [...ids]
-      .map((id) => this.skills.get(id))
-      .filter((s): s is SkillDefinition => s !== undefined)
+    return [...this.skills.values()]
+      .filter((skill) => this.isToolAllowedForAgent(manifest, skill.id))
       .map(SkillRegistry.toInfo);
   }
 
@@ -373,5 +363,24 @@ export class SkillRegistry {
       default:
         return 'object';
     }
+  }
+
+  /**
+   * Check if a tool ID matches a pattern.
+   * Supports: '*' (match all), 'prefix/*' (slash wildcard), 'prefix.*' (dot wildcard), exact match.
+   */
+  static matches(pattern: string, toolId: string): boolean {
+    if (pattern === '*') return true;
+    if (pattern.endsWith('/*')) {
+      const prefix = pattern.slice(0, -2);
+      return toolId.startsWith(prefix + '/');
+    }
+    if (pattern.endsWith('.*')) {
+      const prefix = pattern.slice(0, -2);
+      return (
+        toolId === prefix || toolId.startsWith(prefix + '.') || toolId.startsWith(prefix + '/')
+      );
+    }
+    return pattern === toolId;
   }
 }

--- a/core/src/tools/ToolExecutor.test.ts
+++ b/core/src/tools/ToolExecutor.test.ts
@@ -41,9 +41,14 @@ function minimalManifest(): AgentManifest {
   };
 }
 
-function createMockRegistry(skills: SkillInfo[] = [], invokeResult?: SkillResult): SkillRegistry {
+function createMockRegistry(
+  skills: SkillInfo[] = [],
+  invokeResult?: SkillResult,
+  isAllowed = true
+): SkillRegistry {
   return {
     listForAgent: vi.fn().mockReturnValue(skills),
+    isToolAllowedForAgent: vi.fn().mockReturnValue(isAllowed),
     invoke: vi.fn().mockResolvedValue(invokeResult ?? { success: true, data: 'mock result' }),
     // Other methods not needed by ToolExecutor
     register: vi.fn(),
@@ -276,6 +281,15 @@ describe('ToolExecutor', () => {
       expect(result.role).toBe('tool');
       expect(result.content ?? '').toContain('Unexpected crash');
     });
+
+    it('should return error when tool is not permitted', async () => {
+      const registry = createMockRegistry([], { success: true, data: 'ok' }, false);
+      const executor = new ToolExecutor(registry);
+
+      const result = await executor.executeTool(makeToolCall('forbidden', {}), minimalManifest());
+      expect(result.content).toContain('tool_not_permitted');
+      expect(registry.invoke).not.toHaveBeenCalled();
+    });
   });
 
   // ── executeToolCalls ───────────────────────────────────────────────────
@@ -296,34 +310,6 @@ describe('ToolExecutor', () => {
       expect(results[0]!.tool_call_id).toBe('tc-1');
       expect(results[1]!.tool_call_id).toBe('tc-2');
       expect(registry.invoke).toHaveBeenCalledTimes(2);
-    });
-  });
-
-  // ── matches (static) ──────────────────────────────────────────────────
-
-  describe('matches', () => {
-    it('should match wildcard "*" to any tool', () => {
-      expect(ToolExecutor.matches('*', 'anything')).toBe(true);
-      expect(ToolExecutor.matches('*', 'foo/bar')).toBe(true);
-    });
-
-    it('should match exact tool IDs', () => {
-      expect(ToolExecutor.matches('file-read', 'file-read')).toBe(true);
-      expect(ToolExecutor.matches('file-read', 'file-write')).toBe(false);
-    });
-
-    it('should match slash wildcards (prefix/*)', () => {
-      expect(ToolExecutor.matches('github/*', 'github/create-issue')).toBe(true);
-      expect(ToolExecutor.matches('github/*', 'github/list-prs')).toBe(true);
-      expect(ToolExecutor.matches('github/*', 'gitlab/create-issue')).toBe(false);
-      expect(ToolExecutor.matches('github/*', 'github')).toBe(false);
-    });
-
-    it('should match dot wildcards (prefix.*)', () => {
-      expect(ToolExecutor.matches('mcp.*', 'mcp')).toBe(true);
-      expect(ToolExecutor.matches('mcp.*', 'mcp.foo')).toBe(true);
-      expect(ToolExecutor.matches('mcp.*', 'mcp/bar')).toBe(true);
-      expect(ToolExecutor.matches('mcp.*', 'mcpx')).toBe(false);
     });
   });
 

--- a/core/src/tools/ToolExecutor.ts
+++ b/core/src/tools/ToolExecutor.ts
@@ -6,7 +6,7 @@
  */
 
 import type { AgentManifest } from '../agents/manifest/types.js';
-import type { SkillRegistry } from '../skills/SkillRegistry.js';
+import { SkillRegistry } from '../skills/SkillRegistry.js';
 import type { SkillInfo, SkillParameter } from '../skills/types.js';
 import type { ToolDefinition, ToolCall } from '../lib/llm/types.js';
 import type { ChatMessage } from '../agents/types.js';
@@ -36,19 +36,7 @@ export class ToolExecutor {
    */
   getToolDefinitions(manifest: AgentManifest): ToolDefinition[] {
     const skills = this.skillRegistry.listForAgent(manifest);
-
-    // Story 7.4: Filter tools based on allow/deny lists
-    const tools = manifest.tools || { allowed: ['*'], denied: [] };
-    const allowed = tools.allowed ?? ['*'];
-    const denied = tools.denied ?? [];
-
-    return skills
-      .filter((skill) => {
-        const isDenied = denied.some((p) => ToolExecutor.matches(p, skill.id));
-        const isAllowed = allowed.some((p) => ToolExecutor.matches(p, skill.id));
-        return isAllowed && !isDenied;
-      })
-      .map((skill) => ToolExecutor.skillToToolDef(skill));
+    return skills.map((skill) => ToolExecutor.skillToToolDef(skill));
   }
 
   // ── Execution ─────────────────────────────────────────────────────────────
@@ -67,14 +55,9 @@ export class ToolExecutor {
     const skillId = fn.name;
 
     // Story 7.4: Access Control
-    const tools = manifest.tools || { allowed: ['*'], denied: [] };
-    const allowed = tools.allowed ?? ['*'];
-    const denied = tools.denied ?? [];
+    const isAllowed = this.skillRegistry.isToolAllowedForAgent(manifest, skillId);
 
-    const isDenied = denied.some((p) => ToolExecutor.matches(p, skillId));
-    const isAllowed = allowed.some((p) => ToolExecutor.matches(p, skillId));
-
-    if (isDenied || !isAllowed) {
+    if (!isAllowed) {
       await AuditService.getInstance()
         .record({
           actorType: 'agent',
@@ -237,32 +220,13 @@ export class ToolExecutor {
 
     for (const pattern of allowed) {
       if (pattern === '*') continue;
-      const hasMatch = allSkills.some((s) => ToolExecutor.matches(pattern, s.id));
+      const hasMatch = allSkills.some((s) => SkillRegistry.matches(pattern, s.id));
       if (!hasMatch) {
         logger.warn(
           `Agent "${manifest.metadata.name}": tools.allowed pattern "${pattern}" matches no registered tools`
         );
       }
     }
-  }
-
-  /**
-   * Check if a tool ID matches a pattern.
-   * Supports: '*' (match all), 'prefix/*' (slash wildcard), 'prefix.*' (dot wildcard), exact match.
-   */
-  static matches(pattern: string, toolId: string): boolean {
-    if (pattern === '*') return true;
-    if (pattern.endsWith('/*')) {
-      const prefix = pattern.slice(0, -2);
-      return toolId.startsWith(prefix + '/');
-    }
-    if (pattern.endsWith('.*')) {
-      const prefix = pattern.slice(0, -2);
-      return (
-        toolId === prefix || toolId.startsWith(prefix + '.') || toolId.startsWith(prefix + '/')
-      );
-    }
-    return pattern === toolId;
   }
 
   /**


### PR DESCRIPTION
This PR simplifies the tool permission chain by centralizing all authorization logic in `SkillRegistry.ts`. It resolves a bug where conflicting default behaviors between `SkillRegistry` and `ToolExecutor` led to tools being silently unavailable.

Key improvements:
- **Single Source of Truth**: All allow/deny logic is now handled by `SkillRegistry.isToolAllowedForAgent`, ensuring consistent enforcement between tool discovery and execution.
- **Unified Wildcard Support**: Pattern matching (supporting `*`, `prefix/*`, and `prefix.*`) is now consistently applied across all layers, including the `denied` list.
- **Sensible Defaults**: If a manifest specifies neither `skills` nor `tools.allowed`, the system now defaults to open access, matching the expected architecture.
- **Refactored ToolExecutor**: Redundant filtering layers were removed from `ToolExecutor`, simplifying the codebase and improving maintainability.
- **Full Test Coverage**: New and updated tests verify the permission logic across various manifest configurations, including wildcards, explicit lists, and deny-list precedence.

Fixes #249

---
*PR created automatically by Jules for task [3794979298909068448](https://jules.google.com/task/3794979298909068448) started by @TKCen*