### PR TITLE
feat(sera-plugin-sdk-py): Python SDK + plugin protos + CI (sera-psql)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,3 +48,54 @@ jobs:
 
       - name: Run E2E smoke
         run: ops/e2e/smoke.sh
+
+  validate-sdk-py:
+    name: ci-validate-sdk-py
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            sdk:
+              - 'sdk/**'
+              - 'rust/proto/plugin/**'
+              - '.github/workflows/ci.yml'
+
+      - if: steps.changes.outputs.sdk == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - if: steps.changes.outputs.sdk == 'true'
+        name: Install build tooling
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install hatch
+
+      - if: steps.changes.outputs.sdk == 'true'
+        name: Install SDK (editable + dev)
+        working-directory: sdk/python/sera-plugin-sdk
+        run: python -m pip install -e '.[dev]'
+
+      - if: steps.changes.outputs.sdk == 'true'
+        name: Ruff
+        working-directory: sdk/python/sera-plugin-sdk
+        run: ruff check src tests
+
+      - if: steps.changes.outputs.sdk == 'true'
+        name: Mypy
+        working-directory: sdk/python/sera-plugin-sdk
+        run: mypy src
+
+      - if: steps.changes.outputs.sdk == 'true'
+        name: Pytest
+        working-directory: sdk/python/sera-plugin-sdk
+        run: pytest -q
+
+      - if: steps.changes.outputs.sdk == 'true'
+        name: Build wheel
+        working-directory: sdk/python/sera-plugin-sdk
+        run: hatch build

--- a/rust/proto/plugin/auth_provider.proto
+++ b/rust/proto/plugin/auth_provider.proto
@@ -1,0 +1,37 @@
+// SERA AuthProvider plugin capability.
+//
+// See SPEC-plugins §2.1 and SPEC-identity-authz. Minimal two-method surface:
+// Authenticate(subject) → identity, Authorize(subject, action, resource) → allow.
+
+syntax = "proto3";
+
+package sera.plugin.v1;
+
+service AuthProvider {
+  rpc Authenticate(AuthRequest) returns (AuthResponse);
+  rpc Authorize(AuthzRequest) returns (AuthzResponse);
+}
+
+message AuthRequest {
+  string subject = 1;     // opaque identifier (token, username, …)
+  string credential = 2;  // opaque credential material
+}
+
+message AuthResponse {
+  bool authenticated = 1;
+  string subject_id = 2;           // canonical identity after auth
+  map<string, string> claims = 3;  // additional attributes
+  string reason = 4;               // populated on failure
+}
+
+message AuthzRequest {
+  string subject_id = 1;
+  string action = 2;
+  string resource = 3;
+  map<string, string> context = 4;
+}
+
+message AuthzResponse {
+  bool allow = 1;
+  string reason = 2;
+}

