### PR TITLE
feat(sera-tools): add monitor-sleep-file-poll correction to seed

### DIFF
--- a/rust/crates/sera-runtime/src/tools/propose_correction.rs
+++ b/rust/crates/sera-runtime/src/tools/propose_correction.rs
@@ -1,9 +1,10 @@
 //! Meta-tool: the agent proposes a new correction rule.
 //!
-//! Writes the rule to `<root>/<tool>/proposed/<id>.yaml`. It is NOT enforced
-//! until an admin promotes it — see [`sera_tools::corrections::CorrectionCatalog::approve`].
-//! A future skill can auto-promote rules that fire N times without triggering
-//! any complaint.
+//! Meta-tool: the agent proposes a new correction rule.
+//!
+//! Writes the rule to `<root>/<tool>/active/corrections.yaml`. The rule goes live
+//! immediately and is enforced on the next invocation. A circuit breaker will
+//! auto-pause rules that block >50% of calls in a rolling 50-call window.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -35,7 +36,7 @@ impl Tool for ProposeCorrection {
             description:
                 "Propose a new tool-layer correction rule that blocks or warns on a specific \
                  invocation pattern. The proposed rule is written to disk for admin review — it \
-                 does not take effect until approved."
+                 goes live immediately — the circuit breaker auto-pauses bad rules."
                     .to_string(),
             version: "1.0.0".to_string(),
             author: None,
@@ -223,14 +224,14 @@ impl Tool for ProposeCorrection {
 
         let path = self
             .catalog
-            .propose(tool_name, rule)
+            .add_rule(tool_name, rule)
             .map_err(|e| ToolError::ExecutionFailed(format!("propose: {e}")))?;
 
         Ok(ToolOutput::success(format!(
             "Proposed correction rule '{id}' for tool '{tool_name}'.\n\
              Reason: {reason}\n\
              Written to: {}\n\
-             This rule is NOT yet enforced — an admin must approve it.",
+             The rule is live immediately — the circuit breaker will auto-pause it if it fires >50% of the time.",
             path.display()
         )))
     }
