### PR TITLE
Fix MCP tool filtering for agents with explicit tool lists

### DIFF
--- a/core/src/skills/SkillRegistry.ts
+++ b/core/src/skills/SkillRegistry.ts
@@ -85,14 +85,24 @@ export class SkillRegistry {
    * 5. Otherwise, if not in `skills[]`, it's REJECTED.
    */
   isToolAllowedForAgent(manifest: AgentManifest, toolId: string): boolean {
-    const denied = manifest.tools?.denied || [];
+    const tools = manifest.spec?.tools ?? manifest.tools;
+    const denied = tools?.denied || [];
     if (denied.some((p) => SkillRegistry.matches(p, toolId))) {
       return false;
     }
 
+    // Auto-allow sera-core tools if seraManagement capability is present
+    const capabilities =
+      manifest.capabilities ??
+      (manifest.spec?.capabilities ? Object.keys(manifest.spec.capabilities) : []);
+    if (capabilities.includes('seraManagement') && SkillRegistry.matches('sera-core/*', toolId)) {
+      return true;
+    }
+
     // Explicitly allowed via skills array
-    if (manifest.skills) {
-      const isExplicitSkill = manifest.skills.some((s) => {
+    const skills = manifest.spec?.skills ?? manifest.skills;
+    if (skills) {
+      const isExplicitSkill = skills.some((s) => {
         const id = typeof s === 'string' ? s : s.name;
         return id === toolId;
       });
@@ -100,22 +110,22 @@ export class SkillRegistry {
     }
 
     // Allowed via tools.allowed patterns
-    if (manifest.tools?.allowed) {
+    if (tools?.allowed) {
       // If any pattern explicitly matches, allow it
-      if (manifest.tools.allowed.some((p) => SkillRegistry.matches(p, toolId))) {
+      if (tools.allowed.some((p) => SkillRegistry.matches(p, toolId))) {
         return true;
       }
-      // MCP tools (source: 'mcp') pass through unless explicitly denied above.
-      // tools.allowed governs builtin tools only — MCP tools are additive.
-      const skill = this.skills.get(toolId);
-      if (skill?.source === 'mcp') {
-        return true;
-      }
-      return false;
+    }
+
+    // MCP tools (source: 'mcp') pass through unless explicitly denied above.
+    // MCP tools are additive to any explicit skills or tools.allowed lists.
+    const skill = this.skills.get(toolId);
+    if (skill?.source === 'mcp') {
+      return true;
     }
 
     // Open access if neither is specified
-    if (!manifest.skills && !manifest.tools?.allowed) {
+    if (!skills && !tools?.allowed) {
       return true;
     }
 

--- a/templates/builtin/architect.template.yaml
+++ b/templates/builtin/architect.template.yaml
@@ -42,6 +42,7 @@ spec:
       - knowledge-store
       - knowledge-query
       - web-search
+      - sera-core/*
     denied:
       - shell-exec
       - docker-exec

--- a/templates/builtin/developer.template.yaml
+++ b/templates/builtin/developer.template.yaml
@@ -40,6 +40,7 @@ spec:
       - file-write
       - shell-exec
       - knowledge-query
+      - sera-core/*
     denied:
       - docker-exec
 

--- a/templates/builtin/researcher.template.yaml
+++ b/templates/builtin/researcher.template.yaml
@@ -42,6 +42,7 @@ spec:
       - knowledge-query
       - file-read
       - file-write
+      - sera-core/*
     denied:
       - shell-exec
       - docker-exec

--- a/templates/builtin/sera.template.yaml
+++ b/templates/builtin/sera.template.yaml
@@ -207,6 +207,8 @@ spec:
       - schedule-task
       # Delegation & agent management (native built-in skills)
       - delegate-task
+      # MCP tools (sera-core builtin tools)
+      - sera-core/*
     denied:
       - file-write   # requires explicit permission request per session
 


### PR DESCRIPTION
MCP tools (e.g., skills from the sera-core MCP server) were not available to any agent that has an explicit tools.allowed list in its manifest. This meant agents like Sera, Developer, Architect, and Researcher could not use any MCP tools.

The fix ensures that MCP tools are treated as additive and are only blocked if explicitly denied. It also adds a capability-based shortcut for `sera-core` tools and updates the builtin templates for better visibility.

Fixes #758

---
*PR created automatically by Jules for task [10259015288014572131](https://jules.google.com/task/10259015288014572131) started by @TKCen*