### PR TITLE
🧪 Add unit tests for NewWSClient in tui/ws.go

### DIFF
--- a/tui/ws_test.go
+++ b/tui/ws_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestNewWSClient(t *testing.T) {
+	url := "ws://localhost:8000/connection/websocket"
+	ws := NewWSClient(url, nil)
+
+	if ws == nil {
+		t.Fatal("expected WSClient to be non-nil")
+	}
+
+	if ws.client == nil {
+		t.Error("expected centrifuge client to be initialized")
+	}
+
+	if ws.program != nil {
+		t.Error("expected program to be nil")
+	}
+}
+
+func TestNewWSClientWithProgram(t *testing.T) {
+	url := "ws://localhost:8000/connection/websocket"
+	program := &tea.Program{}
+	ws := NewWSClient(url, program)
+
+	if ws == nil {
+		t.Fatal("expected WSClient to be non-nil")
+	}
+
+	if ws.program != program {
+		t.Errorf("expected program %v, got %v", program, ws.program)
+	}
+}


### PR DESCRIPTION
This PR adds missing unit tests for the `NewWSClient` function in the `tui` package. 

### 🎯 What:
Added a new test file `tui/ws_test.go` containing:
- `TestNewWSClient`: Verifies that `NewWSClient` initializes the centrifuge client and handles a nil program correctly.
- `TestNewWSClientWithProgram`: Verifies that the `tea.Program` is correctly assigned to the `WSClient` struct.

### 📊 Coverage:
The `NewWSClient` function is now fully covered by unit tests, ensuring that:
1. The returned `WSClient` is not nil.
2. The internal `centrifuge.Client` is initialized.
3. The `program` field is correctly set based on input.

### ✨ Result:
Improved reliability of the TUI's WebSocket client initialization logic. Tests were verified to catch regressions by intentionally breaking the constructor logic and observing test failures.

---
*PR created automatically by Jules for task [4147654175326056248](https://jules.google.com/task/4147654175326056248) started by @TKCen*