### PR TITLE
🧹 Remove unused and suppressed LLM config import

### DIFF
--- a/web/src/app/settings/page.tsx
+++ b/web/src/app/settings/page.tsx
@@ -20,7 +20,6 @@ import { toast } from 'sonner';
 import { updateProviderConfig } from '@/lib/api/providers';
 import {
   useProviders,
-  useLLMConfig,
   useDynamicProviders,
   useDynamicProviderStatuses,
   useAddDynamicProvider,
@@ -255,8 +254,6 @@ function SettingsPageContent() {
   const { data: statusesData } = useDynamicProviderStatuses();
   const addDynamic = useAddDynamicProvider();
   const removeDynamic = useRemoveDynamicProvider();
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- reserved for future LLM config UI
-  const { data: _llmConfig } = useLLMConfig();
   const { data: circuitBreakers, refetch: refetchCB } = useCircuitBreakers();
   const resetCB = useResetCircuitBreaker();
 


### PR DESCRIPTION
🎯 **What:** Removed the unused `useLLMConfig` hook call, its import, and the corresponding ESLint suppression in the settings page (`web/src/app/settings/page.tsx`).
💡 **Why:** This improves maintainability and readability by removing dead code and reducing unnecessary hook execution for a feature not yet implemented.
✅ **Verification:** Verified by running `bun run --filter sera-web lint` and `bun run --filter sera-web test`, both of which passed without regressions.
✨ **Result:** Cleaned up the settings page code by removing unused imports and logic.

---
*PR created automatically by Jules for task [3680648484065280558](https://jules.google.com/task/3680648484065280558) started by @TKCen*