### PR TITLE
feat: Discord slash commands, budget source tracking, channel UI updates

### DIFF
--- a/core/bun.lock
+++ b/core/bun.lock
@@ -10,24 +10,22 @@
         "@qdrant/js-client-rest": "^1.11",
         "@slack/web-api": "^7.15.0",
         "@types/nodemailer": "^7.0.11",
-        "@xenova/transformers": "^2.17",
         "argon2": "^0.44.0",
         "axios": "^1.7",
         "chokidar": "^3.6.0",
-        "commander": "^12.1.0",
         "cors": "^2.8",
+        "cron-parser": "^5.5.0",
         "discord.js": "^14.25.1",
         "dockerode": "^4.0",
         "express": "^5.0.0",
         "gray-matter": "^4.0",
         "jose": "^6.2.2",
         "js-yaml": "^4.1",
-        "jsonwebtoken": "^9.0",
         "node-pg-migrate": "^7.0",
-        "nodemailer": "^8.0.3",
+        "nodemailer": "^8.0.4",
         "openai": "^4.0",
-        "openid-client": "^6.1.7",
         "opossum": "^9.0.0",
+        "pdf-parse": "^1.1.1",
         "pg": "^8.11",
         "pg-boss": "^12.14.0",
         "simple-git": "^3.33.0",
@@ -47,13 +45,14 @@
         "@types/jsonwebtoken": "^9.0",
         "@types/node": "^20.0.0",
         "@types/opossum": "^8.1.9",
+        "@types/pdf-parse": "^1.1.4",
         "@types/pg": "^8.11",
         "@types/supertest": "^6.0",
         "@types/uuid": "^10.0",
         "@types/ws": "^8.5",
         "@types/yargs": "^17.0.35",
-        "@vitest/coverage-v8": "^4.1.0",
-        "eslint": "^9",
+        "@vitest/coverage-v8": "^4.1.1",
+        "eslint": "^10",
         "nodemon": "^3.1",
         "prettier": "^3",
         "supertest": "^7.0",
@@ -62,7 +61,7 @@
         "tsx": "^4.0",
         "typescript": "^5.0",
         "typescript-eslint": "^8",
-        "vitest": "^4.1.0",
+        "vitest": "^4.1.1",
       },
     },
   },
@@ -177,19 +176,17 @@
 
     "@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
 
-    "@eslint/config-array": ["@eslint/config-array@0.21.2", "", { "dependencies": { "@eslint/object-schema": "^2.1.7", "debug": "^4.3.1", "minimatch": "^3.1.5" } }, "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw=="],
+    "@eslint/config-array": ["@eslint/config-array@0.23.3", "", { "dependencies": { "@eslint/object-schema": "^3.0.3", "debug": "^4.3.1", "minimatch": "^10.2.4" } }, "sha512-j+eEWmB6YYLwcNOdlwQ6L2OsptI/LO6lNBuLIqe5R7RetD658HLoF+Mn7LzYmAWWNNzdC6cqP+L6r8ujeYXWLw=="],
 
-    "@eslint/config-helpers": ["@eslint/config-helpers@0.4.2", "", { "dependencies": { "@eslint/core": "^0.17.0" } }, "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw=="],
+    "@eslint/config-helpers": ["@eslint/config-helpers@0.5.3", "", { "dependencies": { "@eslint/core": "^1.1.1" } }, "sha512-lzGN0onllOZCGroKJmRwY6QcEHxbjBw1gwB8SgRSqK8YbbtEXMvKynsXc3553ckIEBxsbMBU7oOZXKIPGZNeZw=="],
 
-    "@eslint/core": ["@eslint/core@0.17.0", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ=="],
-
-    "@eslint/eslintrc": ["@eslint/eslintrc@3.3.5", "", { "dependencies": { "ajv": "^6.14.0", "debug": "^4.3.2", "espree": "^10.0.1", "globals": "^14.0.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.1.1", "minimatch": "^3.1.5", "strip-json-comments": "^3.1.1" } }, "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg=="],
+    "@eslint/core": ["@eslint/core@1.1.1", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-QUPblTtE51/7/Zhfv8BDwO0qkkzQL7P/aWWbqcf4xWLEYn1oKjdO0gglQBB4GAsu7u6wjijbCmzsUTy6mnk6oQ=="],
 
     "@eslint/js": ["@eslint/js@9.39.4", "", {}, "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw=="],
 
-    "@eslint/object-schema": ["@eslint/object-schema@2.1.7", "", {}, "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA=="],
+    "@eslint/object-schema": ["@eslint/object-schema@3.0.3", "", {}, "sha512-iM869Pugn9Nsxbh/YHRqYiqd23AmIbxJOcpUMOuWCVNdoQJ5ZtwL6h3t0bcZzJUlC3Dq9jCFCESBZnX0GTv7iQ=="],
 
-    "@eslint/plugin-kit": ["@eslint/plugin-kit@0.4.1", "", { "dependencies": { "@eslint/core": "^0.17.0", "levn": "^0.4.1" } }, "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA=="],
+    "@eslint/plugin-kit": ["@eslint/plugin-kit@0.6.1", "", { "dependencies": { "@eslint/core": "^1.1.1", "levn": "^0.4.1" } }, "sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ=="],
 
     "@google/genai": ["@google/genai@1.46.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" } }, "sha512-ewPMN5JkKfgU5/kdco9ZhXBHDPhVqZpMQqIFQhwsHLf8kyZfx1cNpw1pHo1eV6PGEW7EhIBFi3aYZraFndAXqg=="],
 
@@ -198,8 +195,6 @@
     "@grpc/proto-loader": ["@grpc/proto-loader@0.7.15", "", { "dependencies": { "lodash.camelcase": "^4.3.0", "long": "^5.0.0", "protobufjs": "^7.2.5", "yargs": "^17.7.2" }, "bin": { "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js" } }, ""],
 
     "@hono/node-server": ["@hono/node-server@1.19.11", "", { "peerDependencies": { "hono": "^4" } }, ""],
-
-    "@huggingface/jinja": ["@huggingface/jinja@0.2.2", "", {}, ""],
 
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 
@@ -481,6 +476,8 @@
 
     "@types/dockerode": ["@types/dockerode@3.3.47", "", { "dependencies": { "@types/docker-modem": "*", "@types/node": "*", "@types/ssh2": "*" } }, ""],
 
+    "@types/esrecurse": ["@types/esrecurse@4.3.1", "", {}, "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw=="],
+
     "@types/estree": ["@types/estree@1.0.8", "", {}, ""],
 
     "@types/express": ["@types/express@5.0.6", "", { "dependencies": { "@types/body-parser": "*", "@types/express-serve-static-core": "^5.0.0", "@types/serve-static": "^2" } }, ""],
@@ -495,8 +492,6 @@
 
     "@types/jsonwebtoken": ["@types/jsonwebtoken@9.0.10", "", { "dependencies": { "@types/ms": "*", "@types/node": "*" } }, ""],
 
-    "@types/long": ["@types/long@4.0.2", "", {}, ""],
-
     "@types/methods": ["@types/methods@1.1.4", "", {}, ""],
 
     "@types/ms": ["@types/ms@2.1.0", "", {}, ""],
@@ -508,6 +503,8 @@
     "@types/nodemailer": ["@types/nodemailer@7.0.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-E+U4RzR2dKrx+u3N4DlsmLaDC6mMZOM/TPROxA0UAPiTgI0y4CEFBmZE+coGWTjakDriRsXG368lNk1u9Q0a2g=="],
 
     "@types/opossum": ["@types/opossum@8.1.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-Jm/tYxuJFefiwRYs+/EOsUP3ktk0c8siMgAHPLnA4PXF4wKghzcjqf88dY+Xii5jId5Txw4JV0FMKTpjbd7KJA=="],
+
+    "@types/pdf-parse": ["@types/pdf-parse@1.1.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-kBfrSXsloMnUJOKi25s3+hRmkycHfLK6A09eRGqF/N8BkQoPUmaCr+q8Cli5FnfohEz/rsv82zAiPz/LXtOGhA=="],
 
     "@types/pg": ["@types/pg@8.18.0", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, ""],
 
@@ -555,25 +552,23 @@
 
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.57.1", "", { "dependencies": { "@typescript-eslint/types": "8.57.1", "eslint-visitor-keys": "^5.0.0" } }, "sha512-YWnmJkXbofiz9KbnbbwuA2rpGkFPLbAIetcCNO6mJ8gdhdZ/v7WDXsoGFAJuM6ikUFKTlSQnjWnVO4ux+UzS6A=="],
 
