### PR TITLE
Implement Task Lifecycle Commands (Story 16.7)

### DIFF
--- a/cli/agents.go
+++ b/cli/agents.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"text/tabwriter"
+)
+
+type agentDetail struct {
+	ID            string `json:"id"`
+	Name          string `json:"name"`
+	Status        string `json:"status"`
+	Circle        string `json:"circle"`
+	LifecycleMode string `json:"lifecycle_mode"`
+}
+
+func runAgents(args []string) {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "usage: sera agents <list|start|stop|restart|logs> [args]")
+		os.Exit(1)
+	}
+
+	sub := args[0]
+	rest := args[1:]
+
+	client, err := NewClient()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+
+	switch sub {
+	case "list":
+		runAgentsList(client)
+	case "start":
+		runAgentAction(client, http.MethodPost, "start", rest)
+	case "stop":
+		runAgentAction(client, http.MethodPost, "stop", rest)
+	case "restart":
+		runAgentAction(client, http.MethodPost, "restart", rest)
+	case "logs":
+		runAgentLogs(client, rest)
+	default:
+		fmt.Fprintf(os.Stderr, "unknown agents subcommand: %s\n", sub)
+		os.Exit(1)
+	}
+}
+
+func runAgentsList(c *SeraClient) {
+	var agents []agentDetail
+	if err := c.Do(http.MethodGet, "/api/agents/instances", nil, &agents); err != nil {
+		fmt.Fprintf(os.Stderr, "error listing agents: %v\n", err)
+		os.Exit(1)
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "ID\tNAME\tSTATUS\tCIRCLE\tMODE")
+	for _, a := range agents {
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", a.ID, a.Name, a.Status, a.Circle, a.LifecycleMode)
+	}
+	w.Flush()
+}
+
+func runAgentAction(c *SeraClient, method, action string, args []string) {
+	if len(args) == 0 {
+		fmt.Fprintf(os.Stderr, "usage: sera agents %s <id|name>\n", action)
+		os.Exit(1)
+	}
+
+	id, err := c.ResolveAgentID(args[0])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error resolving agent: %v\n", err)
+		os.Exit(1)
+	}
+
+	path := fmt.Sprintf("/api/agents/instances/%s/%s", id, action)
+	if action == "restart" {
+		path = fmt.Sprintf("/api/agents/%s/restart", id)
+	}
+
+	if err := c.Do(method, path, nil, nil); err != nil {
+		fmt.Fprintf(os.Stderr, "error %s agent: %v\n", action, err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Agent %s %sed successfully.\n", args[0], action)
+}
+
+func runAgentLogs(c *SeraClient, args []string) {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "usage: sera agents logs <id|name>")
+		os.Exit(1)
+	}
+
+	id, err := c.ResolveAgentID(args[0])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error resolving agent: %v\n", err)
+		os.Exit(1)
+	}
+
+	var logs string
+	if err := c.Do(http.MethodGet, fmt.Sprintf("/api/agents/%s/logs", id), nil, &logs); err != nil {
+		fmt.Fprintf(os.Stderr, "error fetching logs: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Println(logs)
+}

--- a/cli/auth.go
+++ b/cli/auth.go
@@ -12,7 +12,7 @@ import (
 	"time"
 )
 
-const credentialsFile = ".sera/credentials"
+const CredentialsFile = ".sera/credentials"
 
 // Credentials written to ~/.sera/credentials (mode 0600).
 // JSON format: { "apiKey": "...", "issuer": "...", "expiresAt": "..." }
@@ -75,7 +75,7 @@ func runAuth(args []string) {
 func runAuthLogin(args []string) {
 	serviceAccount := len(args) > 0 && args[0] == "--service-account"
 
-	apiURL := getenv("SERA_API_URL", "http://localhost:3001")
+	apiURL := Getenv("SERA_API_URL", "http://localhost:3001")
 
 	// Resolve OIDC metadata from sera-core
 	issuerURL, clientID, err := resolveOIDCConfig(apiURL)
@@ -144,7 +144,7 @@ func runAuthLogin(args []string) {
 		if writeErr := writeCredentials(creds); writeErr != nil {
 			fmt.Fprintf(os.Stderr, "warning: could not write credentials: %v\n", writeErr)
 		}
-		fmt.Printf("\nService account key created and stored in ~/%s\n", credentialsFile)
+		fmt.Printf("\nService account key created and stored in ~/%s\n", CredentialsFile)
 		fmt.Println("Use --api-key or set SERA_API_KEY for non-interactive use.")
 		return
 	}
@@ -159,7 +159,7 @@ func runAuthLogin(args []string) {
 		fmt.Fprintf(os.Stderr, "warning: could not write credentials: %v\n", writeErr)
 	}
 
-	fmt.Printf("\nAuthenticated successfully. Credentials stored in ~/%s\n", credentialsFile)
+	fmt.Printf("\nAuthenticated successfully. Credentials stored in ~/%s\n", CredentialsFile)
 	if tokens.ExpiresIn > 0 {
 		fmt.Printf("Token expires: %s\n", expiresAt)
 	}
@@ -168,14 +168,14 @@ func runAuthLogin(args []string) {
 // ── sera auth logout ─────────────────────────────────────────────────────────
 
 func runAuthLogout() {
-	creds, err := readCredentials()
+	creds, err := ReadCredentials()
 	if err == nil && creds.APIKey != "" {
 		// Best-effort token revocation
-		apiURL := getenv("SERA_API_URL", "http://localhost:3001")
+		apiURL := Getenv("SERA_API_URL", "http://localhost:3001")
 		revokeToken(apiURL, creds)
 	}
 
-	path := credentialsPath()
+	path := CredentialsPath()
 	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 		fmt.Fprintf(os.Stderr, "warning: could not remove credentials file: %v\n", err)
 	}
@@ -186,9 +186,9 @@ func runAuthLogout() {
 
 func runAuthStatus() {
 	// Check for --api-key override
-	apiKey := getenv("SERA_API_KEY", "")
+	apiKey := Getenv("SERA_API_KEY", "")
 	if apiKey == "" {
-		creds, err := readCredentials()
+		creds, err := ReadCredentials()
 		if err != nil {
 			fmt.Println("Not logged in. Run: sera auth login")
 			return
@@ -203,7 +203,7 @@ func runAuthStatus() {
 		}
 	}
 
-	apiURL := getenv("SERA_API_URL", "http://localhost:3001")
+	apiURL := Getenv("SERA_API_URL", "http://localhost:3001")
 	me, err := fetchMe(apiURL, apiKey)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "could not fetch identity: %v\n", err)
@@ -225,23 +225,23 @@ func runAuthStatus() {
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
-func getenv(key, fallback string) string {
+func Getenv(key, fallback string) string {
 	if v := os.Getenv(key); v != "" {
 		return v
 	}
 	return fallback
 }
 
-func credentialsPath() string {
+func CredentialsPath() string {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		home = "."
 	}
-	return filepath.Join(home, credentialsFile)
+	return filepath.Join(home, CredentialsFile)
 }
 
 func writeCredentials(creds Credentials) error {
-	path := credentialsPath()
+	path := CredentialsPath()
 	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
 		return err
 	}
@@ -252,8 +252,8 @@ func writeCredentials(creds Credentials) error {
 	return os.WriteFile(path, data, 0600)
 }
 
-func readCredentials() (Credentials, error) {
-	path := credentialsPath()
+func ReadCredentials() (Credentials, error) {
+	path := CredentialsPath()
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return Credentials{}, err
@@ -266,8 +266,8 @@ func resolveOIDCConfig(apiURL string) (issuerURL, clientID string, err error) {
 	resp, err := http.Get(apiURL + "/api/auth/oidc-config")
 	if err != nil {
 		// sera-core might not have this endpoint — fall back to env
-		issuerURL = getenv("OIDC_ISSUER_URL", "")
-		clientID = getenv("OIDC_CLIENT_ID", "sera-web")
+		issuerURL = Getenv("OIDC_ISSUER_URL", "")
+		clientID = Getenv("OIDC_CLIENT_ID", "sera-web")
 		if issuerURL == "" {
 			return "", "", fmt.Errorf("OIDC_ISSUER_URL not set and /api/auth/oidc-config unavailable")
 		}
@@ -280,8 +280,8 @@ func resolveOIDCConfig(apiURL string) (issuerURL, clientID string, err error) {
 		ClientID  string `json:"clientId"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&cfg); err != nil || cfg.IssuerURL == "" {
-		issuerURL = getenv("OIDC_ISSUER_URL", "")
-		clientID = getenv("OIDC_CLIENT_ID", "sera-web")
+		issuerURL = Getenv("OIDC_ISSUER_URL", "")
+		clientID = Getenv("OIDC_CLIENT_ID", "sera-web")
 		if issuerURL == "" {
 			return "", "", fmt.Errorf("could not resolve OIDC issuer URL")
 		}

--- a/cli/client.go
+++ b/cli/client.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type SeraClient struct {
+	BaseURL string
+	APIKey  string
+}
+
+func NewClient() (*SeraClient, error) {
+	apiKey := Getenv("SERA_API_KEY", "")
+	if apiKey == "" {
+		creds, err := ReadCredentials()
+		if err == nil {
+			apiKey = creds.APIKey
+			if creds.ExpiresAt != "" {
+				expiry, parseErr := time.Parse(time.RFC3339, creds.ExpiresAt)
+				if parseErr == nil && time.Now().After(expiry) {
+					return nil, fmt.Errorf("token has expired. Run: sera auth login")
+				}
+			}
+		}
+	}
+
+	if apiKey == "" {
+		return nil, fmt.Errorf("not logged in. Run: sera auth login")
+	}
+
+	return &SeraClient{
+		BaseURL: Getenv("SERA_API_URL", "http://localhost:3001"),
+		APIKey:  apiKey,
+	}, nil
+}
+
+func (c *SeraClient) Do(method, path string, body interface{}, result interface{}) error {
+	var bodyReader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return err
+		}
+		bodyReader = bytes.NewReader(data)
+	}
+
+	req, err := http.NewRequest(method, c.BaseURL+path, bodyReader)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Authorization", "Bearer "+c.APIKey)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		respBody, _ := io.ReadAll(resp.Body)
+		var errResp struct {
+			Error string `json:"error"`
+		}
+		if err := json.Unmarshal(respBody, &errResp); err == nil && errResp.Error != "" {
+			return fmt.Errorf("HTTP %d: %s", resp.StatusCode, errResp.Error)
+		}
+		return fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	if result != nil {
+		if r, ok := result.(*string); ok {
+			data, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return err
+			}
+			*r = string(data)
+			return nil
+		}
+		return json.NewDecoder(resp.Body).Decode(result)
+	}
+
+	return nil
+}
+
+type agentInstance struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+func (c *SeraClient) ResolveAgentID(nameOrID string) (string, error) {
+	// If it looks like a UUID, return it
+	if strings.Contains(nameOrID, "-") && len(nameOrID) >= 32 {
+		return nameOrID, nil
+	}
+
+	var instances []agentInstance
+	if err := c.Do(http.MethodGet, "/api/agents/instances", nil, &instances); err != nil {
+		return "", err
+	}
+
+	for _, inst := range instances {
+		if inst.Name == nameOrID || inst.ID == nameOrID {
+			return inst.ID, nil
+		}
+	}
+
+	return "", fmt.Errorf("agent not found: %s", nameOrID)
+}

--- a/cli/main.go
+++ b/cli/main.go
@@ -17,6 +17,10 @@ func main() {
 	switch cmd {
 	case "auth":
 		runAuth(os.Args[2:])
+	case "agents":
+		runAgents(os.Args[2:])
+	case "tasks":
+		runTasks(os.Args[2:])
 	case "help", "--help", "-h":
 		printUsage()
 	default:
@@ -31,9 +35,19 @@ func printUsage() {
 
 Usage:
   sera auth login              Authenticate via OIDC device flow
-  sera auth login --api-key    Create a long-lived API key for scripting
   sera auth logout             Revoke session and delete stored credentials
   sera auth status             Show current identity and token expiry
+
+  sera agents list             List all agent instances
+  sera agents start <id|name>  Start an agent
+  sera agents stop <id|name>   Stop an agent
+  sera agents restart <id|name> Restart an agent
+  sera agents logs <id|name>   Show agent container logs
+
+  sera tasks list <agent>      List tasks for an agent
+  sera tasks create <agent> <prompt> Create a new task
+  sera tasks get <agent> <id>  Show task details
+  sera tasks cancel <agent> <id> Cancel a queued task
 
 Global flags:
   --api-key <key>   Bypass stored credentials; use this API key instead

--- a/cli/tasks.go
+++ b/cli/tasks.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"text/tabwriter"
+	"time"
+)
+
+type taskDetail struct {
+	ID        string    `json:"id"`
+	Task      string    `json:"task"`
+	Status    string    `json:"status"`
+	CreatedAt time.Time `json:"createdAt"`
+}
+
+func runTasks(args []string) {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "usage: sera tasks <list|create|get|cancel> <agent-id|name> [args]")
+		os.Exit(1)
+	}
+
+	sub := args[0]
+	rest := args[1:]
+
+	client, err := NewClient()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+
+	switch sub {
+	case "list":
+		runTasksList(client, rest)
+	case "create":
+		runTasksCreate(client, rest)
+	case "get":
+		runTasksGet(client, rest)
+	case "cancel":
+		runTasksCancel(client, rest)
+	default:
+		fmt.Fprintf(os.Stderr, "unknown tasks subcommand: %s\n", sub)
+		os.Exit(1)
+	}
+}
+
+func runTasksList(c *SeraClient, args []string) {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "usage: sera tasks list <agent-id|name>")
+		os.Exit(1)
+	}
+
+	agentID, err := c.ResolveAgentID(args[0])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error resolving agent: %v\n", err)
+		os.Exit(1)
+	}
+
+	var tasks []taskDetail
+	if err := c.Do(http.MethodGet, fmt.Sprintf("/api/agents/%s/tasks", agentID), nil, &tasks); err != nil {
+		fmt.Fprintf(os.Stderr, "error listing tasks: %v\n", err)
+		os.Exit(1)
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "ID\tSTATUS\tCREATED\tTASK")
+	for _, t := range tasks {
+		summary := t.Task
+		if len(summary) > 50 {
+			summary = summary[:47] + "..."
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", t.ID, t.Status, t.CreatedAt.Format("2006-01-02 15:04"), summary)
+	}
+	w.Flush()
+}
+
+func runTasksCreate(c *SeraClient, args []string) {
+	if len(args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: sera tasks create <agent-id|name> <prompt>")
+		os.Exit(1)
+	}
+
+	agentID, err := c.ResolveAgentID(args[0])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error resolving agent: %v\n", err)
+		os.Exit(1)
+	}
+
+	prompt := args[1]
+	body := map[string]string{"task": prompt}
+	var resp struct {
+		TaskID string `json:"taskId"`
+		Status string `json:"status"`
+	}
+
+	if err := c.Do(http.MethodPost, fmt.Sprintf("/api/agents/%s/tasks", agentID), body, &resp); err != nil {
+		fmt.Fprintf(os.Stderr, "error creating task: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Task created: %s (status: %s)\n", resp.TaskID, resp.Status)
+}
+
+func runTasksGet(c *SeraClient, args []string) {
+	if len(args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: sera tasks get <agent-id|name> <task-id>")
+		os.Exit(1)
+	}
+
+	agentID, err := c.ResolveAgentID(args[0])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error resolving agent: %v\n", err)
+		os.Exit(1)
+	}
+
+	taskID := args[1]
+	var task interface{}
+	if err := c.Do(http.MethodGet, fmt.Sprintf("/api/agents/%s/tasks/%s", agentID, taskID), nil, &task); err != nil {
+		fmt.Fprintf(os.Stderr, "error fetching task: %v\n", err)
+		os.Exit(1)
+	}
+
+	pretty, _ := json.MarshalIndent(task, "", "  ")
+	fmt.Println(string(pretty))
+}
+
+func runTasksCancel(c *SeraClient, args []string) {
+	if len(args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: sera tasks cancel <agent-id|name> <task-id>")
+		os.Exit(1)
+	}
+
+	agentID, err := c.ResolveAgentID(args[0])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error resolving agent: %v\n", err)
+		os.Exit(1)
+	}
+
+	taskID := args[1]
+	if err := c.Do(http.MethodDelete, fmt.Sprintf("/api/agents/%s/tasks/%s", agentID, taskID), nil, nil); err != nil {
+		fmt.Fprintf(os.Stderr, "error cancelling task: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Task %s cancelled successfully.\n", taskID)
+}

--- a/docs/superpowers/plans/2026-04-02-task-lifecycle-commands.md
+++ b/docs/superpowers/plans/2026-04-02-task-lifecycle-commands.md
@@ -1,0 +1,123 @@
+# Task Lifecycle Commands Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement `sera agents` and `sera tasks` commands in the Go CLI for managing agent lifecycle and task queues.
+
+**Architecture:** Refactor shared request logic into a `Client` struct in `cli/client.go`. Implement subcommands in dedicated files using the shared client.
+
+**Tech Stack:** Go (Standard Library), `tabwriter` for formatting.
+
+---
+
+### Task 1: Shared Client Implementation
+
+**Files:**
+
+- Create: `cli/client.go`
+- Modify: `cli/auth.go` (extract helpers)
+
+- [ ] **Step 1: Extract helpers from `cli/auth.go`**
+      Move `Credentials`, `readCredentials`, `credentialsPath`, `getenv` to a place where they can be shared (or just make them exported if keeping in the same package).
+
+- [ ] **Step 2: Create `cli/client.go`**
+      Implement a `SeraClient` struct that handles:
+- Base URL from `SERA_API_URL` or default.
+- Authorization header from `SERA_API_KEY` or `~/.sera/credentials`.
+- JSON request/response handling.
+- `ResolveAgentID(nameOrID string) (string, error)` helper.
+
+```go
+type SeraClient struct {
+    BaseURL string
+    APIKey  string
+}
+
+func NewClient() (*SeraClient, error) { ... }
+func (c *SeraClient) Do(method, path string, body interface{}, result interface{}) error { ... }
+func (c *SeraClient) ResolveAgentID(nameOrID string) (string, error) { ... }
+```
+
+- [ ] **Step 3: Verify compilation**
+      Run: `go build -o sera.exe ./cli`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cli/auth.go cli/client.go
+git commit -m "cli: add shared HTTP client and refactor auth helpers"
+```
+
+---
+
+### Task 2: Implement `sera agents` Commands
+
+**Files:**
+
+- Create: `cli/agents.go`
+- Modify: `cli/main.go`
+
+- [ ] **Step 1: Implement `runAgents` in `cli/agents.go`**
+      Support `list`, `start`, `stop`, `restart`, `logs`.
+- `list`: GET `/api/agents/instances`, print table with `tabwriter`.
+- `start/stop/restart`: Resolve ID, POST to `/api/agents/instances/:id/start`, etc.
+- `logs`: Resolve ID, GET `/api/agents/:id/logs`, print raw text.
+
+- [ ] **Step 2: Wire up in `cli/main.go`**
+      Add `agents` case to `main` and update `printUsage`.
+
+- [ ] **Step 3: Verify compilation**
+      Run: `go build -o sera.exe ./cli`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cli/agents.go cli/main.go
+git commit -m "cli: implement sera agents commands"
+```
+
+---
+
+### Task 3: Implement `sera tasks` Commands
+
+**Files:**
+
+- Create: `cli/tasks.go`
+- Modify: `cli/main.go`
+
+- [ ] **Step 1: Implement `runTasks` in `cli/tasks.go`**
+      Support `list`, `create`, `get`, `cancel`.
+- `list`: Resolve Agent ID, GET `/api/agents/:id/tasks`, print table.
+- `create`: Resolve Agent ID, POST `/api/agents/:id/tasks` with `{task: prompt}`.
+- `get`: Resolve Agent ID, GET `/api/agents/:id/tasks/:taskId`, print detailed JSON or formatted text.
+- `cancel`: Resolve Agent ID, DELETE `/api/agents/:id/tasks/:taskId`.
+
+- [ ] **Step 2: Wire up in `cli/main.go`**
+      Add `tasks` case to `main` and update `printUsage`.
+
+- [ ] **Step 3: Verify compilation**
+      Run: `go build -o sera.exe ./cli`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cli/tasks.go cli/main.go
+git commit -m "cli: implement sera tasks commands"
+```
+
+---
+
+### Task 4: Final Verification & Cleanup
+
+- [ ] **Step 1: Run help to verify usage strings**
+      Run: `./sera help`
+
+- [ ] **Step 2: Manual dry-run against localhost:3001 (if running)**
+      If core is up, try `sera agents list`.
+
+- [ ] **Step 3: Commit final changes**
+
+```bash
+git add .
+git commit -m "cli: complete task lifecycle commands implementation"
+```

--- a/docs/superpowers/specs/2026-04-02-task-lifecycle-commands-design.md
+++ b/docs/superpowers/specs/2026-04-02-task-lifecycle-commands-design.md
@@ -1,0 +1,93 @@
+# Spec: Task Lifecycle Commands — Story 16.7
+
+**Date:** 2026-04-02
+**Status:** Approved
+**Owner:** Gemini CLI
+
+## 1. Overview
+
+This specification defines the expansion of the `sera` CLI (Go) to support agent lifecycle management and task queue interaction. It builds on the existing OIDC authentication (Story 16.6) and leverages backend routes in `sera-core` (Stories 3.x, 5.x).
+
+## 2. Requirements
+
+### 2.1 Agent Instance Lifecycle
+
+- **List Agents:** Display all agent instances with their current status, circle, and lifecycle mode.
+- **Start/Stop/Restart:** Control the Docker-backed lifecycle of a specific agent.
+- **Logs:** Stream container logs from a running agent.
+
+### 2.2 Task Queue Management
+
+- **List Tasks:** View the per-agent task queue (queued, running, completed, failed).
+- **Create Task:** Enqueue a new prompt for an agent to process.
+- **Get Task:** Retrieve full details, including the final result or error.
+- **Cancel Task:** Remove a task from the queue before it starts.
+
+### 2.3 Non-Functional Requirements
+
+- **Authentication:** Use existing `~/.sera/credentials` (Access Token) or `SERA_API_KEY`.
+- **Resilience:** Clear error messages for network failures, missing agents, or invalid task states.
+- **UX:** Tabular output for lists; consistent argument parsing (ID or Name).
+
+## 3. Design
+
+### 3.1 Command Structure
+
+The CLI will expose two new top-level subcommands: `agents` and `tasks`.
+
+#### `sera agents`
+
+| Subcommand | Arguments    | API Endpoint                           | Description                                 |
+| ---------- | ------------ | -------------------------------------- | ------------------------------------------- |
+| `list`     | None         | `GET /api/agents/instances`            | Table: ID, NAME, STATUS, CIRCLE, MODE.      |
+| `start`    | `<id\|name>` | `POST /api/agents/instances/:id/start` | Spawns the agent container.                 |
+| `stop`     | `<id\|name>` | `POST /api/agents/instances/:id/stop`  | Stops the agent container.                  |
+| `restart`  | `<id\|name>` | `POST /api/agents/:id/restart`         | Restarts the agent.                         |
+| `logs`     | `<id\|name>` | `GET /api/agents/:id/logs`             | Fetches container logs (default 100 lines). |
+
+#### `sera tasks`
+
+| Subcommand | Arguments                     | API Endpoint                           | Description                                 |
+| ---------- | ----------------------------- | -------------------------------------- | ------------------------------------------- |
+| `list`     | `<agent-id\|name>`            | `GET /api/agents/:id/tasks`            | Table: ID, TASK (summary), STATUS, CREATED. |
+| `create`   | `<agent-id\|name> ["prompt"]` | `POST /api/agents/:id/tasks`           | Enqueues a new task.                        |
+| `get`      | `<agent-id\|name> <task-id>`  | `GET /api/agents/:id/tasks/:taskId`    | Detailed view of task.                      |
+| `cancel`   | `<agent-id\|name> <task-id>`  | `DELETE /api/agents/:id/tasks/:taskId` | Cancels a `queued` task.                    |
+
+### 3.2 Implementation Strategy (Go)
+
+#### Shared Client (`cli/client.go`)
+
+Refactor request logic into a reusable `Client` struct:
+
+- **`DoRequest(method, path string, body interface{}) (*http.Response, error)`**: Handles URL resolution, auth headers, and JSON encoding/decoding.
+- **`ResolveAgentID(nameOrID string) (string, error)`**: Fetches the agent list and finds the UUID for a given name if it's not already a UUID.
+
+#### Name Resolution
+
+For `agents` commands, the CLI will use `ResolveAgentID` to ensure the UUID is passed to the backend. For `tasks` commands, the backend already handles resolution, but the CLI will still use it for consistency or just pass it through.
+
+#### Output Formatting
+
+- **Tables:** Use `tabwriter` for aligned columns.
+- **Colors:** Use ANSI escape codes for status coloring (e.g., Green for `running`/`completed`, Yellow for `queued`, Red for `failed`/`error`).
+
+### 3.3 Error Handling
+
+- **401 Unauthorized:** "Not logged in. Run: sera auth login"
+- **404 Not Found:** "Agent/Task not found: <id>"
+- **409 Conflict:** "Action invalid for current state (e.g., agent already running)."
+
+## 4. Testing Plan
+
+### 4.1 Integration Tests
+
+- Verify `sera agents list` returns expected instances.
+- Verify `sera tasks create` results in a new entry in `sera tasks list`.
+- Verify `sera agents stop` transitions status in `sera agents list`.
+
+### 4.2 Manual Verification
+
+- Attempt to start an already running agent.
+- Attempt to cancel a running task.
+- Test with invalid credentials.


### PR DESCRIPTION
This PR implements the sera agents and sera tasks commands in the Go CLI, refactors the shared HTTP client, and adds the corresponding design and implementation plan documents.

Key changes:
- Refactored cli/auth.go to export common helpers.
- Added cli/client.go for reusable HTTP requests to sera-core.
- Implemented sera agents <list|start|stop|restart|logs>.
- Implemented sera tasks <list|create|get|cancel>.
- Updated cli/main.go with the new subcommands and refreshed help output.