### PR TITLE
Implement persistence and enforcement for circle-scoped secrets

### DIFF
--- a/core/src/agents/Orchestrator.ts
+++ b/core/src/agents/Orchestrator.ts
@@ -416,6 +416,7 @@ export class Orchestrator {
                 const secretValue = await SecretsManager.getInstance().get(secretName, {
                   agentId: instance.id,
                   agentName: instance.name,
+                  agentCircle: resolvedCircleId as string | undefined,
                 });
                 if (secretValue !== null) {
                   // Fetch exposure metadata to determine injection mode

--- a/core/src/db/migrations/20260406180000_secrets-allowed-circles.cjs
+++ b/core/src/db/migrations/20260406180000_secrets-allowed-circles.cjs
@@ -1,0 +1,21 @@
+/**
+ * Migration: Add allowed_circles to secrets
+ *
+ * Stores a list of circle IDs that are permitted to access a secret.
+ */
+
+/** @param {import('node-pg-migrate').MigrationBuilder} pgm */
+exports.up = (pgm) => {
+  pgm.addColumn('secrets', {
+    allowed_circles: {
+      type: 'text[]',
+      notNull: true,
+      default: pgm.func("'{}'"),
+    },
+  });
+};
+
+/** @param {import('node-pg-migrate').MigrationBuilder} pgm */
+exports.down = (pgm) => {
+  pgm.dropColumn('secrets', 'allowed_circles');
+};

--- a/core/src/secrets/interfaces.ts
+++ b/core/src/secrets/interfaces.ts
@@ -1,6 +1,7 @@
 export interface SecretAccessContext {
   agentId?: string;
   agentName?: string;
+  agentCircle?: string;
   operator?: {
     sub: string;
     roles: string[];

--- a/core/src/secrets/interfaces.ts
+++ b/core/src/secrets/interfaces.ts
@@ -1,11 +1,13 @@
 export interface SecretAccessContext {
-  agentId?: string;
-  agentName?: string;
-  agentCircle?: string;
-  operator?: {
-    sub: string;
-    roles: string[];
-  };
+  agentId?: string | undefined;
+  agentName?: string | undefined;
+  agentCircle?: string | undefined;
+  operator?:
+    | {
+        sub: string;
+        roles: string[];
+      }
+    | undefined;
 }
 
 export interface SecretMetadata {

--- a/core/src/secrets/postgres-secrets-provider.test.ts
+++ b/core/src/secrets/postgres-secrets-provider.test.ts
@@ -128,6 +128,61 @@ describe('PostgresSecretsProvider', () => {
       expect(value).toBeNull();
     });
 
+    it('should allow access if circle is allowed', async () => {
+      const provider = new PostgresSecretsProvider();
+      const secretName = 'circle-secret';
+      const secretValue = 'circle-data';
+      const agentContext = {
+        agentId: 'agent-1',
+        agentName: 'some-agent',
+        agentCircle: 'circle-1',
+      };
+
+      const { encryptedValue, iv } = (
+        provider as unknown as { encrypt: (v: string) => { encryptedValue: Buffer; iv: Buffer } }
+      ).encrypt(secretValue);
+
+      vi.mocked(db.query).mockResolvedValue({
+        rowCount: 1,
+        rows: [
+          {
+            encrypted_value: encryptedValue,
+            iv: iv,
+            allowed_agents: [],
+            allowed_circles: ['circle-1'],
+          },
+        ],
+      } as unknown as import('pg').QueryResult<Record<string, unknown>>);
+
+      const value = await provider.get(secretName, agentContext);
+      expect(value).toBe(secretValue);
+    });
+
+    it('should deny access if agent and circle are not allowed', async () => {
+      const provider = new PostgresSecretsProvider();
+      const secretName = 'restricted-secret';
+      const agentContext = {
+        agentId: 'agent-1',
+        agentName: 'some-agent',
+        agentCircle: 'circle-2',
+      };
+
+      vi.mocked(db.query).mockResolvedValue({
+        rowCount: 1,
+        rows: [
+          {
+            encrypted_value: Buffer.from('...'),
+            iv: Buffer.alloc(12),
+            allowed_agents: ['authorized-agent'],
+            allowed_circles: ['circle-1'],
+          },
+        ],
+      } as unknown as import('pg').QueryResult<Record<string, unknown>>);
+
+      const value = await provider.get(secretName, agentContext);
+      expect(value).toBeNull();
+    });
+
     it('should allow access if "*" is in allowed_agents', async () => {
       const provider = new PostgresSecretsProvider();
 

--- a/core/src/secrets/postgres-secrets-provider.ts
+++ b/core/src/secrets/postgres-secrets-provider.ts
@@ -60,7 +60,7 @@ export class PostgresSecretsProvider implements SecretsProvider {
 
   async get(name: string, context: SecretAccessContext): Promise<string | null> {
     const result = await query(
-      'SELECT encrypted_value, iv, allowed_agents FROM secrets WHERE name = $1 AND deleted_at IS NULL',
+      'SELECT encrypted_value, iv, allowed_agents, allowed_circles FROM secrets WHERE name = $1 AND deleted_at IS NULL',
       [name]
     );
 
@@ -68,13 +68,18 @@ export class PostgresSecretsProvider implements SecretsProvider {
       return null;
     }
 
-    const { encrypted_value, iv, allowed_agents } = result.rows[0];
+    const { encrypted_value, iv, allowed_agents, allowed_circles } = result.rows[0];
 
-    // Access control: operator has full access, agent must be in allowed_agents
+    // Access control: operator has full access, agent must be in allowed_agents or its circle in allowed_circles
     if (!context.operator) {
-      if (!allowed_agents.includes(context.agentName) && !allowed_agents.includes('*')) {
+      const isAgentAllowed =
+        allowed_agents.includes(context.agentName) || allowed_agents.includes('*');
+      const isCircleAllowed =
+        context.agentCircle && (allowed_circles ?? []).includes(context.agentCircle);
+
+      if (!isAgentAllowed && !isCircleAllowed) {
         logger.warn(
-          `Access denied to secret "${redactSecretName(name)}" for agent "${context.agentName}"`
+          `Access denied to secret "${redactSecretName(name)}" for agent "${context.agentName}" (circle: ${context.agentCircle})`
         );
         return null;
       }
@@ -93,13 +98,14 @@ export class PostgresSecretsProvider implements SecretsProvider {
 
     await query(
       `INSERT INTO secrets (
-        name, encrypted_value, iv, description, allowed_agents, tags, exposure, updated_at
-      ) VALUES ($1, $2, $3, $4, $5, $6, $7, NOW())
+        name, encrypted_value, iv, description, allowed_agents, allowed_circles, tags, exposure, updated_at
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW())
       ON CONFLICT (name) DO UPDATE SET
         encrypted_value = EXCLUDED.encrypted_value,
         iv = EXCLUDED.iv,
         description = COALESCE(EXCLUDED.description, secrets.description),
         allowed_agents = COALESCE(EXCLUDED.allowed_agents, secrets.allowed_agents),
+        allowed_circles = COALESCE(EXCLUDED.allowed_circles, secrets.allowed_circles),
         tags = COALESCE(EXCLUDED.tags, secrets.tags),
         exposure = COALESCE(EXCLUDED.exposure, secrets.exposure),
         updated_at = NOW()`,
@@ -109,6 +115,7 @@ export class PostgresSecretsProvider implements SecretsProvider {
         iv,
         metadata?.description ?? null,
         metadata?.allowedAgents ?? [],
+        metadata?.allowedCircles ?? [],
         metadata?.tags ?? [],
         metadata?.exposure ?? 'per-call',
       ]


### PR DESCRIPTION
This PR fixes a bug where `allowedCircles` for secrets were accepted by the API but silently ignored by the storage and enforcement layers.

Key changes:
- Database migration to add `allowed_circles` (text[]) to the `secrets` table.
- `PostgresSecretsProvider` updated to handle the new column for both storage (INSERT/UPDATE) and retrieval (SELECT + enforcement logic).
- `SecretAccessContext` interface augmented with `agentCircle` to carry circle membership information.
- `Orchestrator` modified to pass the agent's `resolvedCircleId` as `agentCircle` during secret retrieval.
- Comprehensive unit tests added to `postgres-secrets-provider.test.ts` to verify access is correctly granted/denied based on circle membership.

Fixes #793

---
*PR created automatically by Jules for task [9098480181387259544](https://jules.google.com/task/9098480181387259544) started by @TKCen*