### PR TITLE
🧪 Add unit tests for centrifugo.ts

### DIFF
--- a/web/src/lib/centrifugo.test.ts
+++ b/web/src/lib/centrifugo.test.ts
@@ -87,9 +87,11 @@ describe('centrifugo lib', () => {
       subscribeToThoughts(agentId, onThought);
 
       // Get the publication callback
-      const publicationCallback = mockSubscription.on.mock.calls.find(
+      const publicationCall = mockSubscription.on.mock.calls.find(
         (call) => call[0] === 'publication'
-      )[1];
+      );
+      expect(publicationCall).toBeDefined();
+      const publicationCallback = publicationCall![1];
 
       const mockEvent = { data: { text: 'thinking' } };
       publicationCallback(mockEvent);
@@ -123,9 +125,11 @@ describe('centrifugo lib', () => {
       const onOutput = vi.fn();
       subscribeToTerminal('agent', onOutput);
 
-      const publicationCallback = mockSubscription.on.mock.calls.find(
+      const publicationCall = mockSubscription.on.mock.calls.find(
         (call) => call[0] === 'publication'
-      )[1];
+      );
+      expect(publicationCall).toBeDefined();
+      const publicationCallback = publicationCall![1];
 
       const mockData = { data: 'shell output' };
       publicationCallback(mockData);
@@ -147,9 +151,11 @@ describe('centrifugo lib', () => {
       const onDone = vi.fn();
       subscribeToStream('msg', onToken, onDone);
 
-      const publicationCallback = mockSubscription.on.mock.calls.find(
+      const publicationCall = mockSubscription.on.mock.calls.find(
         (call) => call[0] === 'publication'
-      )[1];
+      );
+      expect(publicationCall).toBeDefined();
+      const publicationCallback = publicationCall![1];
 
       // Test token
       publicationCallback({ data: { token: 'hello' } });


### PR DESCRIPTION
🧪 **[testing improvement] Add tests for subscribeToThoughts and Centrifugo client**

🎯 **What:** Addressed the missing test coverage for the `subscribeToThoughts` function and the general Centrifugo client wrapper in `web/src/lib/centrifugo.ts`.

📊 **Coverage:**
- **Client Management:** Verified singleton behavior in `getClient` and correct cleanup in `disconnectClient`.
- **Subscription Lifecycle:** Verified channel naming, publication handling via callbacks, and thorough cleanup (unsubscription and listener removal) for:
    - `subscribeToThoughts` (`internal:agent:${agentId}:thoughts`)
    - `subscribeToTerminal` (`internal:agent:${agentId}:terminal`)
    - `subscribeToStream` (`internal:stream:${messageId}`)
- **Safety Logic:** Verified `safeNewSubscription` correctly handles existing subscriptions by removing them before creating new ones.

✨ **Result:** Significant improvement in the reliability of the real-time communication layer by ensuring that subscriptions are correctly managed and cleaned up, preventing memory leaks and duplicate message handling.

---
*PR created automatically by Jules for task [9154121488471460012](https://jules.google.com/task/9154121488471460012) started by @TKCen*