### PR TITLE
feat(sera-hitl): P0-10 — complete SPEC-hitl-approval surface

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5116,6 +5116,7 @@ dependencies = [
 name = "sera-hitl"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "chrono",
  "sera-errors",
  "sera-types",

--- a/rust/crates/sera-hitl/Cargo.toml
+++ b/rust/crates/sera-hitl/Cargo.toml
@@ -7,6 +7,7 @@ description = "Human-in-the-Loop / Agent-in-the-Loop approval system for SERA"
 [dependencies]
 sera-types.workspace = true
 sera-errors.workspace = true
+async-trait.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/rust/crates/sera-hitl/src/ask_for_approval.rs
+++ b/rust/crates/sera-hitl/src/ask_for_approval.rs
@@ -1,0 +1,158 @@
+//! Five-level `AskForApproval` + per-category `GranularApprovalConfig`.
+//!
+//! SPEC-hitl-approval §3 (`AskForApproval`) and §5a (`GranularApprovalConfig`,
+//! `CategoryRouting`, `ExecAllowRule`). Aligned with Codex's five-level
+//! approval enum and openclaw's `ExecApprovalsFileSchema`.
+
+use serde::{Deserialize, Serialize};
+
+use crate::types::ApprovalRouting;
+
+/// Five-level approval request style.
+///
+/// `Policy` preserves the original SERA routing model for backwards compat;
+/// the other variants align with Codex `AskForApproval`.
+// TODO P1-INTEGRATION: gateway Op::UserTurn.approval_policy already carries an
+//                      AskForApproval variant; unify the type once gateway lands.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum AskForApproval {
+    /// Ask for everything except known-safe read-only operations.
+    UnlessTrusted,
+    /// Model decides when to ask. Default for Tier-2 standard mode.
+    OnRequest,
+    /// Per-category fine control.
+    Granular(Box<GranularApprovalConfig>),
+    /// Full-auto; no HITL ever. Tier-1 autonomous sandbox only.
+    Never,
+    /// Static, dynamic, or delegated policy resolution.
+    Policy(ApprovalRouting),
+}
+
+/// Per-risk-category routing (exec, patch, file_write, network, mcp_call, …).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GranularApprovalConfig {
+    pub exec: CategoryRouting,
+    pub patch: CategoryRouting,
+    pub file_write: CategoryRouting,
+    pub network: CategoryRouting,
+    pub mcp_call: CategoryRouting,
+    pub memory_write: CategoryRouting,
+    pub config_change: CategoryRouting,
+    /// Required for Tier-2/3 self-evolution; `None` on deployments that
+    /// disallow meta-changes outright.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub meta_change: Option<CategoryRouting>,
+}
+
+/// Routing for a single risk category.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CategoryRouting {
+    pub default: ApprovalRouting,
+    /// Per-agent allowlists with argument patterns (openclaw `ExecApprovals`).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub allow_list: Vec<ExecAllowRule>,
+    /// `autoAllowSkills: true` — skill-bound tools bypass approval.
+    #[serde(default)]
+    pub auto_allow_skills: bool,
+}
+
+/// A per-agent allow rule with optional argument pattern.
+///
+/// Wildcard semantics: rules evaluated in order, stricter-wins; `deny`
+/// outranks `ask` outranks `allow`. Session-scoped overrides extend the
+/// ruleset at the runtime layer.
+// TODO P1-INTEGRATION: wildcard evaluator + session override extension live in
+//                      sera-runtime; trait surface lands with that work.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExecAllowRule {
+    /// Agent identifier this rule applies to.
+    pub agent_ref: String,
+    /// Command or tool name glob.
+    pub pattern: String,
+    /// Argument regex (separate from command pattern).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub arg_pattern: Option<String>,
+    /// Human-readable rationale for the audit trail.
+    pub reason: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{ApprovalPolicy, ApprovalTarget};
+
+    fn autonomous_category() -> CategoryRouting {
+        CategoryRouting {
+            default: ApprovalRouting::Autonomous,
+            allow_list: vec![],
+            auto_allow_skills: false,
+        }
+    }
+
+    fn granular() -> GranularApprovalConfig {
+        GranularApprovalConfig {
+            exec: autonomous_category(),
+            patch: autonomous_category(),
+            file_write: autonomous_category(),
+            network: autonomous_category(),
+            mcp_call: autonomous_category(),
+            memory_write: autonomous_category(),
+            config_change: autonomous_category(),
+            meta_change: None,
+        }
+    }
+
+    #[test]
+    fn ask_for_approval_never_serde_roundtrip() {
+        let a = AskForApproval::Never;
+        let json = serde_json::to_string(&a).unwrap();
+        assert!(json.contains("\"never\""));
+        let _parsed: AskForApproval = serde_json::from_str(&json).unwrap();
+    }
+
+    #[test]
+    fn ask_for_approval_policy_serde_roundtrip() {
+        let a = AskForApproval::Policy(ApprovalRouting::Static {
+            targets: vec![ApprovalTarget::Role { name: "ops".to_string() }],
+        });
+        let json = serde_json::to_string(&a).unwrap();
+        let parsed: AskForApproval = serde_json::from_str(&json).unwrap();
+        match parsed {
+            AskForApproval::Policy(ApprovalRouting::Static { targets }) => {
+                assert_eq!(targets.len(), 1);
+            }
+            _ => panic!("expected Policy(Static)"),
+        }
+    }
+
+    #[test]
+    fn ask_for_approval_granular_serde_roundtrip() {
+        let a = AskForApproval::Granular(Box::new(granular()));
+        let json = serde_json::to_string(&a).unwrap();
+        let parsed: AskForApproval = serde_json::from_str(&json).unwrap();
+        assert!(matches!(parsed, AskForApproval::Granular(_)));
+    }
+
+    #[test]
+    fn category_routing_allow_rule_roundtrip() {
+        let cat = CategoryRouting {
+            default: ApprovalRouting::Dynamic(ApprovalPolicy {
+                risk_thresholds: vec![],
+                fallback_chain: vec![],
+            }),
+            allow_list: vec![ExecAllowRule {
+                agent_ref: "agent-42".to_string(),
+                pattern: "git *".to_string(),
+                arg_pattern: Some("^(status|log|diff)".to_string()),
+                reason: "read-only git".to_string(),
+            }],
+            auto_allow_skills: true,
+        };
+        let json = serde_json::to_string(&cat).unwrap();
+        let parsed: CategoryRouting = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.allow_list.len(), 1);
+        assert!(parsed.auto_allow_skills);
+        assert_eq!(parsed.allow_list[0].agent_ref, "agent-42");
+    }
+}

