### PR TITLE
chore(workspace): verify feature matrix (M4)

### DIFF
--- a/scripts/check-feature-matrix.sh
+++ b/scripts/check-feature-matrix.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# M4 feature-matrix gate — exits non-zero on any failure.
+# Checks three configurations: default features, no-default-features, enterprise per-crate.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUST_DIR="$SCRIPT_DIR/../rust"
+
+echo "=== [1/3] cargo check --workspace (default features) ==="
+cargo check --workspace --manifest-path "$RUST_DIR/Cargo.toml"
+
+echo "=== [2/3] cargo check --workspace --no-default-features ==="
+cargo check --workspace --no-default-features --manifest-path "$RUST_DIR/Cargo.toml"
+
+echo "=== [3/3] cargo check per-crate --features enterprise ==="
+ENTERPRISE_CRATES=(sera-auth sera-gateway)
+for crate in "${ENTERPRISE_CRATES[@]}"; do
+    echo "  checking $crate --features enterprise"
+    cargo check -p "$crate" --features enterprise --manifest-path "$RUST_DIR/Cargo.toml"
+done
+
+echo ""
+echo "Feature matrix OK — all three configurations green."


### PR DESCRIPTION
No fixes needed; matrix already green. Adds CI script to keep it that way.

## What

Verifies the Phase 0 M4 feature-matrix gate across three configurations:
1. Default features (`cargo check --workspace`)
2. No default features (`cargo check --workspace --no-default-features`)
3. Enterprise per-crate (`sera-auth`, `sera-gateway` with `--features enterprise`)

All three passed with zero source changes required.

## Added

- `scripts/check-feature-matrix.sh` — exits non-zero on any failure; documents the gate for CI

Closes M4 feature-matrix gate.