### PR TITLE
refactor(sera-db,sera-testing): delete sera-memory re-export stubs (sera-5xvm)

### DIFF
--- a/rust/crates/sera-db/src/lib.rs
+++ b/rust/crates/sera-db/src/lib.rs
@@ -20,8 +20,6 @@ pub mod delegations;
 pub mod memory;
 pub mod notifications;
 pub mod operator_requests;
-pub mod pgvector_store;
-pub mod sqlite_memory_store;
 pub mod secrets;
 pub mod signals;
 pub mod tasks;
@@ -35,4 +33,3 @@ pub mod error;
 
 pub use pool::DbPool;
 pub use error::DbError;
-pub use sqlite_memory_store::{DEFAULT_SQLITE_VEC_DIMENSIONS, SqliteMemoryStore};

--- a/rust/crates/sera-db/src/pgvector_store.rs
+++ b/rust/crates/sera-db/src/pgvector_store.rs
@@ -1,5 +1,0 @@
-//! Thin re-export stub — implementation lives in `sera-memory::PgVectorStore`.
-//!
-//! Downstream code that previously imported from `sera-db::pgvector_store`
-//! continues to work; new callers should import from `sera_memory` directly.
-pub use sera_memory::{PgVectorStore, DEFAULT_SEMANTIC_DIMENSIONS};

--- a/rust/crates/sera-db/src/sqlite_memory_store.rs
+++ b/rust/crates/sera-db/src/sqlite_memory_store.rs
@@ -1,5 +1,0 @@
-//! Thin re-export stub — implementation lives in `sera-memory::SqliteMemoryStore`.
-//!
-//! Downstream code that previously imported from `sera-db::sqlite_memory_store`
-//! continues to work; new callers should import from `sera_memory` directly.
-pub use sera_memory::{SqliteMemoryStore, DEFAULT_SQLITE_VEC_DIMENSIONS};

--- a/rust/crates/sera-gateway/src/bin/sera.rs
+++ b/rust/crates/sera-gateway/src/bin/sera.rs
@@ -41,9 +41,9 @@ use sera_db::sqlite::SqliteDb;
 // (FTS5 + sqlite-vec + RRF). Pairs with PgVectorStore for the enterprise
 // path. Wired in the boot path below via backend selection on
 // SERA_MEMORY_BACKEND + DATABASE_URL.
-use sera_db::pgvector_store::PgVectorStore;
+use sera_memory::PgVectorStore;
 #[allow(unused_imports)]
-use sera_db::{SqliteMemoryStore, DEFAULT_SQLITE_VEC_DIMENSIONS};
+use sera_memory::{SqliteMemoryStore, DEFAULT_SQLITE_VEC_DIMENSIONS};
 use sera_runtime::skill_dispatch::SkillDispatchEngine;
 use sera_memory::SemanticMemoryStore;
 // sera-uwk0: Mail gate ingress correlator (Design B — RFC 5322 headers +

--- a/rust/crates/sera-runtime/src/context_engine/enricher.rs
+++ b/rust/crates/sera-runtime/src/context_engine/enricher.rs
@@ -855,7 +855,7 @@ mod tests {
 
     // ── GH#140: hierarchical scope enrichment ──────────────────────────────
 
-    use sera_testing::semantic_memory::InMemorySemanticStore;
+    use sera_memory::InMemorySemanticStore;
     use sera_memory::{Damping, Scope, ScopeHierarchy};
 
     fn scoped_entry(agent: &str, content: &str, scope: Scope) -> SemanticEntry {

--- a/rust/crates/sera-testing/src/lib.rs
+++ b/rust/crates/sera-testing/src/lib.rs
@@ -8,4 +8,3 @@
 
 pub mod contracts;
 pub mod mocks;
-pub mod semantic_memory;

--- a/rust/crates/sera-testing/src/semantic_memory.rs
+++ b/rust/crates/sera-testing/src/semantic_memory.rs
@@ -1,5 +1,0 @@
-//! Thin re-export stub — implementation lives in `sera-memory::InMemorySemanticStore`.
-//!
-//! Downstream code that previously imported from `sera-testing::semantic_memory`
-//! continues to work; new callers should import from `sera_memory` directly.
-pub use sera_memory::InMemorySemanticStore;


### PR DESCRIPTION
Follow-up to the sera-memory crate extraction (PR #982 / sera-50y1). Three re-export stub files left over from the migration can now be deleted — downstream callers are migrated to import from `sera_memory` directly.

## Deleted stubs

- `rust/crates/sera-db/src/pgvector_store.rs`
- `rust/crates/sera-db/src/sqlite_memory_store.rs`
- `rust/crates/sera-testing/src/semantic_memory.rs`

Module declarations + flat re-exports removed from `sera-db/src/lib.rs` and `sera-testing/src/lib.rs`.

## Migrated callers

- `sera-gateway/src/bin/sera.rs`: `sera_db::pgvector_store::PgVectorStore` → `sera_memory::PgVectorStore`
- `sera-runtime/src/context_engine/enricher.rs`: `sera_testing::semantic_memory::InMemorySemanticStore` → `sera_memory::InMemorySemanticStore`

## Verification

- `cargo check --workspace` → clean (20.67s)
- `cargo test -p sera-db -p sera-testing` → 201 passed
- `cargo clippy -p sera-db -p sera-testing -p sera-gateway -p sera-runtime -- -D warnings` → clean

Closes sera-5xvm.