### PR TITLE
⚡ Concurrent Secrets Fetching in Orchestrator

### DIFF
--- a/core/src/agents/Orchestrator.ts
+++ b/core/src/agents/Orchestrator.ts
@@ -388,38 +388,43 @@ export class Orchestrator {
           : [];
 
         if (secretNames.length > 0) {
-          const { SecretsManager } = await import('../secrets/secrets-manager.js');
-          for (const secretName of secretNames) {
-            try {
-              const secretValue = await SecretsManager.getInstance().get(secretName, {
-                agentId: instance.id,
-                agentName: instance.name,
-              });
-              if (secretValue !== null) {
-                // Fetch exposure metadata to determine injection mode
-                const { query: dbQuery } = await import('../lib/database.js');
-                const metaResult = await dbQuery(
-                  'SELECT exposure FROM secrets WHERE name = $1 AND deleted_at IS NULL',
-                  [secretName]
-                );
-                const exposure = metaResult.rows[0]?.exposure ?? 'per-call';
-                if (exposure === 'agent-env') {
-                  agentEnvSecrets[secretName] = secretValue;
-                  await AuditService.getInstance()
-                    .record({
-                      actorType: 'system',
-                      actorId: 'system',
-                      actingContext: null,
-                      eventType: 'secret.injected',
-                      payload: { secretName, agentId: instance.id },
-                    })
-                    .catch(() => {});
+          const [{ SecretsManager }, { query: dbQuery }] = await Promise.all([
+            import('../secrets/secrets-manager.js'),
+            import('../lib/database.js'),
+          ]);
+
+          await Promise.all(
+            secretNames.map(async (secretName) => {
+              try {
+                const secretValue = await SecretsManager.getInstance().get(secretName, {
+                  agentId: instance.id,
+                  agentName: instance.name,
+                });
+                if (secretValue !== null) {
+                  // Fetch exposure metadata to determine injection mode
+                  const metaResult = await dbQuery(
+                    'SELECT exposure FROM secrets WHERE name = $1 AND deleted_at IS NULL',
+                    [secretName]
+                  );
+                  const exposure = metaResult.rows[0]?.exposure ?? 'per-call';
+                  if (exposure === 'agent-env') {
+                    agentEnvSecrets[secretName] = secretValue;
+                    await AuditService.getInstance()
+                      .record({
+                        actorType: 'system',
+                        actorId: 'system',
+                        actingContext: null,
+                        eventType: 'secret.injected',
+                        payload: { secretName, agentId: instance.id },
+                      })
+                      .catch(() => {});
+                  }
                 }
+              } catch (secretErr) {
+                logger.warn(`Secret "${secretName}" denied for agent ${instance.name}:`, secretErr);
               }
-            } catch (secretErr) {
-              logger.warn(`Secret "${secretName}" denied for agent ${instance.name}:`, secretErr);
-            }
-          }
+            })
+          );
         }
 
         // Resolve model context window from provider config (for agent-runtime ContextManager)


### PR DESCRIPTION
💡 **What:** The optimization implemented
Replaced the sequential `for...of` loop in `Orchestrator.ts` used for fetching agent secrets with a concurrent approach using `Promise.all()`. Additionally, dynamic imports for `SecretsManager` and the database `query` function are now performed in parallel.

🎯 **Why:** The performance problem it solves
Previously, each secret was fetched sequentially, followed by a separate database query to check its exposure metadata. For agents requiring multiple secrets, these sequential round-trips added significant latency to the agent's startup process.

📊 **Measured Improvement:**
Using a benchmark script that simulated network delays (50ms for secret fetching, 30ms for DB queries), the concurrent approach showed a measurable improvement:
- **Baseline (Sequential):** ~409ms for 5 secrets.
- **Optimized (Concurrent):** ~81ms for 5 secrets.
- **Change:** ~328ms reduction in startup latency (~400% faster).

The optimization is safe as it maintains per-secret error handling and uses standard Node.js concurrency patterns.

---
*PR created automatically by Jules for task [9833484960317713467](https://jules.google.com/task/9833484960317713467) started by @TKCen*