### PR TITLE
feat(sera-runtime): extract NDJSON stdio loop + canonical handshake (P0-6)

### DIFF
--- a/rust/crates/sera-runtime/src/lib.rs
+++ b/rust/crates/sera-runtime/src/lib.rs
@@ -49,6 +49,7 @@ pub mod semantic;
 pub mod shadow;
 pub mod signal_emit;
 pub mod skill_dispatch;
+pub mod stdio;
 pub mod tool_hooks;
 
 // Retained modules

--- a/rust/crates/sera-runtime/src/main.rs
+++ b/rust/crates/sera-runtime/src/main.rs
@@ -4,9 +4,10 @@
 //! tool dispatch, context engine, and turn loop. No gateway required.
 //!
 //! Two modes:
-//! - **Interactive** (default when stdin is a TTY): human-friendly chat REPL
+//! - **Interactive** (default when stdin is a TTY): human-friendly chat REPL.
 //! - **NDJSON** (default when stdin is piped, or `--ndjson`): machine-readable
-//!   Submission/Event protocol for gateway integration
+//!   Submission/Event protocol (P0-6 `AppServerTransport::Stdio` contract —
+//!   see [`sera_runtime::stdio`]).
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -18,12 +19,12 @@ use sera_runtime::context_engine::pipeline::ContextPipeline;
 use sera_runtime::default_runtime::DefaultRuntime;
 use sera_runtime::health;
 use sera_runtime::llm_client::LlmClient;
+use sera_runtime::stdio;
 use sera_runtime::tools::TraitToolRegistry;
 use sera_runtime::tools::dispatcher::RegistryDispatcher;
 use sera_types::principal::PrincipalId;
-use sera_types::runtime::{AgentRuntime, TokenUsage, TurnContext, TurnOutcome};
+use sera_types::runtime::{AgentRuntime, TurnContext, TurnOutcome};
 use sera_types::tool::AuthzProviderHandle;
-use serde::{Deserialize, Serialize};
 
 // ── CLI ──────────────────────────────────────────────────────────────────────
 
@@ -91,98 +92,6 @@ impl Cli {
     }
 }
 
-// ── NDJSON envelope types ────────────────────────────────────────────────────
-
-/// Local NDJSON submission type — serde-compatible with sera-gateway's Submission.
-/// Defined locally to avoid a cyclic dependency (sera-gateway depends on sera-runtime).
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct Submission {
-    id: uuid::Uuid,
-    op: Op,
-}
-
-/// Local operation enum — mirrors sera-gateway's Op.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
-enum Op {
-    UserTurn {
-        items: Vec<serde_json::Value>,
-        #[serde(default)]
-        model_override: Option<String>,
-        /// Session key provided by the gateway for per-session context tracking.
-        #[serde(default)]
-        session_key: Option<String>,
-        /// Parent session key — set when this turn belongs to a child session.
-        #[serde(default)]
-        parent_session_key: Option<String>,
-    },
-    Steer {
-        items: Vec<serde_json::Value>,
-        #[serde(default)]
-        session_key: Option<String>,
-        /// Parent session key — propagated from the spawning session.
-        #[serde(default)]
-        parent_session_key: Option<String>,
-    },
-    Interrupt,
-    System(SystemOp),
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "system_op", rename_all = "snake_case")]
-enum SystemOp {
-    Shutdown,
-    HealthCheck,
-}
-
-/// Local NDJSON event type — serde-compatible with sera-gateway's Event.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct Event {
-    id: uuid::Uuid,
-    /// Nil UUID for handshake frames (no associated submission).
-    submission_id: uuid::Uuid,
-    msg: EventMsg,
-    timestamp: chrono::DateTime<chrono::Utc>,
-    /// Parent session key carried on every frame so consumers can route child events.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    parent_session_key: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
-enum EventMsg {
-    /// First frame — protocol negotiation (OpenClaw handshake).
-    Handshake {
-        protocol_version: String,
-        features: Vec<String>,
-        agent_id: String,
-    },
-    TurnStarted { turn_id: uuid::Uuid },
-    /// Terminal turn frame carrying the provider-reported token usage for this
-    /// turn. Consumers (e.g. the gateway) parse `tokens` to report usage back
-    /// through `/api/chat` responses.
-    TurnCompleted {
-        turn_id: uuid::Uuid,
-        #[serde(default)]
-        tokens: TokenUsage,
-    },
-    StreamingDelta { delta: String },
-    /// Tool call started — emitted for each tool invocation during the turn.
-    ToolCallBegin {
-        turn_id: uuid::Uuid,
-        call_id: String,
-        tool: String,
-        arguments: serde_json::Value,
-    },
-    /// Tool call completed — emitted after tool execution with the result.
-    ToolCallEnd {
-        turn_id: uuid::Uuid,
-        call_id: String,
-        result: String,
-    },
-    Error { code: String, message: String },
-}
-
 // ── Authz provider construction ──────────────────────────────────────────────
 
 /// Build an [`AuthzProviderHandle`] from config.
@@ -230,9 +139,6 @@ fn build_authz_provider(config: &RuntimeConfig) -> Arc<dyn AuthzProviderHandle> 
         builder = builder.grant(role, kinds);
     }
 
-    // If no agent-id is available here we still produce a valid provider;
-    // principal assignments are wired at call time or via future config.
-    //
     // Assign the runtime's own agent-id as a full-access principal so the
     // default single-agent deployment works without additional config.
     if let Ok(agent_id) = std::env::var("AGENT_ID")
@@ -276,23 +182,21 @@ async fn main() -> anyhow::Result<()> {
     let system_prompt = cli.system.clone();
     let config = cli.into_config();
 
-    // In interactive mode, only show warnings (no info spam); NDJSON mode uses RUST_LOG
-    if interactive {
-        tracing_subscriber::fmt()
-            .with_env_filter(
-                tracing_subscriber::EnvFilter::try_from_default_env()
-                    .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn")),
-            )
-            .with_writer(std::io::stderr)
-            .init();
+    // NDJSON mode reserves stdout for the protocol — all tracing output
+    // (including info logs) goes to stderr so it cannot corrupt the
+    // Submission/Event byte stream. Interactive mode likewise writes to
+    // stderr to keep stdout clean for the assistant's final response.
+    let filter = if interactive {
+        tracing_subscriber::EnvFilter::try_from_default_env()
+            .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn"))
     } else {
-        tracing_subscriber::fmt()
-            .with_env_filter(
-                tracing_subscriber::EnvFilter::try_from_default_env()
-                    .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
-            )
-            .init();
-    }
+        tracing_subscriber::EnvFilter::try_from_default_env()
+            .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"))
+    };
+    tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_writer(std::io::stderr)
+        .init();
 
     // Start health server in background (unless disabled)
     if config.chat_port > 0 {
@@ -304,12 +208,8 @@ async fn main() -> anyhow::Result<()> {
         });
     }
 
