### PR TITLE
feat(sera-queue): apalis 0.7.x Storage wrapper around QueueBackend

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -154,6 +154,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "apalis"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "504d52557a16b7b202941660f339c9182910d498cac40f93d15f6b31e6bef290"
+dependencies = [
+ "apalis-core",
+ "futures",
+ "pin-project-lite",
+ "serde",
+ "thiserror 2.0.18",
+ "tower 0.5.3",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "apalis-core"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3948d2051795c769e6a44a46549879af39d5e8e4fb113e0011cf99f7cd21b657"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tower 0.5.3",
+ "ulid",
+]
+
+[[package]]
+name = "apalis-cron"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82ce16ed2870e0226b02b242ef7b552f015ee9592bb797c20b32fb37bd796e2d"
+dependencies = [
+ "apalis-core",
+ "async-stream",
+ "chrono",
+ "cron 0.15.0",
+ "futures",
+ "tower 0.5.3",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1168,6 +1214,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cron"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5877d3fbf742507b66bc2a1945106bd30dd8504019d596901ddd012a4dd01740"
+dependencies = [
+ "chrono",
+ "once_cell",
+ "winnow 0.6.26",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1962,6 +2019,12 @@ name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
@@ -5037,7 +5100,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "clap",
- "cron",
+ "cron 0.13.0",
  "futures-util",
  "hex",
  "insta",
@@ -5230,8 +5293,13 @@ dependencies = [
 name = "sera-queue"
 version = "0.1.0"
 dependencies = [
+ "apalis",
+ "apalis-core",
+ "apalis-cron",
+ "async-stream",
  "async-trait",
  "chrono",
+ "futures",
  "sera-errors",
  "sera-types",
  "serde",
@@ -5239,6 +5307,7 @@ dependencies = [
  "sqlx",
  "thiserror 2.0.18",
  "tokio",
+ "tower 0.5.3",
  "tracing",
  "uuid",
 ]
@@ -5469,7 +5538,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
- "cron",
+ "cron 0.13.0",
  "hex",
  "rusqlite",
  "sera-errors",
@@ -6656,6 +6725,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "tracing",
+]
+
+[[package]]
 name = "tracing-log"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6732,6 +6810,16 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "ulid"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
+dependencies = [
+ "rand 0.9.2",
+ "web-time",
+]
 
 [[package]]
 name = "unarray"
@@ -8185,6 +8273,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.6.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e90edd2ac1aa278a5c4599b1d89cf03074b610800f866d4026dc199d7929a28"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"

--- a/rust/crates/sera-queue/Cargo.toml
+++ b/rust/crates/sera-queue/Cargo.toml
@@ -15,11 +15,18 @@ uuid = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
 sqlx = { workspace = true, optional = true }
+apalis = { version = "0.7", optional = true }
+apalis-core = { version = "0.7", optional = true, features = ["json", "sleep"] }
+apalis-cron = { version = "0.7", optional = true }
+async-stream = { workspace = true, optional = true }
+futures = { version = "0.3", optional = true }
+tower = { workspace = true, optional = true }
 
 [features]
 default = ["local"]
 local = []
-apalis = ["dep:sqlx"]
+apalis = ["dep:sqlx", "dep:apalis", "dep:apalis-core", "dep:futures", "dep:tower", "dep:async-stream"]
+apalis-cron = ["apalis", "dep:apalis-cron"]
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }

--- a/rust/crates/sera-queue/src/apalis_backend.rs
+++ b/rust/crates/sera-queue/src/apalis_backend.rs
@@ -1,0 +1,396 @@
+//! Apalis 0.7.x `Storage` adapter that wraps any [`QueueBackend`].
+//!
+//! This module lets sera's queue lane abstraction drive apalis `Worker`s, so
+//! production deployments can use apalis's tower-based middleware stack
+//! (retries, timeouts, tracing, rate-limits) on top of either the in-memory
+//! [`LocalQueueBackend`](crate::local::LocalQueueBackend) or the Postgres
+//! [`SqlxQueueBackend`](crate::sqlx_backend::SqlxQueueBackend).
+//!
+//! `QueueBackend` is a strict FIFO push/pull/ack/nack abstraction. Apalis's
+//! `Storage` trait includes richer lookup / update operations (`fetch_by_id`,
+//! `update`, `reschedule`, `len`, …) that the backend does not model. Those
+//! methods return [`QueueError::Storage`] with an "unsupported" reason — the
+//! wrapper intentionally exposes only the FIFO subset.
+//!
+//! Sera assigns jobs a UUID-based id, but apalis `TaskId` is a strict ULID.
+//! We therefore track the sera id and lane in a custom
+//! [`SeraJobContext`] that travels on each `Request`; ack / nack use that
+//! context to reach the underlying backend.
+
+use std::marker::PhantomData;
+use std::sync::Arc;
+use std::time::Duration;
+
+use apalis_core::backend::Backend;
+use apalis_core::codec::json::JsonCodec;
+use apalis_core::error::Error as ApalisError;
+use apalis_core::layers::{Ack, AckLayer};
+use apalis_core::poller::Poller;
+use apalis_core::poller::controller::Controller;
+use apalis_core::poller::stream::BackendStream;
+use apalis_core::request::{Parts, Request, RequestStream};
+use apalis_core::response::Response;
+use apalis_core::storage::Storage;
+use apalis_core::worker::{Context as WorkerContext, Worker};
+use futures::StreamExt;
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::backend::{QueueBackend, QueueError};
+
+/// Default sleep between empty polls when the lane is idle.
+const DEFAULT_POLL_INTERVAL: Duration = Duration::from_millis(250);
+
+/// Per-job metadata carried through apalis so the wrapper can reach the
+/// underlying `QueueBackend` on ack / nack.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct SeraJobContext {
+    /// The sera-queue job id (as returned by [`QueueBackend::push`]).
+    pub job_id: String,
+    /// The sera-queue lane this job was pulled from.
+    pub lane: String,
+}
+
+/// Apalis `Storage` adapter around an [`Arc<dyn QueueBackend>`].
+///
+/// Typed by the job payload `T`; internally the wrapper serialises to
+/// [`serde_json::Value`] (the queue's opaque payload shape).
+pub struct ApalisSeraStorage<T> {
+    backend: Arc<dyn QueueBackend>,
+    lane: String,
+    poll_interval: Duration,
+    controller: Controller,
+    _marker: PhantomData<fn() -> T>,
+}
+
+impl<T> ApalisSeraStorage<T> {
+    /// Build a wrapper that pushes and pulls jobs on `lane`.
+    pub fn new(backend: Arc<dyn QueueBackend>, lane: impl Into<String>) -> Self {
+        Self {
+            backend,
+            lane: lane.into(),
+            poll_interval: DEFAULT_POLL_INTERVAL,
+            controller: Controller::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    /// Override the idle poll interval (defaults to 250ms).
+    pub fn with_poll_interval(mut self, interval: Duration) -> Self {
+        self.poll_interval = interval;
+        self
+    }
+
+    /// The lane this storage pushes to / pulls from.
+    pub fn lane(&self) -> &str {
+        &self.lane
+    }
+
+    /// Clone the underlying backend handle.
+    pub fn backend(&self) -> Arc<dyn QueueBackend> {
+        Arc::clone(&self.backend)
+    }
+}
+
+impl<T> Clone for ApalisSeraStorage<T> {
+    fn clone(&self) -> Self {
+        Self {
+            backend: Arc::clone(&self.backend),
+            lane: self.lane.clone(),
+            poll_interval: self.poll_interval,
+            controller: self.controller.clone(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<T> std::fmt::Debug for ApalisSeraStorage<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApalisSeraStorage")
+            .field("lane", &self.lane)
+            .field("poll_interval", &self.poll_interval)
+            .field("job_type", &std::any::type_name::<T>())
+            .finish()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Storage impl
+// ---------------------------------------------------------------------------
+
+impl<T> Storage for ApalisSeraStorage<T>
+where
+    T: Serialize + DeserializeOwned + Send + Sync + Unpin + 'static,
+{
+    type Job = T;
+    type Error = QueueError;
+    type Context = SeraJobContext;
+    type Compact = Value;
+
+    async fn push_request(
+        &mut self,
+        req: Request<Self::Job, Self::Context>,
+    ) -> Result<Parts<Self::Context>, Self::Error> {
+        let (job, mut parts) = req.take_parts();
+        let payload = serde_json::to_value(&job).map_err(|e| QueueError::Serde {
+            reason: e.to_string(),
+        })?;
+        let lane = self.resolve_lane(&parts.context);
+        let id = self.backend.push(&lane, payload).await?;
+        parts.context.job_id = id;
+        parts.context.lane = lane;
+        Ok(parts)
+    }
+
+    async fn push_raw_request(
+        &mut self,
+        req: Request<Self::Compact, Self::Context>,
+    ) -> Result<Parts<Self::Context>, Self::Error> {
+        let (payload, mut parts) = req.take_parts();
+        let lane = self.resolve_lane(&parts.context);
+        let id = self.backend.push(&lane, payload).await?;
+        parts.context.job_id = id;
+        parts.context.lane = lane;
+        Ok(parts)
+    }
+
+    async fn schedule_request(
+        &mut self,
+        _req: Request<Self::Job, Self::Context>,
+        _on: i64,
+    ) -> Result<Parts<Self::Context>, Self::Error> {
+        Err(QueueError::Storage {
+            reason: "scheduled enqueue is not supported by sera-queue QueueBackend".into(),
+        })
+    }
+
+    async fn len(&mut self) -> Result<i64, Self::Error> {
+        // QueueBackend exposes no length API; report zero rather than block
+        // callers that only want a health-check style value.
+        Ok(0)
+    }
+
+    async fn fetch_by_id(
+        &mut self,
+        _job_id: &apalis_core::task::task_id::TaskId,
+    ) -> Result<Option<Request<Self::Job, Self::Context>>, Self::Error> {
+        Err(QueueError::Storage {
+            reason: "fetch_by_id is not supported by sera-queue QueueBackend".into(),
+        })
+    }
+
+    async fn update(
+        &mut self,
+        _job: Request<Self::Job, Self::Context>,
+    ) -> Result<(), Self::Error> {
+        Err(QueueError::Storage {
+            reason: "update is not supported by sera-queue QueueBackend".into(),
+        })
+    }
+
+    async fn reschedule(
+        &mut self,
+        _job: Request<Self::Job, Self::Context>,
+        _wait: Duration,
+    ) -> Result<(), Self::Error> {
+        Err(QueueError::Storage {
+            reason: "reschedule is not supported by sera-queue QueueBackend".into(),
+        })
+    }
+
+    async fn is_empty(&mut self) -> Result<bool, Self::Error> {
+        // No size API — be conservative and report non-empty so callers poll.
+        Ok(false)
+    }
+
+    async fn vacuum(&mut self) -> Result<usize, Self::Error> {
+        // No vacuum semantics in QueueBackend — report nothing was removed.
+        Ok(0)
+    }
+}
+
+impl<T> ApalisSeraStorage<T> {
+    fn resolve_lane(&self, ctx: &SeraJobContext) -> String {
+        if ctx.lane.is_empty() {
+            self.lane.clone()
+        } else {
+            ctx.lane.clone()
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Backend impl (stream of Request<T, SeraJobContext>)
+// ---------------------------------------------------------------------------
+
+impl<T> Backend<Request<T, SeraJobContext>> for ApalisSeraStorage<T>
+where
+    T: Serialize + DeserializeOwned + Send + Sync + Unpin + 'static,
+{
+    type Stream = BackendStream<RequestStream<Request<T, SeraJobContext>>>;
+    type Layer = AckLayer<Self, T, SeraJobContext, JsonCodec<Value>>;
+    type Codec = JsonCodec<Value>;
+
+    fn poll(self, _worker: &Worker<WorkerContext>) -> Poller<Self::Stream, Self::Layer> {
+        let layer = AckLayer::new(self.clone());
+        let controller = self.controller.clone();
+        let stream = build_pull_stream(self);
+        let backend_stream = BackendStream::new(stream, controller);
+        Poller::new_with_layer(backend_stream, futures::future::pending(), layer)
+    }
+}
+
+fn build_pull_stream<T>(
+    storage: ApalisSeraStorage<T>,
+) -> RequestStream<Request<T, SeraJobContext>>
+where
+    T: DeserializeOwned + Send + Sync + Unpin + 'static,
+{
+    let backend = Arc::clone(&storage.backend);
+    let lane = storage.lane.clone();
+    let poll_interval = storage.poll_interval;
+    let stream = async_stream::stream! {
+        loop {
+            match backend.pull(&lane).await {
+                Ok(Some((id, payload))) => {
+                    match serde_json::from_value::<T>(payload) {
+                        Ok(job) => {
+                            let ctx = SeraJobContext {
+                                job_id: id,
+                                lane: lane.clone(),
+                            };
+                            let req = Request::new_with_ctx(job, ctx);
+                            yield Ok(Some(req));
+                        }
+                        Err(e) => {
+                            yield Err(ApalisError::SourceError(std::sync::Arc::new(Box::new(
+                                QueueError::Serde { reason: e.to_string() },
+                            ))));
+                        }
+                    }
+                }
+                Ok(None) => {
+                    apalis_core::sleep(poll_interval).await;
+                }
+                Err(e) => {
+                    yield Err(ApalisError::SourceError(std::sync::Arc::new(Box::new(e))));
+                    apalis_core::sleep(poll_interval).await;
+                }
+            }
+        }
+    };
+    stream.boxed()
+}
+
+// ---------------------------------------------------------------------------
+// Ack impl — success → backend.ack, failure → backend.nack
+// ---------------------------------------------------------------------------
+
+impl<T, Res> Ack<T, Res, JsonCodec<Value>> for ApalisSeraStorage<T>
+where
+    T: Send + Sync,
+    Res: Send + Sync + Serialize,
+{
+    type Context = SeraJobContext;
+    type AckError = QueueError;
+
+    async fn ack(
+        &mut self,
+        ctx: &Self::Context,
+        response: &Response<Res>,
+    ) -> Result<(), Self::AckError> {
+        if response.is_success() {
+            self.backend.ack(&ctx.job_id).await
+        } else {
+            // Best-effort nack; LocalQueueBackend reports NotFound for nack
+            // (no persistence), which we swallow so the worker keeps running.
+            match self.backend.nack(&ctx.job_id).await {
+                Ok(()) => Ok(()),
+                Err(QueueError::NotFound { .. }) => Ok(()),
+                Err(e) => Err(e),
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Compile-time: the wrapper must be Send + Sync so apalis Workers (which
+    // are spawned on tokio) can hold it across await points.
+    #[test]
+    fn apalis_sera_storage_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<ApalisSeraStorage<serde_json::Value>>();
+    }
+
+    // Integration test: round-trip a job through ApalisSeraStorage backed by
+    // LocalQueueBackend. This exercises the `Storage::push_request` →
+    // backend.push path and the `Backend::poll` → backend.pull path in
+    // isolation (without actually spinning up an apalis Worker), plus the
+    // Ack success path.
+    #[cfg(feature = "local")]
+    #[tokio::test]
+    async fn roundtrip_push_pull_ack_over_local_backend() {
+        use crate::LocalQueueBackend;
+        use futures::StreamExt;
+
+        #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+        struct Greeting {
+            to: String,
+        }
+
+        let backend: Arc<dyn QueueBackend> = Arc::new(LocalQueueBackend::new());
+        let mut storage: ApalisSeraStorage<Greeting> =
+            ApalisSeraStorage::new(Arc::clone(&backend), "greetings");
+
+        // Push a job via the Storage API.
+        let parts = storage
+            .push(Greeting {
+                to: "world".into(),
+            })
+            .await
+            .expect("push");
+        assert!(!parts.context.job_id.is_empty());
+        assert_eq!(parts.context.lane, "greetings");
+
+        // Pull it back by driving the stream one tick.
+        let mut stream = build_pull_stream(storage.clone());
+        let next = stream.next().await.expect("stream yields");
+        let req = next.expect("ok").expect("some");
+        assert_eq!(req.args.to, "world");
+        assert_eq!(req.parts.context.lane, "greetings");
+        let job_id = req.parts.context.job_id.clone();
+
+        // Ack the job — LocalQueueBackend::ack is a no-op, but the wrapper
+        // must forward without erroring on success responses.
+        let resp: Response<()> = Response::success(
+            (),
+            apalis_core::task::task_id::TaskId::new(),
+            apalis_core::task::attempt::Attempt::default(),
+        );
+        let ack_ctx = SeraJobContext {
+            job_id,
+            lane: "greetings".into(),
+        };
+        <ApalisSeraStorage<Greeting> as Ack<Greeting, (), JsonCodec<Value>>>::ack(
+            &mut storage,
+            &ack_ctx,
+            &resp,
+        )
+        .await
+        .expect("ack");
+    }
+
+    // Integration test: run with a live Postgres via
+    //   DATABASE_URL=postgres://... cargo test -p sera-queue --features apalis
+    // wrapping SqlxQueueBackend in an ApalisSeraStorage and driving a real
+    // apalis Worker with retries + tracing layers. See sqlx_backend.rs for
+    // the table schema.
+}

--- a/rust/crates/sera-queue/src/lib.rs
+++ b/rust/crates/sera-queue/src/lib.rs
@@ -20,3 +20,15 @@ pub mod sqlx_backend;
 
 #[cfg(feature = "apalis")]
 pub use sqlx_backend::SqlxQueueBackend;
+
+#[cfg(feature = "apalis")]
+pub mod apalis_backend;
+
+#[cfg(feature = "apalis")]
+pub use apalis_backend::{ApalisSeraStorage, SeraJobContext};
+
+/// Re-export of [`apalis_cron`] — users enable the `apalis-cron` feature and
+/// call `CronStream::new(...).pipe_to_storage(apalis_sera_storage)` to drive
+/// cron-triggered jobs through `QueueBackend`.
+#[cfg(feature = "apalis-cron")]
+pub use apalis_cron;


### PR DESCRIPTION
## Summary
- Implements bead `sera-wdjx`: wraps any `Arc<dyn QueueBackend>` as an apalis 0.7.x `Storage<T>` so apalis Workers can drive sera-queue lanes with the full tower middleware stack (retries, timeouts, tracing, rate-limits).
- New public surface (behind `apalis` / `apalis-cron` cargo features): `ApalisSeraStorage<T>`, `SeraJobContext { job_id, lane }`, and the `apalis_cron` re-export.
- Leaves `QueueBackend`, `LocalQueueBackend`, `SqlxQueueBackend` untouched. Default build unaffected.

## Design notes
- Sera job ids are UUID while apalis `TaskId` is ULID-only, so id + lane ride on each request inside `SeraJobContext` and are read back on ack/nack.
- Unsupported Storage methods (`fetch_by_id`, `update`, `reschedule`, `schedule_request`) return `QueueError::Storage{reason:"... not supported"}`; worker happy-path never calls them.
- Ack swallows `NotFound` from the LocalQueueBackend's no-op ack semantics so workers stay healthy against the in-memory backend; real Postgres errors propagate.

## Test plan
- [x] `cargo check -p sera-queue` (default)
- [x] `cargo check -p sera-queue --features apalis`
- [x] `cargo check -p sera-queue --features apalis-cron`
- [x] `cargo check --workspace` + `--no-default-features` + `--features enterprise`
- [x] `scripts/check-feature-matrix.sh` — green
- [x] `cargo test -p sera-queue --features apalis` — 32 passed (includes a real `push → stream → ack` round-trip)
- [x] `cargo test -p sera-queue --features apalis-cron` — 32 passed
- [x] `cargo clippy -p sera-queue --features apalis -- -D warnings` — clean
- [ ] Live Postgres integration (no `DATABASE_URL` available locally; doc-comment recipe matches existing `sqlx_backend.rs` pattern; follow-up tracked in bead `sera-kuup`)

## Follow-ups (bead `sera-kuup`)
- Reconcile `len` (returns 0) vs `is_empty` (returns false) — either both error or both wire to backend stats.
- Drop redundant `std::sync::Arc::new(...)` prefix at two call sites.
- Gated Sqlx integration test so CI/devs can exercise the Postgres path with `DATABASE_URL`.

Closes bead `sera-wdjx`.