-    "@vitest/coverage-v8": ["@vitest/coverage-v8@4.1.0", "", { "dependencies": { "@bcoe/v8-coverage": "^1.0.2", "@vitest/utils": "4.1.0", "ast-v8-to-istanbul": "^1.0.0", "istanbul-lib-coverage": "^3.2.2", "istanbul-lib-report": "^3.0.1", "istanbul-reports": "^3.2.0", "magicast": "^0.5.2", "obug": "^2.1.1", "std-env": "^4.0.0-rc.1", "tinyrainbow": "^3.0.3" }, "peerDependencies": { "@vitest/browser": "4.1.0", "vitest": "4.1.0" }, "optionalPeers": ["@vitest/browser"] }, "sha512-nDWulKeik2bL2Va/Wl4x7DLuTKAXa906iRFooIRPR+huHkcvp9QDkPQ2RJdmjOFrqOqvNfoSQLF68deE3xC3CQ=="],
+    "@vitest/coverage-v8": ["@vitest/coverage-v8@4.1.2", "", { "dependencies": { "@bcoe/v8-coverage": "^1.0.2", "@vitest/utils": "4.1.2", "ast-v8-to-istanbul": "^1.0.0", "istanbul-lib-coverage": "^3.2.2", "istanbul-lib-report": "^3.0.1", "istanbul-reports": "^3.2.0", "magicast": "^0.5.2", "obug": "^2.1.1", "std-env": "^4.0.0-rc.1", "tinyrainbow": "^3.1.0" }, "peerDependencies": { "@vitest/browser": "4.1.2", "vitest": "4.1.2" }, "optionalPeers": ["@vitest/browser"] }, "sha512-sPK//PHO+kAkScb8XITeB1bf7fsk85Km7+rt4eeuRR3VS1/crD47cmV5wicisJmjNdfeokTZwjMk4Mj2d58Mgg=="],
 
