### PR TITLE
feat(scripts): sera-local dev boot script for LM Studio loopback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,4 @@ sera.yaml
 # Gateway runtime logs
 logs/
 
+.sera-local/

--- a/scripts/sera-local
+++ b/scripts/sera-local
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# sera-local — Boot a local SERA gateway + runtime against an external LLM
+#
+# Usage:
+#   sera-local                      Boot with defaults (LM Studio, gemma-4-e2b, :42540)
+#   sera-local --model <name>       Override the LLM model name
+#   sera-local --port <n>           Override the gateway HTTP port
+#   sera-local --llm <url>          Override the OpenAI-compatible base URL
+#   sera-local --data-dir <path>    Override the working dir (default: .sera-local/)
+#   sera-local --help               Show this help
+#
+# Defaults target a host-local LM Studio on :1234 with google/gemma-4-e2b loaded.
+# The manifest sets tier=local so the runtime's constitutional gate is permissive
+# (no HookChain required). Ctrl-C stops the gateway.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+MODEL="google/gemma-4-e2b"
+PORT="42540"
+LLM_BASE_URL="http://localhost:1234/v1"
+DATA_DIR="${REPO_ROOT}/.sera-local"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --model)    MODEL="$2"; shift 2 ;;
+    --port)     PORT="$2"; shift 2 ;;
+    --llm)      LLM_BASE_URL="$2"; shift 2 ;;
+    --data-dir) DATA_DIR="$2"; shift 2 ;;
+    --help|-h)  sed -n '2,14p' "$0" | sed 's/^# \?//'; exit 0 ;;
+    *)          echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+GATEWAY_BIN="${REPO_ROOT}/rust/target/debug/sera-gateway"
+RUNTIME_BIN="${REPO_ROOT}/rust/target/debug/sera-runtime"
+
+if [[ ! -x "$GATEWAY_BIN" || ! -x "$RUNTIME_BIN" ]]; then
+  echo "Building sera-gateway + sera-runtime (first run)..." >&2
+  (cd "${REPO_ROOT}/rust" && cargo build -p sera-gateway -p sera-runtime)
+fi
+
+mkdir -p "$DATA_DIR"
+CONFIG="${DATA_DIR}/sera.yaml"
+
+cat > "$CONFIG" <<EOF
+apiVersion: sera.dev/v1
+kind: Instance
+metadata:
+  name: sera-local
+spec:
+  tier: local
+---
+apiVersion: sera.dev/v1
+kind: Provider
+metadata:
+  name: lmstudio
+spec:
+  kind: openai-compatible
+  base_url: "${LLM_BASE_URL}"
+  default_model: ${MODEL}
+---
+apiVersion: sera.dev/v1
+kind: Agent
+metadata:
+  name: sera
+spec:
+  provider: lmstudio
+  model: ${MODEL}
+  persona:
+    immutable_anchor: |
+      You are SERA. Reply briefly.
+EOF
+
+echo "sera-local: starting gateway on http://localhost:${PORT}"
+echo "sera-local: model=${MODEL} llm=${LLM_BASE_URL}"
+echo "sera-local: data=${DATA_DIR}"
+echo "sera-local: chat via: curl -s http://localhost:${PORT}/api/chat -H 'Content-Type: application/json' -d '{\"agent\":\"sera\",\"message\":\"hi\",\"stream\":false}'"
+echo
+
+cd "$DATA_DIR"
+exec env \
+  SERA_RUNTIME_BIN="$RUNTIME_BIN" \
+  LLM_BASE_URL="$LLM_BASE_URL" \
+  RUST_LOG="${RUST_LOG:-sera_gateway=info,sera_runtime=info}" \
+  "$GATEWAY_BIN" start --config "$CONFIG" --port "$PORT"


### PR DESCRIPTION
## Summary

Adds a \`scripts/sera-local\` dev helper that boots the gateway+runtime against an OpenAI-compatible local LLM (defaults: LM Studio at \`:1234\`, model \`google/gemma-4-e2b\`, gateway on \`:42540\`) with no Discord bridge. Uses \`tier: local\` so the constitutional gate is permissive per the opt-in auto-permit landed in sera-2llu (#994). Ctrl-C stops the gateway.

Landed during the 2026-04-21 session validating end-to-end local chat against LM Studio after #994. The Docker \`rust-sera-1\` container is still the full-featured setup with Discord; \`sera-local\` is the no-deps loopback for fast iteration.

## Usage

```bash
scripts/sera-local                      # defaults (LM Studio, gemma-4-e2b, :42540)
scripts/sera-local --model <name>       # override LLM model name
scripts/sera-local --port <n>           # override gateway HTTP port
scripts/sera-local --llm <url>          # override OpenAI-compatible base URL
scripts/sera-local --data-dir <path>    # override working dir (default: .sera-local/)
```

Validation recipe (from the session log):

```bash
scripts/sera-local &
curl -s http://localhost:42540/api/chat \\
  -H 'Content-Type: application/json' \\
  -d '{"agent":"sera","message":"hi","stream":false}'
```

Expects a real response from the loaded LM Studio model.

## Test plan
- [ ] \`scripts/sera-local --help\` prints usage
- [ ] \`scripts/sera-local\` builds gateway+runtime on first run (skips if already built)
- [ ] Gateway reachable on \`localhost:42540\` after boot
- [ ] \`tier: local\` manifest triggers constitutional-gate permissive mode (visible in logs: \"constitutional gate permissive: reason=tier-local\")
- [ ] \`.sera-local/\` (working dir) is gitignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)