### PR TITLE
feat(agent-runtime): Pre/post tool execution hooks

### DIFF
--- a/core/agent-runtime/src/__tests__/hooks.test.ts
+++ b/core/agent-runtime/src/__tests__/hooks.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { HookRunner } from '../hooks.js';
+import { spawn } from 'child_process';
+import { EventEmitter } from 'events';
+
+vi.mock('child_process', () => ({
+  spawn: vi.fn(),
+}));
+
+describe('HookRunner', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const mockSpawn = (code: number, stdout: string, stderr: string = '') => {
+    const child = new EventEmitter() as any;
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    child.stdin = new EventEmitter() as any;
+    child.stdin.write = vi.fn();
+    child.stdin.end = vi.fn();
+
+    vi.mocked(spawn).mockReturnValue(child);
+
+    // Simulate process execution
+    setImmediate(() => {
+      if (stdout) child.stdout.emit('data', Buffer.from(stdout));
+      if (stderr) child.stderr.emit('data', Buffer.from(stderr));
+      child.emit('exit', code);
+    });
+
+    return child;
+  };
+
+  it('should allow execution when no hooks are defined', async () => {
+    const runner = new HookRunner();
+    const result = await runner.run('PreToolUse', { toolName: 'test', toolInput: '{}' });
+    expect(result.status).toBe('allow');
+  });
+
+  it('should run pre-tool hooks and return allow', async () => {
+    mockSpawn(0, 'Hook allowed');
+    const runner = new HookRunner({ preToolUse: ['test-hook'] });
+    const result = await runner.run('PreToolUse', { toolName: 'test', toolInput: '{}' });
+
+    expect(result.status).toBe('allow');
+    expect(result.feedback).toBe('Hook allowed');
+    expect(spawn).toHaveBeenCalledWith('/bin/sh', ['-c', 'test-hook'], expect.anything());
+  });
+
+  it('should deny execution when hook exits with 2', async () => {
+    mockSpawn(2, 'Access denied');
+    const runner = new HookRunner({ preToolUse: ['test-hook'] });
+    const result = await runner.run('PreToolUse', { toolName: 'test', toolInput: '{}' });
+
+    expect(result.status).toBe('deny');
+    expect(result.feedback).toBe('Access denied');
+  });
+
+  it('should warn when hook exits with non-zero non-2', async () => {
+    mockSpawn(1, 'Warning message');
+    const runner = new HookRunner({ preToolUse: ['test-hook'] });
+    const result = await runner.run('PreToolUse', { toolName: 'test', toolInput: '{}' });
+
+    expect(result.status).toBe('warn');
+    expect(result.feedback).toBe('Warning message');
+  });
+
+  it('should concatenate feedback from multiple hooks', async () => {
+    let callCount = 0;
+    vi.mocked(spawn).mockImplementation((() => {
+      const child = new EventEmitter() as any;
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      child.stdin = new EventEmitter() as any;
+      child.stdin.write = vi.fn();
+      child.stdin.end = vi.fn();
+
+      const count = ++callCount;
+      setImmediate(() => {
+        child.stdout.emit('data', Buffer.from(`Feedback ${count}`));
+        child.emit('exit', 0);
+      });
+      return child;
+    }) as any);
+
+    const runner = new HookRunner({ preToolUse: ['hook1', 'hook2'] });
+    const result = await runner.run('PreToolUse', { toolName: 'test', toolInput: '{}' });
+
+    expect(result.status).toBe('allow');
+    expect(result.feedback).toBe('Feedback 1\n\nFeedback 2');
+  });
+
+  it('should stop and deny if the first hook denies', async () => {
+    vi.mocked(spawn).mockImplementation(((shell: string, args: string[]) => {
+      const cmd = args[1];
+      const child = new EventEmitter() as any;
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      child.stdin = new EventEmitter() as any;
+      child.stdin.write = vi.fn();
+      child.stdin.end = vi.fn();
+
+      setImmediate(() => {
+        if (cmd === 'hook1') {
+          child.stdout.emit('data', Buffer.from('Denied by 1'));
+          child.emit('exit', 2);
+        } else {
+          child.stdout.emit('data', Buffer.from('Allowed by 2'));
+          child.emit('exit', 0);
+        }
+      });
+      return child;
+    }) as any);
+
+    const runner = new HookRunner({ preToolUse: ['hook1', 'hook2'] });
+    const result = await runner.run('PreToolUse', { toolName: 'test', toolInput: '{}' });
+
+    expect(result.status).toBe('deny');
+    expect(result.feedback).toBe('Denied by 1');
+    expect(spawn).toHaveBeenCalledTimes(1);
+  });
+
+  it('should pass correct environment variables', async () => {
+    mockSpawn(0, '');
+    const runner = new HookRunner({ preToolUse: ['test-hook'] });
+    await runner.run('PreToolUse', {
+      toolName: 'test-tool',
+      toolInput: '{"arg": 1}',
+    });
+
+    const spawnCall = vi.mocked(spawn).mock.calls[0];
+    const env = spawnCall[2].env;
+    expect(env.HOOK_EVENT).toBe('PreToolUse');
+    expect(env.HOOK_TOOL_NAME).toBe('test-tool');
+    expect(env.HOOK_TOOL_INPUT).toBe('{"arg": 1}');
+    expect(env.HOOK_TOOL_IS_ERROR).toBe('0');
+  });
+
+  it('should handle post-tool hooks with error status', async () => {
+    mockSpawn(0, 'Audit log');
+    const runner = new HookRunner({ postToolUse: ['audit-hook'] });
+    const result = await runner.run('PostToolUse', {
+      toolName: 'test',
+      toolInput: '{}',
+      toolOutput: 'Error: something failed',
+      isError: true
+    });
+
+    expect(result.status).toBe('allow');
+    expect(result.feedback).toBe('Audit log');
+
+    const env = vi.mocked(spawn).mock.calls[0][2].env;
+    expect(env.HOOK_EVENT).toBe('PostToolUse');
+    expect(env.HOOK_TOOL_OUTPUT).toBe('Error: something failed');
+    expect(env.HOOK_TOOL_IS_ERROR).toBe('1');
+  });
+
+  it('should handle spawn errors gracefully', async () => {
+    const child = new EventEmitter() as any;
+    child.stdin = new EventEmitter() as any;
+    child.stdin.write = vi.fn();
+    child.stdin.end = vi.fn();
+    vi.mocked(spawn).mockReturnValue(child);
+
+    setImmediate(() => {
+      child.emit('error', new Error('Spawn failed'));
+    });
+
+    const runner = new HookRunner({ preToolUse: ['test-hook'] });
+    const result = await runner.run('PreToolUse', { toolName: 'test', toolInput: '{}' });
+
+    expect(result.status).toBe('warn');
+    expect(result.feedback).toContain('Hook execution failed: Spawn failed');
+  });
+});