--- a/rust/crates/sera-hitl/src/assessment.rs
+++ b/rust/crates/sera-hitl/src/assessment.rs
@@ -1,0 +1,71 @@
+//! Guardian pre-approval LLM risk assessment.
+//!
+//! SPEC-hitl-approval §2b. An optional pre-gate that adds LLM-informed
+//! context to `ApprovalEvidence` without replacing the downstream chain.
+
+use serde::{Deserialize, Serialize};
+
+/// Risk level returned by the Guardian LLM assessor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GuardianRiskLevel {
+    Low,
+    Medium,
+    High,
+}
+
+/// What the Guardian recommends the runtime do with the proposed action.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GuardianRecommendation {
+    AutoApprove,
+    SurfaceToUser,
+    Block,
+}
+
+/// Structured LLM assessment attached to `ApprovalEvidence`.
+///
+/// Emitted as `EventMsg::GuardianAssessment` on the EQ channel so clients
+/// can display the reasoning inline when the approval is surfaced.
+// TODO P1-INTEGRATION: EventMsg::GuardianAssessment variant lives in sera-types
+//                      envelope; wire emission from runtime turn pipeline.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GuardianAssessment {
+    pub risk_level: GuardianRiskLevel,
+    pub rationale: String,
+    pub recommended_action: GuardianRecommendation,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn guardian_assessment_serde_roundtrip() {
+        let ga = GuardianAssessment {
+            risk_level: GuardianRiskLevel::High,
+            rationale: "destructive filesystem operation".to_string(),
+            recommended_action: GuardianRecommendation::SurfaceToUser,
+        };
+        let json = serde_json::to_string(&ga).unwrap();
+        let parsed: GuardianAssessment = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.risk_level, GuardianRiskLevel::High);
+        assert_eq!(parsed.rationale, ga.rationale);
+        assert_eq!(
+            parsed.recommended_action,
+            GuardianRecommendation::SurfaceToUser
+        );
+    }
+
+    #[test]
+    fn guardian_risk_level_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&GuardianRiskLevel::Medium).unwrap(),
+            "\"medium\""
+        );
+        assert_eq!(
+            serde_json::to_string(&GuardianRecommendation::AutoApprove).unwrap(),
+            "\"auto_approve\""
+        );
+    }
+}

