### PR TITLE
Prevent unregistration of protected MCP servers

### DIFF
--- a/core/src/mcp/registry.ts
+++ b/core/src/mcp/registry.ts
@@ -14,13 +14,14 @@ export interface MCPServerInfo {
   name: string;
   status: 'connected' | 'disconnected' | 'error';
   toolCount: number;
+  protected?: boolean | undefined;
 }
 
 export class MCPRegistry {
   private static instance: MCPRegistry;
   private clients: Map<
     string,
-    { client: MCPClient; instanceId?: string; manifest?: MCPServerManifest }
+    { client: MCPClient; instanceId?: string; manifest?: MCPServerManifest; protected?: boolean }
   > = new Map();
   private manager?: MCPServerManager;
   private intercom?: IntercomService;
@@ -252,6 +253,10 @@ export class MCPRegistry {
     return this.clients.get(name)?.client;
   }
 
+  isProtected(name: string): boolean {
+    return !!this.clients.get(name)?.protected;
+  }
+
   /** Expose all registered clients for iteration. */
   getClients(): Map<string, MCPClient> {
     const map = new Map<string, MCPClient>();
@@ -270,12 +275,14 @@ export class MCPRegistry {
           name,
           status: 'connected',
           toolCount: tools.tools.length,
+          protected: entry.protected,
         });
       } catch {
         infos.push({
           name,
           status: 'error',
           toolCount: 0,
+          protected: entry.protected,
         });
       }
     }
@@ -329,6 +336,7 @@ export class MCPRegistry {
     this.clients.set(name, {
       client: mockClient as MCPClient,
       instanceId: 'local',
+      protected: true,
     });
 
     logger.info(`Registered embedded sera-core MCP tools`);

--- a/core/src/routes/mcp.test.ts
+++ b/core/src/routes/mcp.test.ts
@@ -12,6 +12,7 @@ describe('MCP Routes', () => {
     getClient: ReturnType<typeof vi.fn>;
     registerContainerServer: ReturnType<typeof vi.fn>;
     unregisterClient: ReturnType<typeof vi.fn>;
+    isProtected: ReturnType<typeof vi.fn>;
   };
   let skillRegistryMock: Partial<SkillRegistry>;
 
@@ -24,6 +25,7 @@ describe('MCP Routes', () => {
       getClient: vi.fn(),
       registerContainerServer: vi.fn().mockResolvedValue({}),
       unregisterClient: vi.fn().mockResolvedValue(true),
+      isProtected: vi.fn().mockReturnValue(false),
     };
 
     skillRegistryMock = {};
@@ -171,6 +173,13 @@ describe('MCP Routes', () => {
       mcpRegistryMock.unregisterClient.mockResolvedValueOnce(false);
       const res = await request(app).delete('/api/mcp-servers/nonexistent');
       expect(res.status).toBe(404);
+    });
+
+    it('returns 403 for protected server', async () => {
+      mcpRegistryMock.isProtected.mockReturnValueOnce(true);
+      const res = await request(app).delete('/api/mcp-servers/sera-core');
+      expect(res.status).toBe(403);
+      expect(res.body.error).toContain('protected');
     });
   });
 });

