### PR TITLE
chore(sera-runtime): SPEC §3/§4 polish + trait-object tests (sera-wu3o)

### DIFF
--- a/docs/plan/specs/SPEC-context-engine-pluggability.md
+++ b/docs/plan/specs/SPEC-context-engine-pluggability.md
@@ -139,6 +139,8 @@ Splitting the optional methods across two traits — not one "extended"
 trait — lets a future engine opt into drill tools **without** also
 committing to diagnostics, and vice versa.
 
+The split at `ContextQuery` vs `ContextDiagnostics` is not arbitrary: any engine that implements `ContextQuery` at all has semantic reason to make `search`, `describe_node`, and `expand_node` work (they are the read side of whatever the engine persists), whereas `ContextDiagnostics` methods (`status`, `doctor`) have no semantic home for an engine that persists nothing — defaulting them would be the same dishonest stub problem under a different name.
+
 Capability matrix:
 
 | Engine | `ContextEngine` | `ContextQuery` | `ContextDiagnostics` |
@@ -186,6 +188,11 @@ do NOT leak across the seam. They are encoded as `ContextNodeId(String)`
 + `depth_label: String`. A sera tool that presents LCM output
 stringifies `SummaryNode.node_id` as `"42"` and renders `depth = 1` as
 `"D1"`.
+
+`lcm_expand_query` (LCM's sixth agent-facing tool) has no row in this
+table because it is a composition — search + `expand_node` + LLM
+synthesis — not a 1:1 mapping to a trait method; it lives at the sera
+tool authorship layer described in §7.
 
 ## 5. Default pipeline worked example
 

--- a/rust/crates/sera-runtime/src/context_engine/mod.rs
+++ b/rust/crates/sera-runtime/src/context_engine/mod.rs
@@ -397,4 +397,31 @@ mod pluggability_tests {
         assert_eq!(back.engine.name, "test");
         assert_eq!(back.session_id.as_deref(), Some("sess-1"));
     }
+
+    /// Object-safety smoke: `ContextQuery` must be usable as a trait object.
+    /// If a future change breaks `async_trait` object-safety (e.g. a method
+    /// gains a `Self: Sized` bound) this test fails at compile time.
+    #[test]
+    fn context_query_is_object_safe() {
+        use std::sync::Arc;
+        let _: Arc<dyn ContextQuery> = Arc::new(NodeOnlyQuery);
+    }
+
+    /// Metadata round-trip: `ContextSearchHit::metadata` carries the
+    /// `#[serde(default)]` forward-compat slot. Verify non-null metadata
+    /// survives a JSON round-trip so the slot is locked in.
+    #[test]
+    fn search_hit_metadata_round_trips() {
+        let hit = ContextSearchHit {
+            node_id: Some(ContextNodeId::new("1")),
+            externalized_ref: None,
+            snippet: "test".into(),
+            depth_label: "D0".into(),
+            rank: None,
+            metadata: serde_json::json!({"bucket": "recent", "score": 0.9}),
+        };
+        let s = serde_json::to_string(&hit).unwrap();
+        let back: ContextSearchHit = serde_json::from_str(&s).unwrap();
+        assert_eq!(back.metadata, hit.metadata);
+    }
 }


### PR DESCRIPTION
Non-blocking follow-ups from PR #985 (sera-ze27) code review.

## Changes

- **SPEC §3** — one sentence pinning why it is three traits vs one-with-defaults. Any engine that implements `ContextQuery` has semantic reason to make the core read methods work; defaulting `ContextDiagnostics` instead would be the same dishonest-stub problem under a different name.
- **SPEC §4** — note that `lcm_expand_query` (LCM's sixth agent-facing tool) is a composition (`search` + `expand_node` + LLM synthesis), not a 1:1 trait method. It lives at the sera tool authorship layer per §7.
- **`pluggability_tests`** — two smoke tests:
  - `context_query_is_object_safe`: `Arc<dyn ContextQuery>` construction catches future `async_trait` object-safety breaks at compile time.
  - `search_hit_metadata_round_trips`: non-null metadata survives JSON round-trip, locking the `#[serde(default)]` forward-compat slot.

## Verification

- `cargo test -p sera-runtime --lib context_engine` — 42 passed
- `cargo clippy -p sera-runtime --tests -- -D warnings` — clean
- Diff is purely additive (+34, -0)

Closes sera-wu3o.