--- a/rust/crates/sera-hitl/src/lib.rs
+++ b/rust/crates/sera-hitl/src/lib.rs
@@ -3,18 +3,28 @@
 //! Provides configurable escalation chains that can involve agents, humans, or
 //! both as approvers.  See SPEC-hitl-approval for the full design.
 
+pub mod ask_for_approval;
+pub mod assessment;
 pub mod error;
 pub mod mode;
-pub mod sera_errors;
 pub mod router;
+pub mod security_analyzer;
+pub mod sera_errors;
 pub mod ticket;
+pub mod tool_result;
 pub mod types;
 
 // Convenience re-exports at the crate root.
+pub use ask_for_approval::{AskForApproval, CategoryRouting, ExecAllowRule, GranularApprovalConfig};
+pub use assessment::{GuardianAssessment, GuardianRecommendation, GuardianRiskLevel};
 pub use error::HitlError;
 pub use mode::EnforcementMode;
 pub use router::ApprovalRouter;
+pub use security_analyzer::{
+    ActionSecurityRisk, AnalyzerError, ProposedAction, SecurityAnalyzer,
+};
 pub use ticket::{ApprovalDecision, ApprovalId, ApprovalTicket, TicketStatus};
+pub use tool_result::ToolResult;
 pub use types::{
     ApprovalEvidence, ApprovalPolicy, ApprovalRouting, ApprovalScope, ApprovalSpec,
     ApprovalTarget, ApprovalUrgency, RiskThreshold,
@@ -998,5 +1008,64 @@ mod tests {
             ticket.escalate().unwrap_err(),
             HitlError::EscalationExhausted { .. }
         ));
