### PR TITLE
feat(runtime): emit signals from turn lifecycle

### DIFF
--- a/rust/crates/sera-runtime/src/default_runtime.rs
+++ b/rust/crates/sera-runtime/src/default_runtime.rs
@@ -18,7 +18,9 @@ use sera_types::tool::AuthzProviderHandle;
 
 use crate::context_engine::ContextEnricher;
 use crate::memory_assembler::MemoryBlockAssembler;
+use crate::signal_emit::SignalEmitter;
 use crate::turn::{self, LlmProvider, ReactMode, ToolDispatcher};
+use sera_types::signal::Signal;
 
 // ── TurnTimer ────────────────────────────────────────────────────────────────
 
@@ -78,6 +80,13 @@ pub struct DefaultRuntime {
     /// from `sera-types`; replaced with a `RoleBasedAuthzProvider` wrapped in
     /// `AuthzProviderAdapter` when `tool_authz_enabled = true` in config.
     authz_provider: Arc<dyn AuthzProviderHandle>,
+    /// Optional lifecycle signal emitter. When set, `execute_turn` emits
+    /// [`Signal::Started`] at the top of the turn, [`Signal::Progress`] on
+    /// each tool-call iteration, and one of
+    /// [`Signal::Done`] / [`Signal::Failed`] / [`Signal::Blocked`] /
+    /// [`Signal::Review`] at the terminal outcome. See
+    /// `docs/signal-system-design.md`.
+    signal_emitter: Option<SignalEmitter>,
 }
 
 impl std::fmt::Debug for DefaultRuntime {
@@ -90,6 +99,7 @@ impl std::fmt::Debug for DefaultRuntime {
             .field("failure_threshold", &self.failure_threshold)
             .field("has_memory_assembler", &self.memory_assembler.is_some())
             .field("has_enricher", &self.enricher.is_some())
+            .field("has_signal_emitter", &self.signal_emitter.is_some())
             .finish()
     }
 }
@@ -108,7 +118,21 @@ impl DefaultRuntime {
             memory_assembler: None,
             enricher: None,
             authz_provider: Arc::new(sera_types::tool::DefaultAuthzProviderStub),
+            signal_emitter: None,
         }
+    }
+
+    /// Install a lifecycle [`SignalEmitter`].
+    ///
+    /// When set, `execute_turn` emits `Started` at the top of the turn,
+    /// `Progress` on each tool-call iteration, and a terminal signal
+    /// (`Done` / `Failed` / `Blocked` / `Review`) before returning. Routing
+    /// is driven by the emitter's [`sera_types::signal::SignalTarget`], with
+    /// the invariant that `Blocked` and `Review` always reach HITL regardless
+    /// of the target. See `docs/signal-system-design.md` and PR #947.
+    pub fn with_signal_emitter(mut self, emitter: SignalEmitter) -> Self {
+        self.signal_emitter = Some(emitter);
+        self
     }
 
     /// Install an authorization provider that will be threaded into every
