### PR TITLE
fix(sera-runtime): expose allow_missing_constitutional_gate via env + tier=local auto-permit (sera-2llu)

### DIFF
--- a/rust/crates/sera-gateway/src/bin/sera.rs
+++ b/rust/crates/sera-gateway/src/bin/sera.rs
@@ -2590,6 +2590,21 @@ async fn run_start(config: PathBuf, port: u16) -> anyhow::Result<()> {
         let exe_dir = exe_path.parent().unwrap_or(std::path::Path::new("."));
         exe_dir.join("sera-runtime").to_string_lossy().to_string()
     });
+
+    // Determine whether the manifest declares a local-tier instance.  When
+    // `Instance.spec.tier == "local"` the runtime has no ConstitutionalGate
+    // HookChain wired, so we forward the permissive flag via env so operators
+    // running a local sera.yaml can complete turns without a policy install.
+    let tier_is_local = manifests
+        .instance_spec()
+        .ok()
+        .flatten()
+        .map(|s| s.tier.eq_ignore_ascii_case("local"))
+        .unwrap_or(false);
+    if tier_is_local {
+        tracing::info!("constitutional gate permissive: reason=tier-local");
+    }
+
     let mut harnesses = std::collections::HashMap::new();
 
     for agent_name in manifests.agent_names() {
@@ -2623,6 +2638,14 @@ async fn run_start(config: PathBuf, port: u16) -> anyhow::Result<()> {
         env.insert("LLM_MODEL".to_string(), model.clone());
         env.insert("LLM_API_KEY".to_string(), api_key_val);
         env.insert("AGENT_ID".to_string(), agent_name.to_string());
+        // Forward permissive-gate flag to the runtime process so it can skip
+        // the ConstitutionalGate check on local-tier deployments.
+        if tier_is_local {
+            env.insert(
+                "SERA_ALLOW_MISSING_CONSTITUTIONAL_GATE".to_string(),
+                "true".to_string(),
+            );
+        }
 
         match StdioHarness::spawn(&runtime_bin, env).await {
             Ok(harness) => {

--- a/rust/crates/sera-runtime/src/main.rs
+++ b/rust/crates/sera-runtime/src/main.rs
@@ -233,12 +233,22 @@ async fn main() -> anyhow::Result<()> {
     // unified [`ThinkingConfig`] when the corresponding env vars are set.
     // Absence of either preserves the legacy single-account / no-reasoning
     // behaviour byte-for-byte.
+
+    // Determine whether to permit turns when no ConstitutionalGate HookChain
+    // is installed.  Two opt-in paths; env takes precedence over tier-local.
+    //
+    // 1. `SERA_ALLOW_MISSING_CONSTITUTIONAL_GATE=1|true` (explicit operator opt-in)
+    // 2. Injected by the gateway when `Instance.spec.tier == "local"` (the
+    //    gateway sets the same env var, so the runtime only needs one read path).
+    let permissive_gate = resolve_allow_missing_gate();
+
     let context_engine = Box::new(ContextPipeline::new());
     let llm_client = Box::new(build_llm_client(&config));
     let runtime = DefaultRuntime::new(context_engine)
         .with_llm(llm_client)
         .with_tool_dispatcher(Box::new(dispatcher))
-        .with_authz_provider(authz_provider);
+        .with_authz_provider(authz_provider)
+        .with_allow_missing_constitutional_gate(permissive_gate);
 
     if interactive {
         run_interactive(&config, &runtime, &tool_defs, system_prompt.as_deref()).await
@@ -411,6 +421,92 @@ fn build_llm_client(config: &RuntimeConfig) -> LlmClient {
     }
 
     client
+}
+
+// ── Constitutional gate resolution ───────────────────────────────────────────
+
+/// Read `SERA_ALLOW_MISSING_CONSTITUTIONAL_GATE` and return `true` when the
+/// operator has explicitly opted in (value `"1"` or `"true"`, case-insensitive).
+///
+/// The gateway forwards this env var into the runtime process when it detects
+/// `Instance.spec.tier == "local"` in the manifest, so the runtime sees only
+/// one read path regardless of whether the trigger was explicit env or
+/// tier-auto-permit.
+fn resolve_allow_missing_gate() -> bool {
+    let val = std::env::var("SERA_ALLOW_MISSING_CONSTITUTIONAL_GATE")
+        .map(|v| v.eq_ignore_ascii_case("true") || v == "1")
+        .unwrap_or(false);
+    if val {
+        tracing::info!("constitutional gate permissive: reason=env");
+    }
+    val
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_allow_missing_gate;
+
+    /// `SERA_ALLOW_MISSING_CONSTITUTIONAL_GATE` unset → permissive = false.
+    #[test]
+    fn gate_defaults_to_false_when_env_unset() {
+        // Guard: only run when the env var is not already set by the caller.
+        if std::env::var("SERA_ALLOW_MISSING_CONSTITUTIONAL_GATE").is_ok() {
+            return;
+        }
+        assert!(!resolve_allow_missing_gate());
+    }
+
+    /// Value `"1"` → permissive = true (env path).
+    #[test]
+    fn gate_true_for_value_one() {
+        // Use a scoped env helper to avoid leaking between parallel tests.
+        let _guard = EnvGuard::set("SERA_ALLOW_MISSING_CONSTITUTIONAL_GATE", "1");
+        assert!(resolve_allow_missing_gate());
+    }
+
+    /// Value `"true"` (case-insensitive) → permissive = true.
+    #[test]
+    fn gate_true_for_value_true_case_insensitive() {
+        let _guard = EnvGuard::set("SERA_ALLOW_MISSING_CONSTITUTIONAL_GATE", "TRUE");
+        assert!(resolve_allow_missing_gate());
+    }
+
+    /// Value `"false"` → permissive = false (not opted in).
+    #[test]
+    fn gate_false_for_value_false() {
+        let _guard = EnvGuard::set("SERA_ALLOW_MISSING_CONSTITUTIONAL_GATE", "false");
+        assert!(!resolve_allow_missing_gate());
+    }
+
+    // ── RAII env-var guard ────────────────────────────────────────────────────
+
+    struct EnvGuard {
+        key: &'static str,
+        prev: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let prev = std::env::var(key).ok();
+            // SAFETY: tests run single-threaded (no other threads read this var).
+            unsafe { std::env::set_var(key, value) };
+            Self { key, prev }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            // SAFETY: tests run single-threaded (no other threads read this var).
+            unsafe {
+                match &self.prev {
+                    Some(v) => std::env::set_var(self.key, v),
+                    None => std::env::remove_var(self.key),
+                }
+            }
+        }
+    }
 }
 
 /// Send periodic heartbeats to sera-core.


### PR DESCRIPTION
## Summary

- **Root cause (validated via manual curl):** `DefaultRuntime` in `main.rs` never called `.with_allow_missing_constitutional_gate(...)`, so every `/api/chat` turn against a local `sera.yaml` without a ConstitutionalGate HookChain returned `{"response": "[interrupted: no ConstitutionalGate policy installed]"}`.
- **Fix — runtime (`sera-runtime/src/main.rs`):** Added `resolve_allow_missing_gate()` which reads `SERA_ALLOW_MISSING_CONSTITUTIONAL_GATE` (truthy = `"1"` or `"true"`, case-insensitive) and wires the result into `DefaultRuntime::with_allow_missing_constitutional_gate`. Logs `INFO "constitutional gate permissive: reason=env"` at startup when set. Four unit tests cover unset/`1`/`true`/`false` cases.
- **Fix — gateway (`sera-gateway/src/bin/sera.rs`):** Before spawning each `StdioHarness`, checks `manifests.instance_spec().tier == "local"` (case-insensitive). When true, inserts `SERA_ALLOW_MISSING_CONSTITUTIONAL_GATE=true` into the harness env map and logs `INFO "constitutional gate permissive: reason=tier-local"`. This implements the tier-local auto-permit path without adding any new manifest fields.

## Precedence

Explicit env (`SERA_ALLOW_MISSING_CONSTITUTIONAL_GATE=1`) takes precedence over tier-auto because: the gateway only injects the env var when `tier=local`; if the operator sets the env explicitly in the gateway's own environment, it is already set before the gateway reads the manifest, so the runtime receives `true` regardless of tier. The runtime sees a single env-var read path regardless of which trigger fired.

## What was NOT changed

- `DefaultRuntime::with_allow_missing_constitutional_gate` trait signature — untouched.
- Default remains `false` (fail-closed) — no behavior change for non-local tiers.
- Existing tests in `default_runtime.rs` that use `.with_allow_missing_constitutional_gate(true)` — untouched and still pass.
- No new manifest fields added.

## Test plan

- [ ] `cargo test -p sera-runtime -- --test-threads=1` → 550 passed
- [ ] `cargo clippy -p sera-runtime -- -D warnings` → no issues
- [ ] `cargo clippy -p sera-gateway -- -D warnings` → no issues
- [ ] New unit tests in `main.rs`: `gate_defaults_to_false_when_env_unset`, `gate_true_for_value_one`, `gate_true_for_value_true_case_insensitive`, `gate_false_for_value_false`
- [ ] Manual E2E: run gateway with `tier: local` in `sera.yaml` → `/api/chat` completes without `[interrupted: no ConstitutionalGate policy installed]`
- [ ] Manual E2E: run gateway with `SERA_ALLOW_MISSING_CONSTITUTIONAL_GATE=1` (any tier) → same result

🤖 Generated with [Claude Code](https://claude.com/claude-code)