### PR TITLE
Enhance LLM provider baseUrl validation for SSRF protection

### DIFF
--- a/core/src/lib/llm/LlmRouterProvider.ts
+++ b/core/src/lib/llm/LlmRouterProvider.ts
@@ -28,7 +28,7 @@ export class LlmRouterProvider implements LLMProvider {
       ...(tools && tools.length > 0 ? { tools } : {}),
     };
 
-    const eventStream = this.router.getEventStream(request);
+    const eventStream = await this.router.getEventStream(request);
     const msg = await eventStream.result();
 
     let textContent = '';
@@ -87,7 +87,7 @@ export class LlmRouterProvider implements LLMProvider {
       ...(this.temperature !== undefined ? { temperature: this.temperature } : {}),
     };
 
-    const eventStream = this.router.getEventStream(request);
+    const eventStream = await this.router.getEventStream(request);
 
     for await (const event of eventStream) {
       if (event.type === 'text_delta') {

--- a/core/src/llm/DynamicProviderManager.test.ts
+++ b/core/src/llm/DynamicProviderManager.test.ts
@@ -95,9 +95,9 @@ describe('DynamicProviderManager', () => {
       vi.mocked(fs.existsSync).mockReturnValue(false);
       const manager = new DynamicProviderManager(mockRegistry, configPath);
 
-      const result = await manager.testConnection('http://test-url', 'test-key');
+      const result = await manager.testConnection('http://localhost:11434', 'test-key');
 
-      expect(global.fetch).toHaveBeenCalledWith('http://test-url/models', {
+      expect(global.fetch).toHaveBeenCalledWith('http://localhost:11434/models', {
         headers: { Authorization: 'Bearer test-key' },
       });
       expect(result.success).toBe(true);
@@ -114,9 +114,9 @@ describe('DynamicProviderManager', () => {
       vi.mocked(fs.existsSync).mockReturnValue(false);
       const manager = new DynamicProviderManager(mockRegistry, configPath);
 
-      await manager.testConnection('http://test-url/', 'test-key');
+      await manager.testConnection('http://localhost:11434/', 'test-key');
 
-      expect(global.fetch).toHaveBeenCalledWith('http://test-url/models', {
+      expect(global.fetch).toHaveBeenCalledWith('http://localhost:11434/models', {
         headers: { Authorization: 'Bearer test-key' },
       });
     });
@@ -131,7 +131,7 @@ describe('DynamicProviderManager', () => {
       vi.mocked(fs.existsSync).mockReturnValue(false);
       const manager = new DynamicProviderManager(mockRegistry, configPath);
 
-      const result = await manager.testConnection('http://test-url');
+      const result = await manager.testConnection('http://localhost:11434');
 
       expect(result.success).toBe(false);
       expect(result.models).toEqual([]);
@@ -144,7 +144,7 @@ describe('DynamicProviderManager', () => {
       vi.mocked(fs.existsSync).mockReturnValue(false);
       const manager = new DynamicProviderManager(mockRegistry, configPath);
 
-      const result = await manager.testConnection('http://test-url');
+      const result = await manager.testConnection('http://localhost:11434');
 
       expect(result.success).toBe(false);
       expect(result.error).toBe('Network error');
@@ -164,7 +164,7 @@ describe('DynamicProviderManager', () => {
         id: 'new-id',
         name: 'New',
         type: 'lm-studio',
-        baseUrl: 'http://new',
+        baseUrl: 'http://localhost:11434',
         enabled: true,
         intervalMs: 5000,
       };
@@ -199,7 +199,7 @@ describe('DynamicProviderManager', () => {
         id: 'new-id',
         name: 'New',
         type: 'lm-studio',
-        baseUrl: 'http://new',
+        baseUrl: 'http://localhost:11434',
         enabled: false,
         intervalMs: 5000,
       };
@@ -224,7 +224,7 @@ describe('DynamicProviderManager', () => {
             id: 't1',
             name: 'T1',
             type: 'lm-studio',
-            baseUrl: 'http://t1',
+            baseUrl: 'http://localhost:11434',
             enabled: true,
             intervalMs: 1000,
           },
@@ -232,7 +232,7 @@ describe('DynamicProviderManager', () => {
             id: 't2',
             name: 'T2',
             type: 'lm-studio',
-            baseUrl: 'http://t2',
+            baseUrl: 'http://localhost:11435',
             enabled: false,
             intervalMs: 1000,
           },
@@ -250,7 +250,7 @@ describe('DynamicProviderManager', () => {
 
       // Should check only t1 immediately
       expect(testConnectionSpy).toHaveBeenCalledTimes(1);
-      expect(testConnectionSpy).toHaveBeenCalledWith('http://t1', undefined);
+      expect(testConnectionSpy).toHaveBeenCalledWith('http://localhost:11434', undefined);
 
       testConnectionSpy.mockClear();
 
@@ -271,7 +271,7 @@ describe('DynamicProviderManager', () => {
         id: 't1',
         name: 'T1',
         type: 'lm-studio',
-        baseUrl: 'http://t1',
+        baseUrl: 'http://localhost:11434',
         enabled: true,
         intervalMs: 1000,
       });
@@ -299,7 +299,7 @@ describe('DynamicProviderManager', () => {
         id: 't1',
         name: 'T1',
         type: 'lm-studio',
-        baseUrl: 'http://t1',
+        baseUrl: 'http://localhost:11434',
         enabled: true,
         intervalMs: 1000,
       });
@@ -337,7 +337,7 @@ describe('DynamicProviderManager', () => {
         id: 't2',
         name: 'T2',
         type: 'lm-studio',
-        baseUrl: 'http://t2',
+        baseUrl: 'http://localhost:11434',
         enabled: true,
         intervalMs: 1000,
       });

--- a/core/src/llm/DynamicProviderManager.ts
+++ b/core/src/llm/DynamicProviderManager.ts
@@ -6,6 +6,7 @@ import type {
   ProviderConfig,
   ProviderRegistry,
 } from './ProviderRegistry.js';
+import { validateProviderBaseUrlAsync } from './url-validation.js';
 
 const logger = new Logger('DynamicProviderManager');
 
@@ -133,6 +134,12 @@ export class DynamicProviderManager {
     apiKey?: string
   ): Promise<{ success: boolean; models: string[]; error?: string }> {
     try {
+      // SSRF protection
+      const check = await validateProviderBaseUrlAsync(baseUrl, 'lmstudio');
+      if (!check.valid) {
+        throw new Error(`Connection rejected: ${check.reason}`);
+      }
+
       // LM Studio / OpenAI compatible /v1/models
       const url = baseUrl.endsWith('/') ? `${baseUrl}models` : `${baseUrl}/models`;
       const headers: Record<string, string> = {};
@@ -201,6 +208,12 @@ export class DynamicProviderManager {
   // ── Public API ─────────────────────────────────────────────────────────────
 
   async addProvider(config: DynamicProviderConfig): Promise<void> {
+    // SSRF protection
+    const check = await validateProviderBaseUrlAsync(config.baseUrl, 'lmstudio');
+    if (!check.valid) {
+      throw new Error(`Dynamic provider baseUrl rejected: ${check.reason}`);
+    }
+
     this.providers.set(config.id, config);
     await this.save();
     if (config.enabled) {

--- a/core/src/llm/LlmRouter.ts
+++ b/core/src/llm/LlmRouter.ts
@@ -43,7 +43,7 @@ import type { AssistantMessageEventStream } from '@mariozechner/pi-ai';
 import { Logger } from '../lib/logger.js';
 import type { ProviderConfig, ProviderRegistry } from './ProviderRegistry.js';
 import type { ChatMessage } from '../agents/types.js';
-import { validateProviderBaseUrl } from './url-validation.js';
+import { validateProviderBaseUrlAsync } from './url-validation.js';
 
 const logger = new Logger('LlmRouter');
 
@@ -552,14 +552,14 @@ export class LlmRouter {
   }
 
   /** Dispatch to the appropriate pi-mono provider function. */
-  private dispatch(
+  private async dispatch(
     config: ProviderConfig,
     context: Context,
     extraOptions?: StreamOptions
-  ): AssistantMessageEventStream {
+  ): Promise<AssistantMessageEventStream> {
     // SSRF protection: validate baseUrl before sending any API-key-bearing request.
     if (config.baseUrl) {
-      const check = validateProviderBaseUrl(config.baseUrl, config.provider);
+      const check = await validateProviderBaseUrlAsync(config.baseUrl, config.provider);
       if (!check.valid) {
         throw new Error(`Provider baseUrl rejected: ${check.reason}`);
       }
@@ -617,7 +617,7 @@ export class LlmRouter {
             : {}),
         };
 
-        const eventStream = this.dispatch(modelConfig, context, opts);
+        const eventStream = await this.dispatch(modelConfig, context, opts);
         const msg = await eventStream.result();
 
         const latencyMs = Date.now() - latencyStart;
@@ -684,7 +684,7 @@ export class LlmRouter {
             : {}),
         };
 
-        const eventStream = this.dispatch(modelConfig, context, opts);
+        const eventStream = await this.dispatch(modelConfig, context, opts);
         if (modelName !== request.model) {
           logger.warn(`Failover: ${request.model} → ${modelName} | agent=${agentId}`);
         }
@@ -744,7 +744,7 @@ export class LlmRouter {
 
   /** Register a new provider and persist to config file. */
   async addModel(config: ProviderConfig): Promise<{ modelName: string; api: string }> {
-    this.registry.register(config);
+    await this.registry.register(config);
     await this.registry.save();
     logger.info(`Provider registered | model=${config.modelName} api=${config.api}`);
     return { modelName: config.modelName, api: config.api };
@@ -764,7 +764,7 @@ export class LlmRouter {
    * Return the raw pi-mono AssistantMessageEventStream for a request.
    * Used by LlmRouterProvider to implement the LLMProvider interface.
    */
-  getEventStream(request: ChatCompletionRequest): AssistantMessageEventStream {
+  async getEventStream(request: ChatCompletionRequest): Promise<AssistantMessageEventStream> {
     const cfg = this.registry.resolve(request.model);
     const context = toContext(request);
     const opts: StreamOptions = {
@@ -781,7 +781,7 @@ export class LlmRouter {
       const context: Context = {
         messages: [{ role: 'user', content: 'ping', timestamp: Date.now() } as UserMessage],
       };
-      const eventStream = this.dispatch(config, context, { maxTokens: 1 });
+      const eventStream = await this.dispatch(config, context, { maxTokens: 1 });
       await eventStream.result();
       return { ok: true, latencyMs: Date.now() - start };
     } catch (err: unknown) {

--- a/core/src/llm/ProviderHealthService.ts
+++ b/core/src/llm/ProviderHealthService.ts
@@ -12,6 +12,7 @@
 
 import type { ProviderConfig } from './ProviderRegistry.js';
 import { Logger } from '../lib/logger.js';
+import { validateProviderBaseUrlAsync } from './url-validation.js';
 
 const logger = new Logger('ProviderHealth');
 
@@ -53,6 +54,13 @@ export class ProviderHealthService {
    */
   async discoverModels(config: ProviderConfig): Promise<string[]> {
     try {
+      if (config.baseUrl) {
+        const check = await validateProviderBaseUrlAsync(config.baseUrl, config.provider);
+        if (!check.valid) {
+          throw new Error(`Model discovery rejected: ${check.reason}`);
+        }
+      }
+
       // Google AI Studio native models API
       if (config.provider === 'google') {
         return await this.discoverGoogleModels(config);
@@ -82,6 +90,17 @@ export class ProviderHealthService {
     const start = Date.now();
 
     try {
+      if (config.baseUrl) {
+        const check = await validateProviderBaseUrlAsync(config.baseUrl, config.provider);
+        if (!check.valid) {
+          return {
+            reachable: false,
+            latencyMs: Date.now() - start,
+            error: `Health probe rejected: ${check.reason}`,
+          };
+        }
+      }
+
       if (config.provider === 'google') {
         const models = await this.discoverGoogleModels(config);
         return {

--- a/core/src/llm/ProviderRegistry.test.ts
+++ b/core/src/llm/ProviderRegistry.test.ts
@@ -74,7 +74,7 @@ describe('ProviderRegistry', () => {
     it('should register default from env if not in config', () => {
       vi.mocked(fs.existsSync).mockReturnValue(false);
 
-      process.env.LLM_BASE_URL = 'http://test-url';
+      process.env.LLM_BASE_URL = 'https://api.openai.com';
       process.env.LLM_MODEL = 'env-model';
       process.env.LLM_API_KEY = 'env-key';
 
@@ -82,7 +82,7 @@ describe('ProviderRegistry', () => {
 
       const config = registry.resolve('env-model');
       expect(config.modelName).toBe('env-model');
-      expect(config.baseUrl).toBe('http://test-url');
+      expect(config.baseUrl).toBe('https://api.openai.com');
       expect(config.apiKey).toBe('env-key');
     });
 
@@ -93,20 +93,20 @@ describe('ProviderRegistry', () => {
             modelName: 'env-model',
             api: 'openai-completions',
             provider: 'openai',
-            baseUrl: 'http://existing',
+            baseUrl: 'https://api.openai.com',
           },
         ],
       };
       vi.mocked(fs.existsSync).mockReturnValue(true);
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(mockData));
 
-      process.env.LLM_BASE_URL = 'http://test-url';
+      process.env.LLM_BASE_URL = 'https://api.anthropic.com';
       process.env.LLM_MODEL = 'env-model';
 
       const registry = new ProviderRegistry('/mock/path.json');
 
       const config = registry.resolve('env-model');
-      expect(config.baseUrl).toBe('http://existing'); // Kept existing
+      expect(config.baseUrl).toBe('https://api.openai.com'); // Kept existing
     });
 
     it('should do nothing if env vars missing', () => {
@@ -262,11 +262,11 @@ describe('ProviderRegistry', () => {
   });
 
   describe('register / unregister', () => {
-    it('should register and unregister successfully', () => {
+    it('should register and unregister successfully', async () => {
       vi.mocked(fs.existsSync).mockReturnValue(false);
       const registry = new ProviderRegistry('/mock/path.json');
 
-      registry.register({ modelName: 'new-model', api: 'openai-completions' });
+      await registry.register({ modelName: 'new-model', api: 'openai-completions' });
       expect(registry.list()).toHaveLength(1);
 
       const removed = registry.unregister('new-model');
@@ -328,7 +328,7 @@ describe('ProviderRegistry', () => {
       vi.mocked(fs.existsSync).mockReturnValue(false);
       const registry = new ProviderRegistry('/mock/path.json');
 
-      registry.register({ modelName: 'save-model', api: 'openai-completions' });
+      await registry.register({ modelName: 'save-model', api: 'openai-completions' });
 
       await registry.save();
 

--- a/core/src/llm/ProviderRegistry.ts
+++ b/core/src/llm/ProviderRegistry.ts
@@ -20,7 +20,7 @@
 
 import fs from 'fs';
 import { Logger } from '../lib/logger.js';
-import { validateProviderBaseUrl } from './url-validation.js';
+import { validateProviderBaseUrl, validateProviderBaseUrlAsync } from './url-validation.js';
 
 const logger = new Logger('ProviderRegistry');
 
@@ -154,6 +154,14 @@ export class ProviderRegistry {
       const raw = fs.readFileSync(this.configPath, 'utf-8');
       const data = JSON.parse(raw) as ConfigFile;
       for (const cfg of data.providers ?? []) {
+        // SSRF protection (sync only during loadSync)
+        if (cfg.baseUrl) {
+          const check = validateProviderBaseUrl(cfg.baseUrl, cfg.provider);
+          if (!check.valid) {
+            logger.error(`Skipping insecure provider config for ${cfg.modelName}: ${check.reason}`);
+            continue;
+          }
+        }
         this.configs.set(cfg.modelName, cfg);
       }
       logger.info(`Loaded ${this.configs.size} provider(s) from ${this.configPath}`);
@@ -174,6 +182,13 @@ export class ProviderRegistry {
     const modelName = process.env.LLM_MODEL ?? 'default';
 
     if (baseUrl && !this.configs.has(modelName)) {
+      // SSRF protection
+      const check = validateProviderBaseUrl(baseUrl, 'default');
+      if (!check.valid) {
+        logger.error(`Rejected insecure LLM_BASE_URL bootstrap: ${check.reason}`);
+        return;
+      }
+
       const cfg: ProviderConfig = {
         modelName,
         api: 'openai-completions',
@@ -297,9 +312,9 @@ export class ProviderRegistry {
     );
   }
 
-  register(config: ProviderConfig): void {
+  async register(config: ProviderConfig): Promise<void> {
     if (config.baseUrl) {
-      const check = validateProviderBaseUrl(config.baseUrl, config.provider);
+      const check = await validateProviderBaseUrlAsync(config.baseUrl, config.provider);
       if (!check.valid) {
         throw new Error(`Provider baseUrl rejected: ${check.reason}`);
       }

--- a/core/src/llm/url-validation.test.ts
+++ b/core/src/llm/url-validation.test.ts
@@ -44,7 +44,9 @@ describe('url-validation', () => {
     it('rejects localhost for non-local providers', () => {
       expect(validateProviderBaseUrl('https://localhost', 'openai')).toMatchObject({
         valid: false,
-        reason: expect.stringContaining('Localhost endpoints are only permitted for local providers'),
+        reason: expect.stringContaining(
+          'Localhost endpoints are only permitted for local providers'
+        ),
       });
     });
 
@@ -57,7 +59,9 @@ describe('url-validation', () => {
 
     it('accepts official origins for cloud providers', () => {
       expect(validateProviderBaseUrl('https://api.openai.com', 'openai')).toEqual({ valid: true });
-      expect(validateProviderBaseUrl('https://api.anthropic.com', 'anthropic')).toEqual({ valid: true });
+      expect(validateProviderBaseUrl('https://api.anthropic.com', 'anthropic')).toEqual({
+        valid: true,
+      });
     });
 
     it('respects SERA_PROVIDER_URL_ALLOWLIST', () => {

--- a/core/src/llm/url-validation.test.ts
+++ b/core/src/llm/url-validation.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { validateProviderBaseUrl, validateProviderBaseUrlAsync } from './url-validation.js';
+import dns from 'node:dns/promises';
+
+vi.mock('node:dns/promises', () => ({
+  default: {
+    lookup: vi.fn(),
+  },
+}));
+
+describe('url-validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.SERA_PROVIDER_URL_ALLOWLIST;
+  });
+
+  describe('validateProviderBaseUrl (sync)', () => {
+    it('accepts empty url', () => {
+      expect(validateProviderBaseUrl('')).toEqual({ valid: true });
+    });
+
+    it('rejects invalid url', () => {
+      expect(validateProviderBaseUrl('not-a-url')).toMatchObject({ valid: false });
+    });
+
+    it('rejects non-http/https', () => {
+      expect(validateProviderBaseUrl('ftp://example.com')).toMatchObject({
+        valid: false,
+        reason: expect.stringContaining('must use HTTP or HTTPS'),
+      });
+    });
+
+    it('rejects http for non-local providers', () => {
+      expect(validateProviderBaseUrl('http://example.com')).toMatchObject({
+        valid: false,
+        reason: expect.stringContaining('must use HTTPS for non-local endpoints'),
+      });
+    });
+
+    it('accepts http for localhost (local provider)', () => {
+      expect(validateProviderBaseUrl('http://localhost', 'lmstudio')).toEqual({ valid: true });
+    });
+
+    it('rejects localhost for non-local providers', () => {
+      expect(validateProviderBaseUrl('https://localhost', 'openai')).toMatchObject({
+        valid: false,
+        reason: expect.stringContaining('Localhost endpoints are only permitted for local providers'),
+      });
+    });
+
+    it('rejects unofficial origins for cloud providers', () => {
+      expect(validateProviderBaseUrl('https://attacker.com', 'openai')).toMatchObject({
+        valid: false,
+        reason: expect.stringContaining('restricted to official origins'),
+      });
+    });
+
+    it('accepts official origins for cloud providers', () => {
+      expect(validateProviderBaseUrl('https://api.openai.com', 'openai')).toEqual({ valid: true });
+      expect(validateProviderBaseUrl('https://api.anthropic.com', 'anthropic')).toEqual({ valid: true });
+    });
+
+    it('respects SERA_PROVIDER_URL_ALLOWLIST', () => {
+      process.env.SERA_PROVIDER_URL_ALLOWLIST = 'my-internal-proxy.com,attacker.com';
+      expect(validateProviderBaseUrl('https://attacker.com', 'openai')).toEqual({ valid: true });
+      expect(validateProviderBaseUrl('http://my-internal-proxy.com')).toEqual({ valid: true });
+    });
+
+    it('rejects private IP literals', () => {
+      expect(validateProviderBaseUrl('https://192.168.1.1')).toMatchObject({
+        valid: false,
+        reason: expect.stringContaining('private/internal IP address'),
+      });
+    });
+  });
+
+  describe('validateProviderBaseUrlAsync', () => {
+    it('rejects host resolving to private IP', async () => {
+      vi.mocked(dns.lookup).mockResolvedValue([{ address: '10.0.0.1', family: 4 }] as any);
+      const result = await validateProviderBaseUrlAsync('https://some-internal-host.com');
+      expect(result).toMatchObject({
+        valid: false,
+        reason: expect.stringContaining('resolves to a private/internal IP address'),
+      });
+    });
+
+    it('accepts host resolving to public IP', async () => {
+      vi.mocked(dns.lookup).mockResolvedValue([{ address: '8.8.8.8', family: 4 }] as any);
+      const result = await validateProviderBaseUrlAsync('https://google.com');
+      expect(result).toEqual({ valid: true });
+    });
+
+    it('blocks if DNS resolution fails', async () => {
+      vi.mocked(dns.lookup).mockRejectedValue(new Error('NXDOMAIN'));
+      const result = await validateProviderBaseUrlAsync('https://non-existent.example.com');
+      expect(result).toMatchObject({
+        valid: false,
+        reason: expect.stringContaining('DNS resolution failed'),
+      });
+    });
+  });
+});

--- a/core/src/llm/url-validation.ts
+++ b/core/src/llm/url-validation.ts
@@ -62,7 +62,7 @@ function isPrivateIPv4(host: string): boolean {
   const ip = ipv4ToInt(host);
   if (ip === null) return false;
   for (const [network, mask] of PRIVATE_IPV4_RANGES) {
-    if (((ip & mask) >>> 0) === (network >>> 0)) return true;
+    if ((ip & mask) >>> 0 === network >>> 0) return true;
   }
   return false;
 }

--- a/core/src/llm/url-validation.ts
+++ b/core/src/llm/url-validation.ts
@@ -176,19 +176,21 @@ export function validateProviderBaseUrl(
   }
 
   // ── Cloud provider origin enforcement ────────────────────────────────────────
-  if (provider && CLOUD_PROVIDER_ORIGINS[provider.toLowerCase()]) {
+  if (provider) {
     const allowedOrigins = CLOUD_PROVIDER_ORIGINS[provider.toLowerCase()];
-    const isAllowed = allowedOrigins.some(
-      (origin) => host === origin || host.endsWith(`.${origin}`)
-    );
-    if (!isAllowed) {
-      return {
-        valid: false,
-        reason:
-          `Provider "${provider}" is restricted to official origins (${allowedOrigins.join(', ')}). ` +
-          `The provided baseUrl host "${host}" is not permitted. ` +
-          `Add the domain to SERA_PROVIDER_URL_ALLOWLIST to bypass this restriction.`,
-      };
+    if (allowedOrigins) {
+      const isAllowed = allowedOrigins.some(
+        (origin) => host === origin || host.endsWith(`.${origin}`)
+      );
+      if (!isAllowed) {
+        return {
+          valid: false,
+          reason:
+            `Provider "${provider}" is restricted to official origins (${allowedOrigins.join(', ')}). ` +
+            `The provided baseUrl host "${host}" is not permitted. ` +
+            `Add the domain to SERA_PROVIDER_URL_ALLOWLIST to bypass this restriction.`,
+        };
+      }
     }
   }
 

--- a/core/src/llm/url-validation.ts
+++ b/core/src/llm/url-validation.ts
@@ -9,11 +9,26 @@
  *   - Must use HTTPS (exception: localhost and host.docker.internal for local providers)
  *   - Must not resolve to a private/loopback/link-local IP range
  *   - localhost / 127.x / ::1 allowed only for known local providers (lmstudio, ollama)
+ *   - Known cloud providers (OpenAI, Anthropic, etc.) are restricted to official origins
  *   - Configurable domain allowlist via SERA_PROVIDER_URL_ALLOWLIST env var (comma-separated)
  */
 
+import dns from 'node:dns/promises';
+import net from 'node:net';
+
 /** Provider names that are permitted to use localhost/127.x endpoints. */
 const LOCAL_PROVIDERS = new Set(['lmstudio', 'ollama', 'vllm', 'local', 'default']);
+
+/** Official origins for known cloud providers. */
+const CLOUD_PROVIDER_ORIGINS: Record<string, string[]> = {
+  openai: ['api.openai.com'],
+  anthropic: ['api.anthropic.com'],
+  google: ['generativelanguage.googleapis.com'],
+  groq: ['api.groq.com'],
+  mistral: ['api.mistral.ai'],
+  openrouter: ['openrouter.ai'],
+  kilocode: ['api.kilo.ai'],
+};
 
 /**
  * IPv4 private/reserved ranges that are forbidden as provider endpoints.
@@ -47,7 +62,7 @@ function isPrivateIPv4(host: string): boolean {
   const ip = ipv4ToInt(host);
   if (ip === null) return false;
   for (const [network, mask] of PRIVATE_IPV4_RANGES) {
-    if ((ip & mask) === network) return true;
+    if (((ip & mask) >>> 0) === (network >>> 0)) return true;
   }
   return false;
 }
@@ -80,10 +95,10 @@ function getAllowlistDomains(): string[] {
 
 /**
  * Validate a provider baseUrl against SSRF rules.
+ * Performs synchronous checks only (URL format, scheme, IP literal ranges, cloud origins).
  *
  * @param url      The baseUrl from the provider config.
- * @param provider The provider name (e.g. 'lmstudio', 'ollama') — used to
- *                 permit localhost for known-local providers.
+ * @param provider The provider name (e.g. 'openai', 'lmstudio')
  * @returns        `{ valid: true }` on success or `{ valid: false, reason }` on rejection.
  */
 export function validateProviderBaseUrl(
@@ -160,6 +175,23 @@ export function validateProviderBaseUrl(
     return { valid: true };
   }
 
+  // ── Cloud provider origin enforcement ────────────────────────────────────────
+  if (provider && CLOUD_PROVIDER_ORIGINS[provider.toLowerCase()]) {
+    const allowedOrigins = CLOUD_PROVIDER_ORIGINS[provider.toLowerCase()];
+    const isAllowed = allowedOrigins.some(
+      (origin) => host === origin || host.endsWith(`.${origin}`)
+    );
+    if (!isAllowed) {
+      return {
+        valid: false,
+        reason:
+          `Provider "${provider}" is restricted to official origins (${allowedOrigins.join(', ')}). ` +
+          `The provided baseUrl host "${host}" is not permitted. ` +
+          `Add the domain to SERA_PROVIDER_URL_ALLOWLIST to bypass this restriction.`,
+      };
+    }
+  }
+
   // ── Private IPv4 ranges ───────────────────────────────────────────────────────
   if (isPrivateIPv4(host)) {
     return {
@@ -177,6 +209,72 @@ export function validateProviderBaseUrl(
       reason:
         `Provider baseUrl points to a private/internal IPv6 address "${host}", which is not permitted. ` +
         `Use a public HTTPS endpoint, or add the host to SERA_PROVIDER_URL_ALLOWLIST.`,
+    };
+  }
+
+  return { valid: true };
+}
+
+/**
+ * Asynchronous version of validateProviderBaseUrl that also performs DNS
+ * resolution to detect private IP addresses even when hostnames are used.
+ * Prevents DNS rebinding and access to internal services via custom hostnames.
+ */
+export async function validateProviderBaseUrlAsync(
+  url: string,
+  provider?: string
+): Promise<{ valid: true } | { valid: false; reason: string }> {
+  // First run synchronous checks (format, scheme, literals, origins)
+  const syncCheck = validateProviderBaseUrl(url, provider);
+  if (!syncCheck.valid) return syncCheck;
+
+  if (!url || url.trim() === '') return { valid: true };
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return { valid: false, reason: `Invalid URL: "${url}"` };
+  }
+
+  const host = parsed.hostname.toLowerCase();
+
+  // If it's already an IP, it was checked by sync validation
+  if (net.isIP(host)) return { valid: true };
+
+  // Skip DNS check for localhost/docker internal as they are explicitly handled/allowed in sync check
+  if (host === 'localhost' || host === 'host.docker.internal') return { valid: true };
+
+  // Skip DNS check for allowlisted domains
+  const allowlist = getAllowlistDomains();
+  if (allowlist.some((domain) => host === domain || host.endsWith(`.${domain}`))) {
+    return { valid: true };
+  }
+
+  try {
+    const addresses = await dns.lookup(host, { all: true });
+    for (const { address } of addresses) {
+      if (net.isIPv4(address)) {
+        if (isPrivateIPv4(address)) {
+          return {
+            valid: false,
+            reason: `Provider baseUrl host "${host}" resolves to a private/internal IP address "${address}", which is not permitted.`,
+          };
+        }
+      } else if (net.isIPv6(address)) {
+        if (isPrivateIPv6(address)) {
+          return {
+            valid: false,
+            reason: `Provider baseUrl host "${host}" resolves to a private/internal IPv6 address "${address}", which is not permitted.`,
+          };
+        }
+      }
+    }
+  } catch (err) {
+    // If DNS resolution fails, we block it to be safe
+    return {
+      valid: false,
+      reason: `DNS resolution failed for host "${host}": ${(err as Error).message}`,
     };
   }
 


### PR DESCRIPTION
This PR addresses a critical security vulnerability where arbitrary `baseUrl` values for LLM providers could be used to exfiltrate API keys or perform SSRF attacks against internal services.

Key changes:
1.  **Hardened URL Validation**: Updated `url-validation.ts` to include official origins for known cloud providers and implemented a new asynchronous validation function that performs DNS resolution to block private/internal IP ranges, even when obscured by hostnames.
2.  **End-to-End Enforcement**: Integrated the new validation into `DynamicProviderManager` (for test connections and provider addition), `ProviderHealthService` (for probes and discovery), and `LlmRouter` (for actual request dispatch).
3.  **Secure Bootstrap**: Added synchronous validation to `ProviderRegistry`'s loading and environment bootstrap paths to ensure even file-based configs are checked against security rules.
4.  **Test Suite Reliability**: Added a new unit test suite for URL validation and updated existing tests for `ProviderRegistry` and `DynamicProviderManager` to use secure, valid URLs and handle the new asynchronous patterns.

Fixes #792

---
*PR created automatically by Jules for task [9749087058362746124](https://jules.google.com/task/9749087058362746124) started by @TKCen*