### PR TITLE
Add copy-to-clipboard for IDs and config values

### DIFF
--- a/web/dev_server.log
+++ b/web/dev_server.log
@@ -1,7 +1,0 @@
-$ vite
-
-  VITE v6.4.1  ready in 370 ms
-
-  ➜  Local:   http://localhost:5173/
-  ➜  Network: use --host to expose
-error: script "dev" exited with code 143

--- a/web/src/app/agents/_id/page.tsx
+++ b/web/src/app/agents/_id/page.tsx
@@ -14,6 +14,7 @@ import {
 import { AgentStatusBadge } from '@/components/AgentStatusBadge';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
+import { CopyButton } from '@/components/CopyButton';
 import { AgentForm, type AgentFormInitialValues } from '@/components/AgentForm';
 import { Skeleton } from '@/components/ui/skeleton';
 import {
@@ -145,7 +146,10 @@ export default function AgentDetailPage() {
             <div>
               <h1 className="text-xl font-semibold text-sera-text leading-tight">{displayName}</h1>
               <div className="flex items-center gap-2 mt-1">
-                <span className="text-xs text-sera-text-dim">{id}</span>
+                <div className="flex items-center gap-1">
+                  <span className="text-xs text-sera-text-dim">{id}</span>
+                  <CopyButton value={id} />
+                </div>
                 {agent?.template_ref && <Badge variant="default">{agent.template_ref}</Badge>}
                 {agent?.circle && <Badge variant="default">{agent.circle}</Badge>}
               </div>

--- a/web/src/app/circles/_id/page.tsx
+++ b/web/src/app/circles/_id/page.tsx
@@ -23,6 +23,7 @@ import * as circlesApi from '@/lib/api/circles';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
+import { CopyButton } from '@/components/CopyButton';
 import { Skeleton } from '@/components/ui/skeleton';
 import {
   Dialog,
@@ -162,9 +163,12 @@ export default function CircleDetailPage() {
           <h1 className="text-xl font-bold text-sera-text">
             {circle.displayName ?? circle.metadata?.displayName}
           </h1>
-          <span className="text-xs text-sera-text-dim font-mono">
-            {circle.name ?? circle.metadata?.name}
-          </span>
+          <div className="flex items-center gap-1">
+            <span className="text-xs text-sera-text-dim font-mono">
+              {circle.name ?? circle.metadata?.name}
+            </span>
+            <CopyButton value={circle.name ?? circle.metadata?.name ?? id ?? ''} />
+          </div>
 
           {/* Description — inline editable */}
           <div className="mt-1">

--- a/web/src/app/settings/page.tsx
+++ b/web/src/app/settings/page.tsx
@@ -31,6 +31,7 @@ import * as providersApi from '@/lib/api/providers';
 import { Spinner } from '@/components/ui/spinner';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { CopyButton } from '@/components/CopyButton';
 import { CloudProviderSection } from '@/components/CloudProviderSection';
 import { DynamicProviderCard } from '@/components/DynamicProviderCard';
 import { GeneralTab } from '@/components/GeneralTab';
@@ -110,7 +111,10 @@ function ModelConfigRow({
         className="w-full flex items-center justify-between p-3 hover:bg-sera-surface/50 transition-colors text-left"
       >
         <div className="flex items-center gap-3">
-          <span className="text-sera-text font-mono text-xs">{model.modelName}</span>
+          <div className="flex items-center gap-1">
+            <span className="text-sera-text font-mono text-xs">{model.modelName}</span>
+            <CopyButton value={model.modelName} />
+          </div>
           <span className="text-sera-text-dim text-[10px]">{model.provider ?? ''}</span>
           <Badge
             variant={

--- a/web/src/components/AgentDetailTasksTab.tsx
+++ b/web/src/components/AgentDetailTasksTab.tsx
@@ -2,6 +2,7 @@ import { useAgentTasks, useCancelTask } from '@/hooks/useAgents';
 import { TabLoading } from './AgentDetailTabLoading';
 import { Badge } from './ui/badge';
 import { Button } from './ui/button';
+import { CopyButton } from './CopyButton';
 import { Clock, XCircle, AlertCircle, CheckCircle2, Timer } from 'lucide-react';
 import { toast } from 'sonner';
 
@@ -49,7 +50,10 @@ export function AgentDetailTasksTab({ id }: { id: string }) {
                   >
                     {task.status}
                   </Badge>
-                  <span className="text-xs font-mono text-sera-text-dim truncate">{task.id}</span>
+                  <div className="flex items-center gap-1">
+                    <span className="text-xs font-mono text-sera-text-dim truncate">{task.id}</span>
+                    <CopyButton value={task.id} />
+                  </div>
                   {task.exitReason && (
                     <Badge variant="default" className="text-[10px] uppercase">
                       {task.exitReason}

--- a/web/src/components/CopyButton.tsx
+++ b/web/src/components/CopyButton.tsx
@@ -1,0 +1,37 @@
+import { useState } from 'react';
+import { Check, Copy } from 'lucide-react';
+import { Tooltip } from '@/components/ui/tooltip';
+import { cn } from '@/lib/utils';
+
+interface CopyButtonProps {
+  value: string;
+  className?: string;
+}
+
+export function CopyButton({ value, className }: CopyButtonProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    void navigator.clipboard.writeText(value).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  };
+
+  return (
+    <Tooltip content={copied ? 'Copied!' : 'Copy to clipboard'}>
+      <button
+        onClick={handleCopy}
+        className={cn(
+          'p-1 rounded text-sera-text-dim hover:text-sera-text hover:bg-sera-surface-hover transition-colors',
+          className
+        )}
+        aria-label={copied ? 'Copied to clipboard' : 'Copy to clipboard'}
+      >
+        {copied ? <Check size={12} className="text-sera-success" /> : <Copy size={12} />}
+      </button>
+    </Tooltip>
+  );
+}

--- a/web/src/components/DynamicProviderCard.tsx
+++ b/web/src/components/DynamicProviderCard.tsx
@@ -11,6 +11,7 @@ import {
 import * as providersApi from '@/lib/api/providers';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { CopyButton } from '@/components/CopyButton';
 
 export function DynamicProviderCard({
   provider,
@@ -53,9 +54,12 @@ export function DynamicProviderCard({
                 </Badge>
               )}
             </div>
-            <p className="text-[11px] text-sera-text-muted mt-0.5 font-mono select-all">
-              {provider.baseUrl}
-            </p>
+            <div className="flex items-center gap-1 mt-0.5">
+              <p className="text-[11px] text-sera-text-muted font-mono select-all truncate">
+                {provider.baseUrl}
+              </p>
+              <CopyButton value={provider.baseUrl} />
+            </div>
           </div>
         </div>
         <div className="flex items-center gap-3">


### PR DESCRIPTION
This PR implements "Copy-to-clipboard for agent IDs and config values" from the feature backlog.

### Changes:
- **`web/src/components/CopyButton.tsx`**: New reusable component that copies a string to the clipboard and shows a "Copied!" tooltip for 2 seconds. It uses `e.stopPropagation()` and `e.preventDefault()` to be safe for use inside links or other clickable containers.
- **Agent Detail Page**: Added copy buttons next to the Agent ID (header) and Task IDs (Tasks tab).
- **Circle Detail Page**: Added copy button next to the Circle name/ID in the hero section.
- **Settings Page**: Added copy buttons next to model names in the `ModelConfigRow` and provider base URLs in the `DynamicProviderCard`.

### Verification:
- Ran `bun run lint` and `bun run format:check` in the `web` workspace (all passed).
- Ran existing unit tests in the `web` workspace (all 66 passed).
- Verified visual alignment and functionality using Playwright screenshots.
- Confirmed tooltip behavior and icon state toggling.

---
*PR created automatically by Jules for task [2105943947572275164](https://jules.google.com/task/2105943947572275164) started by @TKCen*