-    // Build authz provider from config (allow-all stub when tool_authz_roles unset).
     let authz_provider = build_authz_provider(&config);
 
-    // Build tool registry with authz kill-switch flag, and dispatcher.
-    // All builtins are native `Tool` impls post bead sera-ttrm-5.
-    //
     // sera-a1u: every runtime owns a shared DelegationBus so the three
     // delegation tools (session_spawn / session_yield / session_send) can
     // coordinate over a single subscriber registry.
@@ -329,8 +229,6 @@ async fn main() -> anyhow::Result<()> {
         })
         .collect();
 
-    // Build the DefaultRuntime.
-    //
     // sera-jvi + sera-48v: opportunistically attach an [`AccountPool`] and a
     // unified [`ThinkingConfig`] when the corresponding env vars are set.
     // Absence of either preserves the legacy single-account / no-reasoning
@@ -351,7 +249,7 @@ async fn main() -> anyhow::Result<()> {
             tool_count = tool_defs.len(),
             "sera-runtime starting (NDJSON transport)"
         );
-        run_ndjson_loop(&config, &runtime, &tool_defs).await
+        stdio::run_ndjson_loop(&config, &runtime, &tool_defs).await
     }
 }
 
@@ -446,366 +344,7 @@ async fn run_interactive(
     Ok(())
 }
 
