### PR TITLE
🧪 add missing tests for NewAPIClient in tui/api.go

### DIFF
--- a/tui/api_test.go
+++ b/tui/api_test.go
@@ -5,7 +5,26 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
+
+func TestNewAPIClient(t *testing.T) {
+	baseURL := "http://example.com"
+	client := NewAPIClient(baseURL)
+
+	if client.BaseURL != baseURL {
+		t.Errorf("expected BaseURL %s, got %s", baseURL, client.BaseURL)
+	}
+
+	if client.client == nil {
+		t.Fatal("expected http.Client to be initialized, got nil")
+	}
+
+	expectedTimeout := 10 * time.Second
+	if client.client.Timeout != expectedTimeout {
+		t.Errorf("expected timeout %v, got %v", expectedTimeout, client.client.Timeout)
+	}
+}
 
 func TestGetInstances(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
This PR addresses the missing unit test for the `NewAPIClient` function in the `tui` package.

🎯 **What:** Added a unit test for the `NewAPIClient` constructor.
📊 **Coverage:**
- Verified `BaseURL` assignment.
- Verified internal `http.Client` initialization.
- Verified default 10-second timeout configuration.
✨ **Result:** Improved test coverage for the TUI package's API client initialization logic, ensuring that configuration changes or regressions are caught early.

---
*PR created automatically by Jules for task [320940111266257508](https://jules.google.com/task/320940111266257508) started by @TKCen*