### PR TITLE
fix(sera-config): lock SERA_ENV_LOCK in DATABASE_URL tests (sera-f2qv)

### DIFF
--- a/rust/crates/sera-config/src/core_config.rs
+++ b/rust/crates/sera-config/src/core_config.rs
@@ -239,6 +239,7 @@ mod tests {
 
     #[test]
     fn core_config_requires_database_url() {
+        let _guard = SERA_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         // Save, remove, test, restore
         let saved = env::var("DATABASE_URL").ok();
         unsafe { env::remove_var("DATABASE_URL") };
@@ -252,6 +253,7 @@ mod tests {
 
     #[test]
     fn core_config_defaults() {
+        let _guard = SERA_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let saved = env::var("DATABASE_URL").ok();
         unsafe { env::set_var("DATABASE_URL", "postgres://test:test@localhost/sera") };
         let result = CoreConfig::from_env();


### PR DESCRIPTION
The core_config_requires_database_url and core_config_defaults tests were mutating DATABASE_URL without acquiring SERA_ENV_LOCK, causing test flakes when run concurrently with other env-touching tests.

Observed flake on PR #985 (sera-ze27) validate-rust CI on 2026-04-20.

Fix: Add lock acquisition before env mutations, matching the pattern already used elsewhere in the tests module.