### PR TITLE
🧹 Refactor Memory Router to use MemoryManager's VectorService

### DIFF
--- a/core/src/memory/manager.ts
+++ b/core/src/memory/manager.ts
@@ -24,7 +24,7 @@ export class MemoryManager {
   public readonly store: MemoryBlockStore;
   public readonly circleId?: string;
   public readonly agentId?: string;
-  private readonly vectorService: VectorService;
+  public readonly vectorService: VectorService;
   private readonly embeddingService = EmbeddingService.getInstance();
 
   // Simple in-memory rate limiting state

--- a/core/src/routes/memory.test.ts
+++ b/core/src/routes/memory.test.ts
@@ -5,8 +5,15 @@ import { createMemoryRouter } from './memory.js';
 import type { MemoryManager } from '../memory/manager.js';
 
 // Mock dependencies
+const mockVectorService = {
+  delete: vi.fn(),
+  search: vi.fn(),
+  getCollectionInfo: vi.fn(),
+};
+
 const mockMemoryManager = {
   deleteEntry: vi.fn(),
+  vectorService: mockVectorService,
 };
 
 const mockScopedStore = {
@@ -15,11 +22,7 @@ const mockScopedStore = {
   listAgentIds: vi.fn().mockResolvedValue([]),
 };
 
-const mockVectorService = {
-  delete: vi.fn(),
-};
-
-// We need to mock the constructor of ScopedMemoryBlockStore and VectorService inside the router file
+// We need to mock the constructor of ScopedMemoryBlockStore inside the router file
 // or just mock the entire modules if we want to control the instances created inside createMemoryRouter.
 // Since createMemoryRouter instantiates them internally, we'll mock the modules.
 
@@ -27,14 +30,6 @@ vi.mock('../memory/blocks/ScopedMemoryBlockStore.js', () => {
   return {
     ScopedMemoryBlockStore: vi.fn().mockImplementation(function () {
       return mockScopedStore;
-    }),
-  };
-});
-
-vi.mock('../services/vector.service.js', () => {
-  return {
-    VectorService: vi.fn().mockImplementation(function () {
-      return mockVectorService;
     }),
   };
 });

--- a/core/src/routes/memory.ts
+++ b/core/src/routes/memory.ts
@@ -1,7 +1,6 @@
 import { Router } from 'express';
 import type { MemoryManager } from '../memory/manager.js';
 import { ScopedMemoryBlockStore } from '../memory/blocks/ScopedMemoryBlockStore.js';
-import { VectorService } from '../services/vector.service.js';
 import type { MemoryNamespace } from '../services/vector.service.js';
 import { MemoryCompactionService } from '../memory/MemoryCompactionService.js';
 import { EmbeddingService } from '../services/embedding.service.js';
@@ -15,7 +14,6 @@ const memLogger = new Logger('MemoryRoutes');
 export function createMemoryRouter(memoryManager: MemoryManager) {
   const router = Router();
   const scopedStore = new ScopedMemoryBlockStore(MEMORY_ROOT);
-  const vectorService = new VectorService('_mem_route_unused');
 
   // ── Legacy Letta-style routes (Epic 5) ─────────────────────────────────────
 
@@ -210,7 +208,7 @@ export function createMemoryRouter(memoryManager: MemoryManager) {
         );
 
         if (namespaces.length > 0) {
-          const results = await vectorService.search(namespaces, vector, limit);
+          const results = await memoryManager.vectorService.search(namespaces, vector, limit);
           const hydrated: Array<{ block: KnowledgeBlock | null; score: number }> = [];
           for (const result of results) {
             const agentId = result.payload?.agent_id as string | undefined;
@@ -320,7 +318,7 @@ export function createMemoryRouter(memoryManager: MemoryManager) {
       const blockCount = await scopedStore.countByAgent(agentId);
 
       const personalNs: MemoryNamespace = `personal:${agentId}`;
-      const personalInfo = await vectorService.getCollectionInfo(personalNs);
+      const personalInfo = await memoryManager.vectorService.getCollectionInfo(personalNs);
 
       res.json({
         agentId,
@@ -492,7 +490,7 @@ export function createMemoryRouter(memoryManager: MemoryManager) {
             ? (agentId as MemoryNamespace)
             : (`personal:${agentId}` as MemoryNamespace);
 
-      await vectorService.delete(id, namespace);
+      await memoryManager.vectorService.delete(id, namespace);
 
       res.status(204).end();
     } catch (err: unknown) {


### PR DESCRIPTION
This PR addresses a code health issue in the Memory Router where a redundant `VectorService` was being instantiated locally with a placeholder name. 

Key changes:
- **`core/src/memory/manager.ts`**: Changed `vectorService` from `private` to `public readonly` to allow other components (like the router) to reuse the instance already managed by the `MemoryManager`.
- **`core/src/routes/memory.ts`**: Removed the local `vectorService` instantiation (`new VectorService('_mem_route_unused')`) and refactored all route handlers (`/search`, `/:agentId/stats`, `/:agentId/blocks/:id`) to use `memoryManager.vectorService`.
- **`core/src/routes/memory.test.ts`**: Updated mocks to align with the new architecture, ensuring `MemoryManager` correctly provides a mocked `vectorService`.

These changes improve maintainability by centralizing vector service configuration and removing dead/confusing code. Verified with `bun run --filter core test src/routes/memory.test.ts` and `bun run --filter core typecheck`.

---
*PR created automatically by Jules for task [17420104621006189629](https://jules.google.com/task/17420104621006189629) started by @TKCen*