+    }
+
+    // ── RevisionRequested (SPEC-hitl-approval §5c) ────────────────────────────
+
+    #[test]
+    fn request_revision_then_submit_returns_to_pending() {
+        let spec = basic_spec(static_routing(), 1, Duration::from_secs(300));
+        let mut ticket = ApprovalTicket::new(spec, "session-rev-1");
+
+        let status = ticket
+            .request_revision(human_ref(), "tighten the scope")
+            .unwrap();
+        assert_eq!(status, TicketStatus::RevisionRequested);
+        assert_eq!(ticket.status, TicketStatus::RevisionRequested);
+        assert_eq!(ticket.revision_feedback.as_deref(), Some("tighten the scope"));
+        // A decision was recorded so audit history survives.
+        assert_eq!(ticket.decisions.len(), 1);
+
+        let status = ticket.submit_revision().unwrap();
+        assert_eq!(status, TicketStatus::Pending);
+        assert!(ticket.revision_feedback.is_none());
+    }
+
+    #[test]
+    fn submit_revision_from_pending_is_invalid() {
+        let spec = basic_spec(static_routing(), 1, Duration::from_secs(300));
+        let mut ticket = ApprovalTicket::new(spec, "session-rev-2");
+        let err = ticket.submit_revision().unwrap_err();
+        assert!(matches!(
+            err,
+            HitlError::InvalidTransition { from: TicketStatus::Pending, .. }
+        ));
+    }
+
+    #[test]
+    fn request_revision_on_terminal_is_invalid_transition() {
+        let spec = basic_spec(static_routing(), 1, Duration::from_secs(300));
+        let mut ticket = ApprovalTicket::new(spec, "session-rev-3");
+        ticket.approve(human_ref(), None).unwrap();
+        let err = ticket
+            .request_revision(agent_ref(), "reconsider")
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            HitlError::InvalidTransition { from: TicketStatus::Approved, .. }
+        ));
+    }
+
+    #[test]
+    fn approve_after_revision_cycle_completes() {
+        // revision → submit → approve — full two-step revision loop.
+        let spec = basic_spec(static_routing(), 1, Duration::from_secs(300));
+        let mut ticket = ApprovalTicket::new(spec, "session-rev-4");
+        ticket
+            .request_revision(human_ref(), "narrow the args")
+            .unwrap();
+        ticket.submit_revision().unwrap();
+        let status = ticket.approve(human_ref(), Some("ok now".to_string())).unwrap();
+        assert_eq!(status, TicketStatus::Approved);
     }
 }

