### PR TITLE
🧪 Add unit tests for LLM configuration API functions in providers.ts

### DIFF
--- a/web/src/lib/api/providers.test.ts
+++ b/web/src/lib/api/providers.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { testLLMConfig, getLLMConfig, updateLLMConfig } from './providers';
+import { request } from './client';
+import type { LLMConfig } from './types';
+
+vi.mock('./client', () => ({
+  request: vi.fn(),
+}));
+
+describe('providers api', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('testLLMConfig', () => {
+    it('should call request with correct parameters for success', async () => {
+      const mockResponse = { success: true, model: 'gpt-4o', response: 'Connected' };
+      vi.mocked(request).mockResolvedValueOnce(mockResponse);
+
+      const result = await testLLMConfig();
+
+      expect(request).toHaveBeenCalledWith('/config/llm/test', {
+        method: 'POST',
+      });
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('should handle failure responses', async () => {
+      const mockResponse = { success: false, error: 'Invalid API key' };
+      vi.mocked(request).mockResolvedValueOnce(mockResponse);
+
+      const result = await testLLMConfig();
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Invalid API key');
+    });
+  });
+
+  describe('getLLMConfig', () => {
+    it('should fetch LLM configuration', async () => {
+      const mockConfig: LLMConfig = {
+        baseUrl: 'http://localhost:11434',
+        model: 'llama3',
+      };
+      vi.mocked(request).mockResolvedValueOnce(mockConfig);
+
+      const result = await getLLMConfig();
+
+      expect(request).toHaveBeenCalledWith('/config/llm');
+      expect(result).toEqual(mockConfig);
+    });
+  });
+
+  describe('updateLLMConfig', () => {
+    it('should update LLM configuration via POST', async () => {
+      const config: LLMConfig = {
+        baseUrl: 'https://api.openai.com/v1',
+        apiKey: 'test-key',
+        model: 'gpt-4o',
+      };
+      const mockResponse = { success: true };
+      vi.mocked(request).mockResolvedValueOnce(mockResponse);
+
+      const result = await updateLLMConfig(config);
+
+      expect(request).toHaveBeenCalledWith('/config/llm', {
+        method: 'POST',
+        body: JSON.stringify(config),
+      });
+      expect(result).toEqual(mockResponse);
+    });
+  });
+});


### PR DESCRIPTION
### 🧪 [testing improvement] Add unit tests for providers API

#### 🎯 What:
Addressed the missing tests for `testLLMConfig` in `web/src/lib/api/providers.ts`.

#### 📊 Coverage:
- `testLLMConfig`: Tested success and failure scenarios, ensuring correct HTTP method (`POST`) and endpoint (`/config/llm/test`).
- `getLLMConfig`: Verified it correctly fetches the current LLM configuration.
- `updateLLMConfig`: Verified it correctly sends a `POST` request with the new configuration in the body.

#### ✨ Result:
Improved test coverage for critical API interaction logic responsible for global LLM configuration. All tests pass and are isolated via Vitest mocks.

---
*PR created automatically by Jules for task [17751302727926874018](https://jules.google.com/task/17751302727926874018) started by @TKCen*