### PR TITLE
⚡ Parallelize tool call audit logging in BaseAgent

### DIFF
--- a/core/src/agents/BaseAgent.ts
+++ b/core/src/agents/BaseAgent.ts
@@ -317,28 +317,29 @@ export abstract class BaseAgent {
               messageId
             );
 
-            // Record audit entries for tool calls
-            for (let i = 0; i < activeCalls.length; i++) {
-              const tc = activeCalls[i]!;
-              const tr = toolResults[i]!;
-              const trContent = tr.content ?? '';
-              try {
-                await AuditService.getInstance().record({
-                  actorType: 'agent',
-                  actorId: this.agentInstanceId || this.name,
-                  actingContext: null,
-                  eventType: 'tool.called',
-                  payload: {
-                    tool: tc.function.name,
-                    args: tc.function.arguments,
-                    result:
-                      trContent.length > 500 ? trContent.substring(0, 500) + '...' : trContent,
-                  },
-                });
-              } catch (auditErr) {
-                this.logger.error('Failed to record audit entry:', auditErr);
-              }
-            }
+            // Record audit entries for tool calls in parallel
+            await Promise.all(
+              activeCalls.map(async (tc, i) => {
+                const tr = toolResults[i]!;
+                const trContent = tr.content ?? '';
+                try {
+                  await AuditService.getInstance().record({
+                    actorType: 'agent',
+                    actorId: this.agentInstanceId || this.name,
+                    actingContext: null,
+                    eventType: 'tool.called',
+                    payload: {
+                      tool: tc.function.name,
+                      args: tc.function.arguments,
+                      result:
+                        trContent.length > 500 ? trContent.substring(0, 500) + '...' : trContent,
+                    },
+                  });
+                } catch (auditErr) {
+                  this.logger.error('Failed to record audit entry:', auditErr);
+                }
+              })
+            );
 
             // Publish results and add to conversation
             for (const result of toolResults) {


### PR DESCRIPTION
### 💡 What:
The optimization parallelizes the audit logging of tool calls in `BaseAgent.ts`. It replaces a sequential `for` loop that awaited each `AuditService.record` call with a `Promise.all(activeCalls.map(...))` implementation.

### 🎯 Why:
Audit logs for tool calls are independent and do not rely on each other. Logging them sequentially adds linear latency based on the number of tool calls in a single agent iteration. By parallelizing these I/O-bound operations, we reduce the total time spent in the audit phase to roughly the duration of the slowest single record operation.

### 📊 Measured Improvement:
Using a benchmark script simulating I/O delay (50ms) for 5 tool calls:
- **Baseline (Sequential):** ~255ms
- **Optimized (Parallel):** ~51ms
- **Improvement:** ~80% reduction in audit logging latency.

Functional correctness is maintained by preserving the per-record `try-catch` block, ensuring that a failure in one audit entry does not interrupt others.

---
*PR created automatically by Jules for task [8107527885046668025](https://jules.google.com/task/8107527885046668025) started by @TKCen*