@@ -202,6 +226,21 @@ impl AgentRuntime for DefaultRuntime {
 
         let original_message_count = ctx.messages.len();
 
+        // Snapshot for lifecycle signal emission. The `task_id` / `artifact_id`
+        // used by the signal system is the turn id — stable across the turn
+        // and easy to correlate with the runtime's own tracing spans.
+        let turn_id = uuid::Uuid::new_v4();
+        let turn_task_id = turn_id.to_string();
+        if let Some(emitter) = self.signal_emitter.as_ref() {
+            let description = extract_last_user_message(&ctx.messages);
+            emitter
+                .emit(&Signal::Started {
+                    task_id: turn_task_id.clone(),
+                    description,
+                })
+                .await;
+        }
+
         // Build a fresh ToolContext for this turn. Populated from session +
         // agent identity; no principal is available on `sera_types::TurnContext`
         // yet, so we fall back to a Default-sourced allow-all authz handle and
@@ -235,7 +274,7 @@ impl AgentRuntime for DefaultRuntime {
             .unwrap_or(ReactMode::Default);
 
         let mut turn_ctx = turn::TurnContext {
-            turn_id: uuid::Uuid::new_v4(),
+            turn_id,
             session_key: ctx.session_key,
             agent_id: ctx.agent_id,
             messages: ctx.messages,
@@ -261,7 +300,8 @@ impl AgentRuntime for DefaultRuntime {
         // execution separation as two distinct iterations sharing one turn.
         let mut pending_plan: Option<turn::Plan> = None;
 
-        for _iteration in 0..self.max_tool_iterations {
+        let max_iterations = self.max_tool_iterations;
+        for _iteration in 0..max_iterations {
             // 1. Observe — filter messages, run ConstitutionalGate hooks on input
             let observed = match turn::observe(&turn_ctx, None, &[]).await {
                 Ok(msgs) => msgs,
@@ -492,10 +532,34 @@ impl AgentRuntime for DefaultRuntime {
                         tokens = tokens_used.total_tokens,
                         "tool-call loop: re-entering think with tool results"
                     );
+
+                    if let Some(emitter) = self.signal_emitter.as_ref() {
+                        let pct = progress_pct(_iteration + 1, max_iterations);
+                        emitter
+                            .emit(&Signal::Progress {
+                                task_id: turn_task_id.clone(),
+                                pct,
+                                note: format!(
+                                    "tool iteration {}/{}",
+                                    _iteration + 1,
+                                    max_iterations
+                                ),
+                            })
+                            .await;
+                    }
                 }
                 // Inject accumulated transcript into FinalOutput before returning
                 TurnOutcome::FinalOutput { response, tool_calls, tokens_used, duration_ms, .. } => {
                     let transcript = turn_ctx.messages[original_message_count..].to_vec();
+                    if let Some(emitter) = self.signal_emitter.as_ref() {
+                        emitter
+                            .emit(&Signal::Done {
+                                artifact_id: turn_task_id.clone(),
+                                summary: summarize(&response),
+                                duration_ms,
+                            })
+                            .await;
+                    }
                     return Ok(TurnOutcome::FinalOutput {
                         response,
                         tool_calls,
@@ -544,20 +608,50 @@ impl AgentRuntime for DefaultRuntime {
                         });
                     pending_plan = Some(staged);
                     turn_ctx.doom_loop_count += 1;
+
+                    if let Some(emitter) = self.signal_emitter.as_ref() {
+                        let pct = progress_pct(_iteration + 1, max_iterations);
+                        emitter
+                            .emit(&Signal::Progress {
+                                task_id: turn_task_id.clone(),
+                                pct,
+                                note: "plan emitted".into(),
+                            })
+                            .await;
+                    }
                 }
-                // Any other outcome (Handoff, Interruption, etc.) — return immediately
-                other => return Ok(other),
+                // Any other outcome (Handoff, Interruption, WaitingForApproval, etc.)
+                // — emit the matching terminal signal and return.
+                other => {
+                    if let Some(emitter) = self.signal_emitter.as_ref() {
+                        if let Some(sig) = terminal_signal_for(&other, &turn_task_id) {
+                            emitter.emit(&sig).await;
+                        }
+                    }
+                    return Ok(other);
+                }
             }
         }
 
-        // Exhausted max_tool_iterations
+        // Exhausted max_tool_iterations — this is a Failed terminal state.
+        let duration_ms = timer.elapsed_ms();
+        let reason = format!(
+            "max tool iterations ({}) exceeded",
+            self.max_tool_iterations
+        );
+        if let Some(emitter) = self.signal_emitter.as_ref() {
+            emitter
+                .emit(&Signal::Failed {
+                    artifact_id: turn_task_id.clone(),
+                    error: reason.clone(),
+                    retries: 0,
+                })
+                .await;
+        }
         Ok(TurnOutcome::Interruption {
             hook_point: "tool_loop".to_string(),
-            reason: format!(
-                "max tool iterations ({}) exceeded",
-                self.max_tool_iterations
-            ),
-            duration_ms: timer.elapsed_ms(),
+            reason,
+            duration_ms,
         })
     }
 
@@ -591,6 +685,94 @@ fn extract_last_user_message(messages: &[serde_json::Value]) -> String {
         }
     }
     String::new()
+}
+
+/// Map a terminal [`TurnOutcome`] to the matching lifecycle [`Signal`].
+///
+/// * `FinalOutput` → emitted inline at the return site as `Signal::Done`; not
+///   produced here (returns `None`).
+/// * `Handoff` → `Signal::Handoff { from_agent, to_agent, artifact_id }`. The
+///   `from_agent` is left empty because [`TurnOutcome::Handoff`] only carries
+///   the target; callers who need the full pair can derive it from their
+///   session context.
+/// * `WaitingForApproval` → `Signal::Review` (attention-required, always HITL).
+/// * `Interruption` with `hook_point == "constitutional_gate"` or
+///   `hook_point == "permission"` → `Signal::Blocked` (attention-required).
+/// * Any other `Interruption`, `Stop`, or `Compact` → `Signal::Failed` /
+///   `Signal::Done` as appropriate.
+/// * `RunAgain` / `PlanEmitted` → no terminal signal (handled by the caller).
+fn terminal_signal_for(outcome: &TurnOutcome, artifact_id: &str) -> Option<Signal> {
+    match outcome {
+        TurnOutcome::FinalOutput { .. } | TurnOutcome::RunAgain { .. } | TurnOutcome::PlanEmitted { .. } => None,
+        TurnOutcome::Handoff { target_agent_id, .. } => Some(Signal::Handoff {
+            from_agent: String::new(),
+            to_agent: target_agent_id.clone(),
+            artifact_id: artifact_id.to_string(),
+        }),
+        TurnOutcome::WaitingForApproval { tool_call, ticket_id, .. } => {
+            let tool_name = tool_call
+                .get("function")
+                .and_then(|f| f.get("name"))
+                .and_then(|n| n.as_str())
+                .unwrap_or("unknown");
+            Some(Signal::Review {
+                artifact_id: artifact_id.to_string(),
+                prompt: format!(
+                    "approval required for tool `{tool_name}` (ticket {ticket_id})"
+                ),
+            })
+        }
+        TurnOutcome::Interruption { hook_point, reason, .. } => {
+            // Constitutional gate / permission refusals are capability blocks —
+            // they require human attention per the design doc invariant.
+            if hook_point == "constitutional_gate" || hook_point == "permission" {
+                Some(Signal::Blocked {
+                    reason: reason.clone(),
+                    requires: Vec::new(),
+                })
+            } else {
+                Some(Signal::Failed {
+                    artifact_id: artifact_id.to_string(),
+                    error: reason.clone(),
+                    retries: 0,
+                })
+            }
+        }
+        TurnOutcome::Stop { summary, duration_ms, .. } => Some(Signal::Done {
+            artifact_id: artifact_id.to_string(),
+            summary: summary.clone(),
+            duration_ms: *duration_ms,
+        }),
+        TurnOutcome::Compact { duration_ms, .. } => Some(Signal::Done {
+            artifact_id: artifact_id.to_string(),
+            summary: "context compacted".into(),
+            duration_ms: *duration_ms,
+        }),
+    }
+}
+
+/// Clamp a fractional progress ratio into the `0..=100` range expected by
+/// [`Signal::Progress::pct`].
+fn progress_pct(done: u32, total: u32) -> u8 {
+    if total == 0 {
+        return 0;
+    }
+    let raw = (done.saturating_mul(100) / total).min(100);
+    raw as u8
+}
+
+/// Truncate a response string to a short summary suitable for
+/// [`Signal::Done::summary`]. Keeps the first 240 chars — enough for a
+/// human glance without bloating the inbox row.
+fn summarize(response: &str) -> String {
+    const MAX: usize = 240;
+    if response.chars().count() <= MAX {
+        response.to_string()
+    } else {
+        let mut s: String = response.chars().take(MAX).collect();
+        s.push('…');
+        s
+    }
 }
 
 /// Compute the character budget remaining in the Tier-1 `MemoryBlock` after

--- a/rust/crates/sera-runtime/src/default_runtime.rs
+++ b/rust/crates/sera-runtime/src/default_runtime.rs
@@ -623,10 +623,10 @@ impl AgentRuntime for DefaultRuntime {
                 // Any other outcome (Handoff, Interruption, WaitingForApproval, etc.)
                 // — emit the matching terminal signal and return.
                 other => {
-                    if let Some(emitter) = self.signal_emitter.as_ref() {
-                        if let Some(sig) = terminal_signal_for(&other, &turn_task_id) {
-                            emitter.emit(&sig).await;
-                        }
+                    if let Some(emitter) = self.signal_emitter.as_ref()
+                        && let Some(sig) = terminal_signal_for(&other, &turn_task_id)
+                    {
+                        emitter.emit(&sig).await;
                     }
                     return Ok(other);
                 }

--- a/rust/crates/sera-runtime/src/lib.rs
+++ b/rust/crates/sera-runtime/src/lib.rs
@@ -47,6 +47,7 @@ pub mod permissions;
 pub mod sera_errors;
 pub mod semantic;
 pub mod shadow;
+pub mod signal_emit;
 pub mod skill_dispatch;
 pub mod tool_hooks;
 

--- a/rust/crates/sera-runtime/src/signal_emit.rs
+++ b/rust/crates/sera-runtime/src/signal_emit.rs
@@ -1,0 +1,201 @@
+//! Turn-lifecycle signal emission.
+//!
+//! Wraps a [`SignalStore`] and applies the delivery-routing rules from
+//! `docs/signal-system-design.md`:
+//!
+//! * `MainSession` — write an inbox row for the dispatching agent.
+//! * `ArtifactOnly` / `Silent` — skip the inbox entirely.
+//! * `Blocked` and `Review` — always route to HITL regardless of target.
+//!
+//! The emitter is plumbed into [`crate::default_runtime::DefaultRuntime`] and
+//! fires at each turn lifecycle point (start, progress, terminal).
+
+use std::sync::Arc;
+
+use sera_db::signals::SignalStore;
+use sera_types::signal::{Signal, SignalTarget};
+
+/// Inbox id used for [`Signal::Blocked`] and [`Signal::Review`]. Per the
+/// design doc's invariant, attention-required signals always land here in
+/// addition to whatever the configured target asks for.
+pub const HITL_AGENT_ID: &str = "sera-hitl";
+
+/// Emits signals generated during a turn, honoring [`SignalTarget`] and the
+/// attention-routing invariant.
+#[derive(Clone)]
+pub struct SignalEmitter {
+    store: Arc<dyn SignalStore>,
+    to_agent_id: String,
+    target: SignalTarget,
+}
+
+impl std::fmt::Debug for SignalEmitter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SignalEmitter")
+            .field("to_agent_id", &self.to_agent_id)
+            .field("target", &self.target)
+            .finish()
+    }
+}
+
+impl SignalEmitter {
+    /// Build an emitter that routes signals to `to_agent_id`'s inbox with the
+    /// default [`SignalTarget::MainSession`] delivery.
+    pub fn new(store: Arc<dyn SignalStore>, to_agent_id: impl Into<String>) -> Self {
+        Self {
+            store,
+            to_agent_id: to_agent_id.into(),
+            target: SignalTarget::MainSession,
+        }
+    }
+
+    /// Override the default delivery target for this emitter.
+    pub fn with_target(mut self, target: SignalTarget) -> Self {
+        self.target = target;
+        self
+    }
+
+    /// Target configured for non-attention signals.
+    pub fn target(&self) -> SignalTarget {
+        self.target
+    }
+
+    /// Recipient agent id for non-attention signals.
+    pub fn to_agent_id(&self) -> &str {
+        &self.to_agent_id
+    }
+
+    /// Emit `signal` according to the routing rules. Errors are logged and
+    /// swallowed — the runtime must not fail a turn because the inbox write
+    /// failed.
+    pub async fn emit(&self, signal: &Signal) {
+        if signal.is_attention_required() {
+            // Invariant: Blocked/Review always reach HITL regardless of target.
+            if let Err(e) = self.store.enqueue(HITL_AGENT_ID, signal).await {
+                tracing::warn!(
+                    signal_kind = signal.kind(),
+                    recipient = HITL_AGENT_ID,
+                    error = %e,
+                    "failed to enqueue HITL signal",
+                );
+            }
+            // Also fan out to the dispatching agent when MainSession is set,
+            // so the caller learns its dispatch is parked on a human.
+            if self.target.writes_inbox() {
+                if let Err(e) = self.store.enqueue(&self.to_agent_id, signal).await {
+                    tracing::warn!(
+                        signal_kind = signal.kind(),
+                        recipient = %self.to_agent_id,
+                        error = %e,
+                        "failed to enqueue attention signal to dispatcher",
+                    );
+                }
+            }
+            return;
+        }
+
+        if !self.target.writes_inbox() {
+            // ArtifactOnly / Silent: no inbox row per design doc.
+            return;
+        }
+
+        if let Err(e) = self.store.enqueue(&self.to_agent_id, signal).await {
+            tracing::warn!(
+                signal_kind = signal.kind(),
+                recipient = %self.to_agent_id,
+                error = %e,
+                "failed to enqueue signal",
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::Connection;
+    use sera_db::signals::SqliteSignalStore;
+    use sera_types::capability::AgentCapability;
+    use tokio::sync::Mutex as AsyncMutex;
+
+    fn new_store() -> Arc<dyn SignalStore> {
+        let conn = Connection::open_in_memory().unwrap();
+        SqliteSignalStore::init_schema(&conn).unwrap();
+        Arc::new(SqliteSignalStore::new(Arc::new(AsyncMutex::new(conn))))
+    }
+
+    #[tokio::test]
+    async fn main_session_writes_inbox_for_recipient() {
+        let store = new_store();
+        let emitter = SignalEmitter::new(Arc::clone(&store), "agent-a");
+        let sig = Signal::Done {
+            artifact_id: "art".into(),
+            summary: "ok".into(),
+            duration_ms: 1,
+        };
+        emitter.emit(&sig).await;
+        let pending = store.peek_pending("agent-a").await.unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].signal, sig);
+    }
+
+    #[tokio::test]
+    async fn artifact_only_target_skips_inbox() {
+        let store = new_store();
+        let emitter = SignalEmitter::new(Arc::clone(&store), "agent-a")
+            .with_target(SignalTarget::ArtifactOnly);
+        let sig = Signal::Done {
+            artifact_id: "art".into(),
+            summary: "ok".into(),
+            duration_ms: 1,
+        };
+        emitter.emit(&sig).await;
+        assert!(store.peek_pending("agent-a").await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn silent_target_skips_inbox() {
+        let store = new_store();
+        let emitter = SignalEmitter::new(Arc::clone(&store), "agent-a")
+            .with_target(SignalTarget::Silent);
+        emitter
+            .emit(&Signal::Progress {
+                task_id: "t".into(),
+                pct: 50,
+                note: "".into(),
+            })
+            .await;
+        assert!(store.peek_pending("agent-a").await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn blocked_routes_to_hitl_even_when_silent() {
+        let store = new_store();
+        let emitter = SignalEmitter::new(Arc::clone(&store), "agent-a")
+            .with_target(SignalTarget::Silent);
+        let sig = Signal::Blocked {
+            reason: "missing cap".into(),
+            requires: vec![AgentCapability::MetaChange],
+        };
+        emitter.emit(&sig).await;
+        // HITL got the attention-required signal.
+        let hitl_pending = store.peek_pending(HITL_AGENT_ID).await.unwrap();
+        assert_eq!(hitl_pending.len(), 1);
+        assert_eq!(hitl_pending[0].signal, sig);
+        // Silent means the dispatcher does NOT also get it.
+        assert!(store.peek_pending("agent-a").await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn review_routes_to_hitl_and_dispatcher_on_main_session() {
+        let store = new_store();
+        let emitter = SignalEmitter::new(Arc::clone(&store), "agent-a");
+        let sig = Signal::Review {
+            artifact_id: "art".into(),
+            prompt: "check this".into(),
+        };
+        emitter.emit(&sig).await;
+        assert_eq!(store.peek_pending(HITL_AGENT_ID).await.unwrap().len(), 1);
+        assert_eq!(store.peek_pending("agent-a").await.unwrap().len(), 1);
+    }
+}

--- a/rust/crates/sera-runtime/src/signal_emit.rs
+++ b/rust/crates/sera-runtime/src/signal_emit.rs
@@ -81,15 +81,15 @@ impl SignalEmitter {
             }
             // Also fan out to the dispatching agent when MainSession is set,
             // so the caller learns its dispatch is parked on a human.
-            if self.target.writes_inbox() {
-                if let Err(e) = self.store.enqueue(&self.to_agent_id, signal).await {
-                    tracing::warn!(
-                        signal_kind = signal.kind(),
-                        recipient = %self.to_agent_id,
-                        error = %e,
-                        "failed to enqueue attention signal to dispatcher",
-                    );
-                }
+            if self.target.writes_inbox()
+                && let Err(e) = self.store.enqueue(&self.to_agent_id, signal).await
+            {
+                tracing::warn!(
+                    signal_kind = signal.kind(),
+                    recipient = %self.to_agent_id,
+                    error = %e,
+                    "failed to enqueue attention signal to dispatcher",
+                );
             }
             return;
         }

--- a/rust/crates/sera-runtime/tests/signal_emission.rs
+++ b/rust/crates/sera-runtime/tests/signal_emission.rs
@@ -1,0 +1,129 @@
+//! End-to-end integration test for turn-lifecycle signal emission.
+//!
+//! Closes the emission gap left by PR #947: the `Signal` / `SignalTarget` /
+//! `Dispatch` types and the `agent_signals` SQLite table existed, but nothing
+//! in `sera-runtime` ever enqueued a signal during a turn. This test runs a
+//! mock turn with the signal emitter wired in and asserts that `Started`
+//! and `Done` both land in the dispatching agent's inbox when the target is
+//! `SignalTarget::MainSession`.
+
+use std::sync::Arc;
+
+use rusqlite::Connection;
+use sera_db::signals::{SignalStore, SqliteSignalStore};
+use sera_runtime::context_engine::pipeline::ContextPipeline;
+use sera_runtime::default_runtime::DefaultRuntime;
+use sera_runtime::signal_emit::{SignalEmitter, HITL_AGENT_ID};
+use sera_types::runtime::{AgentRuntime, TurnContext, TurnOutcome};
+use sera_types::signal::{Signal, SignalTarget};
+use tokio::sync::Mutex as AsyncMutex;
+
+fn make_store() -> Arc<dyn SignalStore> {
+    let conn = Connection::open_in_memory().unwrap();
+    SqliteSignalStore::init_schema(&conn).unwrap();
+    Arc::new(SqliteSignalStore::new(Arc::new(AsyncMutex::new(conn))))
+}
+
+fn make_turn_context(agent_id: &str) -> TurnContext {
+    TurnContext {
+        event_id: "evt-signal-emit".into(),
+        agent_id: agent_id.into(),
+        session_key: format!("session:{agent_id}:u1"),
+        messages: vec![serde_json::json!({
+            "role": "user",
+            "content": "emit lifecycle signals for this turn",
+        })],
+        available_tools: vec![],
+        metadata: std::collections::HashMap::new(),
+        change_artifact: None,
+        parent_session_key: None,
+        tool_use_behavior: Default::default(),
+    }
+}
+
+/// Full end-to-end: a mock turn with no tool calls (think stub returns a
+/// final response) must emit `Started` at the top of the turn and `Done`
+/// on success, both landing in the dispatching agent's inbox under
+/// `SignalTarget::MainSession`.
+#[tokio::test]
+async fn started_and_done_land_in_inbox_with_main_session_target() {
+    let store = make_store();
+    let dispatcher_id = "agent-dispatcher";
+
+    let emitter = SignalEmitter::new(Arc::clone(&store), dispatcher_id)
+        .with_target(SignalTarget::MainSession);
+
+    let runtime = DefaultRuntime::new(Box::new(ContextPipeline::new()))
+        .with_signal_emitter(emitter);
+
+    let outcome = runtime
+        .execute_turn(make_turn_context("agent-worker"))
+        .await
+        .expect("turn must succeed");
+
+    // The think stub produces a FinalOutput; that path emits Signal::Done.
+    assert!(
+        matches!(outcome, TurnOutcome::FinalOutput { .. }),
+        "expected FinalOutput, got {outcome:?}"
+    );
+
+    let inbox = store.peek_pending(dispatcher_id).await.unwrap();
+    assert_eq!(inbox.len(), 2, "expected Started + Done, got {inbox:?}");
+
+    // Ordering in the inbox falls back to UUID tiebreak when both rows share
+    // the same whole-second `created_at`, so assert by kind rather than
+    // position. Both must be present.
+    let started = inbox
+        .iter()
+        .find_map(|row| match &row.signal {
+            Signal::Started { description, .. } => Some(description.clone()),
+            _ => None,
+        })
+        .expect("Started signal must be in the inbox");
+    assert!(
+        started.contains("emit lifecycle signals"),
+        "Started description should carry the last user message, got {started:?}"
+    );
+
+    let summary = inbox
+        .iter()
+        .find_map(|row| match &row.signal {
+            Signal::Done { summary, .. } => Some(summary.clone()),
+            _ => None,
+        })
+        .expect("Done signal must be in the inbox");
+    assert!(!summary.is_empty(), "Done summary should carry the final response");
+
+    // HITL inbox stays empty — neither signal is attention-required.
+    let hitl = store.peek_pending(HITL_AGENT_ID).await.unwrap();
+    assert!(
+        hitl.is_empty(),
+        "HITL inbox must stay empty for non-attention signals, got {hitl:?}"
+    );
+}
+
+/// `SignalTarget::Silent` must NOT write an inbox row for non-attention
+/// signals, per the design doc's routing rules.
+#[tokio::test]
+async fn silent_target_skips_inbox_entirely() {
+    let store = make_store();
+    let emitter = SignalEmitter::new(Arc::clone(&store), "agent-dispatcher")
+        .with_target(SignalTarget::Silent);
+
+    let runtime = DefaultRuntime::new(Box::new(ContextPipeline::new()))
+        .with_signal_emitter(emitter);
+
+    let _ = runtime
+        .execute_turn(make_turn_context("agent-worker"))
+        .await
+        .expect("turn must succeed");
+
+    assert!(
+        store.peek_pending("agent-dispatcher").await.unwrap().is_empty(),
+        "Silent target must skip inbox writes"
+    );
+    assert!(
+        store.peek_pending(HITL_AGENT_ID).await.unwrap().is_empty(),
+        "non-attention signals must not reach HITL"
+    );
+}


### PR DESCRIPTION
## Summary

Wires the signal system into the SERA 2.0 runtime turn loop. PR #947 shipped the `Signal` / `SignalTarget` / `Dispatch` types, the `agent_signals` SQLite table, and the `SessionManager` inbox drain — but `sera-runtime` never actually called the signal store during a turn. This closes that emission gap.

- New `sera_runtime::signal_emit::SignalEmitter` applies the routing rules from `docs/signal-system-design.md`.
- `DefaultRuntime::execute_turn` now emits `Started`, `Progress`, and terminal signals (`Done` / `Failed` / `Blocked` / `Review` / `Handoff`) at the documented lifecycle points.
- `Signal::Blocked` and `Signal::Review` always reach the HITL inbox, regardless of `SignalTarget` — the design-doc invariant.

## Lifecycle emission map

| Runtime event | Signal |
| --- | --- |
| Top of turn | `Started { task_id, description }` |
| Each tool-call iteration | `Progress { task_id, pct, note }` |
| `TurnOutcome::FinalOutput` | `Done { artifact_id, summary, duration_ms }` |
| `TurnOutcome::Handoff` | `Handoff { from_agent, to_agent, artifact_id }` |
| `TurnOutcome::WaitingForApproval` | `Review { artifact_id, prompt }` (always HITL) |
| `Interruption` w/ `hook_point=constitutional_gate\|permission` | `Blocked { reason, requires }` (always HITL) |
| Other `Interruption`, max-iteration exhaustion | `Failed { artifact_id, error, retries }` |
| `Stop` / `Compact` | `Done` (post-turn summary) |

## Routing honors `SignalTarget`

- `MainSession` — writes an inbox row for the dispatching agent.
- `ArtifactOnly` / `Silent` — no inbox row per the design doc; only the artifact is stored.
- `Blocked` / `Review` — always written to the HITL inbox (`sera-hitl`) regardless of target.

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo test -p sera-runtime` — 521 tests pass, including the new ones
- [x] Unit tests for `SignalEmitter` routing rules (5 tests in `signal_emit.rs`)
- [x] End-to-end integration test (`tests/signal_emission.rs`): a mock turn runs through `DefaultRuntime` and asserts that `Started` + `Done` both land in the dispatching agent's inbox under `SignalTarget::MainSession`, with the HITL inbox staying empty for non-attention signals
- [x] `SignalTarget::Silent` integration test confirms the inbox stays empty

Closes the emission gap left by #947.

Ref: `docs/signal-system-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)