### PR TITLE
⚡ Optimize Skill Package Import (N+1 Query Fix)

### DIFF
--- a/core/src/skills/SkillInjector.ts
+++ b/core/src/skills/SkillInjector.ts
@@ -55,15 +55,20 @@ export class SkillInjector {
       }
     }
 
-    // 2. Resolve packages
-    for (const pkgName of declaredPackages) {
-      const pkg = await skillLibrary.getPackage(pkgName);
-      if (pkg) {
-        for (const s of pkg.skills) {
-          initialPins.push({ name: s.name, version: s.version });
+    // 2. Resolve packages (batch query to avoid N+1)
+    if (declaredPackages.length > 0) {
+      const packages = await skillLibrary.getPackages(declaredPackages);
+      const packageMap = new Map(packages.map((p) => [p.name, p]));
+
+      for (const pkgName of declaredPackages) {
+        const pkg = packageMap.get(pkgName);
+        if (pkg) {
+          for (const s of pkg.skills) {
+            initialPins.push({ name: s.name, version: s.version });
+          }
+        } else {
+          logger.warn(`Skill package not found: ${pkgName}`);
         }
-      } else {
-        logger.warn(`Skill package not found: ${pkgName}`);
       }
     }
 

--- a/core/src/skills/SkillLibrary.ts
+++ b/core/src/skills/SkillLibrary.ts
@@ -339,6 +339,25 @@ export class SkillLibrary {
     };
   }
 
+  /**
+   * Fetches the latest version of multiple skill packages in a single query.
+   */
+  async getPackages(names: string[]): Promise<SkillPackage[]> {
+    if (names.length === 0) return [];
+
+    const { rows } = await this.pool.query(
+      'SELECT DISTINCT ON (name) name, version, description, skills FROM skill_packages WHERE name = ANY($1) ORDER BY name, version DESC',
+      [names]
+    );
+
+    return rows.map((row) => ({
+      name: row.name,
+      version: row.version,
+      description: row.description,
+      skills: row.skills,
+    }));
+  }
+
   async listSkills(): Promise<Array<SkillFrontMatter & { maxTokens?: number; source?: string }>> {
     const { rows } = await this.pool.query(
       'SELECT name, version, description, triggers, category, tags, max_tokens, source FROM skills ORDER BY name, version DESC'


### PR DESCRIPTION
This PR optimizes the skill package resolution in `SkillInjector` by replacing a loop that fetched packages one-by-one with a single batch query.

### 💡 What:
- Introduced `SkillLibrary.getPackages(names: string[])` which uses a single PostgreSQL query with `ANY($1)` and `DISTINCT ON (name)` to fetch the latest version of multiple packages.
- Refactored `SkillInjector.inject` to fetch all `declaredPackages` in one call.
- Ensured that the original processing order (input order) and logging for missing packages are preserved by mapping results back to the original list.

### 🎯 Why:
The previous implementation performed one database query per declared package. For agents with many skill packages, this created a significant and unnecessary overhead (N+1 query problem).

### 📊 Measured Improvement:
- **Baseline:** `getPackage` was called **5 times** for 5 packages.
- **Optimized:** `getPackages` is called **1 time** for any number of packages.
- Database round-trips for package resolution reduced from **O(N) to O(1)**.
- Functionality and processing logic remain identical to the original implementation.

All relevant unit tests in `core` passed.

---
*PR created automatically by Jules for task [5296780191039882482](https://jules.google.com/task/5296780191039882482) started by @TKCen*