--- a/rust/crates/sera-hitl/src/security_analyzer.rs
+++ b/rust/crates/sera-hitl/src/security_analyzer.rs
@@ -1,0 +1,119 @@
+//! SecurityAnalyzer trait + ActionSecurityRisk.
+//!
+//! SPEC-hitl-approval §2a. Per-action risk classification runs before the
+//! static approval matrix. Pluggable backends (Invariant, GraySwan, Heuristic)
+//! return `ActionSecurityRisk` that feeds into routing decisions and the
+//! `confirmation_mode` hold-pending pattern.
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::types::ApprovalScope;
+
+/// Coarse risk classification emitted by a [`SecurityAnalyzer`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ActionSecurityRisk {
+    /// Bypass approval unless policy forces it.
+    Low,
+    /// Route through the standard approval chain.
+    Medium,
+    /// Escalate; require meta-quorum for change scopes.
+    High,
+}
+
+/// A proposed action passed to a [`SecurityAnalyzer`] for risk scoring.
+///
+/// Intentionally small: analyzers can read the scope and optional tool args,
+/// and add whatever context they need via `extra`. The wider runtime context
+/// (principal, session) is kept elsewhere to avoid cycles with sera-runtime.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProposedAction {
+    pub scope: ApprovalScope,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_args: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extra: Option<serde_json::Value>,
+}
+
+/// Errors returned by a [`SecurityAnalyzer`] implementation.
+#[derive(Debug, Error)]
+pub enum AnalyzerError {
+    #[error("analyzer backend error: {0}")]
+    Backend(String),
+    #[error("analyzer timed out")]
+    Timeout,
+    #[error("analyzer invalid input: {0}")]
+    InvalidInput(String),
+}
+
+/// Pluggable risk analyzer called before the approval chain resolves.
+///
+/// SPEC-hitl-approval §2a. Reference backends live outside this crate
+/// (`InvariantAnalyzer`, `GraySwanAnalyzer`, `HeuristicAnalyzer`).
+// TODO P1-INTEGRATION: wire into sera-runtime turn pipeline + gateway
+//                      confirmation_mode hold-pending state.
+#[async_trait]
+pub trait SecurityAnalyzer: Send + Sync {
+    async fn security_risk(
+        &self,
+        action: &ProposedAction,
+    ) -> Result<ActionSecurityRisk, AnalyzerError>;
+
+    fn name(&self) -> &str;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sera_types::tool::RiskLevel;
+
+    struct FixedAnalyzer(ActionSecurityRisk);
+
+    #[async_trait]
+    impl SecurityAnalyzer for FixedAnalyzer {
+        async fn security_risk(
+            &self,
+            _action: &ProposedAction,
+        ) -> Result<ActionSecurityRisk, AnalyzerError> {
+            Ok(self.0)
+        }
+        fn name(&self) -> &str {
+            "fixed"
+        }
+    }
+
+    fn action() -> ProposedAction {
+        ProposedAction {
+            scope: ApprovalScope::ToolCall {
+                tool_name: "shell".to_string(),
+                risk_level: RiskLevel::Execute,
+            },
+            tool_args: None,
+            extra: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn analyzer_returns_fixed_risk() {
+        let a = FixedAnalyzer(ActionSecurityRisk::High);
+        let r = a.security_risk(&action()).await.unwrap();
+        assert_eq!(r, ActionSecurityRisk::High);
+        assert_eq!(a.name(), "fixed");
+    }
+
+    #[test]
+    fn action_security_risk_serde_roundtrip() {
+        for (risk, expected) in [
+            (ActionSecurityRisk::Low, "\"low\""),
+            (ActionSecurityRisk::Medium, "\"medium\""),
+            (ActionSecurityRisk::High, "\"high\""),
+        ] {
+            let json = serde_json::to_string(&risk).unwrap();
+            assert_eq!(json, expected);
+            let parsed: ActionSecurityRisk = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, risk);
+        }
+    }
+}

--- a/rust/crates/sera-hitl/src/ticket.rs
+++ b/rust/crates/sera-hitl/src/ticket.rs
@@ -75,6 +75,9 @@ pub enum TicketStatus {
     Escalated,
     /// No decision was reached before the deadline.
     Expired,
+    /// Reviewer found issues but believes the proposer can revise and retry.
+    /// Not terminal: the ticket returns to Pending after revision is submitted.
+    RevisionRequested,
 }
 
 impl TicketStatus {
@@ -123,6 +126,10 @@ pub struct ApprovalTicket {
     pub created_at: DateTime<Utc>,
     /// When the ticket expires.
     pub expires_at: DateTime<Utc>,
+    /// Reviewer feedback attached during the most recent `RevisionRequested`
+    /// transition. Cleared when the proposer calls `submit_revision`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub revision_feedback: Option<String>,
 }
 
 impl ApprovalTicket {
@@ -141,7 +148,54 @@ impl ApprovalTicket {
             decisions: Vec::new(),
             created_at: now,
             expires_at,
+            revision_feedback: None,
         }
+    }
+
+    /// Record a reviewer request-for-revision.
+    ///
+    /// Unlike `reject`, this is a non-terminal signal: the ticket's feedback
+    /// slot is populated and status moves to `RevisionRequested`. The
+    /// proposer calls `submit_revision` to return the ticket to `Pending`.
+    /// Returns [`HitlError::InvalidTransition`] from a terminal state and
+    /// [`HitlError::TicketExpired`] if the deadline has passed.
+    pub fn request_revision(
+        &mut self,
+        reviewer: PrincipalRef,
+        feedback: impl Into<String>,
+    ) -> Result<TicketStatus, HitlError> {
+        self.guard_transition("request_revision")?;
+        let feedback = feedback.into();
+        self.decisions.push(ApprovalDecision {
+            approver: reviewer,
+            status: TicketStatus::RevisionRequested,
+            reason: Some(feedback.clone()),
+            decided_at: Utc::now(),
+        });
+        self.revision_feedback = Some(feedback);
+        self.status = TicketStatus::RevisionRequested;
+        Ok(self.status)
+    }
+
+    /// Proposer submits a revision. Clears `revision_feedback` and returns
+    /// the ticket to `Pending`. Only valid when the ticket is currently in
+    /// `RevisionRequested`.
+    pub fn submit_revision(&mut self) -> Result<TicketStatus, HitlError> {
+        if self.status != TicketStatus::RevisionRequested {
+            return Err(HitlError::InvalidTransition {
+                from: self.status,
+                action: "submit_revision".to_string(),
+            });
+        }
+        // Expiry check still applies — a stale revision cycle can't bypass the
+        // deadline.
+        if self.is_expired() {
+            self.status = TicketStatus::Expired;
+            return Err(HitlError::TicketExpired { id: self.id.clone() });
+        }
+        self.revision_feedback = None;
+        self.status = TicketStatus::Pending;
+        Ok(self.status)
     }
 
     /// Record an approval decision from `approver`.

--- a/rust/crates/sera-hitl/src/tool_result.rs
+++ b/rust/crates/sera-hitl/src/tool_result.rs
@@ -1,0 +1,55 @@
+//! `ToolResult::Rejected { feedback }` — the opencode `CorrectedError` pattern.
+//!
+//! SPEC-hitl-approval §5b. When a user rejects a tool call with a reason,
+//! the reason is fed back to the LLM as a structured tool-result error so
+//! the model can self-correct within the same turn (no turn restart).
+
+use serde::{Deserialize, Serialize};
+
+/// The outcome of a tool call as seen by the model.
+///
+/// `Rejected { feedback }` is the in-turn self-correction signal: the
+/// runtime surfaces the user's rejection text as the tool-call error body
+/// so the next model response can adapt without a turn boundary.
+// TODO P1-INTEGRATION: wire ToolResult::Rejected through sera-runtime turn
+//                      loop so the user's feedback reaches the model directly.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum ToolResult {
+    /// Successful tool invocation.
+    Ok { output: serde_json::Value },
+    /// Tool error — any non-user-rejection failure.
+    Err { error: String },
+    /// User rejected the call; `feedback` is surfaced to the model.
+    Rejected { feedback: String },
+}
+
+impl ToolResult {
+    /// `true` when this result should be fed back as a correction signal
+    /// rather than a fatal error.
+    pub fn is_rejected(&self) -> bool {
+        matches!(self, Self::Rejected { .. })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tool_result_rejected_serde_roundtrip() {
+        let r = ToolResult::Rejected {
+            feedback: "use git status instead".to_string(),
+        };
+        let json = serde_json::to_string(&r).unwrap();
+        let parsed: ToolResult = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, r);
+        assert!(parsed.is_rejected());
+    }
+
+    #[test]
+    fn tool_result_ok_and_err_not_rejected() {
+        assert!(!ToolResult::Ok { output: serde_json::json!({}) }.is_rejected());
+        assert!(!ToolResult::Err { error: "boom".into() }.is_rejected());
+    }
+}


### PR DESCRIPTION
## Summary

Lands the missing SPEC-hitl-approval types for P0-10:

- `SecurityAnalyzer` async trait + `ActionSecurityRisk` enum (§2a)
- `GuardianAssessment` / `GuardianRiskLevel` / `GuardianRecommendation` (§2b)
- Five-level `AskForApproval` + `GranularApprovalConfig` / `CategoryRouting` / `ExecAllowRule` (§3, §5a)
- `ToolResult::Rejected { feedback }` opencode `CorrectedError` pattern (§5b)
- `TicketStatus::RevisionRequested` + `request_revision` / `submit_revision` two-step cycle (§5c)

Cross-crate wiring for runtime turn pipeline, gateway `confirmation_mode`, and `EventMsg::GuardianAssessment` emission is intentionally out of scope — each adapter site is marked `// TODO P1-INTEGRATION`. The type shapes themselves are complete.

## Test plan

- [x] `cargo check -p sera-hitl` — green
- [x] `cargo test -p sera-hitl` — 76 passed (baseline was 62, +14 new tests)
- [x] `cargo clippy -p sera-hitl --all-targets -- -D warnings` — clean
- [x] `cargo check --workspace` — green
- [ ] Follow-up: wire the TODO P1-INTEGRATION adapter sites in sera-runtime and sera-gateway

🤖 Generated with [Claude Code](https://claude.com/claude-code)