-    "@vitest/expect": ["@vitest/expect@4.1.0", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.0", "@vitest/utils": "4.1.0", "chai": "^6.2.2", "tinyrainbow": "^3.0.3" } }, "sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA=="],
+    "@vitest/expect": ["@vitest/expect@4.1.2", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.2", "@vitest/utils": "4.1.2", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ=="],
 
-    "@vitest/mocker": ["@vitest/mocker@4.1.0", "", { "dependencies": { "@vitest/spy": "4.1.0", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0" }, "optionalPeers": ["msw"] }, "sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw=="],
+    "@vitest/mocker": ["@vitest/mocker@4.1.2", "", { "dependencies": { "@vitest/spy": "4.1.2", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q=="],
 
-    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.0", "", { "dependencies": { "tinyrainbow": "^3.0.3" } }, "sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A=="],
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.2", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA=="],
 
-    "@vitest/runner": ["@vitest/runner@4.1.0", "", { "dependencies": { "@vitest/utils": "4.1.0", "pathe": "^2.0.3" } }, "sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ=="],
+    "@vitest/runner": ["@vitest/runner@4.1.2", "", { "dependencies": { "@vitest/utils": "4.1.2", "pathe": "^2.0.3" } }, "sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ=="],
 
-    "@vitest/snapshot": ["@vitest/snapshot@4.1.0", "", { "dependencies": { "@vitest/pretty-format": "4.1.0", "@vitest/utils": "4.1.0", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg=="],
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.2", "", { "dependencies": { "@vitest/pretty-format": "4.1.2", "@vitest/utils": "4.1.2", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A=="],
 
-    "@vitest/spy": ["@vitest/spy@4.1.0", "", {}, "sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw=="],
+    "@vitest/spy": ["@vitest/spy@4.1.2", "", {}, "sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA=="],
 
-    "@vitest/utils": ["@vitest/utils@4.1.0", "", { "dependencies": { "@vitest/pretty-format": "4.1.0", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.0.3" } }, "sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw=="],
+    "@vitest/utils": ["@vitest/utils@4.1.2", "", { "dependencies": { "@vitest/pretty-format": "4.1.2", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ=="],
 
     "@vladfrangu/async_event_emitter": ["@vladfrangu/async_event_emitter@2.4.7", "", {}, "sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g=="],
-
-    "@xenova/transformers": ["@xenova/transformers@2.17.2", "", { "dependencies": { "@huggingface/jinja": "^0.2.2", "onnxruntime-web": "1.14.0", "sharp": "^0.32.0" }, "optionalDependencies": { "onnxruntime-node": "1.14.0" } }, ""],
 
     "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, ""],
 
@@ -621,21 +616,7 @@
 
     "axios": ["axios@1.13.6", "", { "dependencies": { "follow-redirects": "^1.15.11", "form-data": "^4.0.5", "proxy-from-env": "^1.1.0" } }, ""],
 
-    "b4a": ["b4a@1.8.0", "", { "peerDependencies": { "react-native-b4a": "*" }, "optionalPeers": ["react-native-b4a"] }, ""],
-
-    "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
-
-    "bare-events": ["bare-events@2.8.2", "", { "peerDependencies": { "bare-abort-controller": "*" }, "optionalPeers": ["bare-abort-controller"] }, ""],
-
-    "bare-fs": ["bare-fs@4.5.5", "", { "dependencies": { "bare-events": "^2.5.4", "bare-path": "^3.0.0", "bare-stream": "^2.6.4", "bare-url": "^2.2.2", "fast-fifo": "^1.3.2" }, "peerDependencies": { "bare-buffer": "*" }, "optionalPeers": ["bare-buffer"] }, ""],
-
-    "bare-os": ["bare-os@3.8.0", "", {}, ""],
-
-    "bare-path": ["bare-path@3.0.0", "", { "dependencies": { "bare-os": "^3.0.1" } }, ""],
-
-    "bare-stream": ["bare-stream@2.8.1", "", { "dependencies": { "streamx": "^2.21.0", "teex": "^1.0.1" }, "peerDependencies": { "bare-buffer": "*", "bare-events": "*" }, "optionalPeers": ["bare-buffer"] }, ""],
-
-    "bare-url": ["bare-url@2.3.2", "", { "dependencies": { "bare-path": "^3.0.0" } }, ""],
+    "balanced-match": ["balanced-match@4.0.4", "", {}, ""],
 
     "base64-js": ["base64-js@1.5.1", "", {}, ""],
 
@@ -653,7 +634,7 @@
 
     "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
 
-    "brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
+    "brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, ""],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, ""],
 
@@ -671,11 +652,9 @@
 
     "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, ""],
 
-    "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
-
     "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
-    "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+    "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, ""],
 
@@ -683,21 +662,15 @@
 
     "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, ""],
 
-    "color": ["color@4.2.3", "", { "dependencies": { "color-convert": "^2.0.1", "color-string": "^1.9.0" } }, ""],
-
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, ""],
 
     "color-name": ["color-name@1.1.4", "", {}, ""],
 
-    "color-string": ["color-string@1.9.1", "", { "dependencies": { "color-name": "^1.0.0", "simple-swizzle": "^0.2.2" } }, ""],
-
     "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, ""],
 
-    "commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
+    "commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
 
     "component-emitter": ["component-emitter@1.3.1", "", {}, ""],
-
-    "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
 
     "confbox": ["confbox@0.1.8", "", {}, "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="],
 
@@ -728,10 +701,6 @@
     "data-uri-to-buffer": ["data-uri-to-buffer@6.0.2", "", {}, "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, ""],
-
-    "decompress-response": ["decompress-response@6.0.0", "", { "dependencies": { "mimic-response": "^3.1.0" } }, ""],
-
-    "deep-extend": ["deep-extend@0.6.0", "", {}, ""],
 
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
@@ -787,13 +756,13 @@
 
     "escodegen": ["escodegen@2.1.0", "", { "dependencies": { "esprima": "^4.0.1", "estraverse": "^5.2.0", "esutils": "^2.0.2" }, "optionalDependencies": { "source-map": "~0.6.1" }, "bin": { "escodegen": "bin/escodegen.js", "esgenerate": "bin/esgenerate.js" } }, "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w=="],
 
-    "eslint": ["eslint@9.39.4", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.2", "@eslint/config-helpers": "^0.4.2", "@eslint/core": "^0.17.0", "@eslint/eslintrc": "^3.3.5", "@eslint/js": "9.39.4", "@eslint/plugin-kit": "^0.4.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.5", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": "bin/eslint.js" }, "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ=="],
+    "eslint": ["eslint@10.1.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.2", "@eslint/config-array": "^0.23.3", "@eslint/config-helpers": "^0.5.3", "@eslint/core": "^1.1.1", "@eslint/plugin-kit": "^0.6.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^9.1.2", "eslint-visitor-keys": "^5.0.1", "espree": "^11.2.0", "esquery": "^1.7.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "minimatch": "^10.2.4", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-S9jlY/ELKEUwwQnqWDO+f+m6sercqOPSqXM5Go94l7DOmxHVDgmSFGWEzeE/gwgTAr0W103BWt0QLe/7mabIvA=="],
 
-    "eslint-scope": ["eslint-scope@8.4.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg=="],
+    "eslint-scope": ["eslint-scope@9.1.2", "", { "dependencies": { "@types/esrecurse": "^4.3.1", "@types/estree": "^1.0.8", "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ=="],
 
-    "eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
+    "eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
 
-    "espree": ["espree@10.4.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^4.2.1" } }, "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ=="],
+    "espree": ["espree@11.2.0", "", { "dependencies": { "acorn": "^8.16.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^5.0.1" } }, "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw=="],
 
     "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "bin/esparse.js", "esvalidate": "bin/esvalidate.js" } }, ""],
 
@@ -813,13 +782,9 @@
 
     "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
-    "events-universal": ["events-universal@1.0.1", "", { "dependencies": { "bare-events": "^2.7.0" } }, ""],
-
     "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, ""],
 
     "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, ""],
-
-    "expand-template": ["expand-template@2.0.3", "", {}, ""],
 
     "expect-type": ["expect-type@1.3.0", "", {}, ""],
 
@@ -832,8 +797,6 @@
     "extend-shallow": ["extend-shallow@2.0.1", "", { "dependencies": { "is-extendable": "^0.1.0" } }, ""],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, ""],
-
-    "fast-fifo": ["fast-fifo@1.3.2", "", {}, ""],
 
     "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
 
@@ -862,8 +825,6 @@
     "fix-dts-default-cjs-exports": ["fix-dts-default-cjs-exports@1.0.1", "", { "dependencies": { "magic-string": "^0.30.17", "mlly": "^1.7.4", "rollup": "^4.34.8" } }, "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg=="],
 
     "flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
-
-    "flatbuffers": ["flatbuffers@1.12.0", "", {}, ""],
 
     "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
 
@@ -905,13 +866,9 @@
 
     "get-uri": ["get-uri@6.0.5", "", { "dependencies": { "basic-ftp": "^5.0.2", "data-uri-to-buffer": "^6.0.2", "debug": "^4.3.4" } }, "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg=="],
 
-    "github-from-package": ["github-from-package@0.0.0", "", {}, ""],
-
     "glob": ["glob@11.0.3", "", { "dependencies": { "foreground-child": "^3.3.1", "jackspeak": "^4.1.1", "minimatch": "^10.0.3", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^2.0.0" }, "bin": "dist/esm/bin.mjs" }, ""],
 
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
-
-    "globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
 
     "google-auth-library": ["google-auth-library@10.6.2", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.1.4", "gcp-metadata": "8.1.2", "google-logging-utils": "1.1.3", "jws": "^4.0.0" } }, "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw=="],
 
@@ -920,8 +877,6 @@
     "gopd": ["gopd@1.2.0", "", {}, ""],
 
     "gray-matter": ["gray-matter@4.0.3", "", { "dependencies": { "js-yaml": "^3.13.1", "kind-of": "^6.0.2", "section-matter": "^1.0.0", "strip-bom-string": "^1.0.0" } }, ""],
-
-    "guid-typescript": ["guid-typescript@1.0.9", "", {}, ""],
 
     "has-flag": ["has-flag@3.0.0", "", {}, ""],
 
@@ -951,19 +906,13 @@
 
     "ignore-by-default": ["ignore-by-default@1.0.1", "", {}, ""],
 
-    "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
-
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
     "inherits": ["inherits@2.0.4", "", {}, ""],
 
-    "ini": ["ini@1.3.8", "", {}, ""],
-
     "ip-address": ["ip-address@10.1.0", "", {}, ""],
 
     "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, ""],
-
-    "is-arrayish": ["is-arrayish@0.3.4", "", {}, ""],
 
     "is-binary-path": ["is-binary-path@2.1.0", "", { "dependencies": { "binary-extensions": "^2.0.0" } }, ""],
 
@@ -1013,8 +962,6 @@
 
     "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
 
-    "jsonwebtoken": ["jsonwebtoken@9.0.3", "", { "dependencies": { "jws": "^4.0.1", "lodash.includes": "^4.3.0", "lodash.isboolean": "^3.0.3", "lodash.isinteger": "^4.0.4", "lodash.isnumber": "^3.0.3", "lodash.isplainobject": "^4.0.6", "lodash.isstring": "^4.0.1", "lodash.once": "^4.0.0", "ms": "^2.1.1", "semver": "^7.5.4" } }, ""],
-
     "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, ""],
 
     "jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, ""],
@@ -1061,25 +1008,9 @@
 
     "lodash.camelcase": ["lodash.camelcase@4.3.0", "", {}, ""],
 
-    "lodash.includes": ["lodash.includes@4.3.0", "", {}, ""],
-
-    "lodash.isboolean": ["lodash.isboolean@3.0.3", "", {}, ""],
-
-    "lodash.isinteger": ["lodash.isinteger@4.0.4", "", {}, ""],
-
-    "lodash.isnumber": ["lodash.isnumber@3.0.3", "", {}, ""],
-
-    "lodash.isplainobject": ["lodash.isplainobject@4.0.6", "", {}, ""],
-
-    "lodash.isstring": ["lodash.isstring@4.0.1", "", {}, ""],
-
-    "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
-
-    "lodash.once": ["lodash.once@4.1.1", "", {}, ""],
-
     "lodash.snakecase": ["lodash.snakecase@4.1.1", "", {}, "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="],
 
-    "long": ["long@4.0.0", "", {}, ""],
+    "long": ["long@5.3.2", "", {}, ""],
 
     "lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
 
@@ -1109,11 +1040,7 @@
 
     "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, ""],
 
-    "mimic-response": ["mimic-response@3.1.0", "", {}, ""],
-
-    "minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
-
-    "minimist": ["minimist@1.2.8", "", {}, ""],
+    "minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, ""],
 
     "minipass": ["minipass@7.1.3", "", {}, ""],
 
@@ -1127,19 +1054,17 @@
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": "bin/nanoid.cjs" }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
-    "napi-build-utils": ["napi-build-utils@2.0.0", "", {}, ""],
-
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
     "negotiator": ["negotiator@1.0.0", "", {}, ""],
 
     "netmask": ["netmask@2.0.2", "", {}, "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg=="],
 
-    "node-abi": ["node-abi@3.89.0", "", { "dependencies": { "semver": "^7.3.5" } }, ""],
-
     "node-addon-api": ["node-addon-api@8.6.0", "", {}, "sha512-gBVjCaqDlRUk0EwoPNKzIr9KkS9041G/q31IBShPs1Xz6UTA+EXdZADbzqAJQrpDRq71CIMnOP5VMut3SL0z5Q=="],
 
     "node-domexception": ["node-domexception@1.0.0", "", {}, ""],
+
+    "node-ensure": ["node-ensure@0.0.0", "", {}, "sha512-DRI60hzo2oKN1ma0ckc6nQWlHU69RH6xN0sjQTjMpChPfTYvKZdcQFfdYK2RWbJcKyUizSIy/l8OTGxMAM1QDw=="],
 
     "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, ""],
 
@@ -1147,15 +1072,13 @@
 
     "node-pg-migrate": ["node-pg-migrate@7.9.1", "", { "dependencies": { "glob": "~11.0.0", "yargs": "~17.7.0" }, "peerDependencies": { "@types/pg": ">=6.0.0 <9.0.0", "pg": ">=4.3.0 <9.0.0" }, "bin": { "node-pg-migrate": "bin/node-pg-migrate.js", "node-pg-migrate-cjs": "bin/node-pg-migrate.js", "node-pg-migrate-esm": "bin/node-pg-migrate.mjs" } }, ""],
 
-    "nodemailer": ["nodemailer@8.0.3", "", {}, "sha512-JQNBqvK+bj3NMhUFR3wmCl3SYcOeMotDiwDBvIoCuQdF0PvlIY0BH+FJ2CG7u4cXKPChplE78oowlH/Otsc4ZQ=="],
+    "nodemailer": ["nodemailer@8.0.4", "", {}, "sha512-k+jf6N8PfQJ0Fe8ZhJlgqU5qJU44Lpvp2yvidH3vp1lPnVQMgi4yEEMPXg5eJS1gFIJTVq1NHBk7Ia9ARdSBdQ=="],
 
     "nodemon": ["nodemon@3.1.14", "", { "dependencies": { "chokidar": "^3.5.2", "debug": "^4", "ignore-by-default": "^1.0.1", "minimatch": "^10.2.1", "pstree.remy": "^1.1.8", "semver": "^7.5.3", "simple-update-notifier": "^2.0.0", "supports-color": "^5.5.0", "touch": "^3.1.0", "undefsafe": "^2.0.5" }, "bin": "bin/nodemon.js" }, ""],
 
     "non-error": ["non-error@0.1.0", "", {}, "sha512-TMB1uHiGsHRGv1uYclfhivcnf0/PdFp2pNqRxXjncaAsjYMoisaQJI+SSZCqRq+VliwRTC8tsMQfmrWjDMhkPQ=="],
 
     "normalize-path": ["normalize-path@3.0.0", "", {}, ""],
-
-    "oauth4webapi": ["oauth4webapi@3.8.5", "", {}, "sha512-A8jmyUckVhRJj5lspguklcl90Ydqk61H3dcU0oLhH3Yv13KpAliKTt5hknpGGPZSSfOwGyraNEFmofDYH+1kSg=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, ""],
 
@@ -1167,17 +1090,7 @@
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, ""],
 
-    "onnx-proto": ["onnx-proto@4.0.4", "", { "dependencies": { "protobufjs": "^6.8.8" } }, ""],
-
-    "onnxruntime-common": ["onnxruntime-common@1.14.0", "", {}, ""],
-
-    "onnxruntime-node": ["onnxruntime-node@1.14.0", "", { "dependencies": { "onnxruntime-common": "~1.14.0" }, "os": [ "linux", "win32", "darwin", ] }, ""],
-
-    "onnxruntime-web": ["onnxruntime-web@1.14.0", "", { "dependencies": { "flatbuffers": "^1.12.0", "guid-typescript": "^1.0.9", "long": "^4.0.0", "onnx-proto": "^4.0.4", "onnxruntime-common": "~1.14.0", "platform": "^1.3.6" } }, ""],
-
     "openai": ["openai@4.104.0", "", { "dependencies": { "@types/node": "^18.11.18", "@types/node-fetch": "^2.6.4", "abort-controller": "^3.0.0", "agentkeepalive": "^4.2.1", "form-data-encoder": "1.7.2", "formdata-node": "^4.3.2", "node-fetch": "^2.6.7" }, "peerDependencies": { "ws": "^8.18.0", "zod": "^3.23.8" }, "bin": "bin/cli" }, ""],
-
-    "openid-client": ["openid-client@6.8.2", "", { "dependencies": { "jose": "^6.1.3", "oauth4webapi": "^3.8.4" } }, "sha512-uOvTCndr4udZsKihJ68H9bUICrriHdUVJ6Az+4Ns6cW55rwM5h0bjVIzDz2SxgOI84LKjFyjOFvERLzdTUROGA=="],
 
     "opossum": ["opossum@9.0.0", "", {}, "sha512-K76U0QkxOfUZamneQuzz+AP0fyfTJcCplZ2oZL93nxeupuJbN4s6uFNbmVCt4eWqqGqRnnowdFuBicJ1fLMVxw=="],
 
@@ -1201,8 +1114,6 @@
 
     "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, ""],
 
-    "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
-
     "parseurl": ["parseurl@1.3.3", "", {}, ""],
 
     "partial-json": ["partial-json@0.1.7", "", {}, "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA=="],
@@ -1218,6 +1129,8 @@
     "path-to-regexp": ["path-to-regexp@8.3.0", "", {}, ""],
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "pdf-parse": ["pdf-parse@1.1.4", "", { "dependencies": { "node-ensure": "^0.0.0" } }, "sha512-XRIRcLgk6ZnUbsHsYXExMw+krrPE81hJ6FQPLdBNhhBefqIQKXu/WeTgNBGSwPrfU0v+UCEwn7AoAUOsVKHFvQ=="],
 
     "pg": ["pg@8.20.0", "", { "dependencies": { "pg-connection-string": "^2.12.0", "pg-pool": "^3.13.0", "pg-protocol": "^1.13.0", "pg-types": "2.2.0", "pgpass": "1.0.5" }, "optionalDependencies": { "pg-cloudflare": "^1.3.0" }, "peerDependencies": { "pg-native": ">=3.0.1" }, "optionalPeers": ["pg-native"] }, ""],
 
@@ -1247,8 +1160,6 @@
 
     "pkg-types": ["pkg-types@1.3.1", "", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
 
-    "platform": ["platform@1.3.6", "", {}, ""],
-
     "postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
 
     "postcss-load-config": ["postcss-load-config@6.0.1", "", { "dependencies": { "lilconfig": "^3.1.1" }, "peerDependencies": { "jiti": ">=1.21.0", "postcss": ">=8.0.9", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["jiti", "postcss", "tsx", "yaml"] }, "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g=="],
@@ -1260,8 +1171,6 @@
     "postgres-date": ["postgres-date@1.0.7", "", {}, ""],
 
     "postgres-interval": ["postgres-interval@1.2.0", "", { "dependencies": { "xtend": "^4.0.0" } }, ""],
-
-    "prebuild-install": ["prebuild-install@7.1.3", "", { "dependencies": { "detect-libc": "^2.0.0", "expand-template": "^2.0.3", "github-from-package": "0.0.0", "minimist": "^1.2.3", "mkdirp-classic": "^0.5.3", "napi-build-utils": "^2.0.0", "node-abi": "^3.3.0", "pump": "^3.0.0", "rc": "^1.2.7", "simple-get": "^4.0.0", "tar-fs": "^2.0.0", "tunnel-agent": "^0.6.0" }, "bin": "bin.js" }, ""],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
@@ -1286,8 +1195,6 @@
     "range-parser": ["range-parser@1.2.1", "", {}, ""],
 
     "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, ""],
-
-    "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": "cli.js" }, ""],
 
     "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, ""],
 
@@ -1325,8 +1232,6 @@
 
     "setprototypeof": ["setprototypeof@1.2.0", "", {}, ""],
 
-    "sharp": ["sharp@0.32.6", "", { "dependencies": { "color": "^4.2.3", "detect-libc": "^2.0.2", "node-addon-api": "^6.1.0", "prebuild-install": "^7.1.1", "semver": "^7.5.4", "simple-get": "^4.0.1", "tar-fs": "^3.0.4", "tunnel-agent": "^0.6.0" } }, ""],
-
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, ""],
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, ""],
@@ -1343,13 +1248,7 @@
 
     "signal-exit": ["signal-exit@4.1.0", "", {}, ""],
 
-    "simple-concat": ["simple-concat@1.0.1", "", {}, ""],
-
-    "simple-get": ["simple-get@4.0.1", "", { "dependencies": { "decompress-response": "^6.0.0", "once": "^1.3.1", "simple-concat": "^1.0.0" } }, ""],
-
     "simple-git": ["simple-git@3.33.0", "", { "dependencies": { "@kwsites/file-exists": "^1.1.1", "@kwsites/promise-deferred": "^1.1.1", "debug": "^4.4.0" } }, "sha512-D4V/tGC2sjsoNhoMybKyGoE+v8A60hRawKQ1iFRA1zwuDgGZCBJ4ByOzZ5J8joBbi4Oam0qiPH+GhzmSBwbJng=="],
-
-    "simple-swizzle": ["simple-swizzle@0.2.4", "", { "dependencies": { "is-arrayish": "^0.3.1" } }, ""],
 
     "simple-update-notifier": ["simple-update-notifier@2.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, ""],
 
@@ -1377,8 +1276,6 @@
 
     "std-env": ["std-env@4.0.0", "", {}, "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ=="],
 
-    "streamx": ["streamx@2.23.0", "", { "dependencies": { "events-universal": "^1.0.0", "fast-fifo": "^1.3.2", "text-decoder": "^1.1.0" } }, ""],
-
     "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, ""],
 
     "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, ""],
@@ -1386,8 +1283,6 @@
     "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, ""],
 
     "strip-bom-string": ["strip-bom-string@1.0.0", "", {}, ""],
-
-    "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
 
     "strnum": ["strnum@2.2.1", "", {}, "sha512-BwRvNd5/QoAtyW1na1y1LsJGQNvRlkde6Q/ipqqEaivoMdV+B1OMOTVdwR+N/cwVUcIt9PYyHmV8HyexCZSupg=="],
 
@@ -1404,10 +1299,6 @@
     "tar-fs": ["tar-fs@2.1.4", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, ""],
 
     "tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, ""],
-
-    "teex": ["teex@1.0.1", "", { "dependencies": { "streamx": "^2.12.5" } }, ""],
-
-    "text-decoder": ["text-decoder@1.2.7", "", { "dependencies": { "b4a": "^1.6.4" } }, ""],
 
     "thenify": ["thenify@3.3.1", "", { "dependencies": { "any-promise": "^1.0.0" } }, "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="],
 
@@ -1447,8 +1338,6 @@
 
     "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": "dist/cli.mjs" }, ""],
 
-    "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, ""],
-
     "tweetnacl": ["tweetnacl@0.14.5", "", {}, ""],
 
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
@@ -1483,7 +1372,7 @@
 
     "vite": ["vite@8.0.1", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.3", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.10", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@vitejs/devtools", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "yaml"], "bin": "bin/vite.js" }, "sha512-wt+Z2qIhfFt85uiyRt5LPU4oVEJBXj8hZNWKeqFG4gRG/0RaRGJ7njQCwzFVjO+v4+Ipmf5CY7VdmZRAYYBPHw=="],
 
-    "vitest": ["vitest@4.1.0", "", { "dependencies": { "@vitest/expect": "4.1.0", "@vitest/mocker": "4.1.0", "@vitest/pretty-format": "4.1.0", "@vitest/runner": "4.1.0", "@vitest/snapshot": "4.1.0", "@vitest/spy": "4.1.0", "@vitest/utils": "4.1.0", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.0.3", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.0", "@vitest/browser-preview": "4.1.0", "@vitest/browser-webdriverio": "4.1.0", "@vitest/ui": "4.1.0", "happy-dom": "*", "jsdom": "*", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": "vitest.mjs" }, "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw=="],
+    "vitest": ["vitest@4.1.2", "", { "dependencies": { "@vitest/expect": "4.1.2", "@vitest/mocker": "4.1.2", "@vitest/pretty-format": "4.1.2", "@vitest/runner": "4.1.2", "@vitest/snapshot": "4.1.2", "@vitest/spy": "4.1.2", "@vitest/utils": "4.1.2", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.2", "@vitest/browser-preview": "4.1.2", "@vitest/browser-webdriverio": "4.1.2", "@vitest/ui": "4.1.2", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg=="],
 
     "vscode-jsonrpc": ["vscode-jsonrpc@8.2.1", "", {}, ""],
 
@@ -1541,19 +1430,9 @@
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
-    "@eslint/config-array/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
-
-    "@eslint/eslintrc/ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
-
-    "@eslint/eslintrc/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
-
     "@grpc/grpc-js/@grpc/proto-loader": ["@grpc/proto-loader@0.8.0", "", { "dependencies": { "lodash.camelcase": "^4.3.0", "long": "^5.0.0", "protobufjs": "^7.5.3", "yargs": "^17.7.2" }, "bin": { "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js" } }, ""],
 
-    "@grpc/proto-loader/long": ["long@5.3.2", "", {}, ""],
-
     "@mariozechner/pi-ai/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, ""],
-
-    "@mariozechner/pi-ai/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "@mariozechner/pi-ai/openai": ["openai@6.26.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "bin": "bin/cli" }, "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA=="],
 
@@ -1565,15 +1444,9 @@
 
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
-    "@typescript-eslint/typescript-estree/minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, ""],
-
-    "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
-
     "ajv-formats/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, ""],
 
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, ""],
-
-    "chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, ""],
 
@@ -1587,17 +1460,9 @@
 
     "gaxios/node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
 
-    "glob/minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, ""],
-
     "gray-matter/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": "bin/js-yaml.js" }, ""],
 
-    "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
-
     "istanbul-lib-report/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
-
-    "nodemon/minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, ""],
-
-    "onnx-proto/protobufjs": ["protobufjs@6.11.4", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/long": "^4.0.1", "@types/node": ">=13.7.0", "long": "^4.0.0" }, "bin": { "pbjs": "bin/pbjs", "pbts": "bin/pbts" } }, ""],
 
     "openai/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, ""],
 
@@ -1605,23 +1470,9 @@
 
     "path-scurry/lru-cache": ["lru-cache@11.2.7", "", {}, ""],
 
-    "protobufjs/long": ["long@5.3.2", "", {}, ""],
-
-    "rc/strip-json-comments": ["strip-json-comments@2.0.1", "", {}, ""],
-
     "readdirp/picomatch": ["picomatch@2.3.1", "", {}, ""],
 
-    "sharp/node-addon-api": ["node-addon-api@6.1.0", "", {}, ""],
-
-    "sharp/tar-fs": ["tar-fs@3.1.2", "", { "dependencies": { "pump": "^3.0.0", "tar-stream": "^3.1.5" }, "optionalDependencies": { "bare-fs": "^4.0.1", "bare-path": "^3.0.0" } }, ""],
-
-    "sucrase/commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
-
-    "tinyglobby/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
-
     "tsup/chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
-
-    "vite/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
     "vitest/tinyexec": ["tinyexec@1.0.4", "", {}, "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw=="],
 
@@ -1631,58 +1482,28 @@
 
     "@aws-crypto/util/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
 
-    "@eslint/config-array/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
-
-    "@eslint/eslintrc/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
-
-    "@eslint/eslintrc/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
-
-    "@grpc/grpc-js/@grpc/proto-loader/long": ["long@5.3.2", "", {}, ""],
-
     "@mariozechner/pi-ai/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, ""],
 
     "@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, ""],
 
     "@types/ssh2/@types/node/undici-types": ["undici-types@5.26.5", "", {}, ""],
 
-    "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, ""],
-
     "ajv-formats/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, ""],
-
-    "chalk/supports-color/has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
     "form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, ""],
 
     "gaxios/node-fetch/data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
 
-    "glob/minimatch/brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, ""],
-
     "gray-matter/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, ""],
 
     "istanbul-lib-report/supports-color/has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
-    "nodemon/minimatch/brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, ""],
-
-    "onnx-proto/protobufjs/long": ["long@4.0.0", "", {}, ""],
-
     "openai/@types/node/undici-types": ["undici-types@5.26.5", "", {}, ""],
-
-    "sharp/tar-fs/tar-stream": ["tar-stream@3.1.8", "", { "dependencies": { "b4a": "^1.6.4", "bare-fs": "^4.5.5", "fast-fifo": "^1.2.0", "streamx": "^2.15.0" } }, ""],
 
     "tsup/chokidar/readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 
     "@aws-crypto/sha256-browser/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
 
     "@aws-crypto/util/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
-
-    "@eslint/config-array/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
-
-    "@eslint/eslintrc/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
-
-    "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, ""],
-
-    "glob/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, ""],
-
-    "nodemon/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, ""],
   }
 }

--- a/core/src/agents/registry.service.ts
+++ b/core/src/agents/registry.service.ts
@@ -300,13 +300,14 @@ export class AgentRegistry {
 
     await this.pool
       .query(
-        `INSERT INTO token_quotas (agent_id, max_tokens_per_hour, max_tokens_per_day, updated_at)
-         VALUES ($1, $2, $3, NOW())
+        `INSERT INTO token_quotas (agent_id, max_tokens_per_hour, max_tokens_per_day, source, updated_at)
+         VALUES ($1, $2, $3, 'manifest', NOW())
          ON CONFLICT (agent_id)
          DO UPDATE SET
-           max_tokens_per_hour = $2,
-           max_tokens_per_day = $3,
-           updated_at = NOW()`,
+           max_tokens_per_hour = EXCLUDED.max_tokens_per_hour,
+           max_tokens_per_day = EXCLUDED.max_tokens_per_day,
+           updated_at = NOW()
+         WHERE token_quotas.source = 'manifest'`,
         [instanceId, hourly ?? DEFAULT_HOURLY_QUOTA, daily ?? DEFAULT_DAILY_QUOTA]
       )
       .catch((err) => {

--- a/core/src/channels/adapters/DiscordChatAdapter.ts
+++ b/core/src/channels/adapters/DiscordChatAdapter.ts
@@ -102,6 +102,26 @@ const SLASH_COMMANDS = [
     name: 'reset',
     description: 'Start a new conversation session',
   },
+  {
+    name: 'agents',
+    description: 'List available agent instances with status',
+  },
+  {
+    name: 'switch',
+    description: 'Switch the bound agent for your session',
+    options: [
+      {
+        name: 'agent',
+        description: 'Agent instance name or ID',
+        type: 3, // STRING
+        required: true,
+      },
+    ],
+  },
+  {
+    name: 'help',
+    description: 'Show available commands',
+  },
 ];
 
 export class DiscordChatAdapter {
@@ -113,6 +133,14 @@ export class DiscordChatAdapter {
 
   /** Maps Discord userId → SERA sessionId for conversation continuity */
   private userSessions = new Map<string, string>();
+
+  /** Per-user agent override (userId → agentId). Falls back to config.targetAgentId. */
+  private userTargetAgent = new Map<string, string>();
+
+  /** Resolve the effective target agent for a user, respecting per-user overrides. */
+  private getTargetAgent(userId: string): string {
+    return this.userTargetAgent.get(userId) ?? this.config.targetAgentId;
+  }
 
   constructor(
     private channelId: string,
@@ -265,7 +293,6 @@ export class DiscordChatAdapter {
       Array.isArray(msg.mentions) &&
       msg.mentions.some((m) => m.id === this.botUserId);
 
-    // Check if this message type is allowed.
     // Defaults: allowDMs=true, allowMentions=true (must explicitly disable)
     const allowDMs = this.config.allowDMs !== false;
     const allowMentions = this.config.allowMentions !== false;
@@ -296,62 +323,12 @@ export class DiscordChatAdapter {
     }
     if (!text) return;
 
-    // Show typing indicator
     void this.sendTyping(msg.channel_id);
 
     try {
-      // Resolve or create session
       const sessionId = await this.getOrCreateSession(msg.author.id, msg.author.username);
+      const reply = await this.processChat(msg.author.id, text, sessionId);
 
-      // Load conversation history
-      const messages = await this.sessionStore.getMessages(sessionId);
-      const history: ChatMessage[] = messages.map((m) => ({
-        role: m.role as ChatMessage['role'],
-        content: m.content,
-      }));
-
-      // Get the target agent
-      let agent = this.orchestrator.getAgent(this.config.targetAgentId);
-      if (!agent) {
-        try {
-          agent = await this.orchestrator.startInstance(this.config.targetAgentId);
-        } catch {
-          await this.sendDiscordMessage(
-            msg.channel_id,
-            '⚠️ The bound agent is not available. Please contact the operator.'
-          );
-          return;
-        }
-      }
-
-      // Process message — route through container chat for full tool catalog + fixed prompt
-      let reply: string;
-      try {
-        const chatUrl = await this.orchestrator.ensureContainerRunning(this.config.targetAgentId);
-        const chatRes = await fetch(`${chatUrl}/chat`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ message: text, sessionId, history }),
-          signal: AbortSignal.timeout(120_000),
-        });
-        if (chatRes.ok) {
-          const body = (await chatRes.json()) as { result: string | null; error?: string };
-          reply = body.result || 'No response generated.';
-        } else {
-          throw new Error(`Container chat returned ${chatRes.status}`);
-        }
-      } catch (containerErr) {
-        // Fallback to in-process if container unavailable
-        logger.warn('Container chat failed, falling back to in-process:', containerErr);
-        const response = await agent.process(text, history);
-        reply = response.finalAnswer || response.thought || 'No response generated.';
-      }
-
-      // Persist messages
-      await this.sessionStore.addMessage({ sessionId, role: 'user', content: text });
-      await this.sessionStore.addMessage({ sessionId, role: 'assistant', content: reply });
-
-      // Send response (chunked if needed)
       const prefix = this.config.responsePrefix ? `**${this.config.responsePrefix}:** ` : '';
       await this.sendChunked(msg.channel_id, prefix + reply);
     } catch (err) {
@@ -361,6 +338,51 @@ export class DiscordChatAdapter {
         '⚠️ An error occurred while processing your message.'
       );
     }
+  }
+
+  /**
+   * Fetch agent, send message through container chat (with in-process fallback),
+   * and persist both turns to the session store. Returns the assistant reply.
+   */
+  private async processChat(userId: string, text: string, sessionId: string): Promise<string> {
+    const targetAgentId = this.getTargetAgent(userId);
+
+    let agent = this.orchestrator.getAgent(targetAgentId);
+    if (!agent) {
+      agent = await this.orchestrator.startInstance(targetAgentId);
+    }
+
+    const messages = await this.sessionStore.getMessages(sessionId);
+    const history: ChatMessage[] = messages.map((m) => ({
+      role: m.role as ChatMessage['role'],
+      content: m.content,
+    }));
+
+    let reply: string;
+    try {
+      const chatUrl = await this.orchestrator.ensureContainerRunning(targetAgentId);
+      const chatRes = await fetch(`${chatUrl}/chat`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: text, sessionId, history }),
+        signal: AbortSignal.timeout(120_000),
+      });
+      if (chatRes.ok) {
+        const body = (await chatRes.json()) as { result: string | null; error?: string };
+        reply = body.result || 'No response generated.';
+      } else {
+        throw new Error(`Container chat returned ${chatRes.status}`);
+      }
+    } catch (containerErr) {
+      logger.warn('Container chat failed, falling back to in-process:', containerErr);
+      const response = await agent.process(text, history);
+      reply = response.finalAnswer || response.thought || 'No response generated.';
+    }
+
+    await this.sessionStore.addMessage({ sessionId, role: 'user', content: text });
+    await this.sessionStore.addMessage({ sessionId, role: 'assistant', content: reply });
+
+    return reply;
   }
 
   // ── Security ───────────────────────────────────────────────────────────────
@@ -391,7 +413,8 @@ export class DiscordChatAdapter {
    * session with this agent, without needing a separate lookup table.
    */
   private async getOrCreateSession(userId: string, userName: string): Promise<string> {
-    const key = `discord:${userId}:${this.config.targetAgentId}`;
+    const targetAgentId = this.getTargetAgent(userId);
+    const key = `discord:${userId}:${targetAgentId}`;
 
     // Check in-memory cache first
     const cached = this.userSessions.get(key);
@@ -411,8 +434,8 @@ export class DiscordChatAdapter {
     // Create new session with the deterministic ID
     const session = await this.sessionStore.createSession({
       id: deterministicId,
-      agentName: this.config.targetAgentId,
-      agentInstanceId: this.config.targetAgentId,
+      agentName: targetAgentId,
+      agentInstanceId: targetAgentId,
       title: `Discord: ${userName}`,
     });
 
@@ -502,6 +525,15 @@ export class DiscordChatAdapter {
       case 'reset':
         await this.handleResetCommand(interaction, user);
         break;
+      case 'agents':
+        await this.handleAgentsCommand(interaction);
+        break;
+      case 'switch':
+        await this.handleSwitchCommand(interaction, user);
+        break;
+      case 'help':
+        await this.handleHelpCommand(interaction);
+        break;
       default:
         await this.respondToInteraction(interaction.id, interaction.token, 4, {
           content: `Unknown command: ${commandName ?? '(none)'}`,
@@ -528,55 +560,10 @@ export class DiscordChatAdapter {
 
     try {
       const sessionId = await this.getOrCreateSession(user.id, user.username);
-      const messages = await this.sessionStore.getMessages(sessionId);
-      const history: ChatMessage[] = messages.map((m) => ({
-        role: m.role as ChatMessage['role'],
-        content: m.content,
-      }));
+      const reply = await this.processChat(user.id, message.trim(), sessionId);
 
-      let agent = this.orchestrator.getAgent(this.config.targetAgentId);
-      if (!agent) {
-        try {
-          agent = await this.orchestrator.startInstance(this.config.targetAgentId);
-        } catch {
-          await this.editInteractionResponse(
-            interaction.token,
-            '⚠️ The bound agent is not available.'
-          );
-          return;
-        }
-      }
-
-      let reply: string;
-      try {
-        const chatUrl = await this.orchestrator.ensureContainerRunning(this.config.targetAgentId);
-        const chatRes = await fetch(`${chatUrl}/chat`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ message: message.trim(), sessionId, history }),
-          signal: AbortSignal.timeout(120_000),
-        });
-        if (chatRes.ok) {
-          const body = (await chatRes.json()) as { result: string | null; error?: string };
-          reply = body.result || 'No response generated.';
-        } else {
-          throw new Error(`Container chat returned ${chatRes.status}`);
-        }
-      } catch (containerErr) {
-        logger.warn('Container chat failed, falling back to in-process:', containerErr);
-        const response = await agent.process(message.trim(), history);
-        reply = response.finalAnswer || response.thought || 'No response generated.';
-      }
-
-      // Persist messages
-      await this.sessionStore.addMessage({ sessionId, role: 'user', content: message.trim() });
-      await this.sessionStore.addMessage({ sessionId, role: 'assistant', content: reply });
-
-      // Edit the deferred response with the actual reply
       const prefix = this.config.responsePrefix ? `**${this.config.responsePrefix}:** ` : '';
       const fullReply = prefix + reply;
-
-      // Discord interaction responses have a 2000 char limit — truncate if needed
       const truncated =
         fullReply.length > MAX_MESSAGE_LENGTH
           ? fullReply.substring(0, MAX_MESSAGE_LENGTH - 3) + '...'
@@ -595,10 +582,11 @@ export class DiscordChatAdapter {
     interaction: DiscordInteraction,
     user: { id: string; username: string }
   ): Promise<void> {
-    const agent = this.orchestrator.getAgent(this.config.targetAgentId);
+    const targetAgentId = this.getTargetAgent(user.id);
+    const agent = this.orchestrator.getAgent(targetAgentId);
     const status = agent ? 'running' : 'stopped';
 
-    const key = `discord:${user.id}:${this.config.targetAgentId}`;
+    const key = `discord:${user.id}:${targetAgentId}`;
     const sessionId = this.userSessions.get(key);
 
     let messageCount = 0;
@@ -607,15 +595,24 @@ export class DiscordChatAdapter {
       messageCount = messages.length;
     }
 
-    const lines = [
-      `**Agent:** ${this.config.targetAgentId}`,
-      `**Status:** ${status}`,
-      `**Your session:** ${sessionId ?? 'none'}`,
-      `**Messages in session:** ${messageCount}`,
-    ];
-
     await this.respondToInteraction(interaction.id, interaction.token, 4, {
-      content: lines.join('\n'),
+      embeds: [
+        {
+          title: 'Agent Status',
+          color: status === 'running' ? 0x00ff00 : 0xff0000,
+          fields: [
+            { name: 'Agent', value: targetAgentId, inline: true },
+            { name: 'Status', value: status, inline: true },
+            {
+              name: 'Session',
+              value: sessionId ? `\`${sessionId.substring(0, 8)}...\`` : 'none',
+              inline: true,
+            },
+            { name: 'Messages', value: String(messageCount), inline: true },
+          ],
+          footer: { text: 'SERA' },
+        },
+      ],
       flags: 64,
     });
   }
@@ -630,7 +627,8 @@ export class DiscordChatAdapter {
     // ACK with deferred response
     await this.respondToInteraction(interaction.id, interaction.token, 5, { flags: 64 });
 
-    const key = `discord:${user.id}:${this.config.targetAgentId}`;
+    const targetAgentId = this.getTargetAgent(user.id);
+    const key = `discord:${user.id}:${targetAgentId}`;
     const sessionId = this.userSessions.get(key);
 
     if (!sessionId) {
@@ -669,14 +667,118 @@ export class DiscordChatAdapter {
     interaction: DiscordInteraction,
     user: { id: string; username: string }
   ): Promise<void> {
-    const key = `discord:${user.id}:${this.config.targetAgentId}`;
+    const targetAgentId = this.getTargetAgent(user.id);
+    const key = `discord:${user.id}:${targetAgentId}`;
+
+    // Delete the existing session from the store so getOrCreateSession creates a fresh one
+    const oldSessionId = this.userSessions.get(key);
+    if (oldSessionId) {
+      await this.sessionStore.deleteSession(oldSessionId);
+    }
     this.userSessions.delete(key);
 
-    // Create a fresh session immediately so next /ask doesn't reuse the old one
+    // Create a fresh session (deterministic ID will produce the same key, but the
+    // store entry was deleted above so a new empty session is created)
     const newSessionId = await this.getOrCreateSession(user.id, user.username);
 
     await this.respondToInteraction(interaction.id, interaction.token, 4, {
       content: `✅ Session reset. New session: \`${newSessionId.substring(0, 8)}...\`\nUse \`/ask\` to start a new conversation.`,
+      flags: 64,
+    });
+  }
+
+  private async handleAgentsCommand(interaction: DiscordInteraction): Promise<void> {
+    const agents = this.orchestrator.listAgents();
+
+    if (agents.length === 0) {
+      await this.respondToInteraction(interaction.id, interaction.token, 4, {
+        content: 'No agents are currently registered.',
+        flags: 64,
+      });
+      return;
+    }
+
+    const fields = agents.map((a) => ({
+      name: a.name,
+      value: `**Status:** ${a.status}\n**ID:** \`${a.id || 'n/a'}\``,
+      inline: true,
+    }));
+
+    await this.respondToInteraction(interaction.id, interaction.token, 4, {
+      embeds: [
+        {
+          title: 'Available Agents',
+          color: 0x5865f2, // Discord blurple
+          fields,
+          footer: { text: `${agents.length} agent(s) — SERA` },
+        },
+      ],
+      flags: 64,
+    });
+  }
+
+  private async handleSwitchCommand(
+    interaction: DiscordInteraction,
+    user: { id: string; username: string }
+  ): Promise<void> {
+    const agentOpt = interaction.data?.options?.find((o) => o.name === 'agent')?.value;
+    if (typeof agentOpt !== 'string' || !agentOpt.trim()) {
+      await this.respondToInteraction(interaction.id, interaction.token, 4, {
+        content: 'Please provide an agent name or ID.',
+        flags: 64,
+      });
+      return;
+    }
+
+    const agentId = agentOpt.trim();
+
+    // Validate the agent exists (check running agents and manifests)
+    const agent = this.orchestrator.getAgent(agentId);
+    const agentInfo = this.orchestrator.getAgentInfo(agentId);
+    if (!agent && !agentInfo) {
+      await this.respondToInteraction(interaction.id, interaction.token, 4, {
+        content: `⚠️ Agent \`${agentId}\` not found. Use \`/agents\` to see available agents.`,
+        flags: 64,
+      });
+      return;
+    }
+
+    // Clear the old session cache so next /ask creates a fresh session for the new agent
+    const oldTargetId = this.getTargetAgent(user.id);
+    const oldKey = `discord:${user.id}:${oldTargetId}`;
+    this.userSessions.delete(oldKey);
+
+    // Set the per-user override
+    this.userTargetAgent.set(user.id, agentId);
+
+    await this.respondToInteraction(interaction.id, interaction.token, 4, {
+      embeds: [
+        {
+          title: 'Agent Switched',
+          color: 0x57f287, // Discord green
+          fields: [
+            { name: 'Now talking to', value: `\`${agentId}\``, inline: true },
+            { name: 'Previous', value: `\`${oldTargetId}\``, inline: true },
+          ],
+          footer: { text: 'Session reset — use /ask to start chatting. — SERA' },
+        },
+      ],
+      flags: 64,
+    });
+  }
+
+  private async handleHelpCommand(interaction: DiscordInteraction): Promise<void> {
+    const commands = SLASH_COMMANDS.map((cmd) => `**/${cmd.name}** — ${cmd.description}`);
+
+    await this.respondToInteraction(interaction.id, interaction.token, 4, {
+      embeds: [
+        {
+          title: 'SERA Commands',
+          color: 0x5865f2,
+          description: commands.join('\n'),
+          footer: { text: 'SERA' },
+        },
+      ],
       flags: 64,
     });
   }
@@ -691,7 +793,17 @@ export class DiscordChatAdapter {
     interactionId: string,
     interactionToken: string,
     type: number,
-    data?: { content?: string; flags?: number }
+    data?: {
+      content?: string;
+      embeds?: Array<{
+        title?: string;
+        description?: string;
+        color?: number;
+        fields?: Array<{ name: string; value: string; inline?: boolean }>;
+        footer?: { text: string };
+      }>;
+      flags?: number;
+    }
   ): Promise<void> {
     try {
       const resp = await fetch(

--- a/core/src/db/migrations/1711900000000_token_quotas_source.cjs
+++ b/core/src/db/migrations/1711900000000_token_quotas_source.cjs
@@ -1,0 +1,21 @@
+/**
+ * Add `source` column to token_quotas to distinguish manifest-set vs operator-set budgets.
+ * syncManifestBudget() will only overwrite rows where source='manifest', preserving operator overrides.
+ */
+
+/** @param {import('node-pg-migrate').MigrationBuilder} pgm */
+exports.up = (pgm) => {
+  pgm.addColumn('token_quotas', {
+    source: {
+      type: 'text',
+      notNull: true,
+      default: 'manifest',
+      check: "source IN ('manifest', 'operator')",
+    },
+  });
+};
+
+/** @param {import('node-pg-migrate').MigrationBuilder} pgm */
+exports.down = (pgm) => {
+  pgm.dropColumn('token_quotas', 'source');
+};

--- a/core/src/routes/budget.ts
+++ b/core/src/routes/budget.ts
@@ -145,43 +145,34 @@ export function createBudgetRouter(meteringService?: MeteringService): Router {
         maxLlmTokensPerDay?: number | null;
       };
 
-      // Resolve values: null or 0 → 0 (unlimited), undefined → keep existing, positive → use as-is
-      const resolveQuota = (val: number | null | undefined, _fallback: number): number | null => {
+      // Resolve values: null or 0 → 0 (unlimited), undefined → keep existing (represented as null here)
+      const resolveQuota = (val: number | null | undefined): number | null => {
         if (val === undefined) return null; // not in request — keep existing
         if (val === null || val === 0) return 0; // explicit unlimited
         return val;
       };
 
-      const hourly = resolveQuota(maxLlmTokensPerHour, DEFAULT_HOURLY_QUOTA);
-      const daily = resolveQuota(maxLlmTokensPerDay, DEFAULT_DAILY_QUOTA);
+      const hourly = resolveQuota(maxLlmTokensPerHour);
+      const daily = resolveQuota(maxLlmTokensPerDay);
 
-      // Build the upsert dynamically to handle "keep existing" (null = not provided)
-      if (hourly !== null && daily !== null) {
-        await query(
-          `INSERT INTO token_quotas (agent_id, max_tokens_per_hour, max_tokens_per_day, updated_at)
-           VALUES ($1, $2, $3, NOW())
-           ON CONFLICT (agent_id)
-           DO UPDATE SET max_tokens_per_hour = $2, max_tokens_per_day = $3, updated_at = NOW()`,
-          [agentId, hourly, daily]
-        );
-      } else if (hourly !== null) {
-        await query(
-          `INSERT INTO token_quotas (agent_id, max_tokens_per_hour, max_tokens_per_day, updated_at)
-           VALUES ($1, $2, $3, NOW())
-           ON CONFLICT (agent_id)
-           DO UPDATE SET max_tokens_per_hour = $2, updated_at = NOW()`,
-          [agentId, hourly, DEFAULT_DAILY_QUOTA]
-        );
-      } else if (daily !== null) {
-        await query(
-          `INSERT INTO token_quotas (agent_id, max_tokens_per_hour, max_tokens_per_day, updated_at)
-           VALUES ($1, $2, $3, NOW())
-           ON CONFLICT (agent_id)
-           DO UPDATE SET max_tokens_per_day = $3, updated_at = NOW()`,
-          [agentId, DEFAULT_HOURLY_QUOTA, daily]
-        );
+      // Nothing to update if neither field was provided
+      if (hourly === null && daily === null) {
+        res.json({ success: true });
+        return;
       }
-      // If both are null (undefined in request), nothing to update
+
+      // Single upsert: COALESCE preserves the existing column value when the caller omits a field.
+      await query(
+        `INSERT INTO token_quotas (agent_id, max_tokens_per_hour, max_tokens_per_day, source, updated_at)
+         VALUES ($1, COALESCE($2, $3), COALESCE($4, $5), 'operator', NOW())
+         ON CONFLICT (agent_id)
+         DO UPDATE SET
+           max_tokens_per_hour = COALESCE($2, token_quotas.max_tokens_per_hour),
+           max_tokens_per_day  = COALESCE($4, token_quotas.max_tokens_per_day),
+           source = 'operator',
+           updated_at = NOW()`,
+        [agentId, hourly, DEFAULT_HOURLY_QUOTA, daily, DEFAULT_DAILY_QUOTA]
+      );
 
       logger.info(
         `Budget updated for agent=${agentId} hourly=${hourly ?? 'unchanged'} daily=${daily ?? 'unchanged'}`

--- a/web/src/app/channels/page.tsx
+++ b/web/src/app/channels/page.tsx
@@ -18,6 +18,7 @@ import {
   useUpdateChannel,
   useDeleteChannel,
   useTestChannel,
+  useChannelHealth,
   useCreateRoutingRule,
   useUpdateRoutingRule,
   useDeleteRoutingRule,
@@ -31,7 +32,15 @@ import { useAuth } from '@/hooks/useAuth';
 import { useAgents } from '@/hooks/useAgents';
 import { ForbiddenView } from '@/views/ForbiddenView';
 
-const CHANNEL_TYPES = ['webhook', 'email', 'discord', 'discord-chat', 'slack'] as const;
+const CHANNEL_TYPES = [
+  'webhook',
+  'email',
+  'discord',
+  'discord-chat',
+  'slack',
+  'telegram',
+  'whatsapp',
+] as const;
 type ChannelType = (typeof CHANNEL_TYPES)[number];
 
 const SEVERITY_OPTIONS = ['info', 'warning', 'critical'] as const;
@@ -71,6 +80,11 @@ const CONFIG_FIELDS: Record<
       type: 'password',
       placeholder: 'Bot token from discord.dev',
     },
+    {
+      key: 'applicationId',
+      label: 'Application ID',
+      placeholder: 'From discord.dev application page',
+    },
     { key: 'targetAgentId', label: 'Target Agent', type: 'agent-select' },
     {
       key: 'allowedGuilds',
@@ -95,6 +109,26 @@ const CONFIG_FIELDS: Record<
     { key: 'appToken', label: 'App Token (optional)', type: 'password' },
     { key: 'signingSecret', label: 'Signing Secret (optional)', type: 'password' },
   ],
+  telegram: [
+    {
+      key: 'botToken',
+      label: 'Telegram Bot Token',
+      type: 'password',
+      placeholder: 'From @BotFather',
+    },
+    { key: 'targetAgentId', label: 'Target Agent', type: 'agent-select' },
+    {
+      key: 'allowedUsers',
+      label: 'Allowed User IDs (comma-separated)',
+      placeholder: 'Leave empty for all',
+    },
+  ],
+  whatsapp: [
+    { key: 'accessToken', label: 'Meta Cloud API Access Token', type: 'password' },
+    { key: 'phoneNumberId', label: 'Phone Number ID', placeholder: 'From Meta Business Suite' },
+    { key: 'verifyToken', label: 'Webhook Verify Token', placeholder: 'Custom verify token' },
+    { key: 'targetAgentId', label: 'Target Agent', type: 'agent-select' },
+  ],
 };
 
 function typeBadge(type: string) {
@@ -104,8 +138,36 @@ function typeBadge(type: string) {
     discord: 'success',
     'discord-chat': 'accent',
     slack: 'warning',
+    telegram: 'accent',
+    whatsapp: 'success',
   };
   return <Badge variant={colors[type] ?? 'default'}>{type}</Badge>;
+}
+
+function ChannelHealthBadge({ channelId }: { channelId: string }) {
+  const { data: health, isLoading } = useChannelHealth(channelId);
+
+  let color = 'bg-sera-text-dim';
+  let title = 'Unknown';
+  let pulse = false;
+
+  if (isLoading) {
+    title = 'Checking...';
+    pulse = true;
+  } else if (health?.healthy) {
+    color = 'bg-green-500';
+    title = 'Healthy';
+  } else if (health) {
+    color = 'bg-yellow-500';
+    title = health.error ?? 'Degraded';
+  }
+
+  return (
+    <span
+      className={`inline-block w-2 h-2 rounded-full ${color}${pulse ? ' animate-pulse' : ''}`}
+      title={title}
+    />
+  );
 }
 
 // ── Channel Dialog ───────────────────────────────────────────────────────────
@@ -579,6 +641,7 @@ export default function ChannelsPage() {
               >
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2">
+                    <ChannelHealthBadge channelId={ch.id} />
                     <span className="text-sm font-medium text-sera-text">{ch.name}</span>
                     {typeBadge(ch.type)}
                     {!ch.enabled && <Badge variant="default">disabled</Badge>}

--- a/web/src/hooks/useNotifications.ts
+++ b/web/src/hooks/useNotifications.ts
@@ -10,6 +10,7 @@ import {
   updateRoutingRule,
   deleteRoutingRule,
   updateChannel,
+  getChannelHealth,
   type CreateChannelPayload,
   type CreateRoutingRulePayload,
 } from '@/lib/api/notifications';
@@ -23,6 +24,16 @@ export function useChannels() {
 
 export function useRoutingRules() {
   return useQuery({ queryKey: RULES_KEY, queryFn: listRoutingRules });
+}
+
+export function useChannelHealth(id: string | undefined) {
+  return useQuery({
+    queryKey: [...CHANNELS_KEY, id, 'health'] as const,
+    queryFn: () => getChannelHealth(id!),
+    enabled: !!id,
+    refetchInterval: 60_000,
+    retry: false,
+  });
 }
 
 export function useCreateChannel() {

--- a/web/src/lib/api/notifications.ts
+++ b/web/src/lib/api/notifications.ts
@@ -4,7 +4,7 @@ export interface NotificationChannel {
   id: string;
   name: string;
   description?: string;
-  type: 'webhook' | 'email' | 'discord' | 'slack' | 'discord-chat';
+  type: 'webhook' | 'email' | 'discord' | 'slack' | 'discord-chat' | 'telegram' | 'whatsapp';
   config: Record<string, unknown>;
   enabled: boolean;
   createdAt: string;
@@ -98,4 +98,13 @@ export function deleteRoutingRule(id: string): Promise<{ ok: boolean }> {
   return request<{ ok: boolean }>(`/notifications/routing/${encodeURIComponent(id)}`, {
     method: 'DELETE',
   });
+}
+
+export interface ChannelHealth {
+  healthy: boolean;
+  error?: string;
+}
+
+export function getChannelHealth(id: string): Promise<ChannelHealth> {
+  return request<ChannelHealth>(`/channels/${encodeURIComponent(id)}/health`);
 }


### PR DESCRIPTION
## Summary
- **Discord adapter**: Add `/agents`, `/switch`, `/help` slash commands with per-user agent targeting. Refactor duplicated chat logic into shared `processChat()` method. Upgrade `/status` response to Discord embeds. Fix `/reset` to properly delete old session before creating a new one.
- **Token quota source tracking**: New migration adds `source` column (`manifest` | `operator`) to `token_quotas`. Manifest syncs now only overwrite manifest-set budgets, preserving operator overrides. Budget API route marks updates as `operator` source.
- **Web channels UI**: Add Telegram and WhatsApp channel type configs. Add live health indicator dot per channel. Add Discord `applicationId` config field.

## Test plan
- [x] Typecheck passes (`bun run typecheck`)
- [x] Lint passes (warnings only, pre-existing)
- [x] Web tests pass (160/160)
- [ ] Manual: verify `/agents`, `/switch`, `/help` commands in Discord
- [ ] Manual: verify operator budget override persists after container restart
- [ ] Manual: verify channel health dots appear on channels page

🤖 Generated with [Claude Code](https://claude.com/claude-code)