### PR TITLE
feat(web): enrich thought stream with agentId and toolCallId

### DIFF
--- a/web/src/app/chat/page.tsx
+++ b/web/src/app/chat/page.tsx
@@ -56,6 +56,7 @@ interface ThoughtPayload {
   agentDisplayName: string;
   toolName?: string;
   toolArgs?: Record<string, unknown>;
+  toolCallId?: string;
 }
 
 // ── ChatPage ──────────────────────────────────────────────────────────────────
@@ -238,10 +239,11 @@ function ChatPageContent() {
         timestamp: event.timestamp,
         stepType: event.stepType,
         content: event.content,
+        agentId: event.agentId,
         ...(event.toolName ? { toolName: event.toolName } : {}),
         ...(event.toolArgs ? { toolArgs: event.toolArgs } : {}),
+        ...(event.toolCallId ? { toolCallId: event.toolCallId } : {}),
       };
-
       setMessages((prev) =>
         prev.map((msg) =>
           msg.id === streamingMsgId.current ? { ...msg, thoughts: [...msg.thoughts, thought] } : msg


### PR DESCRIPTION
## Summary
- Maps `agentId` and `toolCallId` from Centrifugo thought payload into `MessageThought` objects
- Enables richer debugging and tool call correlation in the chat UI
- Types already existed in `MessageThought` interface — this wires up the mapping

## Test plan
- [x] Typecheck passes
- [x] All 68 web tests pass
- [ ] Manual: verify thought stream in chat UI shows agent attribution

🤖 Generated with [Claude Code](https://claude.com/claude-code)