-// ── NDJSON transport ─────────────────────────────────────────────────────────
-
-/// Read Submissions from stdin (NDJSON), process each, write Events to stdout.
-async fn run_ndjson_loop(
-    config: &RuntimeConfig,
-    runtime: &DefaultRuntime,
-    tool_defs: &[sera_types::tool::ToolDefinition],
-) -> anyhow::Result<()> {
-    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-
-    let stdin = tokio::io::stdin();
-    let mut reader = BufReader::new(stdin);
-    let mut stdout = tokio::io::stdout();
-    let mut line = String::new();
-
-    // Emit handshake frame — first frame the gateway reads to negotiate protocol.
-    let handshake = Event {
-        id: uuid::Uuid::new_v4(),
-        submission_id: uuid::Uuid::nil(),
-        msg: EventMsg::Handshake {
-            protocol_version: "2.0".to_string(),
-            features: vec![
-                "steer".to_string(),
-                "hitl".to_string(),
-                "hooks@v2".to_string(),
-                "parent_session_key".to_string(),
-            ],
-            agent_id: config.agent_id.clone(),
-        },
-        timestamp: chrono::Utc::now(),
-        parent_session_key: None,
-    };
-    let mut handshake_json = serde_json::to_string(&handshake)?;
-    handshake_json.push('\n');
-    stdout.write_all(handshake_json.as_bytes()).await?;
-    stdout.flush().await?;
-
-    loop {
-        line.clear();
-        let n = reader.read_line(&mut line).await?;
-        if n == 0 {
-            tracing::info!("stdin closed, exiting NDJSON loop");
-            break;
-        }
-
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-
-        let submission: Submission = match serde_json::from_str(trimmed) {
-            Ok(s) => s,
-            Err(e) => {
-                let err_event = Event {
-                    id: uuid::Uuid::new_v4(),
-                    submission_id: uuid::Uuid::nil(),
-                    msg: EventMsg::Error {
-                        code: "parse_error".to_string(),
-                        message: format!("failed to parse submission: {e}"),
-                    },
-                    timestamp: chrono::Utc::now(),
-                    parent_session_key: None,
-                };
-                let mut json = serde_json::to_string(&err_event)?;
-                json.push('\n');
-                stdout.write_all(json.as_bytes()).await?;
-                stdout.flush().await?;
-                continue;
-            }
-        };
-
-        // Check for shutdown
-        if matches!(&submission.op, Op::System(SystemOp::Shutdown)) {
-            tracing::info!("received shutdown command, exiting");
-            break;
-        }
-
-        let turn_id = uuid::Uuid::new_v4();
-
-        // Extract parent_session_key from the submission op for propagation.
-        let submission_parent_key = match &submission.op {
-            Op::UserTurn { parent_session_key, .. } => parent_session_key.clone(),
-            Op::Steer { parent_session_key, .. } => parent_session_key.clone(),
-            _ => None,
-        };
-
-        // Emit TurnStarted
-        let started = Event {
-            id: uuid::Uuid::new_v4(),
-            submission_id: submission.id,
-            msg: EventMsg::TurnStarted { turn_id },
-            timestamp: chrono::Utc::now(),
-            parent_session_key: submission_parent_key.clone(),
-        };
-        let mut json = serde_json::to_string(&started)?;
-        json.push('\n');
-        stdout.write_all(json.as_bytes()).await?;
-
-        // Convert Submission to TurnContext and execute via DefaultRuntime
-        let turn_ctx = submission_to_turn_context(&submission, &config.agent_id, turn_id, tool_defs);
-        let outcome = runtime.execute_turn(turn_ctx).await;
-
-        // Extract tokens_used for the terminal TurnCompleted frame. `Interruption`
-        // is the only outcome variant without a `tokens_used` field; errors and
-        // the `Err` arm report zeroed usage (the LLM call never completed).
-        let tokens_for_completion = match &outcome {
-            Ok(TurnOutcome::FinalOutput { tokens_used, .. })
-            | Ok(TurnOutcome::RunAgain { tokens_used, .. })
-            | Ok(TurnOutcome::Handoff { tokens_used, .. })
-            | Ok(TurnOutcome::Compact { tokens_used, .. })
-            | Ok(TurnOutcome::Stop { tokens_used, .. })
-            | Ok(TurnOutcome::WaitingForApproval { tokens_used, .. })
-            | Ok(TurnOutcome::PlanEmitted { tokens_used, .. }) => tokens_used.clone(),
-            Ok(TurnOutcome::Interruption { .. }) | Err(_) => TokenUsage::default(),
-        };
-
-        // Convert TurnOutcome to Event messages
-        match outcome {
-            Ok(TurnOutcome::FinalOutput { response, transcript, .. }) => {
-                // Emit tool call events from the accumulated transcript.
-                // The transcript contains assistant messages (with tool_calls) and
-                // tool result messages accumulated during the tool-call loop.
-                for msg in &transcript {
-                    let role = msg.get("role").and_then(|r| r.as_str()).unwrap_or("");
-                    if role == "assistant" {
-                        if let Some(tool_calls) = msg.get("tool_calls").and_then(|tc| tc.as_array()) {
-                            for tc in tool_calls {
-                                let call_id = tc.get("id").and_then(|id| id.as_str()).unwrap_or("").to_string();
-                                let tool_name = tc.get("function")
-                                    .and_then(|f| f.get("name"))
-                                    .and_then(|n| n.as_str())
-                                    .unwrap_or("")
-                                    .to_string();
-                                let arguments_str = tc.get("function")
-                                    .and_then(|f| f.get("arguments"))
-                                    .and_then(|a| a.as_str())
-                                    .unwrap_or("{}");
-                                let arguments = serde_json::from_str(arguments_str)
-                                    .unwrap_or(serde_json::Value::Object(Default::default()));
-                                let begin_event = Event {
-                                    id: uuid::Uuid::new_v4(),
-                                    submission_id: submission.id,
-                                    msg: EventMsg::ToolCallBegin {
-                                        turn_id,
-                                        call_id: call_id.clone(),
-                                        tool: tool_name,
-                                        arguments,
-                                    },
-                                    timestamp: chrono::Utc::now(),
-                                    parent_session_key: submission_parent_key.clone(),
-                                };
-                                json = serde_json::to_string(&begin_event)?;
-                                json.push('\n');
-                                stdout.write_all(json.as_bytes()).await?;
-                            }
-                        }
-                    } else if role == "tool" {
-                        let call_id = msg.get("tool_call_id").and_then(|id| id.as_str()).unwrap_or("").to_string();
-                        let result_content = msg.get("content").and_then(|c| c.as_str()).unwrap_or("").to_string();
-                        let end_event = Event {
-                            id: uuid::Uuid::new_v4(),
-                            submission_id: submission.id,
-                            msg: EventMsg::ToolCallEnd {
-                                turn_id,
-                                call_id,
-                                result: result_content,
-                            },
-                            timestamp: chrono::Utc::now(),
-                            parent_session_key: submission_parent_key.clone(),
-                        };
-                        json = serde_json::to_string(&end_event)?;
-                        json.push('\n');
-                        stdout.write_all(json.as_bytes()).await?;
-                    }
-                }
-
-                // Emit the final response
-                let delta = Event {
-                    id: uuid::Uuid::new_v4(),
-                    submission_id: submission.id,
-                    msg: EventMsg::StreamingDelta { delta: response },
-                    timestamp: chrono::Utc::now(),
-                    parent_session_key: submission_parent_key.clone(),
-                };
-                json = serde_json::to_string(&delta)?;
-                json.push('\n');
-                stdout.write_all(json.as_bytes()).await?;
-            }
-            Ok(TurnOutcome::RunAgain { .. }) => {
-                let delta = Event {
-                    id: uuid::Uuid::new_v4(),
-                    submission_id: submission.id,
-                    msg: EventMsg::StreamingDelta {
-                        delta: "[run_again — tool calls dispatched]".to_string(),
-                    },
-                    timestamp: chrono::Utc::now(),
-                    parent_session_key: submission_parent_key.clone(),
-                };
-                json = serde_json::to_string(&delta)?;
-                json.push('\n');
-                stdout.write_all(json.as_bytes()).await?;
-            }
-            Ok(TurnOutcome::Handoff { target_agent_id, .. }) => {
-                let delta = Event {
-                    id: uuid::Uuid::new_v4(),
-                    submission_id: submission.id,
-                    msg: EventMsg::StreamingDelta {
-                        delta: format!("[handoff -> {target_agent_id}]"),
-                    },
-                    timestamp: chrono::Utc::now(),
-                    parent_session_key: submission_parent_key.clone(),
-                };
-                json = serde_json::to_string(&delta)?;
-                json.push('\n');
-                stdout.write_all(json.as_bytes()).await?;
-            }
-            Ok(TurnOutcome::Compact { .. }) => {
-                let delta = Event {
-                    id: uuid::Uuid::new_v4(),
-                    submission_id: submission.id,
-                    msg: EventMsg::StreamingDelta {
-                        delta: "[compact — context condensed]".to_string(),
-                    },
-                    timestamp: chrono::Utc::now(),
-                    parent_session_key: submission_parent_key.clone(),
-                };
-                json = serde_json::to_string(&delta)?;
-                json.push('\n');
-                stdout.write_all(json.as_bytes()).await?;
-            }
-            Ok(TurnOutcome::Interruption { reason, .. }) => {
-                let delta = Event {
-                    id: uuid::Uuid::new_v4(),
-                    submission_id: submission.id,
-                    msg: EventMsg::StreamingDelta {
-                        delta: format!("[interrupted: {reason}]"),
-                    },
-                    timestamp: chrono::Utc::now(),
-                    parent_session_key: submission_parent_key.clone(),
-                };
-                json = serde_json::to_string(&delta)?;
-                json.push('\n');
-                stdout.write_all(json.as_bytes()).await?;
-            }
-            Ok(TurnOutcome::Stop { summary, .. }) => {
-                let delta = Event {
-                    id: uuid::Uuid::new_v4(),
-                    submission_id: submission.id,
-                    msg: EventMsg::StreamingDelta {
-                        delta: format!("[stop: {summary}]"),
-                    },
-                    timestamp: chrono::Utc::now(),
-                    parent_session_key: submission_parent_key.clone(),
-                };
-                json = serde_json::to_string(&delta)?;
-                json.push('\n');
-                stdout.write_all(json.as_bytes()).await?;
-            }
-            Ok(TurnOutcome::WaitingForApproval { ticket_id, .. }) => {
-                let delta = Event {
-                    id: uuid::Uuid::new_v4(),
-                    submission_id: submission.id,
-                    msg: EventMsg::StreamingDelta {
-                        delta: format!("[waiting_for_approval: ticket={ticket_id}]"),
-                    },
-                    timestamp: chrono::Utc::now(),
-                    parent_session_key: submission_parent_key.clone(),
-                };
-                json = serde_json::to_string(&delta)?;
-                json.push('\n');
-                stdout.write_all(json.as_bytes()).await?;
-            }
-            Ok(TurnOutcome::PlanEmitted { plan_tool_calls, rationale, .. }) => {
-                let summary = format!(
-                    "[plan_emitted: {} tool call(s); rationale={:?}]",
-                    plan_tool_calls.len(),
-                    rationale
-                );
-                let delta = Event {
-                    id: uuid::Uuid::new_v4(),
-                    submission_id: submission.id,
-                    msg: EventMsg::StreamingDelta { delta: summary },
-                    timestamp: chrono::Utc::now(),
-                    parent_session_key: submission_parent_key.clone(),
-                };
-                json = serde_json::to_string(&delta)?;
-                json.push('\n');
-                stdout.write_all(json.as_bytes()).await?;
-            }
-            Err(e) => {
-                tracing::error!("execute_turn failed: {e:?}");
-                let err_event = Event {
-                    id: uuid::Uuid::new_v4(),
-                    submission_id: submission.id,
-                    msg: EventMsg::Error {
-                        code: "turn_error".to_string(),
-                        message: format!("{e:?}"),
-                    },
-                    timestamp: chrono::Utc::now(),
-                    parent_session_key: submission_parent_key.clone(),
-                };
-                json = serde_json::to_string(&err_event)?;
-                json.push('\n');
-                stdout.write_all(json.as_bytes()).await?;
-            }
-        }
-
-        // Emit TurnCompleted with the usage the LLM reported for this turn.
-        let completed = Event {
-            id: uuid::Uuid::new_v4(),
-            submission_id: submission.id,
-            msg: EventMsg::TurnCompleted {
-                turn_id,
-                tokens: tokens_for_completion,
-            },
-            timestamp: chrono::Utc::now(),
-            parent_session_key: submission_parent_key,
-        };
-        json = serde_json::to_string(&completed)?;
-        json.push('\n');
-        stdout.write_all(json.as_bytes()).await?;
-        stdout.flush().await?;
-    }
-
-    Ok(())
-}
-
-/// Convert a local `Submission` into a `TurnContext` for the runtime.
-fn submission_to_turn_context(
-    submission: &Submission,
-    agent_id: &str,
-    turn_id: uuid::Uuid,
-    tool_defs: &[sera_types::tool::ToolDefinition],
-) -> TurnContext {
-    let (messages, session_key_override, parent_session_key) = match &submission.op {
-        Op::UserTurn { items, session_key, parent_session_key, .. } => {
-            (items.clone(), session_key.clone(), parent_session_key.clone())
-        }
-        Op::Steer { items, session_key, parent_session_key } => {
-            (items.clone(), session_key.clone(), parent_session_key.clone())
-        }
-        Op::Interrupt | Op::System(_) => (vec![], None, None),
-    };
-
-    // Use gateway-provided session_key when available, otherwise generate one.
-    let session_key = session_key_override
-        .unwrap_or_else(|| format!("session:{agent_id}:{}", submission.id));
-
-    TurnContext {
-        event_id: turn_id.to_string(),
-        agent_id: agent_id.to_string(),
-        session_key,
-        messages,
-        available_tools: tool_defs.to_vec(),
-        metadata: HashMap::new(),
-        change_artifact: None,
-        parent_session_key,
-        tool_use_behavior: Default::default(),
-    }
-}
+// ── LLM client wiring ────────────────────────────────────────────────────────
 
 /// Build an [`LlmClient`] with optional sera-jvi account pool + sera-48v
 /// thinking config attached.