--- a/core/src/routes/mcp.ts
+++ b/core/src/routes/mcp.ts
@@ -114,11 +114,19 @@ export function createMCPRouter(mcpRegistry: MCPRegistry, _skillRegistry: SkillR
    */
   router.delete('/:name', async (req, res) => {
     try {
-      const success = await mcpRegistry.unregisterClient(req.params.name);
+      const name = req.params.name;
+
+      if (mcpRegistry.isProtected(name)) {
+        return res.status(403).json({
+          error: `Cannot unregister protected MCP server "${name}"`,
+        });
+      }
+
+      const success = await mcpRegistry.unregisterClient(name);
       if (success) {
-        res.json({ message: `MCP server "${req.params.name}" unregistered successfully` });
+        res.json({ message: `MCP server "${name}" unregistered successfully` });
       } else {
-        res.status(404).json({ error: `MCP server "${req.params.name}" not found` });
+        res.status(404).json({ error: `MCP server "${name}" not found` });
       }
     } catch (err: unknown) {
       res.status(500).json({ error: (err as Error).message });

--- a/dev_server.log
+++ b/dev_server.log
@@ -1,0 +1,289 @@
+sera-web dev:
+sera-web dev:   VITE v6.4.1  ready in 301 ms
+sera-web dev:
+sera-web dev:   ➜  Local:   http://localhost:5173/
+sera-web dev:   ➜  Network: use --host to expose
+sera-web dev: 8:34:50 AM [vite] http proxy error: /api/rt/token
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:34:50 AM [vite] http proxy error: /api/rt/token
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:34:51 AM [vite] http proxy error: /api/rt/token
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:34:52 AM [vite] http proxy error: /api/rt/token
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:34:53 AM [vite] http proxy error: /api/rt/token
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:34:53 AM [vite] http proxy error: /api/rt/token
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:34:54 AM [vite] http proxy error: /api/rt/token
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:34:55 AM [vite] http proxy error: /api/rt/token
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:34:57 AM [vite] http proxy error: /api/rt/token
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:35:00 AM [vite] http proxy error: /api/rt/token
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:35:01 AM [vite] http proxy error: /api/rt/token
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:35:13 AM [vite] http proxy error: /api/rt/token
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:35:48 AM [vite] http proxy error: /api/rt/token
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:35:48 AM [vite] http proxy error: /api/rt/token
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:35:49 AM [vite] http proxy error: /api/rt/token
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:35:50 AM [vite] http proxy error: /api/rt/token
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:36:19 AM [vite] http proxy error: /api/rt/token
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:36:19 AM [vite] http proxy error: /api/rt/token
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:36:20 AM [vite] http proxy error: /api/rt/token
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:36:20 AM [vite] http proxy error: /api/rt/token
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:36:20 AM [vite] http proxy error: /api/health
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:36:20 AM [vite] http proxy error: /api/health/detail
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:36:20 AM [vite] http proxy error: /api/health
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:36:20 AM [vite] http proxy error: /api/providers/list
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:36:20 AM [vite] http proxy error: /api/providers/dynamic
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:36:20 AM [vite] http proxy error: /api/system/circuit-breakers
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:36:20 AM [vite] http proxy error: /api/providers/dynamic/statuses
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:36:20 AM [vite] http proxy error: /api/rt/token
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:36:21 AM [vite] http proxy error: /api/health/detail
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:36:21 AM [vite] http proxy error: /api/providers/list
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:36:21 AM [vite] http proxy error: /api/providers/dynamic
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:36:21 AM [vite] http proxy error: /api/system/circuit-breakers
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:36:21 AM [vite] http proxy error: /api/providers/dynamic/statuses
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:36:21 AM [vite] http proxy error: /api/rt/token
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:36:23 AM [vite] http proxy error: /api/health/detail
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:36:23 AM [vite] http proxy error: /api/providers/list
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:36:23 AM [vite] http proxy error: /api/providers/dynamic
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:36:23 AM [vite] http proxy error: /api/system/circuit-breakers
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:36:23 AM [vite] http proxy error: /api/providers/dynamic/statuses
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:36:23 AM [vite] http proxy error: /api/rt/token
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:36:27 AM [vite] http proxy error: /api/rt/token
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:36:33 AM [vite] http proxy error: /api/rt/token
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:36:38 AM [vite] http proxy error: /api/providers/dynamic/statuses
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:36:39 AM [vite] http proxy error: /api/providers/dynamic/statuses
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:36:40 AM [vite] http proxy error: /api/rt/token
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:36:41 AM [vite] http proxy error: /api/providers/dynamic/statuses
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:36:50 AM [vite] http proxy error: /api/health
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:37:17 AM [vite] http proxy error: /api/rt/token
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:37:17 AM [vite] http proxy error: /api/rt/token
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:37:18 AM [vite] http proxy error: /api/rt/token
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:37:18 AM [vite] http proxy error: /api/rt/token
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:37:18 AM [vite] http proxy error: /api/health
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:37:18 AM [vite] http proxy error: /api/health/detail
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:37:18 AM [vite] http proxy error: /api/health
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:37:18 AM [vite] http proxy error: /api/providers/list
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:37:18 AM [vite] http proxy error: /api/providers/dynamic
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:37:18 AM [vite] http proxy error: /api/providers/dynamic/statuses
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:37:18 AM [vite] http proxy error: /api/system/circuit-breakers
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:37:18 AM [vite] http proxy error: /api/rt/token
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:37:19 AM [vite] http proxy error: /api/health/detail
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:37:19 AM [vite] http proxy error: /api/providers/list
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:37:19 AM [vite] http proxy error: /api/providers/dynamic
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:37:19 AM [vite] http proxy error: /api/providers/dynamic/statuses
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:37:19 AM [vite] http proxy error: /api/system/circuit-breakers
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:37:20 AM [vite] http proxy error: /api/rt/token
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:37:21 AM [vite] http proxy error: /api/health/detail
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:37:21 AM [vite] http proxy error: /api/providers/list
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:37:21 AM [vite] http proxy error: /api/providers/dynamic
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:37:21 AM [vite] http proxy error: /api/providers/dynamic/statuses
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:37:21 AM [vite] http proxy error: /api/system/circuit-breakers
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)
+sera-web dev: 8:37:22 AM [vite] http proxy error: /api/rt/token
+sera-web dev: AggregateError [ECONNREFUSED]:
+sera-web dev:     at internalConnectMultiple (node:net:1134:18)
+sera-web dev:     at afterConnectMultiple (node:net:1715:7)

--- a/web/src/app/mcp-servers/page.tsx
+++ b/web/src/app/mcp-servers/page.tsx
@@ -13,6 +13,7 @@ import {
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
+import { Tooltip } from '@/components/ui/tooltip';
 import { EmptyState } from '@/components/EmptyState';
 import { useMCPServers, useUnregisterMCPServer, useReloadMCPServer } from '@/hooks/useMCPServers';
 import { MCPServerDialog } from '@/components/MCPServerDialog';
@@ -100,14 +101,29 @@ function ServerCard({
           <RefreshCw size={12} /> Reload
         </Button>
         <div className="flex-1" />
-        <Button
-          size="sm"
-          variant="ghost"
-          className="h-7 text-[11px] gap-1 text-red-400 hover:text-red-300 opacity-0 group-hover:opacity-100 transition-opacity"
-          onClick={() => onUnregister(server.name)}
-        >
-          <Trash2 size={12} /> Remove
-        </Button>
+        {server.protected ? (
+          <Tooltip content="Builtin servers cannot be removed">
+            <div className="opacity-0 group-hover:opacity-100 transition-opacity">
+              <Button
+                size="sm"
+                variant="ghost"
+                className="h-7 text-[11px] gap-1 text-red-400/50"
+                disabled
+              >
+                <Trash2 size={12} /> Remove
+              </Button>
+            </div>
+          </Tooltip>
+        ) : (
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-7 text-[11px] gap-1 text-red-400 hover:text-red-300 opacity-0 group-hover:opacity-100 transition-opacity"
+            onClick={() => onUnregister(server.name)}
+          >
+            <Trash2 size={12} /> Remove
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/web/src/components/MCPServersTab.tsx
+++ b/web/src/components/MCPServersTab.tsx
@@ -13,6 +13,7 @@ import {
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
+import { Tooltip } from '@/components/ui/tooltip';
 import { EmptyState } from '@/components/EmptyState';
 import { useMCPServers, useUnregisterMCPServer, useReloadMCPServer } from '@/hooks/useMCPServers';
 import { MCPServerDialog } from '@/components/MCPServerDialog';
@@ -100,14 +101,29 @@ function ServerCard({
           <RefreshCw size={12} /> Reload
         </Button>
         <div className="flex-1" />
-        <Button
-          size="sm"
-          variant="ghost"
-          className="h-7 text-[11px] gap-1 text-red-400 hover:text-red-300 opacity-0 group-hover:opacity-100 transition-opacity"
-          onClick={() => onUnregister(server.name)}
-        >
-          <Trash2 size={12} /> Remove
-        </Button>
+        {server.protected ? (
+          <Tooltip content="Builtin servers cannot be removed">
+            <div className="opacity-0 group-hover:opacity-100 transition-opacity">
+              <Button
+                size="sm"
+                variant="ghost"
+                className="h-7 text-[11px] gap-1 text-red-400/50"
+                disabled
+              >
+                <Trash2 size={12} /> Remove
+              </Button>
+            </div>
+          </Tooltip>
+        ) : (
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-7 text-[11px] gap-1 text-red-400 hover:text-red-300 opacity-0 group-hover:opacity-100 transition-opacity"
+            onClick={() => onUnregister(server.name)}
+          >
+            <Trash2 size={12} /> Remove
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/web/src/lib/api/mcp.ts
+++ b/web/src/lib/api/mcp.ts
@@ -4,6 +4,7 @@ export interface MCPServerInfo {
   name: string;
   status: 'connected' | 'disconnected' | 'error';
   toolCount: number;
+  protected?: boolean;
 }
 
 export interface MCPServerDetail extends MCPServerInfo {


### PR DESCRIPTION
I have implemented a protection mechanism for builtin MCP servers to prevent them from being accidentally or intentionally unregistered.

Key changes:
1. **Registry Enhancement**: Added a `protected` property to the `MCPServerInfo` interface and internal registry state. The `sera-core` server is now explicitly marked as protected upon registration.
2. **Backend Guard**: Updated the `DELETE /api/mcp-servers/:name` endpoint in `core/src/routes/mcp.ts` to check if a server is protected before allowing unregistration. It now returns a `403 Forbidden` error with a clear message if unregistration is attempted on a protected server.
3. **Frontend Protection**: Updated the MCP servers dashboard in both `web/src/app/mcp-servers/page.tsx` and `web/src/components/MCPServersTab.tsx` to disable the "Remove" button for protected servers. A tooltip ("Builtin servers cannot be removed") is displayed when hovering over the disabled button.
4. **Testing**: Added new unit tests to `core/src/routes/mcp.test.ts` to verify the 403 response for protected servers.

This ensures that the critical `sera-core` tools remain available to all agents and prevents accidental platform breakage.

Fixes #759

---
*PR created automatically by Jules for task [1587974707523601886](https://jules.google.com/task/1587974707523601886) started by @TKCen*