### PR TITLE
⚡ Optimize AgentRegistry deletion methods with batch queries

### DIFF
--- a/core/src/agents/registry.service.ts
+++ b/core/src/agents/registry.service.ts
@@ -707,14 +707,16 @@ export class AgentRegistry {
     const removed: string[] = [];
     const errors: string[] = [];
 
-    for (const r of toRemove) {
+    if (toRemove.length > 0) {
+      const names = toRemove.map((r) => r.name);
       try {
-        await this.pool.query('DELETE FROM named_lists WHERE name = $1', [r.name]);
-        removed.push(r.name);
+        await this.pool.query('DELETE FROM named_lists WHERE name = ANY($1)', [names]);
+        removed.push(...names);
       } catch (err: unknown) {
-        errors.push(`${r.name}: ${(err as Error).message}`);
+        errors.push(`Failed to delete named lists: ${(err as Error).message}`);
       }
     }
+
     return { removed, errors };
   }
 
@@ -724,14 +726,16 @@ export class AgentRegistry {
     const removed: string[] = [];
     const errors: string[] = [];
 
-    for (const r of toRemove) {
+    if (toRemove.length > 0) {
+      const names = toRemove.map((r) => r.name);
       try {
-        await this.pool.query('DELETE FROM capability_policies WHERE name = $1', [r.name]);
-        removed.push(r.name);
+        await this.pool.query('DELETE FROM capability_policies WHERE name = ANY($1)', [names]);
+        removed.push(...names);
       } catch (err: unknown) {
-        errors.push(`${r.name}: ${(err as Error).message}`);
+        errors.push(`Failed to delete capability policies: ${(err as Error).message}`);
       }
     }
+
     return { removed, errors };
   }
 
@@ -741,14 +745,16 @@ export class AgentRegistry {
     const removed: string[] = [];
     const errors: string[] = [];
 
-    for (const r of toRemove) {
+    if (toRemove.length > 0) {
+      const names = toRemove.map((r) => r.name);
       try {
-        await this.pool.query('DELETE FROM sandbox_boundaries WHERE name = $1', [r.name]);
-        removed.push(r.name);
+        await this.pool.query('DELETE FROM sandbox_boundaries WHERE name = ANY($1)', [names]);
+        removed.push(...names);
       } catch (err: unknown) {
-        errors.push(`${r.name}: ${(err as Error).message}`);
+        errors.push(`Failed to delete sandbox boundaries: ${(err as Error).message}`);
       }
     }
+
     return { removed, errors };
   }
 


### PR DESCRIPTION
This PR optimizes the resource cleanup logic in `AgentRegistry` by replacing inefficient N+1 database queries with single batched `DELETE` operations using the PostgreSQL `ANY` operator.

### 💡 What
Refactored the following methods in `core/src/agents/registry.service.ts`:
- `deleteNamedListsExcept`
- `deleteCapabilityPoliciesExcept`
- `deleteSandboxBoundariesExcept`

### 🎯 Why
The previous implementation looped over items to be removed and issued a separate `DELETE` query for each one. This resulted in O(N) database round-trips. By batching these into a single query, we reduce the overhead to O(1) round-trips, improving performance and reducing database load.

### 📊 Measured Improvement
While direct benchmarking was restricted by the sandbox environment, this change provides a deterministic reduction in network latency and database execution overhead. Batching is a recommended best practice for high-performance database interactions.

Verified with `bun run typecheck`, `bun run lint`, and existing tests. Code review confirmed the correctness of the implementation.

---
*PR created automatically by Jules for task [3258083512316907705](https://jules.google.com/task/3258083512316907705) started by @TKCen*