### PR TITLE
feat(agent-runtime): add session persistence and resume (sera-04m)

### DIFF
--- a/core/agent-runtime/src/loop.ts
+++ b/core/agent-runtime/src/loop.ts
@@ -29,6 +29,7 @@ import type { CoreMemoryBlock } from './systemPromptBuilder.js';
 import { loadBootContext } from './bootContext.js';
 import { ContextManager } from './contextManager.js';
 import { ToolLoopDetector } from './toolLoopDetector.js';
+import { SessionStore } from './session.js';
 import { log } from './logger.js';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -155,6 +156,7 @@ export class ReasoningLoop {
   /** All tools including deferred ones (for tool-search). */
   private allToolDefs: ToolDefinition[];
   private contextManager: ContextManager;
+  private sessionStore: SessionStore;
   private bootContext: string = '';
   private coreMemoryBlocks: CoreMemoryBlock[] = [];
 
@@ -175,6 +177,8 @@ export class ReasoningLoop {
     this.contextManager = new ContextManager(manifest.model.name);
 
     const workspacePath = process.env['WORKSPACE_PATH'] || '/workspace';
+    this.sessionStore = new SessionStore(workspacePath);
+    this.sessionStore.cleanup();
     this.bootContext = loadBootContext(manifest, workspacePath);
 
     // Initial system prompt — will be refreshed per task with current time/tools
@@ -352,6 +356,21 @@ export class ReasoningLoop {
       role: 'user',
       content: context ? `${context}\n\n${task}` : task,
     });
+
+    // ── Session resume ─────────────────────────────────────────────────────
+    const savedSession = this.sessionStore.load();
+    let sessionCreatedAt: string | undefined;
+    if (savedSession && savedSession.taskId === taskId) {
+      const restored = this.sessionStore.deserialize(savedSession);
+      messages.length = 0;
+      messages.push(...restored);
+      totalPromptTokens = savedSession.totalUsage.promptTokens;
+      totalCompletionTokens = savedSession.totalUsage.completionTokens;
+      sessionCreatedAt = savedSession.createdAt;
+      log('info', `Resumed session for task ${taskId} (${restored.length} messages)`);
+    } else {
+      sessionCreatedAt = new Date().toISOString();
+    }
 
     const toolNames = this.toolDefs.map((t) => t.function.name).join(', ') || 'none';
     await think(
@@ -681,6 +700,18 @@ export class ReasoningLoop {
           );
         }
 
+        // Auto-save session after each iteration (debounced)
+        const agentId = process.env['AGENT_INSTANCE_ID'] || this.manifest.metadata.name;
+        this.sessionStore.save(
+          this.sessionStore.serialize(
+            messages,
+            agentId,
+            taskId,
+            { promptTokens: totalPromptTokens, completionTokens: totalCompletionTokens },
+            sessionCreatedAt
+          )
+        );
+
         // Emit chain-of-thought reasoning if present (e.g. Qwen / DeepSeek)
         if (response.reasoning) {
           await this.centrifugo.publishThought('observe', response.reasoning, iteration);
@@ -918,6 +949,10 @@ export class ReasoningLoop {
           `ReasoningLoop complete after ${iteration} iteration(s) — ${finalReply.length} chars`
         );
 
+        // Clean up session file on successful completion
+        this.sessionStore.flush();
+        this.sessionStore.delete();
+
         return {
           taskId,
           result: finalReply,
@@ -934,6 +969,19 @@ export class ReasoningLoop {
         'reflect',
         `Reached maximum iterations (${MAX_ITERATIONS}) — stopping`,
         MAX_ITERATIONS
+      );
+
+      // Force-save session so it can be resumed
+      this.sessionStore.flush();
+      const agentIdFinal = process.env['AGENT_INSTANCE_ID'] || this.manifest.metadata.name;
+      this.sessionStore.saveSync(
+        this.sessionStore.serialize(
+          messages,
+          agentIdFinal,
+          taskId,
+          { promptTokens: totalPromptTokens, completionTokens: totalCompletionTokens },
+          sessionCreatedAt
+        )
       );
 
       return {
@@ -963,6 +1011,19 @@ export class ReasoningLoop {
       if (err instanceof BudgetExceededError) exitReason = 'budget_exceeded';
       else if (err instanceof ProviderUnavailableError) exitReason = 'provider_unavailable';
       else if (err instanceof ContextOverflowError) exitReason = 'context_overflow';
+
+      // Force-save session so it can be resumed after error
+      this.sessionStore.flush();
+      const agentIdErr = process.env['AGENT_INSTANCE_ID'] || this.manifest.metadata.name;
+      this.sessionStore.saveSync(
+        this.sessionStore.serialize(
+          messages,
+          agentIdErr,
+          taskId,
+          { promptTokens: totalPromptTokens, completionTokens: totalCompletionTokens },
+          sessionCreatedAt
+        )
+      );
 
       return {
         taskId,

--- a/core/agent-runtime/src/session.test.ts
+++ b/core/agent-runtime/src/session.test.ts
@@ -1,0 +1,346 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { SessionStore } from './session.js';
+import type { SerializedSession } from './session.js';
+import type { ChatMessage } from './llmClient.js';
+
+vi.mock('fs');
+vi.mock('./logger.js', () => ({
+  log: vi.fn(),
+}));
+
+describe('SessionStore', () => {
+  const workspacePath = '/workspace';
+  const sessionPath = path.join(workspacePath, '.sera', 'session.json');
+  let store: SessionStore;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.useFakeTimers();
+    store = new SessionStore(workspacePath);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('serialize', () => {
+    it('serializes messages into portable format', () => {
+      const messages: ChatMessage[] = [
+        { role: 'system', content: 'You are helpful.' },
+        { role: 'user', content: 'Hello' },
+        { role: 'assistant', content: 'Hi there!' },
+      ];
+
+      const session = store.serialize(messages, 'agent-1', 'task-1', {
+        promptTokens: 100,
+        completionTokens: 50,
+      });
+
+      expect(session.version).toBe(1);
+      expect(session.agentId).toBe('agent-1');
+      expect(session.taskId).toBe('task-1');
+      expect(session.messages).toHaveLength(3);
+      expect(session.totalUsage).toEqual({ promptTokens: 100, completionTokens: 50 });
+      expect(session.createdAt).toBeDefined();
+      expect(session.updatedAt).toBeDefined();
+    });
+
+    it('filters out internal messages', () => {
+      const messages: ChatMessage[] = [
+        { role: 'system', content: 'You are helpful.' },
+        { role: 'system', content: 'Internal context', internal: true },
+        { role: 'user', content: 'Hello' },
+      ];
+
+      const session = store.serialize(messages, 'agent-1', 'task-1', {
+        promptTokens: 0,
+        completionTokens: 0,
+      });
+
+      expect(session.messages).toHaveLength(2);
+      expect(session.messages[0]!.content).toBe('You are helpful.');
+      expect(session.messages[1]!.content).toBe('Hello');
+    });
+
+    it('preserves tool_calls and tool_call_id', () => {
+      const toolCalls = [
+        {
+          id: 'call_1',
+          type: 'function' as const,
+          function: { name: 'echo', arguments: '{"text":"hi"}' },
+        },
+      ];
+      const messages: ChatMessage[] = [
+        { role: 'assistant', content: 'Using tool', tool_calls: toolCalls },
+        { role: 'tool', content: 'hi', tool_call_id: 'call_1' },
+      ];
+
+      const session = store.serialize(messages, 'agent-1', 'task-1', {
+        promptTokens: 0,
+        completionTokens: 0,
+      });
+
+      expect(session.messages[0]!.tool_calls).toEqual(toolCalls);
+      expect(session.messages[1]!.tool_call_id).toBe('call_1');
+    });
+
+    it('converts array content blocks to string', () => {
+      const messages: ChatMessage[] = [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Hello ' },
+            { type: 'text', text: 'world' },
+          ],
+        },
+      ];
+
+      const session = store.serialize(messages, 'agent-1', 'task-1', {
+        promptTokens: 0,
+        completionTokens: 0,
+      });
+
+      expect(session.messages[0]!.content).toBe('Hello world');
+    });
+  });
+
+  describe('deserialize', () => {
+    it('converts SerializedSession back to ChatMessage[]', () => {
+      const session: SerializedSession = {
+        version: 1,
+        agentId: 'agent-1',
+        taskId: 'task-1',
+        messages: [
+          { role: 'system', content: 'You are helpful.' },
+          { role: 'user', content: 'Hello' },
+          {
+            role: 'assistant',
+            content: 'Hi!',
+            tool_calls: [
+              { id: 'call_1', type: 'function', function: { name: 'echo', arguments: '{}' } },
+            ],
+          },
+          { role: 'tool', content: 'result', tool_call_id: 'call_1' },
+        ],
+        totalUsage: { promptTokens: 100, completionTokens: 50 },
+        createdAt: '2025-01-01T00:00:00.000Z',
+        updatedAt: '2025-01-01T00:01:00.000Z',
+      };
+
+      const messages = store.deserialize(session);
+
+      expect(messages).toHaveLength(4);
+      expect(messages[0]!.role).toBe('system');
+      expect(messages[2]!.tool_calls).toHaveLength(1);
+      expect(messages[3]!.tool_call_id).toBe('call_1');
+    });
+  });
+
+  describe('saveSync', () => {
+    it('creates directory and writes file', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      vi.mocked(fs.mkdirSync).mockReturnValue(undefined);
+      vi.mocked(fs.writeFileSync).mockReturnValue(undefined);
+
+      const session: SerializedSession = {
+        version: 1,
+        agentId: 'agent-1',
+        taskId: 'task-1',
+        messages: [],
+        totalUsage: { promptTokens: 0, completionTokens: 0 },
+        createdAt: '2025-01-01T00:00:00.000Z',
+        updatedAt: '2025-01-01T00:00:00.000Z',
+      };
+
+      store.saveSync(session);
+
+      expect(fs.mkdirSync).toHaveBeenCalledWith(path.join(workspacePath, '.sera'), {
+        recursive: true,
+      });
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        sessionPath,
+        JSON.stringify(session, null, 2),
+        'utf-8'
+      );
+    });
+
+    it('handles write errors gracefully', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {
+        throw new Error('Permission denied');
+      });
+
+      const session: SerializedSession = {
+        version: 1,
+        agentId: 'agent-1',
+        taskId: 'task-1',
+        messages: [],
+        totalUsage: { promptTokens: 0, completionTokens: 0 },
+        createdAt: '2025-01-01T00:00:00.000Z',
+        updatedAt: '2025-01-01T00:00:00.000Z',
+      };
+
+      // Should not throw
+      expect(() => store.saveSync(session)).not.toThrow();
+    });
+  });
+
+  describe('save (debounced)', () => {
+    it('saves immediately on first call', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.writeFileSync).mockReturnValue(undefined);
+
+      const session: SerializedSession = {
+        version: 1,
+        agentId: 'agent-1',
+        taskId: 'task-1',
+        messages: [],
+        totalUsage: { promptTokens: 0, completionTokens: 0 },
+        createdAt: '2025-01-01T00:00:00.000Z',
+        updatedAt: '2025-01-01T00:00:00.000Z',
+      };
+
+      store.save(session);
+
+      expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
+    });
+
+    it('debounces rapid successive saves', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.writeFileSync).mockReturnValue(undefined);
+
+      const session: SerializedSession = {
+        version: 1,
+        agentId: 'agent-1',
+        taskId: 'task-1',
+        messages: [],
+        totalUsage: { promptTokens: 0, completionTokens: 0 },
+        createdAt: '2025-01-01T00:00:00.000Z',
+        updatedAt: '2025-01-01T00:00:00.000Z',
+      };
+
+      // First call saves immediately
+      store.save(session);
+      expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
+
+      // Second call within debounce window is deferred
+      store.save(session);
+      expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
+
+      // After debounce period, it saves
+      vi.advanceTimersByTime(5000);
+      expect(fs.writeFileSync).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('load', () => {
+    it('returns null when no session file exists', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+
+      const result = store.load();
+
+      expect(result).toBeNull();
+    });
+
+    it('loads valid session from disk', () => {
+      const session: SerializedSession = {
+        version: 1,
+        agentId: 'agent-1',
+        taskId: 'task-1',
+        messages: [{ role: 'user', content: 'Hello' }],
+        totalUsage: { promptTokens: 100, completionTokens: 50 },
+        createdAt: '2025-01-01T00:00:00.000Z',
+        updatedAt: '2025-01-01T00:01:00.000Z',
+      };
+
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(session));
+
+      const result = store.load();
+
+      expect(result).toEqual(session);
+    });
+
+    it('returns null for wrong version', () => {
+      const session = {
+        version: 99,
+        agentId: 'agent-1',
+        taskId: 'task-1',
+        messages: [],
+        totalUsage: { promptTokens: 0, completionTokens: 0 },
+        createdAt: '2025-01-01T00:00:00.000Z',
+        updatedAt: '2025-01-01T00:00:00.000Z',
+      };
+
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(session));
+
+      const result = store.load();
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null for invalid JSON', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue('not json');
+
+      const result = store.load();
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('delete', () => {
+    it('deletes existing session file', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.unlinkSync).mockReturnValue(undefined);
+
+      store.delete();
+
+      expect(fs.unlinkSync).toHaveBeenCalledWith(sessionPath);
+    });
+
+    it('does nothing when no session file exists', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+
+      store.delete();
+
+      expect(fs.unlinkSync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('cleanup', () => {
+    it('removes sessions older than 24 hours', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.statSync).mockReturnValue({
+        mtimeMs: Date.now() - 25 * 60 * 60 * 1000, // 25 hours ago
+      } as fs.Stats);
+      vi.mocked(fs.unlinkSync).mockReturnValue(undefined);
+
+      store.cleanup();
+
+      expect(fs.unlinkSync).toHaveBeenCalledWith(sessionPath);
+    });
+
+    it('keeps sessions younger than 24 hours', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.statSync).mockReturnValue({
+        mtimeMs: Date.now() - 12 * 60 * 60 * 1000, // 12 hours ago
+      } as fs.Stats);
+
+      store.cleanup();
+
+      expect(fs.unlinkSync).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when no session file exists', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+
+      store.cleanup();
+
+      expect(fs.statSync).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/core/agent-runtime/src/session.ts
+++ b/core/agent-runtime/src/session.ts
@@ -1,0 +1,236 @@
+/**
+ * SessionStore — serialize, save, load, and clean up agent reasoning sessions.
+ *
+ * Persists session state to the agent workspace bind mount so that
+ * conversations survive container restarts.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import type { ChatMessage, ToolCall } from './llmClient.js';
+import { log } from './logger.js';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface SerializedMessage {
+  role: 'user' | 'assistant' | 'system' | 'tool';
+  content: string;
+  tool_calls?: ToolCall[];
+  tool_call_id?: string;
+  usage?: {
+    promptTokens: number;
+    completionTokens: number;
+  };
+}
+
+export interface SerializedSession {
+  version: number;
+  agentId: string;
+  taskId: string;
+  messages: SerializedMessage[];
+  totalUsage: { promptTokens: number; completionTokens: number };
+  createdAt: string;
+  updatedAt: string;
+}
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+const SESSION_VERSION = 1;
+const SERA_DIR = '.sera';
+const SESSION_FILE = 'session.json';
+const DEBOUNCE_MS = 5_000;
+const STALE_SESSION_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+// ── SessionStore ─────────────────────────────────────────────────────────────
+
+export class SessionStore {
+  private sessionPath: string;
+  private debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  private lastSaveTime = 0;
+
+  constructor(workspacePath: string) {
+    const seraDir = path.join(workspacePath, SERA_DIR);
+    this.sessionPath = path.join(seraDir, SESSION_FILE);
+  }
+
+  /**
+   * Serialize ChatMessage[] into a portable format.
+   * Strips internal-only fields and normalizes content to string.
+   */
+  serialize(
+    messages: ChatMessage[],
+    agentId: string,
+    taskId: string,
+    usage: { promptTokens: number; completionTokens: number },
+    createdAt?: string
+  ): SerializedSession {
+    const serializedMessages: SerializedMessage[] = messages
+      .filter((m) => !m.internal)
+      .map((m) => {
+        const sm: SerializedMessage = {
+          role: m.role,
+          content:
+            typeof m.content === 'string'
+              ? m.content
+              : m.content
+                  .map((block) =>
+                    block.type === 'text' && block.text !== undefined ? block.text : ''
+                  )
+                  .join(''),
+        };
+        if (m.tool_calls && m.tool_calls.length > 0) {
+          sm.tool_calls = m.tool_calls;
+        }
+        if (m.tool_call_id) {
+          sm.tool_call_id = m.tool_call_id;
+        }
+        return sm;
+      });
+
+    return {
+      version: SESSION_VERSION,
+      agentId,
+      taskId,
+      messages: serializedMessages,
+      totalUsage: usage,
+      createdAt: createdAt ?? new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+  }
+
+  /**
+   * Deserialize a SerializedSession back into ChatMessage[].
+   */
+  deserialize(session: SerializedSession): ChatMessage[] {
+    return session.messages.map((sm) => {
+      const msg: ChatMessage = {
+        role: sm.role,
+        content: sm.content,
+      };
+      if (sm.tool_calls && sm.tool_calls.length > 0) {
+        msg.tool_calls = sm.tool_calls;
+      }
+      if (sm.tool_call_id) {
+        msg.tool_call_id = sm.tool_call_id;
+      }
+      return msg;
+    });
+  }
+
+  /**
+   * Save session to disk immediately.
+   */
+  saveSync(session: SerializedSession): void {
+    try {
+      const dir = path.dirname(this.sessionPath);
+      if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir, { recursive: true });
+      }
+      const data = JSON.stringify(session, null, 2);
+      fs.writeFileSync(this.sessionPath, data, 'utf-8');
+      this.lastSaveTime = Date.now();
+      log('debug', `Session saved to ${this.sessionPath}`);
+    } catch (err) {
+      log('warn', `Failed to save session: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  /**
+   * Debounced save — writes at most once per DEBOUNCE_MS.
+   */
+  save(session: SerializedSession): void {
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+    }
+
+    const elapsed = Date.now() - this.lastSaveTime;
+    if (elapsed >= DEBOUNCE_MS) {
+      // Enough time has passed, save immediately
+      this.saveSync(session);
+      return;
+    }
+
+    // Schedule save after remaining debounce time
+    this.debounceTimer = setTimeout(() => {
+      this.debounceTimer = null;
+      this.saveSync(session);
+    }, DEBOUNCE_MS - elapsed);
+  }
+
+  /**
+   * Flush any pending debounced save immediately.
+   */
+  flush(): void {
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = null;
+    }
+  }
+
+  /**
+   * Load a saved session from disk. Returns null if no session file exists
+   * or if the file is invalid.
+   */
+  load(): SerializedSession | null {
+    try {
+      if (!fs.existsSync(this.sessionPath)) {
+        return null;
+      }
+
+      const data = fs.readFileSync(this.sessionPath, 'utf-8');
+      const session = JSON.parse(data) as SerializedSession;
+
+      if (session.version !== SESSION_VERSION) {
+        log(
+          'warn',
+          `Session version mismatch: expected ${SESSION_VERSION}, got ${session.version}`
+        );
+        return null;
+      }
+
+      log('info', `Session loaded from ${this.sessionPath} (${session.messages.length} messages)`);
+      return session;
+    } catch (err) {
+      log('warn', `Failed to load session: ${err instanceof Error ? err.message : String(err)}`);
+      return null;
+    }
+  }
+
+  /**
+   * Delete session file on successful task completion.
+   */
+  delete(): void {
+    try {
+      if (fs.existsSync(this.sessionPath)) {
+        fs.unlinkSync(this.sessionPath);
+        log('info', `Session file deleted: ${this.sessionPath}`);
+      }
+    } catch (err) {
+      log('warn', `Failed to delete session: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  /**
+   * Clean up stale sessions (>24h old) on startup.
+   */
+  cleanup(): void {
+    try {
+      if (!fs.existsSync(this.sessionPath)) {
+        return;
+      }
+
+      const stat = fs.statSync(this.sessionPath);
+      const age = Date.now() - stat.mtimeMs;
+
+      if (age > STALE_SESSION_MS) {
+        fs.unlinkSync(this.sessionPath);
+        log('info', `Cleaned up stale session (${Math.round(age / 3600000)}h old)`);
+      }
+    } catch (err) {
+      log(
+        'warn',
+        `Failed to clean up session: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `SessionStore` class for serializing/deserializing agent conversation state to `/workspace/.sera/session.json`
- Auto-saves after each reasoning iteration (debounced, max once per 5s)
- Resumes from saved session on container restart if taskId matches
- Cleans up stale sessions (>24h) on startup, deletes session file on successful completion
- 18 unit tests covering serialize, deserialize, save, load, delete, and cleanup

## Files
- `core/agent-runtime/src/session.ts` — SessionStore with serialize/deserialize/save/load/delete/cleanup
- `core/agent-runtime/src/loop.ts` — Integration into ReasoningLoop (resume, auto-save, cleanup)
- `core/agent-runtime/src/session.test.ts` — 18 tests

## Test plan
- [x] `npx vitest run src/session.test.ts` — 18 passed
- [x] `npx tsc --noEmit` — clean
- [x] Pre-commit hooks pass (typecheck, lint, web tests)
- [ ] Manual: restart container mid-conversation, verify resume

Closes #546

🤖 Generated with [Claude Code](https://claude.com/claude-code)