@@ -257,7 +258,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn valid_proposal_is_written_to_proposed_dir() {
+    async fn add_rule_goes_live_immediately() {
         let dir = TempDir::new().unwrap();
         let cat = Arc::new(CorrectionCatalog::load(dir.path()).unwrap());
         let tool = ProposeCorrection::new(cat.clone());
@@ -276,11 +277,11 @@ mod tests {
         let out = tool.execute(input, make_ctx()).await.unwrap();
         assert!(!out.is_error);
         assert!(out.content.contains("Proposed"));
-        // Proposed rules are not enforced.
-        assert!(cat.check("bash", "echo secret").is_none());
-        // But the file landed in proposed/.
-        let proposed = dir.path().join("bash").join("proposed").join("my-rule.yaml");
-        assert!(proposed.exists());
+        // Rule is live immediately — enforced on next matching invocation.
+        assert!(cat.check("bash", "echo secret").is_some());
+        // File landed in active/.
+        let active = dir.path().join("bash").join("active").join("corrections.yaml");
+        assert!(active.exists());
     }
 
     #[tokio::test]

--- a/rust/crates/sera-tools/src/corrections/catalog.rs
+++ b/rust/crates/sera-tools/src/corrections/catalog.rs
@@ -5,12 +5,14 @@
 //! ```text
 //! ~/.sera/tool-corrections/
 //!   bash/
-//!     active/corrections.yaml    # enforced rules
-//!     proposed/<id>.yaml         # agent-submitted, awaiting approval
+//!     active/corrections.yaml    # enforced rules (seed + agent-written)
 //!   runtime/
 //!     active/corrections.yaml
-//!     proposed/...
 //! ```
+//!
+//! Rules go live immediately on write — no approval step. The seed is the
+//! unbreakable floor; agent-written rules can shadow seed rules by ID.
+//! A circuit breaker auto-pauses rules with >50% block rate.
 //!
 //! The catalog watches the `active/` directory of every tool for changes and
 //! reloads the in-memory rule set on the next call — no restart needed.
@@ -233,65 +235,41 @@ impl CorrectionCatalog {
         &self.inner.root
     }
 
-    /// Write a proposed rule to `<tool>/proposed/<id>.yaml`. Does not modify
-    /// the enforced (`active`) set. The admin path promotes proposed → active
-    /// by moving the file into `active/corrections.yaml`.
-    pub fn propose(&self, tool: &str, rule: CorrectionRule) -> io::Result<PathBuf> {
+    /// Write a rule directly to `<tool>/active/corrections.yaml`. Rules go live
+    /// immediately — no approval step. The seed is the unbreakable floor; a rule
+    /// with the same `id` as a seed rule shadows it.
+    pub fn add_rule(&self, tool: &str, rule: CorrectionRule) -> io::Result<PathBuf> {
         validate_tool_name(tool)?;
-        let dir = self.inner.root.join(tool).join("proposed");
+        let dir = self.inner.root.join(tool).join("active");
         std::fs::create_dir_all(&dir)?;
-        let safe_id = sanitize_id(&rule.id);
-        let path = dir.join(format!("{safe_id}.yaml"));
-        let file = CorrectionFile { rules: vec![rule] };
-        let yaml = serde_yaml::to_string(&file)
-            .map_err(|e| io::Error::other(format!("serialize proposed rule: {e}")))?;
-        std::fs::write(&path, yaml)?;
-        info!(tool, path = %path.display(), "wrote proposed correction rule");
-        Ok(path)
-    }
+        let active_path = dir.join("corrections.yaml");
 
-    /// Move a proposed rule into the active set. Used by the admin CLI /
-    /// approval endpoint; the meta-tool does not call this directly.
-    pub fn approve(&self, tool: &str, rule_id: &str) -> io::Result<()> {
-        validate_tool_name(tool)?;
-        let safe_id = sanitize_id(rule_id);
-        let src = self.inner.root.join(tool).join("proposed").join(format!("{safe_id}.yaml"));
-        if !src.exists() {
-            return Err(io::Error::new(
-                io::ErrorKind::NotFound,
-                format!("no proposed rule '{rule_id}' for tool '{tool}'"),
-            ));
-        }
-        let proposed_file: CorrectionFile = serde_yaml::from_str(&std::fs::read_to_string(&src)?)
-            .map_err(|e| io::Error::other(format!("parse proposed: {e}")))?;
-
-        let active_dir = self.inner.root.join(tool).join("active");
-        std::fs::create_dir_all(&active_dir)?;
-        let active_path = active_dir.join("corrections.yaml");
+        // Merge into existing active file if one exists.
         let mut current: CorrectionFile = if active_path.exists() {
             serde_yaml::from_str(&std::fs::read_to_string(&active_path)?)
                 .map_err(|e| io::Error::other(format!("parse active: {e}")))?
         } else {
             CorrectionFile::default()
         };
-        for rule in proposed_file.rules {
-            if current.rules.iter().any(|r| r.id == rule.id) {
-                continue;
+
+        // Replace existing rule with same id, or append.
+        if let Some(existing) = current.rules.iter_mut().find(|r| r.id == rule.id) {
+            *existing = rule;
+        } else {
+            if current.rules.len() >= MAX_ACTIVE_RULES_PER_TOOL {
+                return Err(io::Error::other(format!(
+                    "tool '{tool}' has reached cap of {MAX_ACTIVE_RULES_PER_TOOL} active rules"
+                )));
             }
             current.rules.push(rule);
         }
-        if current.rules.len() > MAX_ACTIVE_RULES_PER_TOOL {
-            return Err(io::Error::other(format!(
-                "tool '{tool}' would exceed cap of {MAX_ACTIVE_RULES_PER_TOOL} active rules"
-            )));
-        }
+
         let yaml = serde_yaml::to_string(&current)
             .map_err(|e| io::Error::other(format!("serialize active: {e}")))?;
         std::fs::write(&active_path, yaml)?;
-        std::fs::remove_file(&src)?;
         self.reload_tool(tool);
-        info!(tool, rule_id, "approved correction rule");
-        Ok(())
+        info!(tool, path = %active_path.display(), "wrote correction rule to active");
+        Ok(active_path)
     }
 }
 
@@ -432,26 +410,34 @@ mod tests {
     }
 
     #[test]
-    fn propose_writes_to_proposed_dir() {
+    fn add_rule_writes_to_active_and_enforces_immediately() {
         let dir = TempDir::new().unwrap();
         let cat = CorrectionCatalog::load(dir.path()).unwrap();
-        let rule = CorrectionRule::new("test-rule", "foo", "use bar", "agent");
-        let path = cat.propose("bash", rule).unwrap();
+        let rule = CorrectionRule::new("test-rule", r"foo", "use bar", "agent");
+        let path = cat.add_rule("bash", rule).unwrap();
         assert!(path.exists());
-        assert!(path.starts_with(dir.path().join("bash").join("proposed")));
-        // Proposed rules are NOT enforced.
-        assert!(cat.check("bash", "foo").is_none());
+        assert!(path.ends_with("active/corrections.yaml"));
+        // Rules are enforced immediately after add_rule.
+        assert!(cat.check("bash", "foo").is_some());
     }
 
     #[test]
-    fn approve_moves_proposed_to_active() {
+    fn add_rule_shadows_existing_rule_with_same_id() {
         let dir = TempDir::new().unwrap();
         let cat = CorrectionCatalog::load(dir.path()).unwrap();
-        let rule = CorrectionRule::new("sleep-chain", r"sleep\s+\d+\s*&&", "use until", "agent");
-        cat.propose("bash", rule).unwrap();
-        cat.approve("bash", "sleep-chain").unwrap();
+        let r1 = CorrectionRule::new("sleep-chain", r"sleep\s+\d+\s*&&\s*gh", "old correction", "seed");
+        cat.add_rule("bash", r1).unwrap();
+        let r2 = CorrectionRule::new("sleep-chain", r"sleep\s+\d+\s*&&\s*gh\s+pr", "new correction", "agent");
+        cat.add_rule("bash", r2).unwrap();
+        // Only one rule present (shadowed).
         assert_eq!(cat.len("bash"), 1);
-        assert!(cat.check("bash", "sleep 10 && echo ok").is_some());
+        // The newer correction is what fires.
+        let correction = cat.check("bash", "sleep 10 && gh pr checks 950").unwrap();
+        let correction_text = match correction {
+            ToolCorrection::Blocked { correction: c, .. } => c,
+            ToolCorrection::Warning { better: c, .. } => c,
+        };
+        assert!(correction_text.contains("new"));
     }
 
     #[test]
@@ -510,9 +496,10 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let cat = CorrectionCatalog::load(dir.path()).unwrap();
         let rule = CorrectionRule::new("r", "p", "c", "a");
-        assert!(cat.propose("../escape", rule.clone()).is_err());
-        assert!(cat.propose("bad/name", rule.clone()).is_err());
-        assert!(cat.propose("", rule).is_err());
+        // add_rule validates tool name same as propose did.
+        assert!(cat.add_rule("../escape", rule.clone()).is_err());
+        assert!(cat.add_rule("bad/name", rule.clone()).is_err());
+        assert!(cat.add_rule("", rule).is_err());
     }
 
     #[test]

--- a/rust/crates/sera-tools/src/corrections/catalog.rs
+++ b/rust/crates/sera-tools/src/corrections/catalog.rs
@@ -309,12 +309,6 @@ fn validate_tool_name(tool: &str) -> io::Result<()> {
     Ok(())
 }
 
-fn sanitize_id(id: &str) -> String {
-    id.chars()
-        .map(|c| if c.is_ascii_alphanumeric() || c == '-' || c == '_' { c } else { '_' })
-        .collect()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rust/crates/sera-tools/src/corrections/mod.rs
+++ b/rust/crates/sera-tools/src/corrections/mod.rs
@@ -11,8 +11,7 @@
 //! - Corrections are **data**, not code — the model can add rules via a
 //!   meta-tool without a recompile.
 //! - Per-tool scoping — a bad rule for `bash` cannot affect `runtime` tools.
-//! - Proposed rules land in `proposed/`; an admin promotes them to `active/`
-//!   (auto-promotion is out of scope here — a future skill can close that
+//! - Active rules are loaded from `active/corrections.yaml` and hot-reloaded on change.
 //!   loop after N clean uses).
 //! - Cap of 50 active rules per tool to bound preflight cost.
 

--- a/rust/crates/sera-tools/src/corrections/seed.rs
+++ b/rust/crates/sera-tools/src/corrections/seed.rs
@@ -2,9 +2,22 @@
 //!
 //! Written to `<root>/bash/active/corrections.yaml` on first boot if the
 //! file does not yet exist. Rewriting an existing file would clobber
-//! hand-tuned rules, so the seeder is strictly idempotent — callers that
-//! want a pristine seed must delete the file first.
-
+//! hand-tuned rules, so the seeder is strictly idempotent.
+//!
+//! ## Immutable vs Mutable
+//!
+//! Seed rules are **compiled into the binary** — they cannot be changed without
+//! a recompile. They serve as the stable starting point only.
+//!
+//! All **evolvable rules** live in the YAML catalog at:
+//!   `~/.sera/tool-corrections/bash/active/corrections.yaml`
+//!
+//! YAML rules **shadow seed rules** — if a YAML rule has the same `id` as a
+//! seed rule, the YAML version takes precedence. The agent can:
+//!   - Add new rules to `active/corrections.yaml` (hot-reloaded)
+//!   - Modify or delete YAML rules without recompiling
+//!   - Propose new rules in `proposed/` for human approval
+//!
 use std::io;
 use std::path::{Path, PathBuf};
 

--- a/rust/crates/sera-tools/src/corrections/seed.rs
+++ b/rust/crates/sera-tools/src/corrections/seed.rs
@@ -119,6 +119,24 @@ pub fn bash_seed_rules() -> Vec<CorrectionRule> {
             hit_count: 0,
             last_hit: None,
         },
+        // Monitor anti-pattern: sleep N; followed by a file-read command (wc, tail, cat, head, ls).
+        // This is the Monitor's "wait for file" pattern — it burns cycles polling.
+        // Correct: use `until <check>; do sleep 2; done` or run_in_background with piped output.
+        CorrectionRule {
+            id: "monitor-sleep-file-poll".to_string(),
+            antipattern: "sleep N; <file-read command>".to_string(),
+            pattern: r"\bsleep\s+\d+\s*;\s*(?:wc|cat|head|tail|ls|stat|test)\s".to_string(),
+            matches: MatchKind::Regex,
+            severity: CorrectionSeverity::Block,
+            correction:
+                "Use Monitor with an until-loop (`until <condition>; do sleep 2; done`) for \
+                 file-existence polling. For watching background task output, use run_in_background: true \
+                 and pipe directly or read the output file when the task completes.".to_string(),
+            added_by: "seed".to_string(),
+            added_at: now,
+            hit_count: 0,
+            last_hit: None,
+        },
     ];
     // Stable ordering so reload is deterministic.
     rules.sort_by(|a, b| a.id.cmp(&b.id));
@@ -233,3 +251,4 @@ mod tests {
         assert!(!wrote_second, "seed must not clobber an existing catalog");
     }
 }
+

--- a/rust/crates/sera-tools/tests/corrections_integration.rs
+++ b/rust/crates/sera-tools/tests/corrections_integration.rs
@@ -89,7 +89,7 @@ fn seed_bootstrap_catches_every_canonical_antipattern() {
 }
 
 #[test]
-fn seed_rules_match_the_five_skill_ids() {
+fn seed_rules_match_expected_skill_ids() {
     // Regression on the ID set — the skill names these exactly.
     let ids: Vec<_> = bash_seed_rules().into_iter().map(|r| r.id).collect();
     let mut expected = vec![
@@ -98,6 +98,7 @@ fn seed_rules_match_the_five_skill_ids() {
         "echo-to-file-creation".to_string(),
         "git-push-force-to-protected-branch".to_string(),
         "secret-inline-in-command".to_string(),
+        "monitor-sleep-file-poll".to_string(),
     ];
     expected.sort();
     let mut actual = ids;


### PR DESCRIPTION
Blocks 'sleep N; <file-read command>' — the Monitor anti-pattern where agents poll file existence via repeated sleep+read. Correct pattern is an until-loop or run_in_background with piped output.