--- a/rust/proto/plugin/auth_provider.schema.json
+++ b/rust/proto/plugin/auth_provider.schema.json
@@ -1,0 +1,110 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sera.dev/schemas/plugin/auth_provider.schema.json",
+  "title": "sera.plugin.v1.AuthProvider JSON-RPC envelopes",
+  "description": "Hand-maintained mirror of auth_provider.proto for stdio JSON-RPC transport. Proto is canonical (SPEC-plugins §5.1).",
+  "type": "object",
+  "oneOf": [
+    { "$ref": "#/$defs/AuthenticateRequestEnvelope" },
+    { "$ref": "#/$defs/AuthenticateResponseEnvelope" },
+    { "$ref": "#/$defs/AuthorizeRequestEnvelope" },
+    { "$ref": "#/$defs/AuthorizeResponseEnvelope" }
+  ],
+  "$defs": {
+    "JsonRpcId": {
+      "oneOf": [
+        { "type": "string" },
+        { "type": "integer" },
+        { "type": "null" }
+      ]
+    },
+    "AuthRequest": {
+      "type": "object",
+      "properties": {
+        "subject": { "type": "string" },
+        "credential": { "type": "string" }
+      },
+      "required": ["subject"],
+      "additionalProperties": false
+    },
+    "AuthResponse": {
+      "type": "object",
+      "properties": {
+        "authenticated": { "type": "boolean" },
+        "subject_id": { "type": "string" },
+        "claims": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        },
+        "reason": { "type": "string" }
+      },
+      "required": ["authenticated"],
+      "additionalProperties": false
+    },
+    "AuthzRequest": {
+      "type": "object",
+      "properties": {
+        "subject_id": { "type": "string" },
+        "action": { "type": "string" },
+        "resource": { "type": "string" },
+        "context": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        }
+      },
+      "required": ["subject_id", "action", "resource"],
+      "additionalProperties": false
+    },
+    "AuthzResponse": {
+      "type": "object",
+      "properties": {
+        "allow": { "type": "boolean" },
+        "reason": { "type": "string" }
+      },
+      "required": ["allow"],
+      "additionalProperties": false
+    },
+    "AuthenticateRequestEnvelope": {
+      "type": "object",
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "id": { "$ref": "#/$defs/JsonRpcId" },
+        "method": { "const": "sera.plugin.v1.AuthProvider/Authenticate" },
+        "params": { "$ref": "#/$defs/AuthRequest" }
+      },
+      "required": ["jsonrpc", "id", "method", "params"],
+      "additionalProperties": false
+    },
+    "AuthenticateResponseEnvelope": {
+      "type": "object",
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "id": { "$ref": "#/$defs/JsonRpcId" },
+        "result": { "$ref": "#/$defs/AuthResponse" }
+      },
+      "required": ["jsonrpc", "id", "result"],
+      "additionalProperties": false
+    },
+    "AuthorizeRequestEnvelope": {
+      "type": "object",
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "id": { "$ref": "#/$defs/JsonRpcId" },
+        "method": { "const": "sera.plugin.v1.AuthProvider/Authorize" },
+        "params": { "$ref": "#/$defs/AuthzRequest" }
+      },
+      "required": ["jsonrpc", "id", "method", "params"],
+      "additionalProperties": false
+    },
+    "AuthorizeResponseEnvelope": {
+      "type": "object",
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "id": { "$ref": "#/$defs/JsonRpcId" },
+        "result": { "$ref": "#/$defs/AuthzResponse" }
+      },
+      "required": ["jsonrpc", "id", "result"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/rust/proto/plugin/context_engine.proto
+++ b/rust/proto/plugin/context_engine.proto
@@ -1,0 +1,154 @@
+// SERA ContextEngine plugin capability.
+//
+// See SPEC-plugins §2.1 and SPEC-context-engine-pluggability §2. Three
+// services, one per trait tier (core / query / diagnostics), so a plugin
+// that only implements ContextEngine does not have to stub out Query and
+// Diagnostics methods.
+
+syntax = "proto3";
+
+package sera.plugin.v1;
+
+import "google/protobuf/empty.proto";
+
+// Core context-engine seam — every plugin with PLUGIN_CAPABILITY_CONTEXT_ENGINE
+// MUST implement this service.
+service ContextEngine {
+  rpc Ingest(IngestRequest) returns (IngestAck);
+  rpc Assemble(AssembleRequest) returns (AssembledContext);
+}
+
+// Optional drill-tool surface — implemented by engines with an addressable
+// store (e.g. LCM). Maps to the ContextQuery trait in
+// sera_runtime::context_engine.
+service ContextQuery {
+  rpc Search(CtxSearchRequest) returns (CtxSearchResponse);
+  rpc Describe(DescribeRequest) returns (DescribeResponse);
+  rpc Expand(ExpandRequest) returns (ExpandResponse);
+}
+
+// Optional health/introspection surface — status() and doctor().
+service ContextDiagnostics {
+  rpc Status(StatusRequest) returns (StatusResponse);
+  rpc Doctor(google.protobuf.Empty) returns (DoctorReport);
+}
+
+enum ContextRole {
+  CONTEXT_ROLE_UNSPECIFIED = 0;
+  CONTEXT_ROLE_SYSTEM = 1;
+  CONTEXT_ROLE_USER = 2;
+  CONTEXT_ROLE_ASSISTANT = 3;
+  CONTEXT_ROLE_TOOL = 4;
+}
+
+enum ContextSegmentKind {
+  CONTEXT_SEGMENT_KIND_UNSPECIFIED = 0;
+  CONTEXT_SEGMENT_KIND_SOUL = 1;
+  CONTEXT_SEGMENT_KIND_WORKING = 2;
+  CONTEXT_SEGMENT_KIND_LONGTERM = 3;
+  CONTEXT_SEGMENT_KIND_OVERFLOW = 4;
+}
+
+// ContextEngine.Ingest
+message IngestRequest {
+  string session_id = 1;
+  ContextRole role = 2;
+  string content = 3;
+  map<string, string> metadata = 4;
+}
+
+message IngestAck {
+  bool accepted = 1;
+}
+
+// ContextEngine.Assemble
+message AssembleRequest {
+  string session_id = 1;
+  uint32 budget_tokens = 2;
+  string constraints_json = 3; // engine-specific constraints; opaque JSON
+}
+
+message ContextSegment {
+  ContextSegmentKind kind = 1;
+  string content = 2;
+  uint32 tokens = 3;
+}
+
+message AssembledContext {
+  repeated ContextSegment segments = 1;
+  uint32 total_tokens = 2;
+}
+
+// ContextQuery.Search
+message CtxSearchRequest {
+  string session_id = 1;
+  string query = 2;
+  uint32 limit = 3;
+}
+
+message CtxSearchHit {
+  string node_id = 1;        // opaque, see SPEC-context-engine-pluggability §2.2
+  string depth_label = 2;    // e.g. "D0", "D1"; "" for flat engines
+  string preview = 3;
+  double rank = 4;           // lower is stronger (FTS5 convention)
+  bool rank_present = 5;     // false mirrors Option<f64>::None
+}
+
+message CtxSearchResponse {
+  repeated CtxSearchHit hits = 1;
+}
+
+// ContextQuery.Describe
+message DescribeRequest {
+  string session_id = 1;
+  string node_id = 2; // opaque; plugin interprets
+}
+
+message DescribeResponse {
+  string node_id = 1;
+  string depth_label = 2;
+  uint32 tokens = 3;
+  repeated string child_node_ids = 4;
+  string metadata_json = 5;
+}
+
+// ContextQuery.Expand
+message ExpandRequest {
+  string session_id = 1;
+  string node_id = 2;
+  uint32 max_tokens = 3;
+}
+
+message ExpandResponse {
+  string node_id = 1;
+  string content = 2;
+  uint32 tokens = 3;
+  bool truncated = 4;
+}
+
+// ContextDiagnostics.Status
+message StatusRequest {
+  string session_id = 1; // empty for aggregate status
+}
+
+message StatusResponse {
+  string fields_json = 1; // backend-defined metrics; opaque JSON object
+}
+
+// ContextDiagnostics.Doctor
+enum DoctorSeverity {
+  DOCTOR_SEVERITY_UNSPECIFIED = 0;
+  DOCTOR_SEVERITY_OK = 1;
+  DOCTOR_SEVERITY_WARN = 2;
+  DOCTOR_SEVERITY_FAIL = 3;
+}
+
+message DoctorCheck {
+  string name = 1;
+  DoctorSeverity severity = 2;
+  string message = 3;
+}
+
+message DoctorReport {
+  repeated DoctorCheck checks = 1;
+}

--- a/rust/proto/plugin/context_engine.schema.json
+++ b/rust/proto/plugin/context_engine.schema.json
@@ -1,0 +1,370 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sera.dev/schemas/plugin/context_engine.schema.json",
+  "title": "sera.plugin.v1.ContextEngine / ContextQuery / ContextDiagnostics JSON-RPC envelopes",
+  "description": "Hand-maintained mirror of context_engine.proto for stdio JSON-RPC transport. Proto is canonical (SPEC-plugins §5.1). Three services kept side-by-side so a plugin advertising only ContextEngine need not implement Query/Diagnostics.",
+  "type": "object",
+  "oneOf": [
+    { "$ref": "#/$defs/IngestRequestEnvelope" },
+    { "$ref": "#/$defs/IngestResponseEnvelope" },
+    { "$ref": "#/$defs/AssembleRequestEnvelope" },
+    { "$ref": "#/$defs/AssembleResponseEnvelope" },
+    { "$ref": "#/$defs/SearchRequestEnvelope" },
+    { "$ref": "#/$defs/SearchResponseEnvelope" },
+    { "$ref": "#/$defs/DescribeRequestEnvelope" },
+    { "$ref": "#/$defs/DescribeResponseEnvelope" },
+    { "$ref": "#/$defs/ExpandRequestEnvelope" },
+    { "$ref": "#/$defs/ExpandResponseEnvelope" },
+    { "$ref": "#/$defs/StatusRequestEnvelope" },
+    { "$ref": "#/$defs/StatusResponseEnvelope" },
+    { "$ref": "#/$defs/DoctorRequestEnvelope" },
+    { "$ref": "#/$defs/DoctorResponseEnvelope" }
+  ],
+  "$defs": {
+    "JsonRpcId": {
+      "oneOf": [
+        { "type": "string" },
+        { "type": "integer" },
+        { "type": "null" }
+      ]
+    },
+    "ContextRole": {
+      "type": "string",
+      "enum": [
+        "CONTEXT_ROLE_UNSPECIFIED",
+        "CONTEXT_ROLE_SYSTEM",
+        "CONTEXT_ROLE_USER",
+        "CONTEXT_ROLE_ASSISTANT",
+        "CONTEXT_ROLE_TOOL"
+      ]
+    },
+    "ContextSegmentKind": {
+      "type": "string",
+      "enum": [
+        "CONTEXT_SEGMENT_KIND_UNSPECIFIED",
+        "CONTEXT_SEGMENT_KIND_SOUL",
+        "CONTEXT_SEGMENT_KIND_WORKING",
+        "CONTEXT_SEGMENT_KIND_LONGTERM",
+        "CONTEXT_SEGMENT_KIND_OVERFLOW"
+      ]
+    },
+    "DoctorSeverity": {
+      "type": "string",
+      "enum": [
+        "DOCTOR_SEVERITY_UNSPECIFIED",
+        "DOCTOR_SEVERITY_OK",
+        "DOCTOR_SEVERITY_WARN",
+        "DOCTOR_SEVERITY_FAIL"
+      ]
+    },
+    "IngestRequest": {
+      "type": "object",
+      "properties": {
+        "session_id": { "type": "string" },
+        "role": { "$ref": "#/$defs/ContextRole" },
+        "content": { "type": "string" },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        }
+      },
+      "required": ["session_id", "role", "content"],
+      "additionalProperties": false
+    },
+    "IngestAck": {
+      "type": "object",
+      "properties": { "accepted": { "type": "boolean" } },
+      "required": ["accepted"],
+      "additionalProperties": false
+    },
+    "AssembleRequest": {
+      "type": "object",
+      "properties": {
+        "session_id": { "type": "string" },
+        "budget_tokens": { "type": "integer", "minimum": 0 },
+        "constraints_json": { "type": "string" }
+      },
+      "required": ["session_id", "budget_tokens"],
+      "additionalProperties": false
+    },
+    "ContextSegment": {
+      "type": "object",
+      "properties": {
+        "kind": { "$ref": "#/$defs/ContextSegmentKind" },
+        "content": { "type": "string" },
+        "tokens": { "type": "integer", "minimum": 0 }
+      },
+      "required": ["kind", "content", "tokens"],
+      "additionalProperties": false
+    },
+    "AssembledContext": {
+      "type": "object",
+      "properties": {
+        "segments": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/ContextSegment" }
+        },
+        "total_tokens": { "type": "integer", "minimum": 0 }
+      },
+      "required": ["segments", "total_tokens"],
+      "additionalProperties": false
+    },
+    "CtxSearchRequest": {
+      "type": "object",
+      "properties": {
+        "session_id": { "type": "string" },
+        "query": { "type": "string" },
+        "limit": { "type": "integer", "minimum": 0 }
+      },
+      "required": ["query"],
+      "additionalProperties": false
+    },
+    "CtxSearchHit": {
+      "type": "object",
+      "properties": {
+        "node_id": { "type": "string" },
+        "depth_label": { "type": "string" },
+        "preview": { "type": "string" },
+        "rank": { "type": "number" },
+        "rank_present": { "type": "boolean" }
+      },
+      "required": ["node_id", "rank_present"],
+      "additionalProperties": false
+    },
+    "CtxSearchResponse": {
+      "type": "object",
+      "properties": {
+        "hits": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/CtxSearchHit" }
+        }
+      },
+      "required": ["hits"],
+      "additionalProperties": false
+    },
+    "DescribeRequest": {
+      "type": "object",
+      "properties": {
+        "session_id": { "type": "string" },
+        "node_id": { "type": "string" }
+      },
+      "required": ["node_id"],
+      "additionalProperties": false
+    },
+    "DescribeResponse": {
+      "type": "object",
+      "properties": {
+        "node_id": { "type": "string" },
+        "depth_label": { "type": "string" },
+        "tokens": { "type": "integer", "minimum": 0 },
+        "child_node_ids": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "metadata_json": { "type": "string" }
+      },
+      "required": ["node_id"],
+      "additionalProperties": false
+    },
+    "ExpandRequest": {
+      "type": "object",
+      "properties": {
+        "session_id": { "type": "string" },
+        "node_id": { "type": "string" },
+        "max_tokens": { "type": "integer", "minimum": 0 }
+      },
+      "required": ["node_id", "max_tokens"],
+      "additionalProperties": false
+    },
+    "ExpandResponse": {
+      "type": "object",
+      "properties": {
+        "node_id": { "type": "string" },
+        "content": { "type": "string" },
+        "tokens": { "type": "integer", "minimum": 0 },
+        "truncated": { "type": "boolean" }
+      },
+      "required": ["node_id", "content"],
+      "additionalProperties": false
+    },
+    "StatusRequest": {
+      "type": "object",
+      "properties": { "session_id": { "type": "string" } },
+      "additionalProperties": false
+    },
+    "StatusResponse": {
+      "type": "object",
+      "properties": { "fields_json": { "type": "string" } },
+      "required": ["fields_json"],
+      "additionalProperties": false
+    },
+    "DoctorCheck": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" },
+        "severity": { "$ref": "#/$defs/DoctorSeverity" },
+        "message": { "type": "string" }
+      },
+      "required": ["name", "severity"],
+      "additionalProperties": false
+    },
+    "DoctorReport": {
+      "type": "object",
+      "properties": {
+        "checks": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/DoctorCheck" }
+        }
+      },
+      "required": ["checks"],
+      "additionalProperties": false
+    },
+    "IngestRequestEnvelope": {
+      "type": "object",
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "id": { "$ref": "#/$defs/JsonRpcId" },
+        "method": { "const": "sera.plugin.v1.ContextEngine/Ingest" },
+        "params": { "$ref": "#/$defs/IngestRequest" }
+      },
+      "required": ["jsonrpc", "id", "method", "params"],
+      "additionalProperties": false
+    },
+    "IngestResponseEnvelope": {
+      "type": "object",
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "id": { "$ref": "#/$defs/JsonRpcId" },
+        "result": { "$ref": "#/$defs/IngestAck" }
+      },
+      "required": ["jsonrpc", "id", "result"],
+      "additionalProperties": false
+    },
+    "AssembleRequestEnvelope": {
+      "type": "object",
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "id": { "$ref": "#/$defs/JsonRpcId" },
+        "method": { "const": "sera.plugin.v1.ContextEngine/Assemble" },
+        "params": { "$ref": "#/$defs/AssembleRequest" }
+      },
+      "required": ["jsonrpc", "id", "method", "params"],
+      "additionalProperties": false
+    },
+    "AssembleResponseEnvelope": {
+      "type": "object",
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "id": { "$ref": "#/$defs/JsonRpcId" },
+        "result": { "$ref": "#/$defs/AssembledContext" }
+      },
+      "required": ["jsonrpc", "id", "result"],
+      "additionalProperties": false
+    },
+    "SearchRequestEnvelope": {
+      "type": "object",
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "id": { "$ref": "#/$defs/JsonRpcId" },
+        "method": { "const": "sera.plugin.v1.ContextQuery/Search" },
+        "params": { "$ref": "#/$defs/CtxSearchRequest" }
+      },
+      "required": ["jsonrpc", "id", "method", "params"],
+      "additionalProperties": false
+    },
+    "SearchResponseEnvelope": {
+      "type": "object",
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "id": { "$ref": "#/$defs/JsonRpcId" },
+        "result": { "$ref": "#/$defs/CtxSearchResponse" }
+      },
+      "required": ["jsonrpc", "id", "result"],
+      "additionalProperties": false
+    },
+    "DescribeRequestEnvelope": {
+      "type": "object",
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "id": { "$ref": "#/$defs/JsonRpcId" },
+        "method": { "const": "sera.plugin.v1.ContextQuery/Describe" },
+        "params": { "$ref": "#/$defs/DescribeRequest" }
+      },
+      "required": ["jsonrpc", "id", "method", "params"],
+      "additionalProperties": false
+    },
+    "DescribeResponseEnvelope": {
+      "type": "object",
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "id": { "$ref": "#/$defs/JsonRpcId" },
+        "result": { "$ref": "#/$defs/DescribeResponse" }
+      },
+      "required": ["jsonrpc", "id", "result"],
+      "additionalProperties": false
+    },
+    "ExpandRequestEnvelope": {
+      "type": "object",
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "id": { "$ref": "#/$defs/JsonRpcId" },
+        "method": { "const": "sera.plugin.v1.ContextQuery/Expand" },
+        "params": { "$ref": "#/$defs/ExpandRequest" }
+      },
+      "required": ["jsonrpc", "id", "method", "params"],
+      "additionalProperties": false
+    },
+    "ExpandResponseEnvelope": {
+      "type": "object",
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "id": { "$ref": "#/$defs/JsonRpcId" },
+        "result": { "$ref": "#/$defs/ExpandResponse" }
+      },
+      "required": ["jsonrpc", "id", "result"],
+      "additionalProperties": false
+    },
+    "StatusRequestEnvelope": {
+      "type": "object",
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "id": { "$ref": "#/$defs/JsonRpcId" },
+        "method": { "const": "sera.plugin.v1.ContextDiagnostics/Status" },
+        "params": { "$ref": "#/$defs/StatusRequest" }
+      },
+      "required": ["jsonrpc", "id", "method", "params"],
+      "additionalProperties": false
+    },
+    "StatusResponseEnvelope": {
+      "type": "object",
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "id": { "$ref": "#/$defs/JsonRpcId" },
+        "result": { "$ref": "#/$defs/StatusResponse" }
+      },
+      "required": ["jsonrpc", "id", "result"],
+      "additionalProperties": false
+    },
+    "DoctorRequestEnvelope": {
+      "type": "object",
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "id": { "$ref": "#/$defs/JsonRpcId" },
+        "method": { "const": "sera.plugin.v1.ContextDiagnostics/Doctor" },
+        "params": { "type": "object", "maxProperties": 0 }
+      },
+      "required": ["jsonrpc", "id", "method"],
+      "additionalProperties": false
+    },
+    "DoctorResponseEnvelope": {
+      "type": "object",
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "id": { "$ref": "#/$defs/JsonRpcId" },
+        "result": { "$ref": "#/$defs/DoctorReport" }
+      },
+      "required": ["jsonrpc", "id", "result"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/rust/proto/plugin/memory_backend.proto
+++ b/rust/proto/plugin/memory_backend.proto
@@ -1,0 +1,64 @@
+// SERA MemoryBackend plugin capability.
+//
+// See SPEC-plugins §2.1 and SPEC-memory-pluggability — a MemoryBackend plugin
+// implements the SemanticMemoryStore trait over the wire.
+
+syntax = "proto3";
+
+package sera.plugin.v1;
+
+import "google/protobuf/timestamp.proto";
+
+service MemoryBackend {
+  rpc Store(StoreRequest) returns (StoreResponse);
+  rpc Retrieve(RetrieveRequest) returns (RetrieveResponse);
+  rpc Search(SearchRequest) returns (SearchResponse);
+  rpc Delete(DeleteRequest) returns (DeleteResponse);
+}
+
+message MemoryRecord {
+  string key = 1;
+  string content = 2;
+  map<string, string> metadata = 3;
+  google.protobuf.Timestamp created_at = 4;
+}
+
+message StoreRequest {
+  MemoryRecord record = 1;
+}
+
+message StoreResponse {
+  string key = 1;
+}
+
+message RetrieveRequest {
+  string key = 1;
+}
+
+message RetrieveResponse {
+  MemoryRecord record = 1;
+  bool found = 2;
+}
+
+message SearchRequest {
+  string query = 1;
+  uint32 limit = 2;
+  map<string, string> filter = 3;
+}
+
+message SearchHit {
+  MemoryRecord record = 1;
+  double score = 2; // backend-defined; higher = more relevant unless documented otherwise
+}
+
+message SearchResponse {
+  repeated SearchHit hits = 1;
+}
+
+message DeleteRequest {
+  string key = 1;
+}
+
+message DeleteResponse {
+  bool deleted = 1;
+}

--- a/rust/proto/plugin/memory_backend.schema.json
+++ b/rust/proto/plugin/memory_backend.schema.json
@@ -1,0 +1,197 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sera.dev/schemas/plugin/memory_backend.schema.json",
+  "title": "sera.plugin.v1.MemoryBackend JSON-RPC envelopes",
+  "description": "Hand-maintained mirror of memory_backend.proto for stdio JSON-RPC transport. Proto is canonical (SPEC-plugins §5.1).",
+  "type": "object",
+  "oneOf": [
+    { "$ref": "#/$defs/StoreRequestEnvelope" },
+    { "$ref": "#/$defs/StoreResponseEnvelope" },
+    { "$ref": "#/$defs/RetrieveRequestEnvelope" },
+    { "$ref": "#/$defs/RetrieveResponseEnvelope" },
+    { "$ref": "#/$defs/SearchRequestEnvelope" },
+    { "$ref": "#/$defs/SearchResponseEnvelope" },
+    { "$ref": "#/$defs/DeleteRequestEnvelope" },
+    { "$ref": "#/$defs/DeleteResponseEnvelope" }
+  ],
+  "$defs": {
+    "JsonRpcId": {
+      "oneOf": [
+        { "type": "string" },
+        { "type": "integer" },
+        { "type": "null" }
+      ]
+    },
+    "Timestamp": { "type": "string", "format": "date-time" },
+    "MemoryRecord": {
+      "type": "object",
+      "properties": {
+        "key": { "type": "string" },
+        "content": { "type": "string" },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        },
+        "created_at": { "$ref": "#/$defs/Timestamp" }
+      },
+      "required": ["key", "content"],
+      "additionalProperties": false
+    },
+    "StoreRequest": {
+      "type": "object",
+      "properties": { "record": { "$ref": "#/$defs/MemoryRecord" } },
+      "required": ["record"],
+      "additionalProperties": false
+    },
+    "StoreResponse": {
+      "type": "object",
+      "properties": { "key": { "type": "string" } },
+      "required": ["key"],
+      "additionalProperties": false
+    },
+    "RetrieveRequest": {
+      "type": "object",
+      "properties": { "key": { "type": "string" } },
+      "required": ["key"],
+      "additionalProperties": false
+    },
+    "RetrieveResponse": {
+      "type": "object",
+      "properties": {
+        "record": { "$ref": "#/$defs/MemoryRecord" },
+        "found": { "type": "boolean" }
+      },
+      "required": ["found"],
+      "additionalProperties": false
+    },
+    "SearchRequest": {
+      "type": "object",
+      "properties": {
+        "query": { "type": "string" },
+        "limit": { "type": "integer", "minimum": 0 },
+        "filter": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        }
+      },
+      "required": ["query"],
+      "additionalProperties": false
+    },
+    "SearchHit": {
+      "type": "object",
+      "properties": {
+        "record": { "$ref": "#/$defs/MemoryRecord" },
+        "score": { "type": "number" }
+      },
+      "required": ["record"],
+      "additionalProperties": false
+    },
+    "SearchResponse": {
+      "type": "object",
+      "properties": {
+        "hits": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/SearchHit" }
+        }
+      },
+      "required": ["hits"],
+      "additionalProperties": false
+    },
+    "DeleteRequest": {
+      "type": "object",
+      "properties": { "key": { "type": "string" } },
+      "required": ["key"],
+      "additionalProperties": false
+    },
+    "DeleteResponse": {
+      "type": "object",
+      "properties": { "deleted": { "type": "boolean" } },
+      "required": ["deleted"],
+      "additionalProperties": false
+    },
+    "StoreRequestEnvelope": {
+      "type": "object",
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "id": { "$ref": "#/$defs/JsonRpcId" },
+        "method": { "const": "sera.plugin.v1.MemoryBackend/Store" },
+        "params": { "$ref": "#/$defs/StoreRequest" }
+      },
+      "required": ["jsonrpc", "id", "method", "params"],
+      "additionalProperties": false
+    },
+    "StoreResponseEnvelope": {
+      "type": "object",
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "id": { "$ref": "#/$defs/JsonRpcId" },
+        "result": { "$ref": "#/$defs/StoreResponse" }
+      },
+      "required": ["jsonrpc", "id", "result"],
+      "additionalProperties": false
+    },
+    "RetrieveRequestEnvelope": {
+      "type": "object",
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "id": { "$ref": "#/$defs/JsonRpcId" },
+        "method": { "const": "sera.plugin.v1.MemoryBackend/Retrieve" },
+        "params": { "$ref": "#/$defs/RetrieveRequest" }
+      },
+      "required": ["jsonrpc", "id", "method", "params"],
+      "additionalProperties": false
+    },
+    "RetrieveResponseEnvelope": {
+      "type": "object",
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "id": { "$ref": "#/$defs/JsonRpcId" },
+        "result": { "$ref": "#/$defs/RetrieveResponse" }
+      },
+      "required": ["jsonrpc", "id", "result"],
+      "additionalProperties": false
+    },
+    "SearchRequestEnvelope": {
+      "type": "object",
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "id": { "$ref": "#/$defs/JsonRpcId" },
+        "method": { "const": "sera.plugin.v1.MemoryBackend/Search" },
+        "params": { "$ref": "#/$defs/SearchRequest" }
+      },
+      "required": ["jsonrpc", "id", "method", "params"],
+      "additionalProperties": false
+    },
+    "SearchResponseEnvelope": {
+      "type": "object",
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "id": { "$ref": "#/$defs/JsonRpcId" },
+        "result": { "$ref": "#/$defs/SearchResponse" }
+      },
+      "required": ["jsonrpc", "id", "result"],
+      "additionalProperties": false
+    },
+    "DeleteRequestEnvelope": {
+      "type": "object",
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "id": { "$ref": "#/$defs/JsonRpcId" },
+        "method": { "const": "sera.plugin.v1.MemoryBackend/Delete" },
+        "params": { "$ref": "#/$defs/DeleteRequest" }
+      },
+      "required": ["jsonrpc", "id", "method", "params"],
+      "additionalProperties": false
+    },
+    "DeleteResponseEnvelope": {
+      "type": "object",
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "id": { "$ref": "#/$defs/JsonRpcId" },
+        "result": { "$ref": "#/$defs/DeleteResponse" }
+      },
+      "required": ["jsonrpc", "id", "result"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/rust/proto/plugin/registry.proto
+++ b/rust/proto/plugin/registry.proto
@@ -1,0 +1,103 @@
+// SERA Plugin Registry — canonical wire contract.
+//
+// See docs/plan/specs/SPEC-plugins.md §2.1 (PluginRegistration), §2.3 (Transport).
+// Capability parity across transports (gRPC / stdio) is a spec invariant.
+
+syntax = "proto3";
+
+package sera.plugin.v1;
+
+import "google/protobuf/duration.proto";
+import "google/protobuf/empty.proto";
+import "google/protobuf/timestamp.proto";
+
+// Plugin registry service. Identical surface for gRPC and stdio transports
+// (stdio consumers speak the JSON-RPC mirror defined in registry.schema.json).
+service PluginRegistry {
+  rpc Register(PluginRegistration) returns (RegistrationAck);
+  rpc Heartbeat(PluginHeartbeat) returns (HeartbeatAck);
+  rpc Deregister(PluginId) returns (google.protobuf.Empty);
+}
+
+// Capability set a plugin declares at registration. A plugin may declare
+// multiple capabilities if it implements several trait contracts.
+enum PluginCapability {
+  PLUGIN_CAPABILITY_UNSPECIFIED = 0;
+  PLUGIN_CAPABILITY_MEMORY_BACKEND = 1;
+  PLUGIN_CAPABILITY_TOOL_EXECUTOR = 2;
+  PLUGIN_CAPABILITY_CONTEXT_ENGINE = 3;
+  PLUGIN_CAPABILITY_SANDBOX_PROVIDER = 4;
+  PLUGIN_CAPABILITY_AUTH_PROVIDER = 5;
+  PLUGIN_CAPABILITY_SECRET_PROVIDER = 6;
+  PLUGIN_CAPABILITY_REALTIME_BACKEND = 7;
+  PLUGIN_CAPABILITY_CUSTOM = 8;
+}
+
+// SemVer split. Mirror of PluginVersion in sera-plugins types.rs.
+message PluginVersion {
+  uint32 major = 1;
+  uint32 minor = 2;
+  uint32 patch = 3;
+  string prerelease = 4; // empty when not a prerelease
+}
+
+// TLS material for gRPC transport. Paths are absolute filesystem paths;
+// inline PEM is permitted for tooling that prefers not to materialise files.
+message TlsConfig {
+  string ca_cert_pem = 1;      // absolute path OR inline PEM
+  string client_cert_pem = 2;  // absolute path OR inline PEM
+  string client_key_pem = 3;   // absolute path OR inline PEM
+}
+
+// gRPC transport: reach the plugin over TCP (mTLS required outside localhost dev).
+message GrpcTransport {
+  string endpoint = 1;  // host:port
+  TlsConfig tls = 2;    // optional in dev, required in Tier 2/3
+}
+
+// Stdio transport: gateway spawns the child process. command[0] MUST be an
+// absolute path per SPEC-plugins §6.2 — no $PATH resolution at spawn.
+message StdioTransport {
+  repeated string command = 1;        // argv; command[0] absolute
+  map<string, string> env = 2;        // environment for the child
+}
+
+// Exactly one transport per registration. Capability set, manifest shape,
+// supervision, and audit semantics are identical across transports.
+message PluginTransport {
+  oneof transport {
+    GrpcTransport grpc = 1;
+    StdioTransport stdio = 2;
+  }
+}
+
+message PluginRegistration {
+  string name = 1;
+  PluginVersion version = 2;
+  repeated PluginCapability capabilities = 3;
+  PluginTransport transport = 4;
+  google.protobuf.Duration health_check_interval = 5;
+  // Free-form capability discriminator for PLUGIN_CAPABILITY_CUSTOM entries.
+  // Indexed positionally against `capabilities`.
+  repeated string custom_capability_tags = 6;
+}
+
+message RegistrationAck {
+  string plugin_id = 1;
+  repeated PluginCapability server_capabilities = 2;
+  string protocol_version = 3;  // proto + schema contract version (SPEC §5.3)
+}
+
+message PluginHeartbeat {
+  string plugin_id = 1;
+  uint64 uptime_seconds = 2;
+}
+
+message HeartbeatAck {
+  bool ok = 1;
+  google.protobuf.Timestamp server_time = 2;
+}
+
+message PluginId {
+  string value = 1;
+}

--- a/rust/proto/plugin/registry.schema.json
+++ b/rust/proto/plugin/registry.schema.json
@@ -1,0 +1,225 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sera.dev/schemas/plugin/registry.schema.json",
+  "title": "sera.plugin.v1.PluginRegistry JSON-RPC envelopes",
+  "description": "Hand-maintained mirror of registry.proto for stdio JSON-RPC transport. Proto is canonical (SPEC-plugins §5.1).",
+  "type": "object",
+  "oneOf": [
+    { "$ref": "#/$defs/RegisterRequest" },
+    { "$ref": "#/$defs/RegisterResponse" },
+    { "$ref": "#/$defs/HeartbeatRequest" },
+    { "$ref": "#/$defs/HeartbeatResponse" },
+    { "$ref": "#/$defs/DeregisterRequest" },
+    { "$ref": "#/$defs/DeregisterResponse" }
+  ],
+  "$defs": {
+    "JsonRpcId": {
+      "oneOf": [
+        { "type": "string" },
+        { "type": "integer" },
+        { "type": "null" }
+      ]
+    },
+    "PluginCapability": {
+      "type": "string",
+      "enum": [
+        "PLUGIN_CAPABILITY_UNSPECIFIED",
+        "PLUGIN_CAPABILITY_MEMORY_BACKEND",
+        "PLUGIN_CAPABILITY_TOOL_EXECUTOR",
+        "PLUGIN_CAPABILITY_CONTEXT_ENGINE",
+        "PLUGIN_CAPABILITY_SANDBOX_PROVIDER",
+        "PLUGIN_CAPABILITY_AUTH_PROVIDER",
+        "PLUGIN_CAPABILITY_SECRET_PROVIDER",
+        "PLUGIN_CAPABILITY_REALTIME_BACKEND",
+        "PLUGIN_CAPABILITY_CUSTOM"
+      ]
+    },
+    "PluginVersion": {
+      "type": "object",
+      "properties": {
+        "major": { "type": "integer", "minimum": 0 },
+        "minor": { "type": "integer", "minimum": 0 },
+        "patch": { "type": "integer", "minimum": 0 },
+        "prerelease": { "type": "string" }
+      },
+      "required": ["major", "minor", "patch"],
+      "additionalProperties": false
+    },
+    "TlsConfig": {
+      "type": "object",
+      "properties": {
+        "ca_cert_pem": { "type": "string" },
+        "client_cert_pem": { "type": "string" },
+        "client_key_pem": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "GrpcTransport": {
+      "type": "object",
+      "properties": {
+        "endpoint": { "type": "string" },
+        "tls": { "$ref": "#/$defs/TlsConfig" }
+      },
+      "required": ["endpoint"],
+      "additionalProperties": false
+    },
+    "StdioTransport": {
+      "type": "object",
+      "properties": {
+        "command": {
+          "type": "array",
+          "items": { "type": "string" },
+          "minItems": 1
+        },
+        "env": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        }
+      },
+      "required": ["command"],
+      "additionalProperties": false
+    },
+    "PluginTransport": {
+      "type": "object",
+      "oneOf": [
+        {
+          "properties": { "grpc": { "$ref": "#/$defs/GrpcTransport" } },
+          "required": ["grpc"],
+          "additionalProperties": false
+        },
+        {
+          "properties": { "stdio": { "$ref": "#/$defs/StdioTransport" } },
+          "required": ["stdio"],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "Duration": {
+      "type": "string",
+      "description": "Duration string (e.g. '30s', '1500ms')"
+    },
+    "Timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "PluginRegistration": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" },
+        "version": { "$ref": "#/$defs/PluginVersion" },
+        "capabilities": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/PluginCapability" }
+        },
+        "transport": { "$ref": "#/$defs/PluginTransport" },
+        "health_check_interval": { "$ref": "#/$defs/Duration" },
+        "custom_capability_tags": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      },
+      "required": ["name", "version", "capabilities", "transport"],
+      "additionalProperties": false
+    },
+    "RegistrationAck": {
+      "type": "object",
+      "properties": {
+        "plugin_id": { "type": "string" },
+        "server_capabilities": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/PluginCapability" }
+        },
+        "protocol_version": { "type": "string" }
+      },
+      "required": ["plugin_id", "protocol_version"],
+      "additionalProperties": false
+    },
+    "PluginHeartbeat": {
+      "type": "object",
+      "properties": {
+        "plugin_id": { "type": "string" },
+        "uptime_seconds": { "type": "integer", "minimum": 0 }
+      },
+      "required": ["plugin_id"],
+      "additionalProperties": false
+    },
+    "HeartbeatAck": {
+      "type": "object",
+      "properties": {
+        "ok": { "type": "boolean" },
+        "server_time": { "$ref": "#/$defs/Timestamp" }
+      },
+      "required": ["ok"],
+      "additionalProperties": false
+    },
+    "PluginId": {
+      "type": "object",
+      "properties": { "value": { "type": "string" } },
+      "required": ["value"],
+      "additionalProperties": false
+    },
+    "RegisterRequest": {
+      "type": "object",
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "id": { "$ref": "#/$defs/JsonRpcId" },
+        "method": { "const": "sera.plugin.v1.PluginRegistry/Register" },
+        "params": { "$ref": "#/$defs/PluginRegistration" }
+      },
+      "required": ["jsonrpc", "id", "method", "params"],
+      "additionalProperties": false
+    },
+    "RegisterResponse": {
+      "type": "object",
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "id": { "$ref": "#/$defs/JsonRpcId" },
+        "result": { "$ref": "#/$defs/RegistrationAck" }
+      },
+      "required": ["jsonrpc", "id", "result"],
+      "additionalProperties": false
+    },
+    "HeartbeatRequest": {
+      "type": "object",
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "id": { "$ref": "#/$defs/JsonRpcId" },
+        "method": { "const": "sera.plugin.v1.PluginRegistry/Heartbeat" },
+        "params": { "$ref": "#/$defs/PluginHeartbeat" }
+      },
+      "required": ["jsonrpc", "id", "method", "params"],
+      "additionalProperties": false
+    },
+    "HeartbeatResponse": {
+      "type": "object",
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "id": { "$ref": "#/$defs/JsonRpcId" },
+        "result": { "$ref": "#/$defs/HeartbeatAck" }
+      },
+      "required": ["jsonrpc", "id", "result"],
+      "additionalProperties": false
+    },
+    "DeregisterRequest": {
+      "type": "object",
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "id": { "$ref": "#/$defs/JsonRpcId" },
+        "method": { "const": "sera.plugin.v1.PluginRegistry/Deregister" },
+        "params": { "$ref": "#/$defs/PluginId" }
+      },
+      "required": ["jsonrpc", "id", "method", "params"],
+      "additionalProperties": false
+    },
+    "DeregisterResponse": {
+      "type": "object",
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "id": { "$ref": "#/$defs/JsonRpcId" },
+        "result": { "type": "object", "maxProperties": 0 }
+      },
+      "required": ["jsonrpc", "id", "result"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/rust/proto/plugin/sandbox_provider.proto
+++ b/rust/proto/plugin/sandbox_provider.proto
@@ -1,0 +1,37 @@
+// SERA SandboxProvider plugin capability.
+//
+// See SPEC-plugins §2.1. Minimal execution surface: run a command in the
+// plugin's sandbox, retrieve the combined stdout/stderr/exit, then clean up.
+
+syntax = "proto3";
+
+package sera.plugin.v1;
+
+import "google/protobuf/duration.proto";
+import "google/protobuf/empty.proto";
+
+service SandboxProvider {
+  rpc Execute(SandboxExecRequest) returns (SandboxExecResult);
+  rpc Cleanup(SandboxId) returns (google.protobuf.Empty);
+}
+
+message SandboxId {
+  string value = 1;
+}
+
+message SandboxExecRequest {
+  string sandbox_id = 1;              // optional; empty = ephemeral
+  repeated string command = 2;
+  map<string, string> env = 3;
+  string workdir = 4;
+  uint64 time_limit_seconds = 5;
+  uint64 memory_limit_bytes = 6;
+}
+
+message SandboxExecResult {
+  string sandbox_id = 1;
+  string stdout = 2;
+  string stderr = 3;
+  int32 exit_code = 4;
+  google.protobuf.Duration duration = 5;
+}

--- a/rust/proto/plugin/sandbox_provider.schema.json
+++ b/rust/proto/plugin/sandbox_provider.schema.json
@@ -1,0 +1,106 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sera.dev/schemas/plugin/sandbox_provider.schema.json",
+  "title": "sera.plugin.v1.SandboxProvider JSON-RPC envelopes",
+  "description": "Hand-maintained mirror of sandbox_provider.proto for stdio JSON-RPC transport. Proto is canonical (SPEC-plugins §5.1).",
+  "type": "object",
+  "oneOf": [
+    { "$ref": "#/$defs/ExecuteRequestEnvelope" },
+    { "$ref": "#/$defs/ExecuteResponseEnvelope" },
+    { "$ref": "#/$defs/CleanupRequestEnvelope" },
+    { "$ref": "#/$defs/CleanupResponseEnvelope" }
+  ],
+  "$defs": {
+    "JsonRpcId": {
+      "oneOf": [
+        { "type": "string" },
+        { "type": "integer" },
+        { "type": "null" }
+      ]
+    },
+    "Duration": {
+      "type": "string",
+      "description": "Duration string (e.g. '30s', '1500ms')"
+    },
+    "SandboxId": {
+      "type": "object",
+      "properties": { "value": { "type": "string" } },
+      "required": ["value"],
+      "additionalProperties": false
+    },
+    "SandboxExecRequest": {
+      "type": "object",
+      "properties": {
+        "sandbox_id": { "type": "string" },
+        "command": {
+          "type": "array",
+          "items": { "type": "string" },
+          "minItems": 1
+        },
+        "env": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        },
+        "workdir": { "type": "string" },
+        "time_limit_seconds": { "type": "integer", "minimum": 0 },
+        "memory_limit_bytes": { "type": "integer", "minimum": 0 }
+      },
+      "required": ["command"],
+      "additionalProperties": false
+    },
+    "SandboxExecResult": {
+      "type": "object",
+      "properties": {
+        "sandbox_id": { "type": "string" },
+        "stdout": { "type": "string" },
+        "stderr": { "type": "string" },
+        "exit_code": { "type": "integer" },
+        "duration": { "$ref": "#/$defs/Duration" }
+      },
+      "required": ["exit_code"],
+      "additionalProperties": false
+    },
+    "ExecuteRequestEnvelope": {
+      "type": "object",
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "id": { "$ref": "#/$defs/JsonRpcId" },
+        "method": { "const": "sera.plugin.v1.SandboxProvider/Execute" },
+        "params": { "$ref": "#/$defs/SandboxExecRequest" }
+      },
+      "required": ["jsonrpc", "id", "method", "params"],
+      "additionalProperties": false
+    },
+    "ExecuteResponseEnvelope": {
+      "type": "object",
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "id": { "$ref": "#/$defs/JsonRpcId" },
+        "result": { "$ref": "#/$defs/SandboxExecResult" }
+      },
+      "required": ["jsonrpc", "id", "result"],
+      "additionalProperties": false
+    },
+    "CleanupRequestEnvelope": {
+      "type": "object",
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "id": { "$ref": "#/$defs/JsonRpcId" },
+        "method": { "const": "sera.plugin.v1.SandboxProvider/Cleanup" },
+        "params": { "$ref": "#/$defs/SandboxId" }
+      },
+      "required": ["jsonrpc", "id", "method", "params"],
+      "additionalProperties": false
+    },
+    "CleanupResponseEnvelope": {
+      "type": "object",
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "id": { "$ref": "#/$defs/JsonRpcId" },
+        "result": { "type": "object", "maxProperties": 0 }
+      },
+      "required": ["jsonrpc", "id", "result"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/rust/proto/plugin/secret_provider.proto
+++ b/rust/proto/plugin/secret_provider.proto
@@ -1,0 +1,29 @@
+// SERA SecretProvider plugin capability.
+//
+// See SPEC-plugins §2.1 and SPEC-secrets. Plugins resolve secret *references*
+// to values; the gateway never passes raw secrets to plugins (SPEC-plugins §6.3).
+
+syntax = "proto3";
+
+package sera.plugin.v1;
+
+import "google/protobuf/empty.proto";
+
+service SecretProvider {
+  rpc Resolve(SecretRef) returns (SecretValue);
+  rpc List(google.protobuf.Empty) returns (SecretList);
+}
+
+message SecretRef {
+  string name = 1;
+}
+
+message SecretValue {
+  string name = 1;
+  bytes value = 2;        // opaque bytes
+  map<string, string> metadata = 3;
+}
+
+message SecretList {
+  repeated SecretRef refs = 1;
+}

--- a/rust/proto/plugin/secret_provider.schema.json
+++ b/rust/proto/plugin/secret_provider.schema.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sera.dev/schemas/plugin/secret_provider.schema.json",
+  "title": "sera.plugin.v1.SecretProvider JSON-RPC envelopes",
+  "description": "Hand-maintained mirror of secret_provider.proto for stdio JSON-RPC transport. Proto is canonical (SPEC-plugins §5.1).",
+  "type": "object",
+  "oneOf": [
+    { "$ref": "#/$defs/ResolveRequestEnvelope" },
+    { "$ref": "#/$defs/ResolveResponseEnvelope" },
+    { "$ref": "#/$defs/ListRequestEnvelope" },
+    { "$ref": "#/$defs/ListResponseEnvelope" }
+  ],
+  "$defs": {
+    "JsonRpcId": {
+      "oneOf": [
+        { "type": "string" },
+        { "type": "integer" },
+        { "type": "null" }
+      ]
+    },
+    "SecretRef": {
+      "type": "object",
+      "properties": { "name": { "type": "string" } },
+      "required": ["name"],
+      "additionalProperties": false
+    },
+    "SecretValue": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" },
+        "value": {
+          "type": "string",
+          "contentEncoding": "base64"
+        },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        }
+      },
+      "required": ["name", "value"],
+      "additionalProperties": false
+    },
+    "SecretList": {
+      "type": "object",
+      "properties": {
+        "refs": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/SecretRef" }
+        }
+      },
+      "required": ["refs"],
+      "additionalProperties": false
+    },
+    "ResolveRequestEnvelope": {
+      "type": "object",
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "id": { "$ref": "#/$defs/JsonRpcId" },
+        "method": { "const": "sera.plugin.v1.SecretProvider/Resolve" },
+        "params": { "$ref": "#/$defs/SecretRef" }
+      },
+      "required": ["jsonrpc", "id", "method", "params"],
+      "additionalProperties": false
+    },
+    "ResolveResponseEnvelope": {
+      "type": "object",
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "id": { "$ref": "#/$defs/JsonRpcId" },
+        "result": { "$ref": "#/$defs/SecretValue" }
+      },
+      "required": ["jsonrpc", "id", "result"],
+      "additionalProperties": false
+    },
+    "ListRequestEnvelope": {
+      "type": "object",
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "id": { "$ref": "#/$defs/JsonRpcId" },
+        "method": { "const": "sera.plugin.v1.SecretProvider/List" },
+        "params": { "type": "object", "maxProperties": 0 }
+      },
+      "required": ["jsonrpc", "id", "method"],
+      "additionalProperties": false
+    },
+    "ListResponseEnvelope": {
+      "type": "object",
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "id": { "$ref": "#/$defs/JsonRpcId" },
+        "result": { "$ref": "#/$defs/SecretList" }
+      },
+      "required": ["jsonrpc", "id", "result"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/rust/proto/plugin/tool_executor.proto
+++ b/rust/proto/plugin/tool_executor.proto
@@ -1,0 +1,48 @@
+// SERA ToolExecutor plugin capability.
+//
+// See SPEC-plugins §3 (S7 PLC example) and SPEC-tools. ToolExecutor plugins
+// register their tool manifest and receive dispatched ToolCalls from the
+// gateway. arguments_json / content_json carry structured payloads; each
+// tool's input_schema_json is the contract the gateway validates against
+// before dispatch.
+
+syntax = "proto3";
+
+package sera.plugin.v1;
+
+import "google/protobuf/empty.proto";
+
+service ToolExecutor {
+  rpc ListTools(google.protobuf.Empty) returns (ListToolsResponse);
+  rpc ExecuteTool(ToolCall) returns (ToolResult);
+}
+
+enum ToolRiskLevel {
+  TOOL_RISK_LEVEL_UNSPECIFIED = 0;
+  TOOL_RISK_LEVEL_READ = 1;
+  TOOL_RISK_LEVEL_WRITE = 2;
+  TOOL_RISK_LEVEL_EXEC = 3;
+}
+
+message ToolDefinition {
+  string name = 1;
+  string description = 2;
+  string input_schema_json = 3; // JSON Schema for tool arguments
+  ToolRiskLevel risk_level = 4;
+}
+
+message ListToolsResponse {
+  repeated ToolDefinition tools = 1;
+}
+
+message ToolCall {
+  string tool_name = 1;
+  string arguments_json = 2; // JSON object matching tool.input_schema_json
+  string call_id = 3;
+}
+
+message ToolResult {
+  string call_id = 1;
+  string content_json = 2; // tool-defined result payload as JSON
+  bool is_error = 3;
+}

--- a/rust/proto/plugin/tool_executor.schema.json
+++ b/rust/proto/plugin/tool_executor.schema.json
@@ -1,0 +1,115 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sera.dev/schemas/plugin/tool_executor.schema.json",
+  "title": "sera.plugin.v1.ToolExecutor JSON-RPC envelopes",
+  "description": "Hand-maintained mirror of tool_executor.proto for stdio JSON-RPC transport. Proto is canonical (SPEC-plugins §5.1).",
+  "type": "object",
+  "oneOf": [
+    { "$ref": "#/$defs/ListToolsRequestEnvelope" },
+    { "$ref": "#/$defs/ListToolsResponseEnvelope" },
+    { "$ref": "#/$defs/ExecuteToolRequestEnvelope" },
+    { "$ref": "#/$defs/ExecuteToolResponseEnvelope" }
+  ],
+  "$defs": {
+    "JsonRpcId": {
+      "oneOf": [
+        { "type": "string" },
+        { "type": "integer" },
+        { "type": "null" }
+      ]
+    },
+    "ToolRiskLevel": {
+      "type": "string",
+      "enum": [
+        "TOOL_RISK_LEVEL_UNSPECIFIED",
+        "TOOL_RISK_LEVEL_READ",
+        "TOOL_RISK_LEVEL_WRITE",
+        "TOOL_RISK_LEVEL_EXEC"
+      ]
+    },
+    "ToolDefinition": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" },
+        "description": { "type": "string" },
+        "input_schema_json": { "type": "string" },
+        "risk_level": { "$ref": "#/$defs/ToolRiskLevel" }
+      },
+      "required": ["name", "input_schema_json", "risk_level"],
+      "additionalProperties": false
+    },
+    "ListToolsResponse": {
+      "type": "object",
+      "properties": {
+        "tools": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/ToolDefinition" }
+        }
+      },
+      "required": ["tools"],
+      "additionalProperties": false
+    },
+    "ToolCall": {
+      "type": "object",
+      "properties": {
+        "tool_name": { "type": "string" },
+        "arguments_json": { "type": "string" },
+        "call_id": { "type": "string" }
+      },
+      "required": ["tool_name", "arguments_json", "call_id"],
+      "additionalProperties": false
+    },
+    "ToolResult": {
+      "type": "object",
+      "properties": {
+        "call_id": { "type": "string" },
+        "content_json": { "type": "string" },
+        "is_error": { "type": "boolean" }
+      },
+      "required": ["call_id", "content_json", "is_error"],
+      "additionalProperties": false
+    },
+    "ListToolsRequestEnvelope": {
+      "type": "object",
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "id": { "$ref": "#/$defs/JsonRpcId" },
+        "method": { "const": "sera.plugin.v1.ToolExecutor/ListTools" },
+        "params": { "type": "object", "maxProperties": 0 }
+      },
+      "required": ["jsonrpc", "id", "method"],
+      "additionalProperties": false
+    },
+    "ListToolsResponseEnvelope": {
+      "type": "object",
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "id": { "$ref": "#/$defs/JsonRpcId" },
+        "result": { "$ref": "#/$defs/ListToolsResponse" }
+      },
+      "required": ["jsonrpc", "id", "result"],
+      "additionalProperties": false
+    },
+    "ExecuteToolRequestEnvelope": {
+      "type": "object",
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "id": { "$ref": "#/$defs/JsonRpcId" },
+        "method": { "const": "sera.plugin.v1.ToolExecutor/ExecuteTool" },
+        "params": { "$ref": "#/$defs/ToolCall" }
+      },
+      "required": ["jsonrpc", "id", "method", "params"],
+      "additionalProperties": false
+    },
+    "ExecuteToolResponseEnvelope": {
+      "type": "object",
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "id": { "$ref": "#/$defs/JsonRpcId" },
+        "result": { "$ref": "#/$defs/ToolResult" }
+      },
+      "required": ["jsonrpc", "id", "result"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/sdk/python/sera-plugin-sdk/.gitignore
+++ b/sdk/python/sera-plugin-sdk/.gitignore
@@ -1,0 +1,13 @@
+src/sera_plugin_sdk/_generated/*.py
+!src/sera_plugin_sdk/_generated/__init__.py
+__pycache__/
+*.pyc
+*.pyo
+dist/
+build/
+.tox/
+.venv/
+*.egg-info/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/

--- a/sdk/python/sera-plugin-sdk/LICENSE
+++ b/sdk/python/sera-plugin-sdk/LICENSE
@@ -1,0 +1,17 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+   Copyright 2026 SERA Contributors

--- a/sdk/python/sera-plugin-sdk/README.md
+++ b/sdk/python/sera-plugin-sdk/README.md
@@ -1,0 +1,65 @@
+# sera-plugin-sdk
+
+Python SDK for authoring SERA plugins. See
+[SPEC-plugins](../../../docs/plan/specs/SPEC-plugins.md) §5 for the design record.
+
+## What it is
+
+A thin ergonomic wrapper over SERA's plugin wire contract. Plugin authors
+subclass the capability ABCs they implement, wire the plugin into the stdio or
+gRPC runtime, and ship it. The SDK owns transport framing, heartbeats, the
+JSON-RPC codec, and graceful shutdown — the plugin owns the domain logic.
+
+## Who it is for
+
+- Developers building custom SERA backends (`MemoryBackend`, `ContextEngine`,
+  `ToolExecutor`, `SandboxProvider`, `AuthProvider`, `SecretProvider`).
+- Enterprise integrators wrapping proprietary services behind the SERA plugin
+  contract.
+
+## Minimal example
+
+```python
+# sera_context_lcm/__main__.py
+from sera_plugin_sdk import (
+    run_stdio_plugin,
+    ContextEngine,
+    ContextQuery,
+    ContextDiagnostics,
+)
+
+
+class LcmPlugin(ContextEngine, ContextQuery, ContextDiagnostics):
+    async def ingest(self, msg): ...
+    async def assemble(self, budget): ...
+    async def search(self, req): ...
+    async def describe(self, req): ...
+    async def expand(self, req): ...
+    async def status(self, session_id): ...
+    async def doctor(self): ...
+
+
+if __name__ == "__main__":
+    run_stdio_plugin(LcmPlugin())
+```
+
+## Install and test
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install -e '.[dev]'
+python -m pytest -q
+ruff check src tests
+mypy src
+hatch build
+```
+
+`hatch build` invokes `grpc_tools.protoc` against `rust/proto/plugin/*.proto`
+and writes generated modules into `src/sera_plugin_sdk/_generated/`. The build
+hook gracefully no-ops (with a warning) when the proto directory is absent, so
+`pip install -e .` works in a standalone checkout.
+
+## License
+
+Apache-2.0. See `LICENSE`.

--- a/sdk/python/sera-plugin-sdk/hatch_build.py
+++ b/sdk/python/sera-plugin-sdk/hatch_build.py
@@ -1,0 +1,96 @@
+"""Hatch custom build hook that invokes ``grpc_tools.protoc`` at build time.
+
+SPEC-plugins §5.1 keeps the ``.proto`` files in ``rust/proto/plugin/`` as the
+canonical wire contract. This hook compiles those protos into Python modules
+under ``src/sera_plugin_sdk/_generated/`` during the Hatch build. The hook is
+tolerant of missing protos so editable installs (``pip install -e .``) work in
+a standalone checkout; in that case the gRPC transport remains importable but
+the capability servicers raise ``UNIMPLEMENTED`` if invoked.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+
+PROTO_SRC = Path("../../../rust/proto/plugin")
+OUT_DIR = Path("src/sera_plugin_sdk/_generated")
+
+
+class ProtocBuildHook(BuildHookInterface):
+    PLUGIN_NAME = "custom"
+
+    def initialize(self, version: str, build_data: dict[str, Any]) -> None:
+        root = Path(self.root)
+        proto_dir = (root / PROTO_SRC).resolve()
+        out_dir = root / OUT_DIR
+
+        out_dir.mkdir(parents=True, exist_ok=True)
+        init_file = out_dir / "__init__.py"
+        if not init_file.exists():
+            init_file.write_text(
+                '"""Auto-generated protobuf / gRPC modules. Do not edit by hand."""\n'
+            )
+
+        if not proto_dir.is_dir():
+            print(
+                f"[sera-plugin-sdk] WARNING: proto source {proto_dir} absent — "
+                "skipping codegen."
+            )
+            return
+
+        proto_files = sorted(proto_dir.glob("*.proto"))
+        if not proto_files:
+            print(
+                f"[sera-plugin-sdk] WARNING: no .proto files found in {proto_dir} — "
+                "skipping codegen."
+            )
+            return
+
+        try:
+            import grpc_tools
+            from grpc_tools import protoc
+        except ImportError:
+            print(
+                "[sera-plugin-sdk] WARNING: grpc_tools is not installed — "
+                "skipping codegen. Install with `pip install grpcio-tools`."
+            )
+            return
+
+        # grpc_tools ships the well-known protos (google/protobuf/*.proto)
+        # under its package directory; add that to the import path so that
+        # ``import "google/protobuf/empty.proto"`` resolves.
+        wkt_include = Path(grpc_tools.__file__).parent / "_proto"
+
+        args = [
+            "grpc_tools.protoc",
+            f"--proto_path={proto_dir}",
+            f"--proto_path={wkt_include}",
+            f"--python_out={out_dir}",
+            f"--grpc_python_out={out_dir}",
+            *[str(p) for p in proto_files],
+        ]
+        rc = protoc.main(args)
+        if rc != 0:
+            raise SystemExit(f"protoc failed with exit code {rc}")
+
+        # Rewrite `import foo_pb2` to `from . import foo_pb2` so the generated
+        # modules resolve within the _generated package rather than the top
+        # level import path.
+        for f in out_dir.glob("*_pb2*.py"):
+            text = f.read_text()
+            text = re.sub(
+                r"^import (\w+_pb2)(\s|$)",
+                r"from . import \1\2",
+                text,
+                flags=re.MULTILINE,
+            )
+            f.write_text(text)
+
+        print(
+            f"[sera-plugin-sdk] Generated {len(proto_files)} proto module(s) "
+            f"into {out_dir}"
+        )

--- a/sdk/python/sera-plugin-sdk/pyproject.toml
+++ b/sdk/python/sera-plugin-sdk/pyproject.toml
@@ -1,0 +1,86 @@
+[build-system]
+requires = ["hatchling>=1.22", "grpcio-tools>=1.60"]
+build-backend = "hatchling.build"
+
+[project]
+name = "sera-plugin-sdk"
+version = "0.1.0"
+description = "SERA plugin SDK (Python) — stdio + gRPC, ABC-based capabilities"
+readme = "README.md"
+license = "Apache-2.0"
+requires-python = ">=3.11"
+authors = [{ name = "SERA Contributors" }]
+keywords = ["sera", "plugin", "sdk", "grpc", "stdio"]
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: Apache Software License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Topic :: Software Development :: Libraries :: Python Modules",
+]
+dependencies = [
+  "grpcio>=1.60",
+  "protobuf>=4.25",
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=8",
+  "pytest-asyncio>=0.23",
+  "mypy>=1.10",
+  "ruff>=0.5",
+  "grpcio-tools>=1.60",
+]
+
+[project.urls]
+Homepage = "https://github.com/sera-project/sera"
+Issues = "https://github.com/sera-project/sera/issues"
+
+[tool.hatch.build.hooks.custom]
+path = "hatch_build.py"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/sera_plugin_sdk"]
+
+[tool.hatch.build.targets.sdist]
+include = [
+  "src",
+  "README.md",
+  "LICENSE",
+  "hatch_build.py",
+  "pyproject.toml",
+]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+extend-exclude = ["src/sera_plugin_sdk/_generated"]
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "UP", "B", "SIM", "RUF"]
+ignore = ["E501"]  # line length handled by formatter where needed
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["B018"]
+
+[tool.mypy]
+python_version = "3.11"
+strict = true
+packages = ["sera_plugin_sdk"]
+mypy_path = "src"
+exclude = ["_generated/"]
+
+[[tool.mypy.overrides]]
+module = "sera_plugin_sdk._generated.*"
+ignore_errors = true
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "grpc.*"
+ignore_missing_imports = true

--- a/sdk/python/sera-plugin-sdk/src/sera_plugin_sdk/__init__.py
+++ b/sdk/python/sera-plugin-sdk/src/sera_plugin_sdk/__init__.py
@@ -1,0 +1,55 @@
+"""sera-plugin-sdk — Python SDK for authoring SERA plugins.
+
+Public API:
+
+- Capability ABCs: :class:`ContextEngine`, :class:`ContextQuery`,
+  :class:`ContextDiagnostics`, :class:`MemoryBackend`, :class:`ToolExecutor`,
+  :class:`SandboxProvider`, :class:`AuthProvider`, :class:`SecretProvider`.
+- Runtime entrypoints: :func:`run_stdio_plugin`, :func:`run_grpc_plugin`.
+- Error hierarchy: :class:`PluginError` and subclasses.
+- Wire-neutral dataclasses in :mod:`sera_plugin_sdk.types`.
+"""
+
+from __future__ import annotations
+
+from .capabilities import (
+    AuthProvider,
+    Capability,
+    ContextDiagnostics,
+    ContextEngine,
+    ContextQuery,
+    MemoryBackend,
+    SandboxProvider,
+    SecretProvider,
+    ToolExecutor,
+)
+from .errors import (
+    PluginCapabilityError,
+    PluginDispatchError,
+    PluginError,
+    PluginRegistrationError,
+    PluginTransportError,
+)
+from .runtime import run_grpc_plugin, run_stdio_plugin
+
+__version__ = "0.1.0"
+
+__all__ = [
+    "AuthProvider",
+    "Capability",
+    "ContextDiagnostics",
+    "ContextEngine",
+    "ContextQuery",
+    "MemoryBackend",
+    "PluginCapabilityError",
+    "PluginDispatchError",
+    "PluginError",
+    "PluginRegistrationError",
+    "PluginTransportError",
+    "SandboxProvider",
+    "SecretProvider",
+    "ToolExecutor",
+    "__version__",
+    "run_grpc_plugin",
+    "run_stdio_plugin",
+]

--- a/sdk/python/sera-plugin-sdk/src/sera_plugin_sdk/_generated/__init__.py
+++ b/sdk/python/sera-plugin-sdk/src/sera_plugin_sdk/_generated/__init__.py
@@ -1,0 +1,1 @@
+"""Auto-generated protobuf / gRPC modules. Populated by the Hatch build hook."""

--- a/sdk/python/sera-plugin-sdk/src/sera_plugin_sdk/_protocol.py
+++ b/sdk/python/sera-plugin-sdk/src/sera_plugin_sdk/_protocol.py
@@ -1,0 +1,170 @@
+"""JSON-RPC 2.0 codec for the stdio plugin transport.
+
+Framing: newline-delimited JSON. One JSON object per line, no headers. This is
+the simplest robust framing for stdio pipes and matches the claw-code
+subprocess pattern referenced in SPEC-plugins §2.3 / SPEC-hooks §2.6.
+
+Method names use ``Capability.method`` format, e.g. ``ContextEngine.ingest``.
+Registry methods use ``PluginRegistry.Register`` / ``.Heartbeat`` / ``.Deregister``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from .errors import (
+    PluginCapabilityError,
+    PluginDispatchError,
+    PluginError,
+    PluginRegistrationError,
+    PluginTransportError,
+)
+
+JSONRPC_VERSION = "2.0"
+
+# JSON-RPC error code mapping. Each PluginError subclass gets a stable code so
+# the gateway can classify failures without string-matching the message.
+ERROR_CODE_PLUGIN = -32000
+ERROR_CODE_REGISTRATION = -32001
+ERROR_CODE_TRANSPORT = -32002
+ERROR_CODE_DISPATCH = -32003
+ERROR_CODE_CAPABILITY = -32004
+ERROR_CODE_INTERNAL = -32603
+ERROR_CODE_PARSE = -32700
+ERROR_CODE_INVALID_REQUEST = -32600
+ERROR_CODE_METHOD_NOT_FOUND = -32601
+
+
+def _error_code_for(exc: BaseException) -> int:
+    if isinstance(exc, PluginRegistrationError):
+        return ERROR_CODE_REGISTRATION
+    if isinstance(exc, PluginTransportError):
+        return ERROR_CODE_TRANSPORT
+    if isinstance(exc, PluginDispatchError):
+        return ERROR_CODE_DISPATCH
+    if isinstance(exc, PluginCapabilityError):
+        return ERROR_CODE_CAPABILITY
+    if isinstance(exc, PluginError):
+        return ERROR_CODE_PLUGIN
+    return ERROR_CODE_INTERNAL
+
+
+def encode_request(request_id: int | str, method: str, params: dict[str, Any]) -> bytes:
+    payload = {
+        "jsonrpc": JSONRPC_VERSION,
+        "id": request_id,
+        "method": method,
+        "params": params,
+    }
+    return (json.dumps(payload, separators=(",", ":")) + "\n").encode("utf-8")
+
+
+def decode_request(line: bytes) -> tuple[int | str | None, str, dict[str, Any]]:
+    """Parse a request frame.
+
+    Returns ``(id, method, params)``. ``id`` may be ``None`` for notifications.
+    Raises :class:`PluginTransportError` on malformed input.
+    """
+    try:
+        obj = json.loads(line)
+    except json.JSONDecodeError as exc:
+        raise PluginTransportError(
+            "PLUGIN_TRANSPORT_ERROR", f"invalid JSON: {exc}"
+        ) from exc
+
+    if not isinstance(obj, dict):
+        raise PluginTransportError("PLUGIN_TRANSPORT_ERROR", "request must be a JSON object")
+
+    if obj.get("jsonrpc") != JSONRPC_VERSION:
+        raise PluginTransportError(
+            "PLUGIN_TRANSPORT_ERROR", f"unsupported jsonrpc version: {obj.get('jsonrpc')!r}"
+        )
+
+    method = obj.get("method")
+    if not isinstance(method, str) or not method:
+        raise PluginTransportError("PLUGIN_TRANSPORT_ERROR", "missing or invalid 'method'")
+
+    params = obj.get("params")
+    if params is None:
+        params = {}
+    if not isinstance(params, dict):
+        raise PluginTransportError(
+            "PLUGIN_TRANSPORT_ERROR", "'params' must be an object if present"
+        )
+
+    request_id = obj.get("id")
+    if request_id is not None and not isinstance(request_id, int | str):
+        raise PluginTransportError(
+            "PLUGIN_TRANSPORT_ERROR", "'id' must be int, string, or null"
+        )
+
+    return request_id, method, params
+
+
+def encode_response(request_id: int | str | None, result: Any) -> bytes:
+    payload: dict[str, Any] = {
+        "jsonrpc": JSONRPC_VERSION,
+        "id": request_id,
+        "result": result,
+    }
+    return (json.dumps(payload, separators=(",", ":")) + "\n").encode("utf-8")
+
+
+def decode_response(line: bytes) -> dict[str, Any]:
+    try:
+        obj = json.loads(line)
+    except json.JSONDecodeError as exc:
+        raise PluginTransportError(
+            "PLUGIN_TRANSPORT_ERROR", f"invalid JSON: {exc}"
+        ) from exc
+    if not isinstance(obj, dict):
+        raise PluginTransportError("PLUGIN_TRANSPORT_ERROR", "response must be a JSON object")
+    if obj.get("jsonrpc") != JSONRPC_VERSION:
+        raise PluginTransportError(
+            "PLUGIN_TRANSPORT_ERROR", f"unsupported jsonrpc version: {obj.get('jsonrpc')!r}"
+        )
+    return obj
+
+
+def encode_error(
+    request_id: int | str | None,
+    exc: BaseException,
+    *,
+    code: int | None = None,
+    data: dict[str, Any] | None = None,
+) -> bytes:
+    resolved_code = code if code is not None else _error_code_for(exc)
+    error_obj: dict[str, Any] = {
+        "code": resolved_code,
+        "message": str(exc),
+    }
+    if isinstance(exc, PluginError):
+        error_obj["data"] = {"code": exc.code, "message": exc.message}
+    if data is not None:
+        error_obj.setdefault("data", {}).update(data)
+    payload = {
+        "jsonrpc": JSONRPC_VERSION,
+        "id": request_id,
+        "error": error_obj,
+    }
+    return (json.dumps(payload, separators=(",", ":")) + "\n").encode("utf-8")
+
+
+__all__ = [
+    "ERROR_CODE_CAPABILITY",
+    "ERROR_CODE_DISPATCH",
+    "ERROR_CODE_INTERNAL",
+    "ERROR_CODE_INVALID_REQUEST",
+    "ERROR_CODE_METHOD_NOT_FOUND",
+    "ERROR_CODE_PARSE",
+    "ERROR_CODE_PLUGIN",
+    "ERROR_CODE_REGISTRATION",
+    "ERROR_CODE_TRANSPORT",
+    "JSONRPC_VERSION",
+    "decode_request",
+    "decode_response",
+    "encode_error",
+    "encode_request",
+    "encode_response",
+]

--- a/sdk/python/sera-plugin-sdk/src/sera_plugin_sdk/capabilities/__init__.py
+++ b/sdk/python/sera-plugin-sdk/src/sera_plugin_sdk/capabilities/__init__.py
@@ -1,0 +1,23 @@
+"""Capability ABCs. A plugin inherits from one or more of these."""
+
+from __future__ import annotations
+
+from .auth import AuthProvider
+from .base import Capability
+from .context import ContextDiagnostics, ContextEngine, ContextQuery
+from .memory import MemoryBackend
+from .sandbox import SandboxProvider
+from .secrets import SecretProvider
+from .tools import ToolExecutor
+
+__all__ = [
+    "AuthProvider",
+    "Capability",
+    "ContextDiagnostics",
+    "ContextEngine",
+    "ContextQuery",
+    "MemoryBackend",
+    "SandboxProvider",
+    "SecretProvider",
+    "ToolExecutor",
+]

--- a/sdk/python/sera-plugin-sdk/src/sera_plugin_sdk/capabilities/auth.py
+++ b/sdk/python/sera-plugin-sdk/src/sera_plugin_sdk/capabilities/auth.py
@@ -1,0 +1,19 @@
+"""AuthProvider capability ABC."""
+
+from __future__ import annotations
+
+import abc
+
+from ..types import AuthRequest, AuthResponse, AuthzRequest, AuthzResponse
+from .base import Capability
+
+
+class AuthProvider(Capability, abc.ABC):
+    @abc.abstractmethod
+    async def authenticate(self, req: AuthRequest) -> AuthResponse: ...
+
+    @abc.abstractmethod
+    async def authorize(self, req: AuthzRequest) -> AuthzResponse: ...
+
+
+__all__ = ["AuthProvider"]

--- a/sdk/python/sera-plugin-sdk/src/sera_plugin_sdk/capabilities/base.py
+++ b/sdk/python/sera-plugin-sdk/src/sera_plugin_sdk/capabilities/base.py
@@ -1,0 +1,17 @@
+"""Empty base class so consumers can ``isinstance(plugin, Capability)``."""
+
+from __future__ import annotations
+
+
+class Capability:
+    """Marker base for every capability ABC.
+
+    The runtime uses this to identify which capability contracts a plugin
+    implements without enumerating every subclass. It is intentionally not
+    an ``abc.ABC`` — the concrete capability classes (``MemoryBackend`` etc.)
+    are the ABCs with abstract methods; this is just a shared supertype for
+    ``isinstance`` checks.
+    """
+
+
+__all__ = ["Capability"]

--- a/sdk/python/sera-plugin-sdk/src/sera_plugin_sdk/capabilities/context.py
+++ b/sdk/python/sera-plugin-sdk/src/sera_plugin_sdk/capabilities/context.py
@@ -1,0 +1,62 @@
+"""ContextEngine / ContextQuery / ContextDiagnostics capability ABCs.
+
+Mirrors the three services in ``rust/proto/plugin/context_engine.proto``. A
+plugin that implements the full context-engine contract inherits from all
+three; engines that only provide the core seam inherit just ``ContextEngine``.
+"""
+
+from __future__ import annotations
+
+import abc
+
+from ..types import (
+    AssembleBudget,
+    AssembledContext,
+    CtxSearchRequest,
+    CtxSearchResponse,
+    DescribeRequest,
+    DescribeResponse,
+    DoctorReport,
+    ExpandRequest,
+    ExpandResponse,
+    IngestAck,
+    IngestMessage,
+    StatusResponse,
+)
+from .base import Capability
+
+
+class ContextEngine(Capability, abc.ABC):
+    """Core context-engine seam. Required for PLUGIN_CAPABILITY_CONTEXT_ENGINE."""
+
+    @abc.abstractmethod
+    async def ingest(self, msg: IngestMessage) -> IngestAck: ...
+
+    @abc.abstractmethod
+    async def assemble(self, budget: AssembleBudget) -> AssembledContext: ...
+
+
+class ContextQuery(Capability, abc.ABC):
+    """Drill-tool surface — implemented by engines with an addressable store."""
+
+    @abc.abstractmethod
+    async def search(self, req: CtxSearchRequest) -> CtxSearchResponse: ...
+
+    @abc.abstractmethod
+    async def describe(self, req: DescribeRequest) -> DescribeResponse: ...
+
+    @abc.abstractmethod
+    async def expand(self, req: ExpandRequest) -> ExpandResponse: ...
+
+
+class ContextDiagnostics(Capability, abc.ABC):
+    """Health / introspection surface. status() and doctor()."""
+
+    @abc.abstractmethod
+    async def status(self, session_id: str) -> StatusResponse: ...
+
+    @abc.abstractmethod
+    async def doctor(self) -> DoctorReport: ...
+
+
+__all__ = ["ContextDiagnostics", "ContextEngine", "ContextQuery"]

--- a/sdk/python/sera-plugin-sdk/src/sera_plugin_sdk/capabilities/memory.py
+++ b/sdk/python/sera-plugin-sdk/src/sera_plugin_sdk/capabilities/memory.py
@@ -1,0 +1,25 @@
+"""MemoryBackend capability ABC."""
+
+from __future__ import annotations
+
+import abc
+
+from ..types import MemoryQuery, MemoryRecord, StoreAck
+from .base import Capability
+
+
+class MemoryBackend(Capability, abc.ABC):
+    @abc.abstractmethod
+    async def store(self, record: MemoryRecord) -> StoreAck: ...
+
+    @abc.abstractmethod
+    async def retrieve(self, key: str) -> MemoryRecord | None: ...
+
+    @abc.abstractmethod
+    async def search(self, query: MemoryQuery) -> list[MemoryRecord]: ...
+
+    @abc.abstractmethod
+    async def delete(self, key: str) -> bool: ...
+
+
+__all__ = ["MemoryBackend"]

--- a/sdk/python/sera-plugin-sdk/src/sera_plugin_sdk/capabilities/sandbox.py
+++ b/sdk/python/sera-plugin-sdk/src/sera_plugin_sdk/capabilities/sandbox.py
@@ -1,0 +1,19 @@
+"""SandboxProvider capability ABC."""
+
+from __future__ import annotations
+
+import abc
+
+from ..types import SandboxExecRequest, SandboxExecResult
+from .base import Capability
+
+
+class SandboxProvider(Capability, abc.ABC):
+    @abc.abstractmethod
+    async def execute(self, req: SandboxExecRequest) -> SandboxExecResult: ...
+
+    @abc.abstractmethod
+    async def cleanup(self, sandbox_id: str) -> None: ...
+
+
+__all__ = ["SandboxProvider"]

--- a/sdk/python/sera-plugin-sdk/src/sera_plugin_sdk/capabilities/secrets.py
+++ b/sdk/python/sera-plugin-sdk/src/sera_plugin_sdk/capabilities/secrets.py
@@ -1,0 +1,19 @@
+"""SecretProvider capability ABC."""
+
+from __future__ import annotations
+
+import abc
+
+from ..types import SecretRef, SecretValue
+from .base import Capability
+
+
+class SecretProvider(Capability, abc.ABC):
+    @abc.abstractmethod
+    async def resolve(self, ref: SecretRef) -> SecretValue: ...
+
+    @abc.abstractmethod
+    async def list_secrets(self) -> list[SecretRef]: ...
+
+
+__all__ = ["SecretProvider"]

--- a/sdk/python/sera-plugin-sdk/src/sera_plugin_sdk/capabilities/tools.py
+++ b/sdk/python/sera-plugin-sdk/src/sera_plugin_sdk/capabilities/tools.py
@@ -1,0 +1,19 @@
+"""ToolExecutor capability ABC."""
+
+from __future__ import annotations
+
+import abc
+
+from ..types import ToolCall, ToolDefinition, ToolResult
+from .base import Capability
+
+
+class ToolExecutor(Capability, abc.ABC):
+    @abc.abstractmethod
+    async def list_tools(self) -> list[ToolDefinition]: ...
+
+    @abc.abstractmethod
+    async def execute_tool(self, call: ToolCall) -> ToolResult: ...
+
+
+__all__ = ["ToolExecutor"]

--- a/sdk/python/sera-plugin-sdk/src/sera_plugin_sdk/errors.py
+++ b/sdk/python/sera-plugin-sdk/src/sera_plugin_sdk/errors.py
@@ -1,0 +1,53 @@
+"""Plugin error hierarchy.
+
+Every error exposes a stable ``code`` string and a human-readable ``message``.
+The JSON-RPC codec (``sera_plugin_sdk._protocol``) maps each class to a
+JSON-RPC error code so the gateway can classify failures without string
+matching.
+"""
+
+from __future__ import annotations
+
+
+class PluginError(Exception):
+    """Base class for all SDK-visible plugin errors."""
+
+    DEFAULT_CODE: str = "PLUGIN_ERROR"
+
+    def __init__(self, code: str | None = None, message: str = "") -> None:
+        self.code: str = code or self.DEFAULT_CODE
+        self.message: str = message or self.code
+        super().__init__(f"[{self.code}] {self.message}")
+
+
+class PluginRegistrationError(PluginError):
+    """Raised when registration or capability validation fails."""
+
+    DEFAULT_CODE = "PLUGIN_REGISTRATION_ERROR"
+
+
+class PluginTransportError(PluginError):
+    """Raised for transport-layer failures (framing, I/O, codec)."""
+
+    DEFAULT_CODE = "PLUGIN_TRANSPORT_ERROR"
+
+
+class PluginDispatchError(PluginError):
+    """Raised when a request cannot be routed to a capability method."""
+
+    DEFAULT_CODE = "PLUGIN_DISPATCH_ERROR"
+
+
+class PluginCapabilityError(PluginError):
+    """Raised by capability implementations when they fail a request."""
+
+    DEFAULT_CODE = "PLUGIN_CAPABILITY_ERROR"
+
+
+__all__ = [
+    "PluginCapabilityError",
+    "PluginDispatchError",
+    "PluginError",
+    "PluginRegistrationError",
+    "PluginTransportError",
+]

--- a/sdk/python/sera-plugin-sdk/src/sera_plugin_sdk/lifecycle.py
+++ b/sdk/python/sera-plugin-sdk/src/sera_plugin_sdk/lifecycle.py
@@ -1,0 +1,39 @@
+"""Optional lifecycle hook detection.
+
+Plugin authors may define ``async def on_startup(self)`` / ``async def
+on_shutdown(self)`` on their plugin class. The runtime calls the hook if
+present, no-ops otherwise, and rejects sync definitions explicitly — an async
+runtime cannot safely run a blocking startup hook.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from .errors import PluginError
+
+LIFECYCLE_ERROR_CODE = "PLUGIN_LIFECYCLE_NOT_ASYNC"
+
+
+async def call_on_startup(plugin: object) -> None:
+    """Invoke ``plugin.on_startup()`` if defined. Must be async."""
+    await _invoke_hook(plugin, "on_startup")
+
+
+async def call_on_shutdown(plugin: object) -> None:
+    """Invoke ``plugin.on_shutdown()`` if defined. Must be async."""
+    await _invoke_hook(plugin, "on_shutdown")
+
+
+async def _invoke_hook(plugin: object, name: str) -> None:
+    hook = getattr(plugin, name, None)
+    if hook is None:
+        return
+    if not callable(hook):
+        raise PluginError(LIFECYCLE_ERROR_CODE, f"{name} must be callable")
+    if not inspect.iscoroutinefunction(hook):
+        raise PluginError(LIFECYCLE_ERROR_CODE, f"{name} must be an async def")
+    await hook()
+
+
+__all__ = ["LIFECYCLE_ERROR_CODE", "call_on_shutdown", "call_on_startup"]

--- a/sdk/python/sera-plugin-sdk/src/sera_plugin_sdk/runtime.py
+++ b/sdk/python/sera-plugin-sdk/src/sera_plugin_sdk/runtime.py
@@ -1,0 +1,92 @@
+"""Top-level plugin runtime entrypoints.
+
+``run_stdio_plugin`` wires the plugin to ``sys.stdin`` / ``sys.stdout`` with
+NDJSON framing. ``run_grpc_plugin`` starts a gRPC server bound to ``bind``.
+Both call the optional ``on_startup`` hook before serving and ``on_shutdown``
+on graceful termination.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import signal
+import sys
+
+from .lifecycle import call_on_shutdown, call_on_startup
+from .transport import stdio as stdio_transport
+
+
+async def _stdin_stdout_streams() -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+    loop = asyncio.get_running_loop()
+    reader = asyncio.StreamReader()
+    await loop.connect_read_pipe(
+        lambda: asyncio.StreamReaderProtocol(reader), sys.stdin
+    )
+    transport, protocol = await loop.connect_write_pipe(
+        asyncio.streams.FlowControlMixin, sys.stdout
+    )
+    writer = asyncio.StreamWriter(transport, protocol, reader, loop)
+    return reader, writer
+
+
+def _install_signal_handlers(stop: asyncio.Event) -> None:
+    loop = asyncio.get_running_loop()
+    for signame in ("SIGTERM", "SIGINT"):
+        sig = getattr(signal, signame, None)
+        if sig is None:
+            continue
+        try:
+            loop.add_signal_handler(sig, stop.set)
+        except NotImplementedError:  # pragma: no cover - Windows
+            signal.signal(sig, lambda *_args: stop.set())
+
+
+async def _run_stdio(plugin: object) -> None:
+    await call_on_startup(plugin)
+    reader, writer = await _stdin_stdout_streams()
+    stop = asyncio.Event()
+    _install_signal_handlers(stop)
+
+    serve_task = asyncio.create_task(stdio_transport.serve(plugin, reader, writer))
+    stop_task = asyncio.create_task(stop.wait())
+
+    done, pending = await asyncio.wait(
+        {serve_task, stop_task}, return_when=asyncio.FIRST_COMPLETED
+    )
+    for task in pending:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError, Exception):
+            await task
+    for task in done:
+        exc = task.exception()
+        if exc is not None:
+            raise exc
+
+
+def run_stdio_plugin(plugin: object) -> None:
+    """Entrypoint for stdio plugins. Blocks until the gateway deregisters."""
+    asyncio.run(_run_stdio(plugin))
+
+
+async def _run_grpc(plugin: object, bind: str) -> None:
+    from .transport.grpc import GrpcServer
+
+    server = GrpcServer(plugin, bind=bind)
+    await call_on_startup(plugin)
+    await server.start()
+    stop = asyncio.Event()
+    _install_signal_handlers(stop)
+    try:
+        await stop.wait()
+    finally:
+        await server.stop()
+        await call_on_shutdown(plugin)
+
+
+def run_grpc_plugin(plugin: object, bind: str = "0.0.0.0:0") -> None:
+    """Entrypoint for gRPC plugins. Blocks until the server is signalled."""
+    asyncio.run(_run_grpc(plugin, bind))
+
+
+__all__ = ["run_grpc_plugin", "run_stdio_plugin"]

--- a/sdk/python/sera-plugin-sdk/src/sera_plugin_sdk/transport/__init__.py
+++ b/sdk/python/sera-plugin-sdk/src/sera_plugin_sdk/transport/__init__.py
@@ -1,0 +1,7 @@
+"""Transport implementations: stdio (NDJSON JSON-RPC) and gRPC (async)."""
+
+from __future__ import annotations
+
+from . import stdio
+
+__all__ = ["stdio"]

--- a/sdk/python/sera-plugin-sdk/src/sera_plugin_sdk/transport/grpc.py
+++ b/sdk/python/sera-plugin-sdk/src/sera_plugin_sdk/transport/grpc.py
@@ -1,0 +1,100 @@
+"""gRPC transport scaffold.
+
+This is a minimal scaffold that starts an ``grpc.aio`` server and wires a
+``PluginRegistry`` servicer. Capability servicers raise ``UNIMPLEMENTED`` —
+the Rust gateway already knows how to treat that as "capability not served
+by this plugin." The intent is that the server starts, accepts Registry
+calls, and lets the operator verify connectivity. Full capability dispatch
+is a follow-up bead.
+
+Imports of the generated protobuf modules are lazy (and typed as ``Any``) so
+the module stays importable and type-checkable before the Hatch build hook
+has populated ``sera_plugin_sdk._generated``.
+"""
+
+from __future__ import annotations
+
+import importlib
+import time
+from typing import Any
+
+
+class GrpcServer:
+    """Minimal async gRPC server wrapper.
+
+    The full capability-to-proto wiring depends on generated protobuf modules
+    that are populated by the Hatch build hook; if those modules are absent
+    this wrapper raises ``RuntimeError`` on :meth:`start`.
+    """
+
+    def __init__(self, plugin: object, bind: str = "0.0.0.0:0") -> None:
+        self.plugin = plugin
+        self.bind = bind
+        self._server: Any = None
+        self._actual_port: int | None = None
+        self._started_at: float = 0.0
+
+    async def start(self) -> None:
+        try:
+            grpc_aio: Any = importlib.import_module("grpc.aio")
+        except ImportError as exc:  # pragma: no cover - grpcio is a hard dep
+            raise RuntimeError(
+                "grpcio is not installed; install sera-plugin-sdk with the "
+                "gRPC extras to use the gRPC transport"
+            ) from exc
+
+        try:
+            registry_pb2: Any = importlib.import_module(
+                "sera_plugin_sdk._generated.registry_pb2"
+            )
+            registry_pb2_grpc: Any = importlib.import_module(
+                "sera_plugin_sdk._generated.registry_pb2_grpc"
+            )
+        except ImportError as exc:
+            raise RuntimeError(
+                "generated protobuf modules missing; run `hatch build` or "
+                "install the SDK via a wheel so the build hook can run protoc"
+            ) from exc
+
+        plugin = self.plugin
+        self._started_at = time.monotonic()
+
+        class _RegistryServicer(registry_pb2_grpc.PluginRegistryServicer):  # type: ignore[misc]
+            async def Register(self, _request: Any, _context: Any) -> Any:
+                ack = registry_pb2.RegistrationAck()
+                ack.plugin_id = getattr(plugin, "plugin_id", "")
+                ack.protocol_version = "v1"
+                return ack
+
+            async def Heartbeat(self, _request: Any, _context: Any) -> Any:
+                ack = registry_pb2.HeartbeatAck()
+                ack.ok = True
+                return ack
+
+            async def Deregister(self, _request: Any, _context: Any) -> Any:
+                empty_pb2: Any = importlib.import_module("google.protobuf.empty_pb2")
+                return empty_pb2.Empty()
+
+        server = grpc_aio.server()
+        registry_pb2_grpc.add_PluginRegistryServicer_to_server(
+            _RegistryServicer(), server
+        )
+        self._actual_port = server.add_insecure_port(self.bind)
+        await server.start()
+        self._server = server
+
+    async def stop(self, grace: float = 5.0) -> None:
+        if self._server is not None:
+            await self._server.stop(grace)
+            self._server = None
+
+    async def wait_closed(self) -> None:
+        if self._server is not None:
+            await self._server.wait_for_termination()
+
+    @property
+    def port(self) -> int | None:
+        return self._actual_port
+
+
+__all__ = ["GrpcServer"]

--- a/sdk/python/sera-plugin-sdk/src/sera_plugin_sdk/transport/stdio.py
+++ b/sdk/python/sera-plugin-sdk/src/sera_plugin_sdk/transport/stdio.py
@@ -1,0 +1,264 @@
+"""Stdio transport — NDJSON framed JSON-RPC over stdin/stdout.
+
+The dispatcher maps ``Capability.method`` strings onto capability methods on
+the plugin. Top-level registry methods (``PluginRegistry.Heartbeat`` etc.) are
+handled by the runtime regardless of capability.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from .. import _protocol as proto
+from ..capabilities import (
+    AuthProvider,
+    ContextDiagnostics,
+    ContextEngine,
+    ContextQuery,
+    MemoryBackend,
+    SandboxProvider,
+    SecretProvider,
+    ToolExecutor,
+)
+from ..errors import PluginDispatchError, PluginError
+from ..lifecycle import call_on_shutdown
+from ..types import (
+    AssembleBudget,
+    AuthRequest,
+    AuthzRequest,
+    CtxSearchRequest,
+    DescribeRequest,
+    ExpandRequest,
+    IngestMessage,
+    MemoryQuery,
+    MemoryRecord,
+    SandboxExecRequest,
+    SecretRef,
+    ToolCall,
+)
+
+Handler = Callable[[dict[str, Any]], Awaitable[Any]]
+
+
+def _build_dispatch_table(plugin: object) -> dict[str, Handler]:
+    """Map ``Capability.method`` strings to awaitable handlers."""
+    table: dict[str, Handler] = {}
+
+    if isinstance(plugin, ContextEngine):
+        engine = plugin
+
+        async def _ingest(params: dict[str, Any]) -> dict[str, Any]:
+            msg = IngestMessage.from_wire(params)
+            return (await engine.ingest(msg)).to_wire()
+
+        async def _assemble(params: dict[str, Any]) -> dict[str, Any]:
+            budget = AssembleBudget.from_wire(params)
+            return (await engine.assemble(budget)).to_wire()
+
+        table["ContextEngine.ingest"] = _ingest
+        table["ContextEngine.assemble"] = _assemble
+
+    if isinstance(plugin, ContextQuery):
+        query = plugin
+
+        async def _search(params: dict[str, Any]) -> dict[str, Any]:
+            return (await query.search(CtxSearchRequest.from_wire(params))).to_wire()
+
+        async def _describe(params: dict[str, Any]) -> dict[str, Any]:
+            return (await query.describe(DescribeRequest.from_wire(params))).to_wire()
+
+        async def _expand(params: dict[str, Any]) -> dict[str, Any]:
+            return (await query.expand(ExpandRequest.from_wire(params))).to_wire()
+
+        table["ContextQuery.search"] = _search
+        table["ContextQuery.describe"] = _describe
+        table["ContextQuery.expand"] = _expand
+
+    if isinstance(plugin, ContextDiagnostics):
+        diag = plugin
+
+        async def _status(params: dict[str, Any]) -> dict[str, Any]:
+            return (await diag.status(str(params.get("session_id") or ""))).to_wire()
+
+        async def _doctor(_params: dict[str, Any]) -> dict[str, Any]:
+            return (await diag.doctor()).to_wire()
+
+        table["ContextDiagnostics.status"] = _status
+        table["ContextDiagnostics.doctor"] = _doctor
+
+    if isinstance(plugin, MemoryBackend):
+        mem = plugin
+
+        async def _store(params: dict[str, Any]) -> dict[str, Any]:
+            record = MemoryRecord.from_wire(params.get("record") or params)
+            return (await mem.store(record)).to_wire()
+
+        async def _retrieve(params: dict[str, Any]) -> dict[str, Any]:
+            result = await mem.retrieve(str(params["key"]))
+            return {
+                "found": result is not None,
+                "record": result.to_wire() if result is not None else None,
+            }
+
+        async def _search_mem(params: dict[str, Any]) -> dict[str, Any]:
+            hits = await mem.search(MemoryQuery.from_wire(params))
+            return {"records": [r.to_wire() for r in hits]}
+
+        async def _delete(params: dict[str, Any]) -> dict[str, Any]:
+            return {"deleted": bool(await mem.delete(str(params["key"])))}
+
+        table["MemoryBackend.store"] = _store
+        table["MemoryBackend.retrieve"] = _retrieve
+        table["MemoryBackend.search"] = _search_mem
+        table["MemoryBackend.delete"] = _delete
+
+    if isinstance(plugin, ToolExecutor):
+        tools = plugin
+
+        async def _list_tools(_params: dict[str, Any]) -> dict[str, Any]:
+            defs = await tools.list_tools()
+            return {"tools": [d.to_wire() for d in defs]}
+
+        async def _execute_tool(params: dict[str, Any]) -> dict[str, Any]:
+            return (await tools.execute_tool(ToolCall.from_wire(params))).to_wire()
+
+        table["ToolExecutor.list_tools"] = _list_tools
+        table["ToolExecutor.execute_tool"] = _execute_tool
+
+    if isinstance(plugin, SandboxProvider):
+        sandbox = plugin
+
+        async def _execute(params: dict[str, Any]) -> dict[str, Any]:
+            return (await sandbox.execute(SandboxExecRequest.from_wire(params))).to_wire()
+
+        async def _cleanup(params: dict[str, Any]) -> dict[str, Any]:
+            await sandbox.cleanup(str(params["sandbox_id"]))
+            return {}
+
+        table["SandboxProvider.execute"] = _execute
+        table["SandboxProvider.cleanup"] = _cleanup
+
+    if isinstance(plugin, AuthProvider):
+        auth = plugin
+
+        async def _authenticate(params: dict[str, Any]) -> dict[str, Any]:
+            return (await auth.authenticate(AuthRequest.from_wire(params))).to_wire()
+
+        async def _authorize(params: dict[str, Any]) -> dict[str, Any]:
+            return (await auth.authorize(AuthzRequest.from_wire(params))).to_wire()
+
+        table["AuthProvider.authenticate"] = _authenticate
+        table["AuthProvider.authorize"] = _authorize
+
+    if isinstance(plugin, SecretProvider):
+        secrets = plugin
+
+        async def _resolve(params: dict[str, Any]) -> dict[str, Any]:
+            return (await secrets.resolve(SecretRef.from_wire(params))).to_wire()
+
+        async def _list_secrets(_params: dict[str, Any]) -> dict[str, Any]:
+            refs = await secrets.list_secrets()
+            return {"refs": [r.to_wire() for r in refs]}
+
+        table["SecretProvider.resolve"] = _resolve
+        table["SecretProvider.list_secrets"] = _list_secrets
+
+    return table
+
+
+class _StdioServer:
+    """Internal helper that owns the dispatch loop and shutdown state."""
+
+    def __init__(self, plugin: object) -> None:
+        self.plugin = plugin
+        self.dispatch = _build_dispatch_table(plugin)
+        self.started_at = time.monotonic()
+        self._shutdown = asyncio.Event()
+
+    async def handle_registry(
+        self, method: str, _params: dict[str, Any]
+    ) -> dict[str, Any]:
+        if method == "PluginRegistry.Heartbeat":
+            return {
+                "ok": True,
+                "uptime_seconds": time.monotonic() - self.started_at,
+            }
+        if method == "PluginRegistry.Register":
+            return {
+                "plugin_id": getattr(self.plugin, "plugin_id", ""),
+                "server_capabilities": sorted(
+                    name.split(".", 1)[0] for name in self.dispatch
+                ),
+                "protocol_version": "v1",
+            }
+        if method == "PluginRegistry.Deregister":
+            self._shutdown.set()
+            return {}
+        raise PluginDispatchError(
+            "PLUGIN_DISPATCH_ERROR", f"unknown registry method: {method}"
+        )
+
+    async def handle_one(
+        self, line: bytes, writer: asyncio.StreamWriter
+    ) -> None:
+        request_id: int | str | None = None
+        try:
+            request_id, method, params = proto.decode_request(line)
+            if method.startswith("PluginRegistry."):
+                result = await self.handle_registry(method, params)
+            else:
+                handler = self.dispatch.get(method)
+                if handler is None:
+                    raise PluginDispatchError(
+                        "PLUGIN_DISPATCH_ERROR", f"unknown method: {method}"
+                    )
+                result = await handler(params)
+            if request_id is not None:
+                writer.write(proto.encode_response(request_id, result))
+                await writer.drain()
+        except PluginError as exc:
+            if request_id is not None:
+                writer.write(proto.encode_error(request_id, exc))
+                await writer.drain()
+        except Exception as exc:  # pragma: no cover - defensive
+            if request_id is not None:
+                writer.write(
+                    proto.encode_error(request_id, exc, code=proto.ERROR_CODE_INTERNAL)
+                )
+                await writer.drain()
+
+    async def serve(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        try:
+            while not self._shutdown.is_set():
+                line = await reader.readline()
+                if not line:
+                    break
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                await self.handle_one(stripped, writer)
+        finally:
+            await call_on_shutdown(self.plugin)
+            try:
+                writer.close()
+                await writer.wait_closed()
+            except Exception:  # pragma: no cover - best-effort close
+                pass
+
+
+async def serve(
+    plugin: object,
+    reader: asyncio.StreamReader,
+    writer: asyncio.StreamWriter,
+) -> None:
+    """Run the stdio dispatch loop against the given reader/writer pair."""
+    server = _StdioServer(plugin)
+    await server.serve(reader, writer)
+
+
+__all__ = ["serve"]

--- a/sdk/python/sera-plugin-sdk/src/sera_plugin_sdk/types.py
+++ b/sdk/python/sera-plugin-sdk/src/sera_plugin_sdk/types.py
@@ -1,0 +1,661 @@
+"""Wire-neutral Python dataclasses mirroring ``rust/proto/plugin/*.proto``.
+
+Each dataclass exposes ``to_wire()`` and ``from_wire()`` helpers so the stdio
+JSON-RPC transport can serialise without depending on the generated protobuf
+modules at runtime. The gRPC transport converts between these dataclasses and
+the generated protobuf messages lazily.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+# --- MemoryBackend ----------------------------------------------------------
+
+
+@dataclass(slots=True)
+class MemoryRecord:
+    key: str
+    content: str
+    metadata: dict[str, str] = field(default_factory=dict)
+    created_at: str | None = None  # ISO 8601
+
+    def to_wire(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "key": self.key,
+            "content": self.content,
+            "metadata": dict(self.metadata),
+        }
+        if self.created_at is not None:
+            out["created_at"] = self.created_at
+        return out
+
+    @classmethod
+    def from_wire(cls, data: dict[str, Any]) -> MemoryRecord:
+        return cls(
+            key=str(data["key"]),
+            content=str(data["content"]),
+            metadata=dict(data.get("metadata") or {}),
+            created_at=data.get("created_at"),
+        )
+
+
+@dataclass(slots=True)
+class StoreAck:
+    key: str
+
+    def to_wire(self) -> dict[str, Any]:
+        return {"key": self.key}
+
+    @classmethod
+    def from_wire(cls, data: dict[str, Any]) -> StoreAck:
+        return cls(key=str(data["key"]))
+
+
+@dataclass(slots=True)
+class MemoryQuery:
+    query: str
+    limit: int = 10
+    filter: dict[str, str] = field(default_factory=dict)
+
+    def to_wire(self) -> dict[str, Any]:
+        return {
+            "query": self.query,
+            "limit": int(self.limit),
+            "filter": dict(self.filter),
+        }
+
+    @classmethod
+    def from_wire(cls, data: dict[str, Any]) -> MemoryQuery:
+        return cls(
+            query=str(data["query"]),
+            limit=int(data.get("limit", 10)),
+            filter=dict(data.get("filter") or {}),
+        )
+
+
+# --- ContextEngine ----------------------------------------------------------
+
+
+@dataclass(slots=True)
+class IngestMessage:
+    session_id: str
+    role: str  # "system" | "user" | "assistant" | "tool"
+    content: str
+    metadata: dict[str, str] = field(default_factory=dict)
+
+    def to_wire(self) -> dict[str, Any]:
+        return {
+            "session_id": self.session_id,
+            "role": self.role,
+            "content": self.content,
+            "metadata": dict(self.metadata),
+        }
+
+    @classmethod
+    def from_wire(cls, data: dict[str, Any]) -> IngestMessage:
+        return cls(
+            session_id=str(data["session_id"]),
+            role=str(data["role"]),
+            content=str(data["content"]),
+            metadata=dict(data.get("metadata") or {}),
+        )
+
+
+@dataclass(slots=True)
+class IngestAck:
+    accepted: bool
+
+    def to_wire(self) -> dict[str, Any]:
+        return {"accepted": self.accepted}
+
+    @classmethod
+    def from_wire(cls, data: dict[str, Any]) -> IngestAck:
+        return cls(accepted=bool(data.get("accepted", False)))
+
+
+@dataclass(slots=True)
+class AssembleBudget:
+    session_id: str
+    budget_tokens: int
+    constraints_json: str = ""
+
+    def to_wire(self) -> dict[str, Any]:
+        return {
+            "session_id": self.session_id,
+            "budget_tokens": int(self.budget_tokens),
+            "constraints_json": self.constraints_json,
+        }
+
+    @classmethod
+    def from_wire(cls, data: dict[str, Any]) -> AssembleBudget:
+        return cls(
+            session_id=str(data["session_id"]),
+            budget_tokens=int(data["budget_tokens"]),
+            constraints_json=str(data.get("constraints_json") or ""),
+        )
+
+
+@dataclass(slots=True)
+class ContextSegment:
+    kind: str  # "soul" | "working" | "longterm" | "overflow"
+    content: str
+    tokens: int
+
+    def to_wire(self) -> dict[str, Any]:
+        return {"kind": self.kind, "content": self.content, "tokens": int(self.tokens)}
+
+    @classmethod
+    def from_wire(cls, data: dict[str, Any]) -> ContextSegment:
+        return cls(
+            kind=str(data["kind"]),
+            content=str(data["content"]),
+            tokens=int(data.get("tokens", 0)),
+        )
+
+
+@dataclass(slots=True)
+class AssembledContext:
+    segments: list[ContextSegment] = field(default_factory=list)
+    total_tokens: int = 0
+
+    def to_wire(self) -> dict[str, Any]:
+        return {
+            "segments": [s.to_wire() for s in self.segments],
+            "total_tokens": int(self.total_tokens),
+        }
+
+    @classmethod
+    def from_wire(cls, data: dict[str, Any]) -> AssembledContext:
+        return cls(
+            segments=[ContextSegment.from_wire(s) for s in data.get("segments") or []],
+            total_tokens=int(data.get("total_tokens", 0)),
+        )
+
+
+@dataclass(slots=True)
+class CtxSearchRequest:
+    session_id: str
+    query: str
+    limit: int = 10
+
+    def to_wire(self) -> dict[str, Any]:
+        return {
+            "session_id": self.session_id,
+            "query": self.query,
+            "limit": int(self.limit),
+        }
+
+    @classmethod
+    def from_wire(cls, data: dict[str, Any]) -> CtxSearchRequest:
+        return cls(
+            session_id=str(data["session_id"]),
+            query=str(data["query"]),
+            limit=int(data.get("limit", 10)),
+        )
+
+
+@dataclass(slots=True)
+class CtxSearchHit:
+    node_id: str
+    depth_label: str
+    preview: str
+    rank: float | None = None
+
+    def to_wire(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "node_id": self.node_id,
+            "depth_label": self.depth_label,
+            "preview": self.preview,
+        }
+        if self.rank is not None:
+            out["rank"] = float(self.rank)
+        return out
+
+    @classmethod
+    def from_wire(cls, data: dict[str, Any]) -> CtxSearchHit:
+        rank_val = data.get("rank")
+        return cls(
+            node_id=str(data["node_id"]),
+            depth_label=str(data.get("depth_label") or ""),
+            preview=str(data.get("preview") or ""),
+            rank=float(rank_val) if rank_val is not None else None,
+        )
+
+
+@dataclass(slots=True)
+class CtxSearchResponse:
+    hits: list[CtxSearchHit] = field(default_factory=list)
+
+    def to_wire(self) -> dict[str, Any]:
+        return {"hits": [h.to_wire() for h in self.hits]}
+
+    @classmethod
+    def from_wire(cls, data: dict[str, Any]) -> CtxSearchResponse:
+        return cls(hits=[CtxSearchHit.from_wire(h) for h in data.get("hits") or []])
+
+
+@dataclass(slots=True)
+class DescribeRequest:
+    session_id: str
+    node_id: str
+
+    def to_wire(self) -> dict[str, Any]:
+        return {"session_id": self.session_id, "node_id": self.node_id}
+
+    @classmethod
+    def from_wire(cls, data: dict[str, Any]) -> DescribeRequest:
+        return cls(session_id=str(data["session_id"]), node_id=str(data["node_id"]))
+
+
+@dataclass(slots=True)
+class DescribeResponse:
+    node_id: str
+    depth_label: str = ""
+    tokens: int = 0
+    child_node_ids: list[str] = field(default_factory=list)
+    metadata_json: str = ""
+
+    def to_wire(self) -> dict[str, Any]:
+        return {
+            "node_id": self.node_id,
+            "depth_label": self.depth_label,
+            "tokens": int(self.tokens),
+            "child_node_ids": list(self.child_node_ids),
+            "metadata_json": self.metadata_json,
+        }
+
+    @classmethod
+    def from_wire(cls, data: dict[str, Any]) -> DescribeResponse:
+        return cls(
+            node_id=str(data["node_id"]),
+            depth_label=str(data.get("depth_label") or ""),
+            tokens=int(data.get("tokens", 0)),
+            child_node_ids=[str(x) for x in data.get("child_node_ids") or []],
+            metadata_json=str(data.get("metadata_json") or ""),
+        )
+
+
+@dataclass(slots=True)
+class ExpandRequest:
+    session_id: str
+    node_id: str
+    max_tokens: int = 0
+
+    def to_wire(self) -> dict[str, Any]:
+        return {
+            "session_id": self.session_id,
+            "node_id": self.node_id,
+            "max_tokens": int(self.max_tokens),
+        }
+
+    @classmethod
+    def from_wire(cls, data: dict[str, Any]) -> ExpandRequest:
+        return cls(
+            session_id=str(data["session_id"]),
+            node_id=str(data["node_id"]),
+            max_tokens=int(data.get("max_tokens", 0)),
+        )
+
+
+@dataclass(slots=True)
+class ExpandResponse:
+    node_id: str
+    content: str = ""
+    tokens: int = 0
+    truncated: bool = False
+
+    def to_wire(self) -> dict[str, Any]:
+        return {
+            "node_id": self.node_id,
+            "content": self.content,
+            "tokens": int(self.tokens),
+            "truncated": bool(self.truncated),
+        }
+
+    @classmethod
+    def from_wire(cls, data: dict[str, Any]) -> ExpandResponse:
+        return cls(
+            node_id=str(data["node_id"]),
+            content=str(data.get("content") or ""),
+            tokens=int(data.get("tokens", 0)),
+            truncated=bool(data.get("truncated", False)),
+        )
+
+
+@dataclass(slots=True)
+class StatusResponse:
+    fields_json: str = ""
+
+    def to_wire(self) -> dict[str, Any]:
+        return {"fields_json": self.fields_json}
+
+    @classmethod
+    def from_wire(cls, data: dict[str, Any]) -> StatusResponse:
+        return cls(fields_json=str(data.get("fields_json") or ""))
+
+
+@dataclass(slots=True)
+class DoctorCheck:
+    name: str
+    severity: str  # "ok" | "warn" | "fail"
+    message: str = ""
+
+    def to_wire(self) -> dict[str, Any]:
+        return {"name": self.name, "severity": self.severity, "message": self.message}
+
+    @classmethod
+    def from_wire(cls, data: dict[str, Any]) -> DoctorCheck:
+        return cls(
+            name=str(data["name"]),
+            severity=str(data["severity"]),
+            message=str(data.get("message") or ""),
+        )
+
+
+@dataclass(slots=True)
+class DoctorReport:
+    checks: list[DoctorCheck] = field(default_factory=list)
+
+    def to_wire(self) -> dict[str, Any]:
+        return {"checks": [c.to_wire() for c in self.checks]}
+
+    @classmethod
+    def from_wire(cls, data: dict[str, Any]) -> DoctorReport:
+        return cls(checks=[DoctorCheck.from_wire(c) for c in data.get("checks") or []])
+
+
+# --- ToolExecutor -----------------------------------------------------------
+
+
+@dataclass(slots=True)
+class ToolDefinition:
+    name: str
+    description: str = ""
+    input_schema_json: str = ""
+    risk_level: str = "read"  # "read" | "write" | "exec"
+
+    def to_wire(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "description": self.description,
+            "input_schema_json": self.input_schema_json,
+            "risk_level": self.risk_level,
+        }
+
+    @classmethod
+    def from_wire(cls, data: dict[str, Any]) -> ToolDefinition:
+        return cls(
+            name=str(data["name"]),
+            description=str(data.get("description") or ""),
+            input_schema_json=str(data.get("input_schema_json") or ""),
+            risk_level=str(data.get("risk_level") or "read"),
+        )
+
+
+@dataclass(slots=True)
+class ToolCall:
+    tool_name: str
+    arguments_json: str
+    call_id: str
+
+    def to_wire(self) -> dict[str, Any]:
+        return {
+            "tool_name": self.tool_name,
+            "arguments_json": self.arguments_json,
+            "call_id": self.call_id,
+        }
+
+    @classmethod
+    def from_wire(cls, data: dict[str, Any]) -> ToolCall:
+        return cls(
+            tool_name=str(data["tool_name"]),
+            arguments_json=str(data.get("arguments_json") or ""),
+            call_id=str(data["call_id"]),
+        )
+
+
+@dataclass(slots=True)
+class ToolResult:
+    call_id: str
+    content_json: str = ""
+    is_error: bool = False
+
+    def to_wire(self) -> dict[str, Any]:
+        return {
+            "call_id": self.call_id,
+            "content_json": self.content_json,
+            "is_error": bool(self.is_error),
+        }
+
+    @classmethod
+    def from_wire(cls, data: dict[str, Any]) -> ToolResult:
+        return cls(
+            call_id=str(data["call_id"]),
+            content_json=str(data.get("content_json") or ""),
+            is_error=bool(data.get("is_error", False)),
+        )
+
+
+# --- SandboxProvider --------------------------------------------------------
+
+
+@dataclass(slots=True)
+class SandboxExecRequest:
+    command: list[str]
+    sandbox_id: str = ""
+    env: dict[str, str] = field(default_factory=dict)
+    workdir: str = ""
+    time_limit_seconds: int = 0
+    memory_limit_bytes: int = 0
+
+    def to_wire(self) -> dict[str, Any]:
+        return {
+            "sandbox_id": self.sandbox_id,
+            "command": list(self.command),
+            "env": dict(self.env),
+            "workdir": self.workdir,
+            "time_limit_seconds": int(self.time_limit_seconds),
+            "memory_limit_bytes": int(self.memory_limit_bytes),
+        }
+
+    @classmethod
+    def from_wire(cls, data: dict[str, Any]) -> SandboxExecRequest:
+        return cls(
+            command=[str(x) for x in data.get("command") or []],
+            sandbox_id=str(data.get("sandbox_id") or ""),
+            env=dict(data.get("env") or {}),
+            workdir=str(data.get("workdir") or ""),
+            time_limit_seconds=int(data.get("time_limit_seconds", 0)),
+            memory_limit_bytes=int(data.get("memory_limit_bytes", 0)),
+        )
+
+
+@dataclass(slots=True)
+class SandboxExecResult:
+    sandbox_id: str
+    stdout: str = ""
+    stderr: str = ""
+    exit_code: int = 0
+    duration_seconds: float = 0.0
+
+    def to_wire(self) -> dict[str, Any]:
+        return {
+            "sandbox_id": self.sandbox_id,
+            "stdout": self.stdout,
+            "stderr": self.stderr,
+            "exit_code": int(self.exit_code),
+            "duration_seconds": float(self.duration_seconds),
+        }
+
+    @classmethod
+    def from_wire(cls, data: dict[str, Any]) -> SandboxExecResult:
+        return cls(
+            sandbox_id=str(data["sandbox_id"]),
+            stdout=str(data.get("stdout") or ""),
+            stderr=str(data.get("stderr") or ""),
+            exit_code=int(data.get("exit_code", 0)),
+            duration_seconds=float(data.get("duration_seconds", 0.0)),
+        )
+
+
+# --- AuthProvider -----------------------------------------------------------
+
+
+@dataclass(slots=True)
+class AuthRequest:
+    subject: str
+    credential: str
+
+    def to_wire(self) -> dict[str, Any]:
+        return {"subject": self.subject, "credential": self.credential}
+
+    @classmethod
+    def from_wire(cls, data: dict[str, Any]) -> AuthRequest:
+        return cls(
+            subject=str(data["subject"]),
+            credential=str(data.get("credential") or ""),
+        )
+
+
+@dataclass(slots=True)
+class AuthResponse:
+    authenticated: bool
+    subject_id: str = ""
+    claims: dict[str, str] = field(default_factory=dict)
+    reason: str = ""
+
+    def to_wire(self) -> dict[str, Any]:
+        return {
+            "authenticated": bool(self.authenticated),
+            "subject_id": self.subject_id,
+            "claims": dict(self.claims),
+            "reason": self.reason,
+        }
+
+    @classmethod
+    def from_wire(cls, data: dict[str, Any]) -> AuthResponse:
+        return cls(
+            authenticated=bool(data.get("authenticated", False)),
+            subject_id=str(data.get("subject_id") or ""),
+            claims=dict(data.get("claims") or {}),
+            reason=str(data.get("reason") or ""),
+        )
+
+
+@dataclass(slots=True)
+class AuthzRequest:
+    subject_id: str
+    action: str
+    resource: str
+    context: dict[str, str] = field(default_factory=dict)
+
+    def to_wire(self) -> dict[str, Any]:
+        return {
+            "subject_id": self.subject_id,
+            "action": self.action,
+            "resource": self.resource,
+            "context": dict(self.context),
+        }
+
+    @classmethod
+    def from_wire(cls, data: dict[str, Any]) -> AuthzRequest:
+        return cls(
+            subject_id=str(data["subject_id"]),
+            action=str(data["action"]),
+            resource=str(data["resource"]),
+            context=dict(data.get("context") or {}),
+        )
+
+
+@dataclass(slots=True)
+class AuthzResponse:
+    allow: bool
+    reason: str = ""
+
+    def to_wire(self) -> dict[str, Any]:
+        return {"allow": bool(self.allow), "reason": self.reason}
+
+    @classmethod
+    def from_wire(cls, data: dict[str, Any]) -> AuthzResponse:
+        return cls(
+            allow=bool(data.get("allow", False)),
+            reason=str(data.get("reason") or ""),
+        )
+
+
+# --- SecretProvider ---------------------------------------------------------
+
+
+@dataclass(slots=True)
+class SecretRef:
+    name: str
+
+    def to_wire(self) -> dict[str, Any]:
+        return {"name": self.name}
+
+    @classmethod
+    def from_wire(cls, data: dict[str, Any]) -> SecretRef:
+        return cls(name=str(data["name"]))
+
+
+@dataclass(slots=True)
+class SecretValue:
+    name: str
+    value: bytes = b""
+    metadata: dict[str, str] = field(default_factory=dict)
+
+    def to_wire(self) -> dict[str, Any]:
+        import base64
+
+        return {
+            "name": self.name,
+            "value_b64": base64.b64encode(self.value).decode("ascii"),
+            "metadata": dict(self.metadata),
+        }
+
+    @classmethod
+    def from_wire(cls, data: dict[str, Any]) -> SecretValue:
+        import base64
+
+        b64 = data.get("value_b64")
+        raw = base64.b64decode(b64) if b64 else b""
+        return cls(
+            name=str(data["name"]),
+            value=raw,
+            metadata=dict(data.get("metadata") or {}),
+        )
+
+
+__all__ = [
+    "AssembleBudget",
+    "AssembledContext",
+    "AuthRequest",
+    "AuthResponse",
+    "AuthzRequest",
+    "AuthzResponse",
+    "ContextSegment",
+    "CtxSearchHit",
+    "CtxSearchRequest",
+    "CtxSearchResponse",
+    "DescribeRequest",
+    "DescribeResponse",
+    "DoctorCheck",
+    "DoctorReport",
+    "ExpandRequest",
+    "ExpandResponse",
+    "IngestAck",
+    "IngestMessage",
+    "MemoryQuery",
+    "MemoryRecord",
+    "SandboxExecRequest",
+    "SandboxExecResult",
+    "SecretRef",
+    "SecretValue",
+    "StatusResponse",
+    "StoreAck",
+    "ToolCall",
+    "ToolDefinition",
+    "ToolResult",
+]

--- a/sdk/python/sera-plugin-sdk/tests/test_capabilities.py
+++ b/sdk/python/sera-plugin-sdk/tests/test_capabilities.py
@@ -1,0 +1,102 @@
+"""Tests for capability ABCs."""
+
+from __future__ import annotations
+
+import pytest
+
+from sera_plugin_sdk.capabilities import (
+    Capability,
+    ContextDiagnostics,
+    ContextEngine,
+    ContextQuery,
+    MemoryBackend,
+)
+from sera_plugin_sdk.types import (
+    AssembleBudget,
+    AssembledContext,
+    CtxSearchRequest,
+    CtxSearchResponse,
+    DescribeRequest,
+    DescribeResponse,
+    DoctorReport,
+    ExpandRequest,
+    ExpandResponse,
+    IngestAck,
+    IngestMessage,
+    MemoryQuery,
+    MemoryRecord,
+    StatusResponse,
+    StoreAck,
+)
+
+
+def test_memory_backend_cannot_be_instantiated_abstract() -> None:
+    with pytest.raises(TypeError):
+        MemoryBackend()  # type: ignore[abstract]
+
+
+def test_context_engine_cannot_be_instantiated_abstract() -> None:
+    with pytest.raises(TypeError):
+        ContextEngine()  # type: ignore[abstract]
+
+
+def test_partial_implementation_still_abstract() -> None:
+    class Partial(MemoryBackend):
+        async def store(self, record: MemoryRecord) -> StoreAck:
+            return StoreAck(key=record.key)
+
+    with pytest.raises(TypeError):
+        Partial()  # type: ignore[abstract]
+
+
+def test_memory_backend_full_impl_instantiates() -> None:
+    class InMem(MemoryBackend):
+        def __init__(self) -> None:
+            self.store_map: dict[str, MemoryRecord] = {}
+
+        async def store(self, record: MemoryRecord) -> StoreAck:
+            self.store_map[record.key] = record
+            return StoreAck(key=record.key)
+
+        async def retrieve(self, key: str) -> MemoryRecord | None:
+            return self.store_map.get(key)
+
+        async def search(self, query: MemoryQuery) -> list[MemoryRecord]:
+            return list(self.store_map.values())[: query.limit]
+
+        async def delete(self, key: str) -> bool:
+            return self.store_map.pop(key, None) is not None
+
+    backend = InMem()
+    assert isinstance(backend, MemoryBackend)
+    assert isinstance(backend, Capability)
+
+
+def test_multi_inheritance_context_triad() -> None:
+    class LcmLike(ContextEngine, ContextQuery, ContextDiagnostics):
+        async def ingest(self, msg: IngestMessage) -> IngestAck:
+            return IngestAck(accepted=True)
+
+        async def assemble(self, budget: AssembleBudget) -> AssembledContext:
+            return AssembledContext()
+
+        async def search(self, req: CtxSearchRequest) -> CtxSearchResponse:
+            return CtxSearchResponse()
+
+        async def describe(self, req: DescribeRequest) -> DescribeResponse:
+            return DescribeResponse(node_id=req.node_id)
+
+        async def expand(self, req: ExpandRequest) -> ExpandResponse:
+            return ExpandResponse(node_id=req.node_id)
+
+        async def status(self, session_id: str) -> StatusResponse:
+            return StatusResponse(fields_json="{}")
+
+        async def doctor(self) -> DoctorReport:
+            return DoctorReport()
+
+    plugin = LcmLike()
+    assert isinstance(plugin, ContextEngine)
+    assert isinstance(plugin, ContextQuery)
+    assert isinstance(plugin, ContextDiagnostics)
+    assert isinstance(plugin, Capability)

--- a/sdk/python/sera-plugin-sdk/tests/test_errors.py
+++ b/sdk/python/sera-plugin-sdk/tests/test_errors.py
@@ -1,0 +1,54 @@
+"""Tests for :mod:`sera_plugin_sdk.errors`."""
+
+from __future__ import annotations
+
+import pytest
+
+from sera_plugin_sdk.errors import (
+    PluginCapabilityError,
+    PluginDispatchError,
+    PluginError,
+    PluginRegistrationError,
+    PluginTransportError,
+)
+
+
+def test_plugin_error_defaults_code_and_message() -> None:
+    err = PluginError()
+    assert err.code == "PLUGIN_ERROR"
+    assert err.message == "PLUGIN_ERROR"
+    assert str(err) == "[PLUGIN_ERROR] PLUGIN_ERROR"
+
+
+def test_plugin_error_explicit_code_and_message() -> None:
+    err = PluginError("MY_CODE", "something went wrong")
+    assert err.code == "MY_CODE"
+    assert err.message == "something went wrong"
+    assert str(err) == "[MY_CODE] something went wrong"
+
+
+@pytest.mark.parametrize(
+    ("cls", "expected_code"),
+    [
+        (PluginRegistrationError, "PLUGIN_REGISTRATION_ERROR"),
+        (PluginTransportError, "PLUGIN_TRANSPORT_ERROR"),
+        (PluginDispatchError, "PLUGIN_DISPATCH_ERROR"),
+        (PluginCapabilityError, "PLUGIN_CAPABILITY_ERROR"),
+    ],
+)
+def test_subclass_default_codes(cls: type[PluginError], expected_code: str) -> None:
+    err = cls()
+    assert err.code == expected_code
+    assert isinstance(err, PluginError)
+
+
+def test_subclasses_accept_custom_message() -> None:
+    err = PluginCapabilityError(message="capability X broke")
+    assert err.code == "PLUGIN_CAPABILITY_ERROR"
+    assert err.message == "capability X broke"
+
+
+def test_subclass_code_override_wins() -> None:
+    err = PluginRegistrationError("CUSTOM", "oops")
+    assert err.code == "CUSTOM"
+    assert err.message == "oops"

--- a/sdk/python/sera-plugin-sdk/tests/test_lifecycle.py
+++ b/sdk/python/sera-plugin-sdk/tests/test_lifecycle.py
@@ -1,0 +1,62 @@
+"""Tests for :mod:`sera_plugin_sdk.lifecycle`."""
+
+from __future__ import annotations
+
+import pytest
+
+from sera_plugin_sdk.errors import PluginError
+from sera_plugin_sdk.lifecycle import (
+    LIFECYCLE_ERROR_CODE,
+    call_on_shutdown,
+    call_on_startup,
+)
+
+
+class WithAsyncHooks:
+    def __init__(self) -> None:
+        self.startup_calls = 0
+        self.shutdown_calls = 0
+
+    async def on_startup(self) -> None:
+        self.startup_calls += 1
+
+    async def on_shutdown(self) -> None:
+        self.shutdown_calls += 1
+
+
+class WithSyncStartup:
+    # Intentionally sync to trigger rejection.
+    def on_startup(self) -> None:
+        return None
+
+
+class NoHooks:
+    pass
+
+
+async def test_calls_async_on_startup_exactly_once() -> None:
+    plugin = WithAsyncHooks()
+    await call_on_startup(plugin)
+    assert plugin.startup_calls == 1
+    assert plugin.shutdown_calls == 0
+
+
+async def test_calls_async_on_shutdown_exactly_once() -> None:
+    plugin = WithAsyncHooks()
+    await call_on_shutdown(plugin)
+    assert plugin.shutdown_calls == 1
+    assert plugin.startup_calls == 0
+
+
+async def test_no_hooks_is_noop() -> None:
+    plugin = NoHooks()
+    await call_on_startup(plugin)
+    await call_on_shutdown(plugin)
+
+
+async def test_sync_hook_is_rejected() -> None:
+    plugin = WithSyncStartup()
+    with pytest.raises(PluginError) as excinfo:
+        await call_on_startup(plugin)
+    assert excinfo.value.code == LIFECYCLE_ERROR_CODE
+    assert "on_startup" in excinfo.value.message

--- a/sdk/python/sera-plugin-sdk/tests/test_protocol.py
+++ b/sdk/python/sera-plugin-sdk/tests/test_protocol.py
@@ -1,0 +1,104 @@
+"""Tests for the JSON-RPC 2.0 codec in :mod:`sera_plugin_sdk._protocol`."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from sera_plugin_sdk import _protocol as proto
+from sera_plugin_sdk.errors import (
+    PluginCapabilityError,
+    PluginDispatchError,
+    PluginError,
+    PluginRegistrationError,
+    PluginTransportError,
+)
+
+
+def test_encode_decode_request_roundtrip() -> None:
+    payload = proto.encode_request(42, "ContextEngine.ingest", {"session_id": "s1"})
+    assert payload.endswith(b"\n")
+    request_id, method, params = proto.decode_request(payload.strip())
+    assert request_id == 42
+    assert method == "ContextEngine.ingest"
+    assert params == {"session_id": "s1"}
+
+
+def test_encode_decode_response_roundtrip() -> None:
+    payload = proto.encode_response("req-1", {"ok": True})
+    assert payload.endswith(b"\n")
+    obj = proto.decode_response(payload.strip())
+    assert obj["id"] == "req-1"
+    assert obj["result"] == {"ok": True}
+    assert obj["jsonrpc"] == "2.0"
+
+
+def test_encode_error_includes_data_for_plugin_error() -> None:
+    exc = PluginCapabilityError("LCM_ERR", "engine crashed")
+    payload = proto.encode_error("req-2", exc)
+    obj = json.loads(payload)
+    assert obj["id"] == "req-2"
+    assert obj["error"]["code"] == proto.ERROR_CODE_CAPABILITY
+    assert obj["error"]["data"]["code"] == "LCM_ERR"
+    assert obj["error"]["data"]["message"] == "engine crashed"
+
+
+@pytest.mark.parametrize(
+    ("exc", "expected_code"),
+    [
+        (PluginError(), proto.ERROR_CODE_PLUGIN),
+        (PluginRegistrationError(), proto.ERROR_CODE_REGISTRATION),
+        (PluginTransportError(), proto.ERROR_CODE_TRANSPORT),
+        (PluginDispatchError(), proto.ERROR_CODE_DISPATCH),
+        (PluginCapabilityError(), proto.ERROR_CODE_CAPABILITY),
+        (RuntimeError("boom"), proto.ERROR_CODE_INTERNAL),
+    ],
+)
+def test_error_code_mapping(exc: BaseException, expected_code: int) -> None:
+    payload = proto.encode_error(None, exc)
+    obj = json.loads(payload)
+    assert obj["error"]["code"] == expected_code
+
+
+def test_decode_request_rejects_malformed_json() -> None:
+    with pytest.raises(PluginTransportError):
+        proto.decode_request(b"{not json")
+
+
+def test_decode_request_rejects_non_object() -> None:
+    with pytest.raises(PluginTransportError):
+        proto.decode_request(b"[1,2,3]")
+
+
+def test_decode_request_rejects_bad_version() -> None:
+    with pytest.raises(PluginTransportError):
+        proto.decode_request(b'{"jsonrpc":"1.0","id":1,"method":"X"}')
+
+
+def test_decode_request_rejects_missing_method() -> None:
+    with pytest.raises(PluginTransportError):
+        proto.decode_request(b'{"jsonrpc":"2.0","id":1}')
+
+
+def test_decode_request_rejects_non_object_params() -> None:
+    with pytest.raises(PluginTransportError):
+        proto.decode_request(b'{"jsonrpc":"2.0","id":1,"method":"X","params":"oops"}')
+
+
+def test_decode_request_allows_missing_params() -> None:
+    request_id, method, params = proto.decode_request(
+        b'{"jsonrpc":"2.0","id":1,"method":"PluginRegistry.Heartbeat"}'
+    )
+    assert request_id == 1
+    assert method == "PluginRegistry.Heartbeat"
+    assert params == {}
+
+
+def test_decode_request_allows_notification() -> None:
+    request_id, method, params = proto.decode_request(
+        b'{"jsonrpc":"2.0","method":"PluginRegistry.Heartbeat","params":{}}'
+    )
+    assert request_id is None
+    assert method == "PluginRegistry.Heartbeat"
+    assert params == {}

--- a/sdk/python/sera-plugin-sdk/tests/test_stdio_runtime.py
+++ b/sdk/python/sera-plugin-sdk/tests/test_stdio_runtime.py
@@ -1,0 +1,238 @@
+"""End-to-end stdio transport test.
+
+Wires an in-process plugin to an ``asyncio.StreamReader`` / ``StreamWriter``
+pair backed by an in-memory pipe, then sends JSON-RPC frames and inspects
+the responses.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from sera_plugin_sdk.capabilities import ContextEngine
+from sera_plugin_sdk.transport import stdio as stdio_transport
+from sera_plugin_sdk.types import (
+    AssembleBudget,
+    AssembledContext,
+    IngestAck,
+    IngestMessage,
+)
+
+
+class _FakeEngine(ContextEngine):
+    def __init__(self) -> None:
+        self.startup_calls = 0
+        self.shutdown_calls = 0
+        self.ingested: list[IngestMessage] = []
+
+    async def on_startup(self) -> None:
+        self.startup_calls += 1
+
+    async def on_shutdown(self) -> None:
+        self.shutdown_calls += 1
+
+    async def ingest(self, msg: IngestMessage) -> IngestAck:
+        self.ingested.append(msg)
+        return IngestAck(accepted=True)
+
+    async def assemble(self, budget: AssembleBudget) -> AssembledContext:
+        return AssembledContext(total_tokens=budget.budget_tokens)
+
+
+class _InMemoryWriteTransport(asyncio.WriteTransport):
+    """Funnels ``write`` calls into a target ``StreamReader``.
+
+    Implements the minimum transport protocol surface that ``StreamWriter``
+    needs (``write``, ``close``, ``is_closing``, and signalling
+    ``connection_lost`` on close so ``wait_closed()`` resolves promptly).
+    """
+
+    def __init__(
+        self,
+        target: asyncio.StreamReader,
+        protocol: asyncio.StreamReaderProtocol,
+    ) -> None:
+        super().__init__()
+        self._target = target
+        self._protocol = protocol
+        self._closed = False
+
+    def write(self, data: bytes | bytearray | memoryview) -> None:
+        if not self._closed:
+            self._target.feed_data(bytes(data))
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        self._target.feed_eof()
+        loop = asyncio.get_event_loop()
+        loop.call_soon(self._protocol.connection_lost, None)
+
+    def is_closing(self) -> bool:
+        return self._closed
+
+    def get_write_buffer_size(self) -> int:
+        return 0
+
+    def can_write_eof(self) -> bool:
+        return True
+
+    def write_eof(self) -> None:
+        self.close()
+
+
+def _pipe_writer(target: asyncio.StreamReader) -> asyncio.StreamWriter:
+    """Build a ``StreamWriter`` that funnels writes into ``target``."""
+    loop = asyncio.get_event_loop()
+    # A dummy upstream reader is required by StreamReaderProtocol;
+    # we only care about the protocol's flow-control hooks here.
+    dummy = asyncio.StreamReader()
+    protocol = asyncio.StreamReaderProtocol(dummy)
+    transport = _InMemoryWriteTransport(target, protocol)
+    protocol.connection_made(transport)
+    return asyncio.StreamWriter(transport, protocol, dummy, loop)
+
+
+async def _exchange(
+    plugin: object, lines: list[bytes]
+) -> tuple[list[dict[str, object]], object]:
+    """Drive the stdio server through ``lines`` and collect response frames."""
+    client_to_server = asyncio.StreamReader()
+    server_to_client = asyncio.StreamReader()
+
+    for line in lines:
+        client_to_server.feed_data(line)
+    client_to_server.feed_eof()
+
+    server_writer = _pipe_writer(server_to_client)
+    await stdio_transport.serve(plugin, client_to_server, server_writer)
+
+    responses: list[dict[str, object]] = []
+    while True:
+        line = await server_to_client.readline()
+        if not line:
+            break
+        responses.append(json.loads(line))
+    return responses, plugin
+
+
+def _frame(**payload: object) -> bytes:
+    return (json.dumps({"jsonrpc": "2.0", **payload}) + "\n").encode("utf-8")
+
+
+async def test_heartbeat_returns_ok() -> None:
+    plugin = _FakeEngine()
+    responses, _ = await _exchange(
+        plugin, [_frame(id=1, method="PluginRegistry.Heartbeat", params={})]
+    )
+    assert len(responses) == 1
+    response = responses[0]
+    assert response["jsonrpc"] == "2.0"
+    assert response["id"] == 1
+    result = response["result"]
+    assert isinstance(result, dict)
+    assert result["ok"] is True
+    assert "uptime_seconds" in result
+
+
+async def test_capability_dispatch_ingest() -> None:
+    plugin = _FakeEngine()
+    responses, returned = await _exchange(
+        plugin,
+        [
+            _frame(
+                id="abc",
+                method="ContextEngine.ingest",
+                params={
+                    "session_id": "s1",
+                    "role": "user",
+                    "content": "hello",
+                    "metadata": {"k": "v"},
+                },
+            )
+        ],
+    )
+    assert isinstance(returned, _FakeEngine)
+    assert responses == [
+        {"jsonrpc": "2.0", "id": "abc", "result": {"accepted": True}}
+    ]
+    assert len(returned.ingested) == 1
+    assert returned.ingested[0].session_id == "s1"
+    assert returned.ingested[0].content == "hello"
+
+
+async def test_deregister_triggers_shutdown_hook_and_exits_loop() -> None:
+    plugin = _FakeEngine()
+    responses, _ = await _exchange(
+        plugin, [_frame(id=7, method="PluginRegistry.Deregister", params={})]
+    )
+    assert responses[0]["id"] == 7
+    assert responses[0]["result"] == {}
+    assert plugin.shutdown_calls == 1
+
+
+async def test_shutdown_hook_fires_on_eof() -> None:
+    plugin = _FakeEngine()
+    # No frames at all — just EOF. The serve loop must exit and on_shutdown
+    # must still fire.
+    _, _ = await _exchange(plugin, [])
+    assert plugin.shutdown_calls == 1
+
+
+async def test_unknown_method_returns_dispatch_error() -> None:
+    plugin = _FakeEngine()
+    responses, _ = await _exchange(
+        plugin, [_frame(id=99, method="ContextEngine.does_not_exist", params={})]
+    )
+    assert responses[0]["id"] == 99
+    assert "error" in responses[0]
+    err = responses[0]["error"]
+    assert isinstance(err, dict)
+    assert err["code"] == -32003  # ERROR_CODE_DISPATCH
+
+
+async def test_malformed_input_does_not_crash_loop() -> None:
+    plugin = _FakeEngine()
+    responses, _ = await _exchange(
+        plugin,
+        [
+            b"{not json\n",
+            _frame(id=123, method="PluginRegistry.Heartbeat", params={}),
+        ],
+    )
+    # The malformed frame must not produce a response (no id to route to),
+    # but the subsequent valid frame must be answered.
+    assert len(responses) == 1
+    assert responses[0]["id"] == 123
+    result = responses[0]["result"]
+    assert isinstance(result, dict)
+    assert result["ok"] is True
+
+
+@pytest.mark.parametrize("method", ["PluginRegistry.Heartbeat"])
+async def test_heartbeat_uptime_is_monotonic(method: str) -> None:
+    plugin = _FakeEngine()
+    responses, _ = await _exchange(
+        plugin, [_frame(id=1, method=method, params={})]
+    )
+    result = responses[0]["result"]
+    assert isinstance(result, dict)
+    assert float(result["uptime_seconds"]) >= 0.0
+
+
+async def test_blank_lines_are_skipped() -> None:
+    plugin = _FakeEngine()
+    responses, _ = await _exchange(
+        plugin,
+        [
+            b"\n",
+            b"   \n",
+            _frame(id=5, method="PluginRegistry.Heartbeat", params={}),
+        ],
+    )
+    assert len(responses) == 1
+    assert responses[0]["id"] == 5


### PR DESCRIPTION
## Summary
Lands the first two follow-up beads from the SPEC-plugins dual-transport amendment (SPEC §5.2, parent `sera-xx48`):

- **Python plugin SDK** at `sdk/python/sera-plugin-sdk/` — hatch build backend, Python 3.11+, async ABC capabilities (`MemoryBackend`, `ContextEngine`/`ContextQuery`/`ContextDiagnostics`, `ToolExecutor`, `SandboxProvider`, `AuthProvider`, `SecretProvider`), optional `on_startup`/`on_shutdown` lifecycle hooks, `PluginError` hierarchy mapped to JSON-RPC error codes, NDJSON JSON-RPC 2.0 stdio transport, `grpc.aio` scaffold. Protoc-at-build-time via a Hatch custom build hook (gracefully warns-and-skips when the proto tree is absent so editable installs work standalone).
- **Canonical plugin protos** at `rust/proto/plugin/` — 7 proto3 services in package `sera.plugin.v1` (registry, memory_backend, tool_executor, context_engine triad, sandbox_provider, auth_provider, secret_provider). Each pairs with a hand-maintained JSON Schema draft 2020-12 mirror that describes the stdio JSON-RPC envelope.
- **`validate-sdk-py` CI job** in `.github/workflows/ci.yml` — gated by `dorny/paths-filter@v3` on `sdk/**`, `rust/proto/plugin/**`, or the workflow file itself; runs ruff, mypy (strict), pytest, and `hatch build`.

Rust-side wiring (build.rs codegen in `sera-plugins`, `ManifestSpec.transport:` field) is explicitly out of scope here — tracked as separate follow-up beads under `sera-1bg4` per the amendment.

## Test plan
- [x] `pip install -e '.[dev]'` in a clean venv — succeeds; protoc hook generates 7 proto modules from the newly-created `rust/proto/plugin/*.proto`.
- [x] `pytest -q` — **41 tests pass** (errors, lifecycle, protocol codec, ABC instantiation rules, end-to-end stdio runtime with heartbeat + deregister + on_shutdown).
- [x] `ruff check src tests` — clean.
- [x] `mypy src` in strict mode — clean across 17 source files.
- [x] `hatch build` — produces wheel + sdist; proto codegen confirmed.
- [x] `protoc --dry_run rust/proto/plugin/*.proto` — compiles.
- [x] All seven `.schema.json` mirrors parse as valid JSON.
- [ ] CI job passes on this PR (first real run).

## Spec references
- [SPEC-plugins §5 — Plugin SDK](docs/plan/specs/SPEC-plugins.md)
- [SPEC-plugins §5.1 — Schema canonicalisation](docs/plan/specs/SPEC-plugins.md)
- [SPEC-plugins §5.2 — SDK follow-up beads](docs/plan/specs/SPEC-plugins.md)
- [SPEC-plugins §2.3 — Transport](docs/plan/specs/SPEC-plugins.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)