--- a/rust/crates/sera-runtime/src/stdio.rs
+++ b/rust/crates/sera-runtime/src/stdio.rs
@@ -1,0 +1,575 @@
+//! NDJSON Submission/Event stdio transport for sera-runtime (P0-6).
+//!
+//! This module implements the runtime's half of the `AppServerTransport::Stdio`
+//! contract: one Submission JSON object per line on stdin, one Event JSON object
+//! per line on stdout. The first frame emitted is a canonical
+//! [`HandshakeFrame`] from `sera_types::envelope`; subsequent frames are the
+//! protocol-v1 [`Event`] envelope defined below (serde-compatible with
+//! `sera_gateway::bin::sera::StdioHarness`).
+//!
+//! The local [`Submission`], [`Event`], [`Op`], [`SystemOp`] and [`EventMsg`]
+//! types are intentionally duplicated here rather than pulled from
+//! `sera_types::envelope`:
+//!
+//! * `sera-runtime` must not depend on `sera-gateway` (cycle), and the gateway's
+//!   [`StdioHarness`](sera_gateway::bin::sera::StdioHarness) currently emits the
+//!   v1 shape. Switching both sides to canonical types simultaneously is P1
+//!   follow-up work — tracked via `TODO(P0-6/P1-canonical-envelope)`.
+//! * The handshake is already on the canonical `HandshakeFrame`, so v2
+//!   consumers can negotiate without reading any event body.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use sera_types::envelope::HandshakeFrame;
+use sera_types::runtime::{AgentRuntime, TokenUsage, TurnContext, TurnOutcome};
+
+use crate::config::RuntimeConfig;
+use crate::default_runtime::DefaultRuntime;
+
+// ── Protocol-v1 envelope (runtime ↔ gateway stdio) ──────────────────────────
+
+/// Local NDJSON submission type — serde-compatible with `sera-gateway`'s
+/// `Submission`. Defined locally to avoid a cyclic dependency (`sera-gateway`
+/// depends on `sera-runtime`). See module-level docs for the P1 plan to
+/// migrate onto `sera_types::envelope`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Submission {
+    pub id: uuid::Uuid,
+    pub op: Op,
+}
+
+/// Local operation enum — mirrors `sera-gateway`'s `Op`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Op {
+    UserTurn {
+        items: Vec<serde_json::Value>,
+        #[serde(default)]
+        model_override: Option<String>,
+        /// Session key provided by the gateway for per-session context tracking.
+        #[serde(default)]
+        session_key: Option<String>,
+        /// Parent session key — set when this turn belongs to a child session.
+        #[serde(default)]
+        parent_session_key: Option<String>,
+    },
+    Steer {
+        items: Vec<serde_json::Value>,
+        #[serde(default)]
+        session_key: Option<String>,
+        /// Parent session key — propagated from the spawning session.
+        #[serde(default)]
+        parent_session_key: Option<String>,
+    },
+    Interrupt,
+    System(SystemOp),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "system_op", rename_all = "snake_case")]
+pub enum SystemOp {
+    Shutdown,
+    HealthCheck,
+}
+
+/// Local NDJSON event type — serde-compatible with `sera-gateway`'s `Event`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Event {
+    pub id: uuid::Uuid,
+    /// Nil UUID for handshake frames (no associated submission).
+    pub submission_id: uuid::Uuid,
+    pub msg: EventMsg,
+    pub timestamp: chrono::DateTime<chrono::Utc>,
+    /// Parent session key carried on every frame so consumers can route child events.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_session_key: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum EventMsg {
+    TurnStarted {
+        turn_id: uuid::Uuid,
+    },
+    /// Terminal turn frame carrying the provider-reported token usage for this
+    /// turn. Consumers (e.g. the gateway) parse `tokens` to report usage back
+    /// through `/api/chat` responses.
+    TurnCompleted {
+        turn_id: uuid::Uuid,
+        #[serde(default)]
+        tokens: TokenUsage,
+    },
+    StreamingDelta {
+        delta: String,
+    },
+    /// Tool call started — emitted for each tool invocation during the turn.
+    ToolCallBegin {
+        turn_id: uuid::Uuid,
+        call_id: String,
+        tool: String,
+        arguments: serde_json::Value,
+    },
+    /// Tool call completed — emitted after tool execution with the result.
+    ToolCallEnd {
+        turn_id: uuid::Uuid,
+        call_id: String,
+        result: String,
+    },
+    Error {
+        code: String,
+        message: String,
+    },
+}
+
+// ── NDJSON loop ─────────────────────────────────────────────────────────────
+
+/// Read [`Submission`] frames from stdin, dispatch each through the runtime,
+/// and stream [`Event`] frames back on stdout. Exits on
+/// `Op::System(SystemOp::Shutdown)` or EOF (stdin closed).
+///
+/// First frame emitted is the canonical [`HandshakeFrame::v2`] so any v2-aware
+/// consumer can negotiate protocol capabilities without parsing an `Event`
+/// body.
+pub async fn run_ndjson_loop(
+    config: &RuntimeConfig,
+    runtime: &DefaultRuntime,
+    tool_defs: &[sera_types::tool::ToolDefinition],
+) -> anyhow::Result<()> {
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+    let stdin = tokio::io::stdin();
+    let mut reader = BufReader::new(stdin);
+    let mut stdout = tokio::io::stdout();
+    let mut line = String::new();
+
+    // Emit canonical HandshakeFrame — v2-aware consumers negotiate capabilities
+    // here; legacy consumers treat the first line as an informational frame and
+    // skip it (non-Event JSON).
+    let handshake = HandshakeFrame::v2(config.agent_id.clone(), None);
+    let mut handshake_json = serde_json::to_string(&handshake)?;
+    handshake_json.push('\n');
+    stdout.write_all(handshake_json.as_bytes()).await?;
+    stdout.flush().await?;
+
+    loop {
+        line.clear();
+        let n = reader.read_line(&mut line).await?;
+        if n == 0 {
+            tracing::info!("stdin closed, exiting NDJSON loop");
+            break;
+        }
+
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        let submission: Submission = match serde_json::from_str(trimmed) {
+            Ok(s) => s,
+            Err(e) => {
+                emit(
+                    &mut stdout,
+                    Event {
+                        id: uuid::Uuid::new_v4(),
+                        submission_id: uuid::Uuid::nil(),
+                        msg: EventMsg::Error {
+                            code: "parse_error".to_string(),
+                            message: format!("failed to parse submission: {e}"),
+                        },
+                        timestamp: chrono::Utc::now(),
+                        parent_session_key: None,
+                    },
+                )
+                .await?;
+                continue;
+            }
+        };
+
+        // Check for shutdown
+        if matches!(&submission.op, Op::System(SystemOp::Shutdown)) {
+            tracing::info!("received shutdown command, exiting");
+            break;
+        }
+
+        process_submission(&mut stdout, config, runtime, tool_defs, submission).await?;
+    }
+
+    Ok(())
+}
+
+/// Dispatch a single submission through the runtime and stream the resulting
+/// [`Event`] frames to `stdout`.
+async fn process_submission(
+    stdout: &mut tokio::io::Stdout,
+    config: &RuntimeConfig,
+    runtime: &DefaultRuntime,
+    tool_defs: &[sera_types::tool::ToolDefinition],
+    submission: Submission,
+) -> anyhow::Result<()> {
+    let turn_id = uuid::Uuid::new_v4();
+
+    // Extract parent_session_key from the submission op for propagation.
+    let submission_parent_key = match &submission.op {
+        Op::UserTurn { parent_session_key, .. } => parent_session_key.clone(),
+        Op::Steer { parent_session_key, .. } => parent_session_key.clone(),
+        _ => None,
+    };
+
+    // Emit TurnStarted
+    emit(
+        stdout,
+        Event {
+            id: uuid::Uuid::new_v4(),
+            submission_id: submission.id,
+            msg: EventMsg::TurnStarted { turn_id },
+            timestamp: chrono::Utc::now(),
+            parent_session_key: submission_parent_key.clone(),
+        },
+    )
+    .await?;
+
+    let turn_ctx = submission_to_turn_context(&submission, &config.agent_id, turn_id, tool_defs);
+    let outcome = runtime.execute_turn(turn_ctx).await;
+
+    // Extract tokens_used for the terminal TurnCompleted frame. `Interruption`
+    // is the only outcome variant without a `tokens_used` field; errors and
+    // the `Err` arm report zeroed usage (the LLM call never completed).
+    let tokens_for_completion = match &outcome {
+        Ok(TurnOutcome::FinalOutput { tokens_used, .. })
+        | Ok(TurnOutcome::RunAgain { tokens_used, .. })
+        | Ok(TurnOutcome::Handoff { tokens_used, .. })
+        | Ok(TurnOutcome::Compact { tokens_used, .. })
+        | Ok(TurnOutcome::Stop { tokens_used, .. })
+        | Ok(TurnOutcome::WaitingForApproval { tokens_used, .. })
+        | Ok(TurnOutcome::PlanEmitted { tokens_used, .. }) => tokens_used.clone(),
+        Ok(TurnOutcome::Interruption { .. }) | Err(_) => TokenUsage::default(),
+    };
+
+    match outcome {
+        Ok(TurnOutcome::FinalOutput { response, transcript, .. }) => {
+            emit_tool_events_from_transcript(stdout, &submission, turn_id, &submission_parent_key, &transcript)
+                .await?;
+            emit(
+                stdout,
+                Event {
+                    id: uuid::Uuid::new_v4(),
+                    submission_id: submission.id,
+                    msg: EventMsg::StreamingDelta { delta: response },
+                    timestamp: chrono::Utc::now(),
+                    parent_session_key: submission_parent_key.clone(),
+                },
+            )
+            .await?;
+        }
+        Ok(TurnOutcome::RunAgain { .. }) => {
+            emit_delta(
+                stdout,
+                &submission,
+                &submission_parent_key,
+                "[run_again — tool calls dispatched]".into(),
+            )
+            .await?;
+        }
+        Ok(TurnOutcome::Handoff { target_agent_id, .. }) => {
+            emit_delta(
+                stdout,
+                &submission,
+                &submission_parent_key,
+                format!("[handoff -> {target_agent_id}]"),
+            )
+            .await?;
+        }
+        Ok(TurnOutcome::Compact { .. }) => {
+            emit_delta(
+                stdout,
+                &submission,
+                &submission_parent_key,
+                "[compact — context condensed]".into(),
+            )
+            .await?;
+        }
+        Ok(TurnOutcome::Interruption { reason, .. }) => {
+            emit_delta(
+                stdout,
+                &submission,
+                &submission_parent_key,
+                format!("[interrupted: {reason}]"),
+            )
+            .await?;
+        }
+        Ok(TurnOutcome::Stop { summary, .. }) => {
+            emit_delta(
+                stdout,
+                &submission,
+                &submission_parent_key,
+                format!("[stop: {summary}]"),
+            )
+            .await?;
+        }
+        Ok(TurnOutcome::WaitingForApproval { ticket_id, .. }) => {
+            emit_delta(
+                stdout,
+                &submission,
+                &submission_parent_key,
+                format!("[waiting_for_approval: ticket={ticket_id}]"),
+            )
+            .await?;
+        }
+        Ok(TurnOutcome::PlanEmitted { plan_tool_calls, rationale, .. }) => {
+            let summary = format!(
+                "[plan_emitted: {} tool call(s); rationale={:?}]",
+                plan_tool_calls.len(),
+                rationale
+            );
+            emit_delta(stdout, &submission, &submission_parent_key, summary).await?;
+        }
+        Err(e) => {
+            tracing::error!("execute_turn failed: {e:?}");
+            emit(
+                stdout,
+                Event {
+                    id: uuid::Uuid::new_v4(),
+                    submission_id: submission.id,
+                    msg: EventMsg::Error {
+                        code: "turn_error".to_string(),
+                        message: format!("{e:?}"),
+                    },
+                    timestamp: chrono::Utc::now(),
+                    parent_session_key: submission_parent_key.clone(),
+                },
+            )
+            .await?;
+        }
+    }
+
+    // Emit TurnCompleted with the usage the LLM reported for this turn.
+    emit(
+        stdout,
+        Event {
+            id: uuid::Uuid::new_v4(),
+            submission_id: submission.id,
+            msg: EventMsg::TurnCompleted {
+                turn_id,
+                tokens: tokens_for_completion,
+            },
+            timestamp: chrono::Utc::now(),
+            parent_session_key: submission_parent_key,
+        },
+    )
+    .await?;
+
+    use tokio::io::AsyncWriteExt;
+    stdout.flush().await?;
+    Ok(())
+}
+
+/// Fan out `ToolCallBegin` / `ToolCallEnd` frames reconstructed from the
+/// runtime transcript (assistant tool_calls + tool result messages).
+async fn emit_tool_events_from_transcript(
+    stdout: &mut tokio::io::Stdout,
+    submission: &Submission,
+    turn_id: uuid::Uuid,
+    parent_session_key: &Option<String>,
+    transcript: &[serde_json::Value],
+) -> anyhow::Result<()> {
+    for msg in transcript {
+        let role = msg.get("role").and_then(|r| r.as_str()).unwrap_or("");
+        if role == "assistant" {
+            if let Some(tool_calls) = msg.get("tool_calls").and_then(|tc| tc.as_array()) {
+                for tc in tool_calls {
+                    let call_id = tc
+                        .get("id")
+                        .and_then(|id| id.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    let tool_name = tc
+                        .get("function")
+                        .and_then(|f| f.get("name"))
+                        .and_then(|n| n.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    let arguments_str = tc
+                        .get("function")
+                        .and_then(|f| f.get("arguments"))
+                        .and_then(|a| a.as_str())
+                        .unwrap_or("{}");
+                    let arguments = serde_json::from_str(arguments_str)
+                        .unwrap_or(serde_json::Value::Object(Default::default()));
+                    emit(
+                        stdout,
+                        Event {
+                            id: uuid::Uuid::new_v4(),
+                            submission_id: submission.id,
+                            msg: EventMsg::ToolCallBegin {
+                                turn_id,
+                                call_id,
+                                tool: tool_name,
+                                arguments,
+                            },
+                            timestamp: chrono::Utc::now(),
+                            parent_session_key: parent_session_key.clone(),
+                        },
+                    )
+                    .await?;
+                }
+            }
+        } else if role == "tool" {
+            let call_id = msg
+                .get("tool_call_id")
+                .and_then(|id| id.as_str())
+                .unwrap_or("")
+                .to_string();
+            let result_content = msg
+                .get("content")
+                .and_then(|c| c.as_str())
+                .unwrap_or("")
+                .to_string();
+            emit(
+                stdout,
+                Event {
+                    id: uuid::Uuid::new_v4(),
+                    submission_id: submission.id,
+                    msg: EventMsg::ToolCallEnd {
+                        turn_id,
+                        call_id,
+                        result: result_content,
+                    },
+                    timestamp: chrono::Utc::now(),
+                    parent_session_key: parent_session_key.clone(),
+                },
+            )
+            .await?;
+        }
+    }
+    Ok(())
+}
+
+async fn emit_delta(
+    stdout: &mut tokio::io::Stdout,
+    submission: &Submission,
+    parent_session_key: &Option<String>,
+    delta: String,
+) -> anyhow::Result<()> {
+    emit(
+        stdout,
+        Event {
+            id: uuid::Uuid::new_v4(),
+            submission_id: submission.id,
+            msg: EventMsg::StreamingDelta { delta },
+            timestamp: chrono::Utc::now(),
+            parent_session_key: parent_session_key.clone(),
+        },
+    )
+    .await
+}
+
+async fn emit(stdout: &mut tokio::io::Stdout, event: Event) -> anyhow::Result<()> {
+    use tokio::io::AsyncWriteExt;
+    let mut json = serde_json::to_string(&event)?;
+    json.push('\n');
+    stdout.write_all(json.as_bytes()).await?;
+    Ok(())
+}
+
+/// Convert a local [`Submission`] into a [`TurnContext`] for the runtime.
+fn submission_to_turn_context(
+    submission: &Submission,
+    agent_id: &str,
+    turn_id: uuid::Uuid,
+    tool_defs: &[sera_types::tool::ToolDefinition],
+) -> TurnContext {
+    let (messages, session_key_override, parent_session_key) = match &submission.op {
+        Op::UserTurn { items, session_key, parent_session_key, .. } => {
+            (items.clone(), session_key.clone(), parent_session_key.clone())
+        }
+        Op::Steer { items, session_key, parent_session_key } => {
+            (items.clone(), session_key.clone(), parent_session_key.clone())
+        }
+        Op::Interrupt | Op::System(_) => (vec![], None, None),
+    };
+
+    // Use gateway-provided session_key when available, otherwise generate one.
+    let session_key = session_key_override
+        .unwrap_or_else(|| format!("session:{agent_id}:{}", submission.id));
+
+    TurnContext {
+        event_id: turn_id.to_string(),
+        agent_id: agent_id.to_string(),
+        session_key,
+        messages,
+        available_tools: tool_defs.to_vec(),
+        metadata: HashMap::new(),
+        change_artifact: None,
+        parent_session_key,
+        tool_use_behavior: Default::default(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn handshake_first_line_is_canonical_v2() {
+        let frame = HandshakeFrame::v2("agent-demo", None);
+        let json = serde_json::to_string(&frame).unwrap();
+        let parsed: HandshakeFrame = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.protocol_version, "2.0");
+        assert_eq!(parsed.frame_type, "handshake");
+        assert!(parsed.capabilities.supports("steer"));
+        assert!(parsed.capabilities.supports("hitl"));
+    }
+
+    #[test]
+    fn submission_user_turn_with_session_key_roundtrip() {
+        let json = r#"{
+            "id": "00000000-0000-0000-0000-000000000000",
+            "op": {
+                "type": "user_turn",
+                "items": [{"role":"user","content":"hi"}],
+                "session_key": "session:agent-x:abc"
+            }
+        }"#;
+        let sub: Submission = serde_json::from_str(json).unwrap();
+        match sub.op {
+            Op::UserTurn { items, session_key, .. } => {
+                assert_eq!(items.len(), 1);
+                assert_eq!(session_key.as_deref(), Some("session:agent-x:abc"));
+            }
+            _ => panic!("expected UserTurn"),
+        }
+    }
+
+    #[test]
+    fn submission_system_shutdown_roundtrip() {
+        let json = r#"{
+            "id": "00000000-0000-0000-0000-000000000000",
+            "op": {"type":"system","system_op":"shutdown"}
+        }"#;
+        let sub: Submission = serde_json::from_str(json).unwrap();
+        assert!(matches!(sub.op, Op::System(SystemOp::Shutdown)));
+    }
+
+    #[test]
+    fn event_turn_completed_serializes_tokens() {
+        let ev = Event {
+            id: uuid::Uuid::nil(),
+            submission_id: uuid::Uuid::nil(),
+            msg: EventMsg::TurnCompleted {
+                turn_id: uuid::Uuid::nil(),
+                tokens: TokenUsage {
+                    prompt_tokens: 10,
+                    completion_tokens: 20,
+                    total_tokens: 30,
+                },
+            },
+            timestamp: chrono::Utc::now(),
+            parent_session_key: None,
+        };
+        let json = serde_json::to_string(&ev).unwrap();
+        assert!(json.contains("\"prompt_tokens\":10"));
+        assert!(json.contains("\"completion_tokens\":20"));
+        assert!(json.contains("\"total_tokens\":30"));
+    }
+}

--- a/rust/crates/sera-runtime/src/turn.rs
+++ b/rust/crates/sera-runtime/src/turn.rs
@@ -15,6 +15,14 @@ use crate::handoff::Handoff;
 /// Doom loop threshold — triggers Interruption after this many consecutive act cycles.
 pub const DOOM_LOOP_THRESHOLD: u32 = 3;
 
+/// Maximum compaction checkpoints retained per session (SPEC-runtime §6a / P0-6 M2 gate).
+///
+/// Re-exported here alongside [`DOOM_LOOP_THRESHOLD`] so the turn-loop budget
+/// constants live next to each other; the canonical definition lives in
+/// [`crate::context_engine::MAX_COMPACTION_CHECKPOINTS_PER_SESSION`].
+pub const MAX_COMPACTION_CHECKPOINTS_PER_SESSION: u32 =
+    crate::context_engine::MAX_COMPACTION_CHECKPOINTS_PER_SESSION;
+
 /// React mode for the think step.
 #[derive(Debug, Clone)]
 pub enum ReactMode {

--- a/rust/crates/sera-runtime/tests/stdio_transport.rs
+++ b/rust/crates/sera-runtime/tests/stdio_transport.rs
@@ -1,0 +1,82 @@
+//! P0-6 acceptance test #15 — spawn the `sera-runtime` binary, send an NDJSON
+//! `Shutdown` submission, and assert the subprocess emits a canonical
+//! `HandshakeFrame` on its first line and exits cleanly.
+//!
+//! Covers the `AppServerTransport::Stdio` contract from the runtime side
+//! without requiring a live LLM: the submission is a `System::Shutdown` which
+//! short-circuits the turn loop, so no LLM call happens.
+
+use std::process::Stdio;
+use std::time::Duration;
+
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::Command;
+use tokio::time::timeout;
+
+use sera_types::envelope::HandshakeFrame;
+
+/// Locate the just-built `sera-runtime` binary. Cargo sets `CARGO_BIN_EXE_sera-runtime`
+/// for integration tests in this crate.
+fn binary_path() -> String {
+    env!("CARGO_BIN_EXE_sera-runtime").to_string()
+}
+
+#[tokio::test]
+async fn main_binary_boots_under_stdio_transport() {
+    let bin = binary_path();
+    let mut child = Command::new(&bin)
+        .arg("--ndjson")
+        .arg("--no-health")
+        // Minimal env so the runtime can build its config without touching network.
+        .env("AGENT_ID", "stdio-acceptance-agent")
+        .env("LLM_BASE_URL", "http://127.0.0.1:1")
+        .env("LLM_MODEL", "mock-model")
+        .env("LLM_API_KEY", "mock-key")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn sera-runtime");
+
+    let mut stdin = child.stdin.take().expect("stdin piped");
+    let stdout = child.stdout.take().expect("stdout piped");
+    let mut reader = BufReader::new(stdout);
+
+    // First line MUST be the canonical HandshakeFrame per P0-6 §main.rs rewrite.
+    let mut line = String::new();
+    let read = timeout(Duration::from_secs(10), reader.read_line(&mut line))
+        .await
+        .expect("handshake read timed out")
+        .expect("read handshake line");
+    assert!(read > 0, "runtime produced no handshake line");
+
+    let frame: HandshakeFrame =
+        serde_json::from_str(line.trim()).expect("first line must be a HandshakeFrame");
+    assert_eq!(frame.protocol_version, "2.0", "handshake must advertise v2 protocol");
+    assert_eq!(frame.frame_type, "handshake");
+    assert_eq!(
+        frame.agent_id.as_deref(),
+        Some("stdio-acceptance-agent"),
+        "handshake must echo the agent id"
+    );
+    assert!(frame.capabilities.supports("steer"));
+    assert!(frame.capabilities.supports("hitl"));
+    assert!(frame.capabilities.supports("hooks@v2"));
+
+    // Send a `System::Shutdown` submission and assert the subprocess exits.
+    let shutdown = serde_json::json!({
+        "id": uuid::Uuid::new_v4(),
+        "op": { "type": "system", "system_op": "shutdown" }
+    });
+    let mut json = serde_json::to_string(&shutdown).unwrap();
+    json.push('\n');
+    stdin.write_all(json.as_bytes()).await.unwrap();
+    stdin.flush().await.unwrap();
+    drop(stdin); // close stdin so the runtime can see EOF too
+
+    let status = timeout(Duration::from_secs(10), child.wait())
+        .await
+        .expect("runtime did not exit within timeout")
+        .expect("wait for runtime exit");
+    assert!(status.success(), "runtime exited non-zero: {status:?}");
+}


### PR DESCRIPTION
## Summary

- Extract the NDJSON Submission/Event loop out of `sera-runtime/src/main.rs` into a new `sera_runtime::stdio` module; `main.rs` becomes a thin CLI that dispatches to either the interactive REPL or `stdio::run_ndjson_loop`.
- Emit a canonical `sera_types::envelope::HandshakeFrame::v2` as the first stdout line so v2-aware consumers can negotiate protocol capabilities without parsing an `Event` body.
- Redirect tracing to stderr in **both** interactive and NDJSON modes so stdout is reserved for protocol data — previously the NDJSON path wrote `tracing` output to stdout and relied on the gateway to skip non-JSON lines.
- `turn.rs` re-exports `MAX_COMPACTION_CHECKPOINTS_PER_SESSION` from `context_engine` so the turn-loop budget constants (`DOOM_LOOP_THRESHOLD` + the compaction cap) live next to each other per SPEC-runtime §6a / P0-6 M2 gate.

## P0-6 acceptance test #15

Adds `tests/stdio_transport.rs::main_binary_boots_under_stdio_transport`:

1. Spawn the built `sera-runtime --ndjson --no-health` binary with a piped stdio pair.
2. Assert the first stdout line parses as a `HandshakeFrame` with `protocol_version == "2.0"`, matching `agent_id`, and the canonical feature set (`steer`, `hitl`, `hooks@v2`).
3. Send `Op::System(SystemOp::Shutdown)` and assert the process exits cleanly within 10 s.

No live LLM is required — the submission short-circuits through the `Shutdown` branch of the NDJSON loop.

## Scope note

The local protocol-v1 types (`Submission`, `Event`, `Op`, `SystemOp`, `EventMsg`) are deliberately kept as serde-compatible duplicates of `sera_types::envelope` rather than replaced wholesale. The gateway's `StdioHarness` in `sera-gateway/src/bin/sera.rs` still speaks that shape, and swapping both sides onto canonical `sera_types::envelope::{Submission, Event, Op, EventMsg}` is tracked as P1 follow-up work (noted in the stdio module docs).

## Test plan

- [x] `cargo check -p sera-runtime` clean
- [x] `cargo clippy -p sera-runtime --bin sera-runtime --lib -- -D warnings` clean
- [x] `cargo clippy -p sera-runtime --tests -- -D warnings` clean
- [x] `cargo test -p sera-runtime` — 533 passed across 13 suites (includes the new `stdio_transport` acceptance test)
- [x] `cargo test -p sera-gateway --lib` — 45 passed (envelope/harness_dispatch contract unchanged)
- [x] `cargo test -p sera-gateway --bin sera-gateway` — 129 passed (StdioHarness mock tests unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)