### PR TITLE
fix(sera-queue): apalis backend follow-ups from #981 (sera-kuup)

### DIFF
--- a/rust/crates/sera-queue/src/apalis_backend.rs
+++ b/rust/crates/sera-queue/src/apalis_backend.rs
@@ -389,9 +389,65 @@ mod tests {
         .expect("ack");
     }
 
-    // Integration test: run with a live Postgres via
-    //   DATABASE_URL=postgres://... cargo test -p sera-queue --features apalis
-    // wrapping SqlxQueueBackend in an ApalisSeraStorage and driving a real
-    // apalis Worker with retries + tracing layers. See sqlx_backend.rs for
-    // the table schema.
+    // Integration test: round-trip a job through ApalisSeraStorage backed by
+    // SqlxQueueBackend. Requires a live Postgres instance with the
+    // sera_queue_jobs table (schema in sqlx_backend.rs). Run with:
+    //   DATABASE_URL=postgres://... cargo test -p sera-queue --features apalis -- --ignored
+    #[cfg(feature = "apalis")]
+    #[ignore]
+    #[tokio::test]
+    async fn roundtrip_push_pull_ack_over_sqlx_backend() {
+        use crate::sqlx_backend::SqlxQueueBackend;
+        use futures::StreamExt;
+
+        #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+        struct Task {
+            name: String,
+        }
+
+        let db_url = std::env::var("DATABASE_URL")
+            .expect("DATABASE_URL must be set for sqlx integration test");
+        let pool = sqlx::PgPool::connect(&db_url)
+            .await
+            .expect("connect to Postgres");
+        let backend: Arc<dyn QueueBackend> =
+            Arc::new(SqlxQueueBackend::new(Arc::new(pool)));
+        let mut storage: ApalisSeraStorage<Task> =
+            ApalisSeraStorage::new(Arc::clone(&backend), "test-lane");
+
+        // Push a job via the Storage API.
+        let parts = storage
+            .push(Task { name: "hello".into() })
+            .await
+            .expect("push");
+        let pushed_id = parts.context.job_id.clone();
+        assert!(!pushed_id.is_empty());
+        assert_eq!(parts.context.lane, "test-lane");
+
+        // Pull it back by driving the stream one tick.
+        let mut stream = build_pull_stream(storage.clone());
+        let next = stream.next().await.expect("stream yields");
+        let req = next.expect("ok").expect("some");
+        assert_eq!(req.args.name, "hello");
+        assert_eq!(req.parts.context.job_id, pushed_id);
+        assert_eq!(req.parts.context.lane, "test-lane");
+
+        // Ack the job — deletes it from the table.
+        let resp: Response<()> = Response::success(
+            (),
+            apalis_core::task::task_id::TaskId::new(),
+            apalis_core::task::attempt::Attempt::default(),
+        );
+        let ack_ctx = SeraJobContext {
+            job_id: pushed_id,
+            lane: "test-lane".into(),
+        };
+        <ApalisSeraStorage<Task> as Ack<Task, (), JsonCodec<Value>>>::ack(
+            &mut storage,
+            &ack_ctx,
+            &resp,
+        )
+        .await
+        .expect("ack");
+    }
 }

--- a/rust/crates/sera-queue/src/apalis_backend.rs
+++ b/rust/crates/sera-queue/src/apalis_backend.rs
@@ -166,9 +166,9 @@ where
     }
 
     async fn len(&mut self) -> Result<i64, Self::Error> {
-        // QueueBackend exposes no length API; report zero rather than block
-        // callers that only want a health-check style value.
-        Ok(0)
+        Err(QueueError::Storage {
+            reason: "len is not supported by sera-queue QueueBackend".into(),
+        })
     }
 
     async fn fetch_by_id(
@@ -200,8 +200,9 @@ where
     }
 
     async fn is_empty(&mut self) -> Result<bool, Self::Error> {
-        // No size API — be conservative and report non-empty so callers poll.
-        Ok(false)
+        Err(QueueError::Storage {
+            reason: "is_empty is not supported by sera-queue QueueBackend".into(),
+        })
     }
 
     async fn vacuum(&mut self) -> Result<usize, Self::Error> {

--- a/rust/crates/sera-queue/src/apalis_backend.rs
+++ b/rust/crates/sera-queue/src/apalis_backend.rs
@@ -265,7 +265,7 @@ where
                             yield Ok(Some(req));
                         }
                         Err(e) => {
-                            yield Err(ApalisError::SourceError(std::sync::Arc::new(Box::new(
+                            yield Err(ApalisError::SourceError(Arc::new(Box::new(
                                 QueueError::Serde { reason: e.to_string() },
                             ))));
                         }
@@ -275,7 +275,7 @@ where
                     apalis_core::sleep(poll_interval).await;
                 }
                 Err(e) => {
-                    yield Err(ApalisError::SourceError(std::sync::Arc::new(Box::new(e))));
+                    yield Err(ApalisError::SourceError(Arc::new(Box::new(e))));
                     apalis_core::sleep(poll_interval).await;
                 }
             }


### PR DESCRIPTION
## Summary

Code-review follow-ups from PR #981 (apalis 0.7.x backend). Three small cleanups, no behavioural changes to the happy path.

- **[x] Reconcile len/is_empty semantics** — both methods now return `Err(QueueError::Storage { reason: "... is not supported ..." })`, matching the pattern used by `fetch_by_id`, `update`, `reschedule`, and `schedule_request`. Previously `len` returned `Ok(0)` while `is_empty` returned `Ok(false)`, which contradict each other.

- **[x] Drop redundant Arc prefix** — removed `std::sync::` qualifier from two `Arc::new(Box::new(...))` calls in `build_pull_stream`; `Arc` is already imported at the top of the file.

- **[x] Sqlx integration test (#[ignore]-gated)** — added `roundtrip_push_pull_ack_over_sqlx_backend` behind `#[cfg(feature = "apalis")]` and `#[ignore]`. Requires a live Postgres with the `sera_queue_jobs` table. Run with:
  ```
  DATABASE_URL=postgres://... cargo test -p sera-queue --features apalis -- --ignored
  ```
  Mirrors the existing `LocalQueueBackend` round-trip test (push → pull → ack, assert payload and job-id identity).

## Test plan

- [x] `cargo check -p sera-queue` — clean
- [x] `cargo check -p sera-queue --features apalis` — clean
- [x] `cargo test -p sera-queue` — 29 passed
- [x] `cargo clippy -p sera-queue -- -D warnings` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)