### PR TITLE
🧹 core: move vectorService declaration to local scope in knowledge-store skill

### DIFF
--- a/core/src/skills/builtins/knowledge-store.ts
+++ b/core/src/skills/builtins/knowledge-store.ts
@@ -34,7 +34,6 @@ function checkRateLimit(agentId: string): boolean {
   return recent.length <= 10;
 }
 
-const vectorService = new VectorService('_ks_unused');
 const embeddingService = EmbeddingService.getInstance();
 
 export function createKnowledgeStoreSkill(): SkillDefinition {
@@ -125,6 +124,7 @@ export function createKnowledgeStoreSkill(): SkillDefinition {
 
         if (embeddingService.isAvailable()) {
           try {
+            const vectorService = new VectorService('_ks_unused');
             const namespace: MemoryNamespace = `personal:${agentId}`;
             const vector = await embeddingService.embed(`${block.title}\n${block.content}`);
             await vectorService.upsert(block.id, namespace, vector, {


### PR DESCRIPTION
Moved the `vectorService` declaration from the global scope into the local `handler` function in `core/src/skills/builtins/knowledge-store.ts`. This ensures that the service is only instantiated when needed (during personal scope indexing) and follows better encapsulation practices. I also verified the fix by running relevant unit tests.

---
*PR created automatically by Jules for task [8028779551187119384](https://jules.google.com/task/8028779551187119384) started by @TKCen*