### PR TITLE
🧪 [testing] Add tests for registerMCPServer and unregisterMCPServer API functions

### DIFF
--- a/web/src/lib/api/mcp.test.ts
+++ b/web/src/lib/api/mcp.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { registerMCPServer, unregisterMCPServer } from './mcp';
+import { request } from './client';
+
+vi.mock('./client', () => ({
+  request: vi.fn(),
+}));
+
+describe('mcp api', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('registerMCPServer', () => {
+    it('should call request with correct parameters', async () => {
+      const manifest = { name: 'test-server', version: '1.0.0' };
+      const mockResponse = { message: 'Server registered' };
+      vi.mocked(request).mockResolvedValueOnce(mockResponse);
+
+      const result = await registerMCPServer(manifest);
+
+      expect(request).toHaveBeenCalledWith('/mcp-servers', {
+        method: 'POST',
+        body: JSON.stringify(manifest),
+      });
+      expect(result).toEqual(mockResponse);
+    });
+  });
+
+  describe('unregisterMCPServer', () => {
+    it('should call request with correct parameters and encoded name', async () => {
+      const serverName = 'test server';
+      const mockResponse = { message: 'Server unregistered' };
+      vi.mocked(request).mockResolvedValueOnce(mockResponse);
+
+      const result = await unregisterMCPServer(serverName);
+
+      expect(request).toHaveBeenCalledWith(`/mcp-servers/${encodeURIComponent(serverName)}`, {
+        method: 'DELETE',
+      });
+      expect(result).toEqual(mockResponse);
+    });
+  });
+});


### PR DESCRIPTION
This PR adds missing unit tests for the MCP API client functions in the `web` workspace. 

🎯 **What:** The testing gap for `web/src/lib/api/mcp.ts` has been addressed.
📊 **Coverage:** 
- `registerMCPServer`: Verifies that it sends a POST request with the correct path and stringified manifest.
- `unregisterMCPServer`: Verifies that it sends a DELETE request with a correctly URI-encoded server name in the path.
✨ **Result:** Improved reliability and maintainability of the MCP server registration logic.

---
*PR created automatically by Jules for task [7619714146348561762](https://jules.google.com/task/7619714146348561762) started by @TKCen*