--- a/core/agent-runtime/src/__tests__/loop.test.ts
+++ b/core/agent-runtime/src/__tests__/loop.test.ts
@@ -88,6 +88,87 @@ describe('ReasoningLoop E2E', () => {
     expect(publisher.publishThought).toHaveBeenCalledWith('reflect', expect.stringContaining('Tool result: hello'), 1, undefined);
   });
 
+  it('executes pre and post tool hooks', async () => {
+    const manifestWithHooks: RuntimeManifest = {
+      ...mockManifest,
+      hooks: {
+        preToolUse: ['echo "Pre hook"'],
+        postToolUse: ['echo "Post hook"'],
+      },
+    };
+
+    const llm = new ScriptedLLMClient([
+      {
+        content: 'I will echo that.',
+        toolCalls: [
+          { id: 'call_hook', type: 'function', function: { name: 'echo', arguments: '{"text": "hello"}' } },
+        ],
+      },
+      { content: 'Done' },
+    ]);
+
+    const tools = new StaticToolExecutor().register(echoTool, (args) => {
+      const parsed = JSON.parse(args);
+      return parsed.text;
+    });
+
+    const publisher = createMockPublisher();
+    const loop = new ReasoningLoop(llm, tools, publisher, manifestWithHooks);
+
+    const output = await loop.run({
+      taskId: 'task-hook',
+      task: 'Echo hello',
+    });
+
+    expect(output.result).toBe('Done');
+    expect(llm.getCallCount()).toBe(2);
+
+    // Check if feedback was merged into the tool result
+    const toolResultMessage = llm.getLastMessages().find(m => m.role === 'tool');
+    expect(toolResultMessage?.content).toContain('hello');
+    expect(toolResultMessage?.content).toContain('Hook feedback:');
+    expect(toolResultMessage?.content).toContain('Pre hook');
+    expect(toolResultMessage?.content).toContain('Post hook');
+  });
+
+  it('denies tool execution via PreToolUse hook', async () => {
+    const manifestWithDenyHook: RuntimeManifest = {
+      ...mockManifest,
+      hooks: {
+        preToolUse: ['echo "Denied by policy"; exit 2'],
+      },
+    };
+
+    const llm = new ScriptedLLMClient([
+      {
+        content: 'I will echo that.',
+        toolCalls: [
+          { id: 'call_deny', type: 'function', function: { name: 'echo', arguments: '{"text": "hello"}' } },
+        ],
+      },
+      { content: 'Hook stopped me' },
+    ]);
+
+    const handler = vi.fn().mockImplementation((args) => JSON.parse(args).text);
+    const tools = new StaticToolExecutor().register(echoTool, handler);
+
+    const publisher = createMockPublisher();
+    const loop = new ReasoningLoop(llm, tools, publisher, manifestWithDenyHook);
+
+    await loop.run({
+      taskId: 'task-deny',
+      task: 'Echo hello',
+    });
+
+    // Tool should NOT have been called
+    expect(handler).not.toHaveBeenCalled();
+
+    // Error should have been sent to LLM
+    const toolResultMessage = llm.getLastMessages().find(m => m.role === 'tool');
+    expect(toolResultMessage?.content).toContain('Error: Execution denied by hook.');
+    expect(toolResultMessage?.content).toContain('Denied by policy');
+  });
+
   it('handles unknown tool call by returning error to LLM', async () => {
     const llm = new ScriptedLLMClient([
       {

--- a/core/agent-runtime/src/__tests__/testHelpers.ts
+++ b/core/agent-runtime/src/__tests__/testHelpers.ts
@@ -15,10 +15,11 @@ import type { CentrifugoPublisher, ToolOutputCallback } from '../centrifugo.js';
  */
 export class ScriptedLLMClient implements ILLMClient {
   private callCount = 0;
+  private lastMessages: ChatMessage[] = [];
   constructor(private responses: LLMResponse[]) {}
 
   async chat(
-    _messages: ChatMessage[],
+    messages: ChatMessage[],
     _tools?: ToolDefinition[],
     _temperature?: number,
 
@@ -26,6 +27,7 @@ export class ScriptedLLMClient implements ILLMClient {
     _timeoutMs?: number,
     _model?: string
   ): Promise<LLMResponse> {
+    this.lastMessages = messages;
     const response = this.responses[this.callCount];
     if (!response) {
       throw new Error(
@@ -38,6 +40,10 @@ export class ScriptedLLMClient implements ILLMClient {
 
   getCallCount(): number {
     return this.callCount;
+  }
+
+  getLastMessages(): ChatMessage[] {
+    return this.lastMessages;
   }
 }
 

--- a/core/agent-runtime/src/hooks.ts
+++ b/core/agent-runtime/src/hooks.ts
@@ -1,0 +1,136 @@
+import { spawn } from 'child_process';
+import { log } from './logger.js';
+
+export type HookEvent = 'PreToolUse' | 'PostToolUse';
+
+export interface HookContext {
+  toolName: string;
+  toolInput: string;
+  toolOutput?: string;
+  isError?: boolean;
+}
+
+export interface HookRunResult {
+  status: 'allow' | 'deny' | 'warn';
+  feedback?: string;
+}
+
+export class HookRunner {
+  private preHooks: string[];
+  private postHooks: string[];
+
+  constructor(hooks?: { preToolUse?: string[]; postToolUse?: string[] }) {
+    this.preHooks = hooks?.preToolUse || [];
+    this.postHooks = hooks?.postToolUse || [];
+  }
+
+  /**
+   * Run all hooks for a given event.
+   * Hooks run sequentially. The first hook to deny (exit 2) stops further execution.
+   * Feedback from all hooks is concatenated.
+   */
+  async run(event: HookEvent, context: HookContext): Promise<HookRunResult> {
+    const commands = event === 'PreToolUse' ? this.preHooks : this.postHooks;
+    if (commands.length === 0) {
+      return { status: 'allow' };
+    }
+
+    let finalStatus: 'allow' | 'deny' | 'warn' = 'allow';
+    const feedbacks: string[] = [];
+
+    for (const command of commands) {
+      const result = await this.runCommand(command, event, context);
+
+      if (result.feedback) {
+        feedbacks.push(result.feedback);
+      }
+
+      if (result.status === 'deny') {
+        return {
+          status: 'deny',
+          feedback: feedbacks.join('\n\n'),
+        };
+      }
+
+      if (result.status === 'warn') {
+        finalStatus = 'warn';
+      }
+    }
+
+    return {
+      status: finalStatus,
+      feedback: feedbacks.length > 0 ? feedbacks.join('\n\n') : undefined,
+    };
+  }
+
+  private async runCommand(
+    command: string,
+    event: HookEvent,
+    context: HookContext
+  ): Promise<HookRunResult> {
+    return new Promise((resolve) => {
+      const env = {
+        ...process.env,
+        HOOK_EVENT: event,
+        HOOK_TOOL_NAME: context.toolName,
+        HOOK_TOOL_INPUT: context.toolInput,
+        HOOK_TOOL_OUTPUT: context.toolOutput || '',
+        HOOK_TOOL_IS_ERROR: context.isError ? '1' : '0',
+      };
+
+      const payload = JSON.stringify({
+        event,
+        toolName: context.toolName,
+        toolInput: context.toolInput,
+        toolOutput: context.toolOutput,
+        isError: context.isError,
+      });
+
+      log('debug', `Running hook (${event}): ${command}`);
+
+      // We use /bin/sh -c to support complex commands with pipes/args
+      const child = spawn('/bin/sh', ['-c', command], {
+        env,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+
+      let stdout = '';
+      let stderr = '';
+
+      child.stdout?.on('data', (data) => {
+        stdout += data.toString();
+      });
+
+      child.stderr?.on('data', (data) => {
+        stderr += data.toString();
+      });
+
+      child.stdin?.on('error', (err) => {
+        log('debug', `Hook stdin error (${command}): ${err.message}`);
+      });
+      child.stdin?.write(payload);
+      child.stdin?.end();
+
+      child.on('error', (err) => {
+        log('error', `Hook spawn error (${command}): ${err.message}`);
+        resolve({ status: 'warn', feedback: `Hook execution failed: ${err.message}` });
+      });
+
+      child.on('exit', (code) => {
+        const output = stdout.trim();
+        const errorOutput = stderr.trim();
+
+        if (code === 0) {
+          resolve({ status: 'allow', feedback: output || undefined });
+        } else if (code === 2) {
+          log('info', `Hook denied execution (exit 2): ${command}`);
+          resolve({ status: 'deny', feedback: output || errorOutput || 'Access denied by hook.' });
+        } else {
+          log('warn', `Hook warning (exit ${code}): ${command}. Stderr: ${errorOutput}`);
+          // For warnings, we might want to include the error output if stdout is empty
+          resolve({ status: 'warn', feedback: output || errorOutput || undefined });
+        }
+      });
+    });
+  }
+}

--- a/core/agent-runtime/src/loop.ts
+++ b/core/agent-runtime/src/loop.ts
@@ -24,6 +24,7 @@ import type { RuntimeManifest } from './manifest.js';
 import { generateSystemPrompt } from './manifest.js';
 import { ContextManager } from './contextManager.js';
 import { ToolLoopDetector } from './toolLoopDetector.js';
+import { HookRunner } from './hooks.js';
 import { log } from './logger.js';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -91,6 +92,7 @@ export class ReasoningLoop {
   /** All tools including deferred ones (for tool-search). */
   private allToolDefs: ToolDefinition[];
   private contextManager: ContextManager;
+  private hookRunner: HookRunner;
 
   /** Set to true when SIGTERM received; loop exits after current step. */
   shutdownRequested = false;
@@ -107,6 +109,7 @@ export class ReasoningLoop {
     this.manifest = manifest;
     this.allToolDefs = tools.getToolDefinitions(manifest.tools?.allowed);
     this.contextManager = new ContextManager(manifest.model.name);
+    this.hookRunner = new HookRunner(manifest.hooks);
 
     // Initial system prompt — will be refreshed per task with current time/tools
     this.systemPrompt = this.refreshSystemPrompt();
@@ -613,7 +616,56 @@ export class ReasoningLoop {
               );
             });
           };
-          const toolResults = await this.tools.executeToolCalls(response.toolCalls, onToolOutput);
+          const toolResults: ToolExecutionResult[] = await Promise.all(
+            response.toolCalls.map(async (tc) => {
+              const toolName = tc.function.name;
+              const toolInput = tc.function.arguments || '{}';
+
+              // PreToolUse hooks
+              const preResult = await this.hookRunner.run('PreToolUse', {
+                toolName,
+                toolInput,
+              });
+
+              if (preResult.status === 'deny') {
+                const feedback = preResult.feedback ? `\n\nHook feedback:\n${preResult.feedback}` : '';
+                await think('reflect', `Hook denied execution for ${toolName}`, iteration, {
+                  anomaly: true,
+                });
+                return {
+                  message: {
+                    role: 'tool',
+                    tool_call_id: tc.id,
+                    content: `Error: Execution denied by hook.${feedback}`,
+                  },
+                  toolName,
+                  argRepaired: false,
+                  repairStrategy: null,
+                };
+              }
+
+              // Execute the tool
+              const [result] = await this.tools.executeToolCalls([tc], onToolOutput);
+
+              // PostToolUse hooks
+              const isError = result.message.content.startsWith('Error:');
+              const postResult = await this.hookRunner.run('PostToolUse', {
+                toolName,
+                toolInput,
+                toolOutput: result.message.content,
+                isError,
+              });
+
+              // Merge feedback
+              const feedbacks = [preResult.feedback, postResult.feedback].filter(Boolean);
+              if (feedbacks.length > 0) {
+                result.message.content += `\n\nHook feedback:\n${feedbacks.join('\n\n')}`;
+              }
+
+              return result;
+            })
+          );
+
           for (const result of toolResults) {
             // 1. Per-result absolute cap (TOOL_OUTPUT_MAX_TOKENS)
             result.message.content = this.contextManager.truncateToolOutput(result.message.content);

--- a/core/agent-runtime/src/manifest.ts
+++ b/core/agent-runtime/src/manifest.ts
@@ -71,6 +71,10 @@ export interface RuntimeManifest {
     priority?: 'high' | 'normal' | 'low';
   }>;
   outputFormat?: string;
+  hooks?: {
+    preToolUse?: string[];
+    postToolUse?: string[];
+  };
 }
 
 /**
@@ -99,6 +103,7 @@ export function loadManifest(manifestPath: string): RuntimeManifest {
     if (spec['contextFiles'] && !raw['contextFiles']) raw['contextFiles'] = spec['contextFiles'];
     if (spec['outputFormat'] && !raw['outputFormat']) raw['outputFormat'] = spec['outputFormat'];
     if (spec['notes'] && !raw['notes']) raw['notes'] = spec['notes'];
+    if (spec['hooks'] && !raw['hooks']) raw['hooks'] = spec['hooks'];
   }
 
   const parsed = raw as unknown as RuntimeManifest;


### PR DESCRIPTION
This PR implements a pre/post tool execution hook system in the `agent-runtime`. 

Key features:
- **PreToolUse hooks**: Run before tool execution. Can deny (exit 2), warn (other non-zero), or allow (exit 0).
- **PostToolUse hooks**: Run after tool execution for auditing or feedback.
- **Hook Context**: Hooks receive tool name, input, output, and error status via environment variables and JSON on stdin.
- **Feedback Merging**: Hook stdout is appended to the tool result so the LLM can see it.
- **Manifest Configuration**: Hooks are defined in `AGENT.yaml` under `spec.hooks`.

Implementation details:
- Created `core/agent-runtime/src/hooks.ts` for the `HookRunner` logic.
- Modified `core/agent-runtime/src/loop.ts` to wrap tool execution with hook calls.
- Updated `core/agent-runtime/src/manifest.ts` to support hook configuration.
- Added unit tests in `core/agent-runtime/src/__tests__/hooks.test.ts` and E2E tests in `core/agent-runtime/src/__tests__/loop.test.ts`.

Fixes #544

---
*PR created automatically by Jules for task [9730410205264007128](https://jules.google.com/task/9730410205264007128) started by @TKCen*