### PR TITLE
🧪 Add tests for useAgentStatus hook

### DIFF
--- a/web/src/hooks/useAgentStatus.test.ts
+++ b/web/src/hooks/useAgentStatus.test.ts
@@ -36,7 +36,7 @@ describe('useAgentStatus', () => {
   it('should return null if payload exists but status is missing', () => {
     vi.mocked(useChannel).mockReturnValue({
       agentId: 'agent-123',
-    } as any);
+    } as unknown as { status: string; agentId: string });
     const { result } = renderHook(() => useAgentStatus('agent-123'));
     expect(result.current).toBeNull();
   });


### PR DESCRIPTION
This PR adds unit tests for the `useAgentStatus` hook in the `web` workspace. The tests cover:
- Handling of empty `agentId` (returns `null`).
- Handling of `null` payload from the underlying `useChannel` hook (returns `null`).
- Correct extraction of `status` from a valid payload.
- Graceful handling of payloads with missing `status` property.

Tests were implemented using `vitest` and `renderHook` from `@testing-library/react`. No changes were made to the hook's implementation.

---
*PR created automatically by Jules for task [9354246482548641983](https://jules.google.com/task/9354246482548641983) started by @TKCen*