### PR TITLE
feat(sera-gateway): two-layer session persistence — PartTable + shadow git (sera-r9ed)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2130,6 +2130,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "git2"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2977,6 +2990,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.17.0+1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3001,6 +3026,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
  "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
+dependencies = [
+ "cc",
+ "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -5103,6 +5140,7 @@ dependencies = [
  "clap",
  "cron 0.13.0",
  "futures-util",
+ "git2",
  "hex",
  "insta",
  "jsonwebtoken",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -113,7 +113,7 @@ tokio-util = "0.7"
 
 # Knowledge / Vector
 qdrant-client = "1"
-git2 = "0.19"
+git2 = { version = "0.19", default-features = false }
 
 # OIDC
 openidconnect = "4"

--- a/rust/crates/sera-gateway/Cargo.toml
+++ b/rust/crates/sera-gateway/Cargo.toml
@@ -56,8 +56,10 @@ tokio-stream.workspace = true
 tokio-util.workspace = true
 async-stream.workspace = true
 futures-util.workspace = true
-# qdrant-client and git2 deferred — native deps need Docker build env
+# qdrant-client deferred — native deps need Docker build env
 # openidconnect deferred — uses reqwest directly for token exchange
+# git2 backs the shadow-repo half of two-layer session persistence (sera-r9ed).
+git2.workspace = true
 rand.workspace = true
 cron.workspace = true
 chrono.workspace = true

--- a/rust/crates/sera-gateway/src/lib.rs
+++ b/rust/crates/sera-gateway/src/lib.rs
@@ -8,9 +8,10 @@ pub mod harness_dispatch;
 pub mod kill_switch;
 pub mod party;
 pub mod plugin;
-pub mod signals;
 pub mod process_manager;
 pub mod session_persist;
+pub mod session_store;
+pub mod signals;
 pub mod transcript_persist;
 pub mod transport;
 

--- a/rust/crates/sera-gateway/src/session_store.rs
+++ b/rust/crates/sera-gateway/src/session_store.rs
@@ -1,0 +1,689 @@
+//! Two-layer session persistence — `SessionStore` (sera-r9ed, Phase 1).
+//!
+//! Per SPEC-gateway §6.1b, the gateway keeps current session state in a SQLite
+//! **PartTable** and pushes an audit-grade replay log into a **shadow git**
+//! repo. PartTable rows reference a commit SHA on the shadow repo; replaying
+//! from that SHA reproduces the session byte-for-byte.
+//!
+//! This module exposes:
+//!
+//! * [`SessionStore`] — the trait the gateway session lifecycle calls into.
+//! * [`SqliteGitSessionStore`] — the default implementation backing PartTable
+//!   by SQLite (via `rusqlite`, following the [`sera_db::signals`] pattern)
+//!   and the shadow repo by bare `git2` repositories on disk.
+//!
+//! Each submission (with its emitted events) becomes exactly **one** commit on
+//! `refs/heads/main` in a per-session bare repo at
+//! `<data_root>/sessions/<session_id>/git`. The commit's tree contains:
+//!
+//! * `submission.json` — serialized [`sera_types::envelope::Submission`]
+//! * `emissions/<0000>.json` … `emissions/<NNNN>.json` — serialized
+//!   [`sera_types::envelope::Event`]s in emission order
+//!
+//! The head SHA of that commit is the durable [`SubmissionRef`]; PartTable
+//! stores it as the session head plus one row per part for fast indexed
+//! access.
+//!
+//! # Minimal API
+//!
+//! The trait intentionally exposes only what the sera-r1g8 envelope wrapping
+//! needs. More session methods will arrive in a follow-up when the route
+//! layer asks for them.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use rusqlite::{Connection, OptionalExtension, params};
+use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
+
+use sera_types::envelope::{Event, Submission};
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/// Reference to an appended submission — a session-scoped (commit, index)
+/// pair. Equality is structural; the commit SHA alone uniquely identifies the
+/// entry within a session.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SubmissionRef {
+    pub session_id: String,
+    /// Full (40-hex) commit SHA on `refs/heads/main`.
+    pub commit: String,
+    /// Zero-based position in the session's submission chain.
+    pub index: u64,
+}
+
+/// Bundle persisted atomically for one gateway turn — the inbound
+/// [`Submission`] and every outbound [`Event`] it produced.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StoredSubmission {
+    pub submission: Submission,
+    #[serde(default)]
+    pub emissions: Vec<Event>,
+}
+
+/// Errors surfaced by [`SessionStore`] implementations.
+#[derive(Debug, thiserror::Error)]
+pub enum SessionStoreError {
+    #[error("sqlite error: {0}")]
+    Sqlite(#[from] rusqlite::Error),
+    #[error("git error: {0}")]
+    Git(#[from] git2::Error),
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("serialization error: {0}")]
+    Serde(#[from] serde_json::Error),
+    #[error("session head moved under us for session {session_id}")]
+    HeadConflict { session_id: String },
+}
+
+// ---------------------------------------------------------------------------
+// Trait
+// ---------------------------------------------------------------------------
+
+/// Two-layer session persistence contract.
+///
+/// Implementations MUST make [`append_submission`](Self::append_submission)
+/// atomic with respect to concurrent callers targetting the same
+/// `session_id`: PartTable rows and the shadow-repo HEAD must both point at
+/// the new commit before any subsequent call observes either, and two racing
+/// callers must serialize so neither loses a write.
+#[async_trait]
+pub trait SessionStore: Send + Sync {
+    /// Append a submission + its emissions to the session. Returns the new
+    /// head reference.
+    async fn append_submission(
+        &self,
+        session_id: &str,
+        bundle: &StoredSubmission,
+    ) -> Result<SubmissionRef, SessionStoreError>;
+
+    /// Return the current head ref for `session_id`, or `None` if the
+    /// session has no submissions yet.
+    async fn head(&self, session_id: &str) -> Result<Option<SubmissionRef>, SessionStoreError>;
+
+    /// Replay every submission for `session_id` in the order it was appended.
+    async fn replay(&self, session_id: &str) -> Result<Vec<Submission>, SessionStoreError>;
+}
+
+// ---------------------------------------------------------------------------
+// SqliteGitSessionStore
+// ---------------------------------------------------------------------------
+
+/// PartTable (SQLite) + shadow-git backed [`SessionStore`].
+///
+/// Construct via [`SqliteGitSessionStore::open`] for normal use or
+/// [`SqliteGitSessionStore::open_with_conn`] when the SQLite connection is
+/// shared with other gateway tables.
+#[derive(Clone)]
+pub struct SqliteGitSessionStore {
+    conn: Arc<Mutex<Connection>>,
+    /// Root containing per-session bare repos at `<root>/<session_id>/git`.
+    sessions_root: PathBuf,
+}
+
+impl SqliteGitSessionStore {
+    /// Create the PartTable schema. Idempotent.
+    pub fn init_schema(conn: &Connection) -> rusqlite::Result<()> {
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS session_heads (
+                session_id TEXT PRIMARY KEY,
+                head_commit TEXT NOT NULL,
+                head_index INTEGER NOT NULL,
+                updated_at INTEGER NOT NULL
+             );
+
+             CREATE TABLE IF NOT EXISTS session_parts (
+                session_id TEXT NOT NULL,
+                part_index INTEGER NOT NULL,
+                commit_sha TEXT NOT NULL,
+                submission_id TEXT NOT NULL,
+                emission_count INTEGER NOT NULL,
+                op_kind TEXT NOT NULL,
+                created_at INTEGER NOT NULL,
+                PRIMARY KEY (session_id, part_index)
+             );
+             CREATE INDEX IF NOT EXISTS idx_session_parts_session
+                ON session_parts(session_id, part_index);
+             CREATE INDEX IF NOT EXISTS idx_session_parts_commit
+                ON session_parts(commit_sha);",
+        )
+    }
+
+    /// Open a store rooted at `sessions_root`, creating the root directory and
+    /// SQLite schema if missing. `db_path` is a single-file SQLite database.
+    pub fn open(
+        db_path: impl AsRef<Path>,
+        sessions_root: impl Into<PathBuf>,
+    ) -> Result<Self, SessionStoreError> {
+        let conn = Connection::open(db_path.as_ref())?;
+        Self::init_schema(&conn)?;
+        let sessions_root = sessions_root.into();
+        std::fs::create_dir_all(&sessions_root)?;
+        Ok(Self {
+            conn: Arc::new(Mutex::new(conn)),
+            sessions_root,
+        })
+    }
+
+    /// Open against an existing shared connection. The caller is responsible
+    /// for calling [`init_schema`](Self::init_schema) before first use.
+    pub fn open_with_conn(
+        conn: Arc<Mutex<Connection>>,
+        sessions_root: impl Into<PathBuf>,
+    ) -> Result<Self, SessionStoreError> {
+        let sessions_root = sessions_root.into();
+        std::fs::create_dir_all(&sessions_root)?;
+        Ok(Self {
+            conn,
+            sessions_root,
+        })
+    }
+
+    fn repo_path(&self, session_id: &str) -> PathBuf {
+        self.sessions_root.join(session_id).join("git")
+    }
+
+    /// Shared deterministic signature — replay stays byte-for-byte identical
+    /// across runs regardless of the operator's git config.
+    fn signature<'a>() -> Result<git2::Signature<'a>, git2::Error> {
+        // Fixed epoch (2026-01-01T00:00:00Z) so replay is reproducible; the
+        // submission's own timestamps live inside the JSON payload.
+        git2::Signature::new(
+            "sera-gateway",
+            "sera-gateway@sera.local",
+            &git2::Time::new(1_767_225_600, 0),
+        )
+    }
+}
+
+// Internal helpers that need Repository borrows but are pure enough to keep
+// outside the `impl SessionStore` block.
+
+fn write_bundle_tree(
+    repo: &git2::Repository,
+    bundle: &StoredSubmission,
+) -> Result<git2::Oid, SessionStoreError> {
+    // Top-level entries: submission.json + emissions/ tree.
+    let submission_blob = repo.blob(&serde_json::to_vec_pretty(&bundle.submission)?)?;
+
+    let mut emissions_tb = repo.treebuilder(None)?;
+    for (i, event) in bundle.emissions.iter().enumerate() {
+        let name = format!("{i:04}.json");
+        let blob = repo.blob(&serde_json::to_vec_pretty(event)?)?;
+        emissions_tb.insert(&name, blob, git2::FileMode::Blob.into())?;
+    }
+    let emissions_tree = emissions_tb.write()?;
+
+    let mut root_tb = repo.treebuilder(None)?;
+    root_tb.insert(
+        "submission.json",
+        submission_blob,
+        git2::FileMode::Blob.into(),
+    )?;
+    root_tb.insert("emissions", emissions_tree, git2::FileMode::Tree.into())?;
+    Ok(root_tb.write()?)
+}
+
+fn op_kind_label(sub: &Submission) -> &'static str {
+    use sera_types::envelope::Op;
+    match &sub.op {
+        Op::UserTurn { .. } => "user_turn",
+        Op::Steer { .. } => "steer",
+        Op::Interrupt => "interrupt",
+        Op::System(_) => "system",
+        Op::ApprovalResponse { .. } => "approval_response",
+        Op::Register(_) => "register",
+    }
+}
+
+fn now_secs() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+#[async_trait]
+impl SessionStore for SqliteGitSessionStore {
+    async fn append_submission(
+        &self,
+        session_id: &str,
+        bundle: &StoredSubmission,
+    ) -> Result<SubmissionRef, SessionStoreError> {
+        // Single connection-level lock serialises concurrent writers to the
+        // same session (and, acceptably, to other sessions sharing this store;
+        // PartTable writes are O(µs) so contention is negligible). This
+        // guarantees the git HEAD + SQL head_commit flip happens atomically.
+        let conn = self.conn.lock().await;
+
+        // Pin the prior head so we can (a) parent the new commit and (b)
+        // detect index collisions if something ever bypassed the mutex.
+        let prior: Option<(String, i64)> = conn
+            .query_row(
+                "SELECT head_commit, head_index FROM session_heads WHERE session_id = ?1",
+                params![session_id],
+                |row| Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?)),
+            )
+            .optional()?;
+
+        let next_index: u64 = match &prior {
+            Some((_, idx)) => (*idx as u64) + 1,
+            None => 0,
+        };
+
+        // Write the new commit to the shadow repo. Git IO is blocking; spawn
+        // it onto a blocking thread so the async runtime stays responsive.
+        let repo_path = self.repo_path(session_id);
+        let parent_commit = prior.as_ref().map(|(sha, _)| sha.clone());
+        let bundle_owned = bundle.clone();
+        let new_commit =
+            tokio::task::spawn_blocking(move || -> Result<String, SessionStoreError> {
+                // Ensure the bare repo exists.
+                let repo = if repo_path.join("HEAD").exists() {
+                    git2::Repository::open_bare(&repo_path)?
+                } else {
+                    std::fs::create_dir_all(&repo_path)?;
+                    git2::Repository::init_bare(&repo_path)?
+                };
+
+                let tree_oid = write_bundle_tree(&repo, &bundle_owned)?;
+                let tree = repo.find_tree(tree_oid)?;
+                let sig = SqliteGitSessionStore::signature()?;
+
+                let parents_owned: Vec<git2::Commit> = match parent_commit.as_deref() {
+                    Some(sha) => {
+                        let oid = git2::Oid::from_str(sha)?;
+                        vec![repo.find_commit(oid)?]
+                    }
+                    None => Vec::new(),
+                };
+                let parents_ref: Vec<&git2::Commit> = parents_owned.iter().collect();
+
+                let message = format!("submission {}\n", bundle_owned.submission.id);
+                let commit_oid = repo.commit(
+                    Some("refs/heads/main"),
+                    &sig,
+                    &sig,
+                    &message,
+                    &tree,
+                    &parents_ref,
+                )?;
+                Ok(commit_oid.to_string())
+            })
+            .await
+            .map_err(|e| SessionStoreError::Io(std::io::Error::other(e.to_string())))??;
+
+        // Flip PartTable rows — INSERT new part then UPSERT the head. If any
+        // step fails SQLite rolls back the transaction and we bubble up.
+        let now = now_secs();
+        let op_kind = op_kind_label(&bundle.submission).to_string();
+        let submission_id = bundle.submission.id.to_string();
+        let emission_count = bundle.emissions.len() as i64;
+
+        conn.execute_batch("BEGIN IMMEDIATE")?;
+        let tx_result: Result<(), SessionStoreError> = (|| {
+            conn.execute(
+                "INSERT INTO session_parts
+                    (session_id, part_index, commit_sha, submission_id,
+                     emission_count, op_kind, created_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                params![
+                    session_id,
+                    next_index as i64,
+                    new_commit,
+                    submission_id,
+                    emission_count,
+                    op_kind,
+                    now,
+                ],
+            )?;
+            conn.execute(
+                "INSERT INTO session_heads
+                    (session_id, head_commit, head_index, updated_at)
+                 VALUES (?1, ?2, ?3, ?4)
+                 ON CONFLICT(session_id) DO UPDATE SET
+                    head_commit = excluded.head_commit,
+                    head_index = excluded.head_index,
+                    updated_at = excluded.updated_at",
+                params![session_id, new_commit, next_index as i64, now],
+            )?;
+            Ok(())
+        })();
+
+        match tx_result {
+            Ok(()) => {
+                conn.execute_batch("COMMIT")?;
+            }
+            Err(e) => {
+                let _ = conn.execute_batch("ROLLBACK");
+                return Err(e);
+            }
+        }
+
+        Ok(SubmissionRef {
+            session_id: session_id.to_string(),
+            commit: new_commit,
+            index: next_index,
+        })
+    }
+
+    async fn head(&self, session_id: &str) -> Result<Option<SubmissionRef>, SessionStoreError> {
+        let conn = self.conn.lock().await;
+        let row: Option<(String, i64)> = conn
+            .query_row(
+                "SELECT head_commit, head_index FROM session_heads WHERE session_id = ?1",
+                params![session_id],
+                |row| Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?)),
+            )
+            .optional()?;
+        Ok(row.map(|(commit, index)| SubmissionRef {
+            session_id: session_id.to_string(),
+            commit,
+            index: index as u64,
+        }))
+    }
+
+    async fn replay(&self, session_id: &str) -> Result<Vec<Submission>, SessionStoreError> {
+        // Walk the git history back from HEAD so replay reflects the shadow
+        // repo directly — PartTable is only the index; the audit log lives in
+        // git.
+        let head = self.head(session_id).await?;
+        let Some(head) = head else {
+            return Ok(Vec::new());
+        };
+        let repo_path = self.repo_path(session_id);
+
+        tokio::task::spawn_blocking(move || -> Result<Vec<Submission>, SessionStoreError> {
+            let repo = git2::Repository::open_bare(&repo_path)?;
+            let mut revwalk = repo.revwalk()?;
+            revwalk.push(git2::Oid::from_str(&head.commit)?)?;
+            // Default order is topological newest-first; we want oldest-first.
+            revwalk.set_sorting(git2::Sort::TOPOLOGICAL | git2::Sort::REVERSE)?;
+
+            let mut out = Vec::with_capacity(head.index as usize + 1);
+            for oid in revwalk {
+                let oid = oid?;
+                let commit = repo.find_commit(oid)?;
+                let tree = commit.tree()?;
+                let entry = tree
+                    .get_name("submission.json")
+                    .ok_or_else(|| git2::Error::from_str("submission.json missing"))?;
+                let blob = repo.find_blob(entry.id())?;
+                let sub: Submission = serde_json::from_slice(blob.content())?;
+                out.push(sub);
+            }
+            Ok(out)
+        })
+        .await
+        .map_err(|e| SessionStoreError::Io(std::io::Error::other(e.to_string())))?
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sera_types::content_block::ContentBlock;
+    use sera_types::envelope::{EventMsg, Op, W3cTraceContext};
+    use tempfile::TempDir;
+
+    fn user_turn(text: &str) -> Submission {
+        Submission {
+            id: uuid::Uuid::new_v4(),
+            op: Op::UserTurn {
+                items: vec![ContentBlock::Text {
+                    text: text.to_string(),
+                }],
+                cwd: None,
+                approval_policy: None,
+                sandbox_policy: None,
+                model_override: None,
+                effort: None,
+                final_output_schema: None,
+            },
+            trace: W3cTraceContext::default(),
+            change_artifact: None,
+        }
+    }
+
+    fn event(submission_id: uuid::Uuid, delta: &str) -> Event {
+        Event {
+            id: uuid::Uuid::new_v4(),
+            submission_id,
+            msg: EventMsg::StreamingDelta {
+                delta: delta.to_string(),
+            },
+            trace: W3cTraceContext::default(),
+            timestamp: chrono::Utc::now(),
+        }
+    }
+
+    fn fresh_store() -> (SqliteGitSessionStore, TempDir) {
+        let dir = TempDir::new().unwrap();
+        let db = dir.path().join("parts.sqlite");
+        let sessions = dir.path().join("sessions");
+        let store = SqliteGitSessionStore::open(&db, &sessions).unwrap();
+        (store, dir)
+    }
+
+    #[tokio::test]
+    async fn init_schema_idempotent() {
+        let conn = Connection::open_in_memory().unwrap();
+        SqliteGitSessionStore::init_schema(&conn).unwrap();
+        SqliteGitSessionStore::init_schema(&conn).unwrap();
+        SqliteGitSessionStore::init_schema(&conn).unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn head_returns_none_for_unknown_session() {
+        let (store, _d) = fresh_store();
+        assert!(store.head("nope").await.unwrap().is_none());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn append_then_head_returns_latest() {
+        let (store, _d) = fresh_store();
+        let bundle = StoredSubmission {
+            submission: user_turn("hello"),
+            emissions: vec![],
+        };
+        let refa = store.append_submission("s1", &bundle).await.unwrap();
+        assert_eq!(refa.session_id, "s1");
+        assert_eq!(refa.index, 0);
+        assert_eq!(refa.commit.len(), 40);
+
+        let head = store.head("s1").await.unwrap().unwrap();
+        assert_eq!(head, refa);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn append_increments_index_and_parents_commit() {
+        let (store, _d) = fresh_store();
+        let b1 = StoredSubmission {
+            submission: user_turn("one"),
+            emissions: vec![],
+        };
+        let b2 = StoredSubmission {
+            submission: user_turn("two"),
+            emissions: vec![],
+        };
+
+        let r1 = store.append_submission("s1", &b1).await.unwrap();
+        let r2 = store.append_submission("s1", &b2).await.unwrap();
+        assert_eq!(r1.index, 0);
+        assert_eq!(r2.index, 1);
+        assert_ne!(r1.commit, r2.commit);
+
+        // r2's commit should list r1's commit as its parent in the shadow repo.
+        let repo = git2::Repository::open_bare(store.repo_path("s1")).unwrap();
+        let c2 = repo
+            .find_commit(git2::Oid::from_str(&r2.commit).unwrap())
+            .unwrap();
+        assert_eq!(c2.parent_count(), 1);
+        assert_eq!(c2.parent(0).unwrap().id().to_string(), r1.commit);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn replay_returns_submissions_in_order() {
+        let (store, _d) = fresh_store();
+        let texts = ["one", "two", "three", "four"];
+        let mut appended_ids = Vec::new();
+        for t in &texts {
+            let sub = user_turn(t);
+            appended_ids.push(sub.id);
+            let bundle = StoredSubmission {
+                submission: sub,
+                emissions: vec![],
+            };
+            store.append_submission("s1", &bundle).await.unwrap();
+        }
+        let replayed = store.replay("s1").await.unwrap();
+        assert_eq!(replayed.len(), 4);
+        let replayed_ids: Vec<_> = replayed.iter().map(|s| s.id).collect();
+        assert_eq!(replayed_ids, appended_ids);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn replay_is_byte_for_byte_deterministic() {
+        let (store, _d) = fresh_store();
+        let sub = user_turn("deterministic");
+        let sub_id = sub.id;
+        let ev = event(sub_id, "hi");
+        let bundle = StoredSubmission {
+            submission: sub,
+            emissions: vec![ev],
+        };
+        let r1 = store.append_submission("s1", &bundle).await.unwrap();
+
+        // Re-open the store (fresh conn, same on-disk state) — the head commit
+        // must be byte-for-byte identical, i.e. the same SHA.
+        let db_path = store.sessions_root.parent().unwrap().join("parts.sqlite");
+        drop(store);
+        let reopened =
+            SqliteGitSessionStore::open(&db_path, db_path.with_file_name("sessions")).unwrap();
+        let head2 = reopened.head("s1").await.unwrap().unwrap();
+        assert_eq!(
+            head2.commit, r1.commit,
+            "head sha must be stable across reopens"
+        );
+        let replayed = reopened.replay("s1").await.unwrap();
+        assert_eq!(replayed.len(), 1);
+        assert_eq!(replayed[0].id, sub_id);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn concurrent_appends_to_same_session_are_serialised() {
+        let (store, _d) = fresh_store();
+        let store = Arc::new(store);
+        let n = 16;
+        let mut handles = Vec::new();
+        for i in 0..n {
+            let s = Arc::clone(&store);
+            handles.push(tokio::spawn(async move {
+                let bundle = StoredSubmission {
+                    submission: user_turn(&format!("msg-{i}")),
+                    emissions: vec![],
+                };
+                s.append_submission("s1", &bundle).await.unwrap()
+            }));
+        }
+        let mut refs = Vec::new();
+        for h in handles {
+            refs.push(h.await.unwrap());
+        }
+
+        // Exactly n distinct indices 0..n appeared, the head matches the
+        // highest-index ref, and no two commits collide.
+        let mut indices: Vec<u64> = refs.iter().map(|r| r.index).collect();
+        indices.sort();
+        assert_eq!(indices, (0..n as u64).collect::<Vec<_>>());
+
+        let mut commits: Vec<&str> = refs.iter().map(|r| r.commit.as_str()).collect();
+        commits.sort();
+        commits.dedup();
+        assert_eq!(
+            commits.len(),
+            n,
+            "each submission must have a unique commit"
+        );
+
+        let head = store.head("s1").await.unwrap().unwrap();
+        assert_eq!(head.index, (n as u64) - 1);
+
+        // Replay should yield n submissions.
+        let replayed = store.replay("s1").await.unwrap();
+        assert_eq!(replayed.len(), n);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn emissions_land_in_git_tree() {
+        let (store, _d) = fresh_store();
+        let sub = user_turn("carrying emissions");
+        let sub_id = sub.id;
+        let bundle = StoredSubmission {
+            submission: sub,
+            emissions: vec![event(sub_id, "alpha"), event(sub_id, "beta")],
+        };
+        let r = store.append_submission("s1", &bundle).await.unwrap();
+
+        let repo = git2::Repository::open_bare(store.repo_path("s1")).unwrap();
+        let commit = repo
+            .find_commit(git2::Oid::from_str(&r.commit).unwrap())
+            .unwrap();
+        let tree = commit.tree().unwrap();
+        let emissions_entry = tree.get_name("emissions").expect("emissions tree present");
+        let emissions_tree = repo
+            .find_tree(emissions_entry.id())
+            .expect("emissions is a tree");
+        let names: Vec<String> = emissions_tree
+            .iter()
+            .map(|e| e.name().unwrap().to_string())
+            .collect();
+        assert_eq!(
+            names,
+            vec!["0000.json".to_string(), "0001.json".to_string()]
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn part_rows_track_session_and_index() {
+        let (store, _d) = fresh_store();
+        let b1 = StoredSubmission {
+            submission: user_turn("a"),
+            emissions: vec![],
+        };
+        let b2 = StoredSubmission {
+            submission: user_turn("b"),
+            emissions: vec![],
+        };
+        store.append_submission("alpha", &b1).await.unwrap();
+        store.append_submission("beta", &b2).await.unwrap();
+
+        let conn = store.conn.lock().await;
+        let mut stmt = conn
+            .prepare(
+                "SELECT session_id, part_index, op_kind
+                 FROM session_parts ORDER BY session_id, part_index",
+            )
+            .unwrap();
+        let rows: Vec<(String, i64, String)> = stmt
+            .query_map([], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)))
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap();
+        assert_eq!(
+            rows,
+            vec![
+                ("alpha".to_string(), 0, "user_turn".to_string()),
+                ("beta".to_string(), 0, "user_turn".to_string()),
+            ]
+        );
+    }
+}

--- a/rust/crates/sera-gateway/tests/session_store_integration.rs
+++ b/rust/crates/sera-gateway/tests/session_store_integration.rs
@@ -1,0 +1,212 @@
+//! End-to-end integration test for `sera-r9ed` two-layer session
+//! persistence: submit envelopes, commit to the shadow repo, replay from the
+//! SHA alone, and verify byte-for-byte reproduction of the PartTable state.
+
+use std::sync::Arc;
+
+use sera_gateway::session_store::{
+    SessionStore, SqliteGitSessionStore, StoredSubmission, SubmissionRef,
+};
+use sera_types::content_block::ContentBlock;
+use sera_types::envelope::{Event, EventMsg, Op, Submission, W3cTraceContext};
+use tempfile::TempDir;
+
+fn new_store() -> (SqliteGitSessionStore, TempDir) {
+    let dir = TempDir::new().unwrap();
+    let db = dir.path().join("parts.sqlite");
+    let sessions = dir.path().join("sessions");
+    let store = SqliteGitSessionStore::open(&db, &sessions).unwrap();
+    (store, dir)
+}
+
+fn turn(text: &str) -> Submission {
+    Submission {
+        id: uuid::Uuid::new_v4(),
+        op: Op::UserTurn {
+            items: vec![ContentBlock::Text {
+                text: text.to_string(),
+            }],
+            cwd: None,
+            approval_policy: None,
+            sandbox_policy: None,
+            model_override: None,
+            effort: None,
+            final_output_schema: None,
+        },
+        trace: W3cTraceContext::default(),
+        change_artifact: None,
+    }
+}
+
+fn streaming_event(submission_id: uuid::Uuid, delta: &str) -> Event {
+    Event {
+        id: uuid::Uuid::new_v4(),
+        submission_id,
+        msg: EventMsg::StreamingDelta {
+            delta: delta.to_string(),
+        },
+        // Freeze timestamp to keep the assertion stable if someone reruns.
+        trace: W3cTraceContext::default(),
+        timestamp: chrono::DateTime::<chrono::Utc>::from_timestamp(1_767_225_600, 0).unwrap(),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn submission_commit_replay_full_cycle() {
+    let (store, _dir) = new_store();
+
+    // Turn 1 — one submission, two emissions.
+    let sub1 = turn("hello");
+    let sub1_id = sub1.id;
+    let bundle1 = StoredSubmission {
+        submission: sub1,
+        emissions: vec![
+            streaming_event(sub1_id, "he"),
+            streaming_event(sub1_id, "llo"),
+        ],
+    };
+    let ref1 = store.append_submission("sess-A", &bundle1).await.unwrap();
+
+    // Turn 2 — only a submission.
+    let sub2 = turn("goodbye");
+    let sub2_id = sub2.id;
+    let bundle2 = StoredSubmission {
+        submission: sub2,
+        emissions: vec![],
+    };
+    let ref2 = store.append_submission("sess-A", &bundle2).await.unwrap();
+
+    // Head matches the most recent append.
+    let head = store.head("sess-A").await.unwrap().unwrap();
+    assert_eq!(head, ref2);
+    assert_eq!(ref1.index, 0);
+    assert_eq!(ref2.index, 1);
+
+    // Replay returns both submissions in append order.
+    let replayed = store.replay("sess-A").await.unwrap();
+    assert_eq!(replayed.len(), 2);
+    assert_eq!(replayed[0].id, sub1_id);
+    assert_eq!(replayed[1].id, sub2_id);
+
+    // Other sessions are isolated.
+    assert!(store.head("sess-B").await.unwrap().is_none());
+    assert!(store.replay("sess-B").await.unwrap().is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn replay_from_sha_alone_reproduces_session_state() {
+    let (store, dir) = new_store();
+
+    // Build up a session.
+    let mut submitted_ids = Vec::new();
+    let mut last_ref: Option<SubmissionRef> = None;
+    for text in ["a", "b", "c"] {
+        let sub = turn(text);
+        submitted_ids.push(sub.id);
+        let bundle = StoredSubmission {
+            submission: sub,
+            emissions: vec![],
+        };
+        last_ref = Some(store.append_submission("s", &bundle).await.unwrap());
+    }
+    let last_ref = last_ref.unwrap();
+
+    // Drop the store and open a fresh one against the same on-disk state —
+    // nothing else is needed to replay.
+    drop(store);
+    let reopened =
+        SqliteGitSessionStore::open(dir.path().join("parts.sqlite"), dir.path().join("sessions"))
+            .unwrap();
+
+    let head = reopened.head("s").await.unwrap().unwrap();
+    assert_eq!(
+        head.commit, last_ref.commit,
+        "head SHA must survive reopen byte-for-byte"
+    );
+
+    let replayed = reopened.replay("s").await.unwrap();
+    let replayed_ids: Vec<_> = replayed.iter().map(|s| s.id).collect();
+    assert_eq!(replayed_ids, submitted_ids);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_writers_to_same_session_preserve_order_and_atomic_head() {
+    let (store, _dir) = new_store();
+    let store = Arc::new(store);
+
+    let total = 24;
+    let mut handles = Vec::with_capacity(total);
+    for i in 0..total {
+        let s = Arc::clone(&store);
+        handles.push(tokio::spawn(async move {
+            let bundle = StoredSubmission {
+                submission: turn(&format!("msg-{i}")),
+                emissions: vec![],
+            };
+            s.append_submission("race", &bundle).await.unwrap()
+        }));
+    }
+    let mut results = Vec::new();
+    for h in handles {
+        results.push(h.await.unwrap());
+    }
+
+    // Every writer got a distinct index 0..total and a distinct commit SHA —
+    // the head moved atomically, no two submissions ever produced the same
+    // parent chain position.
+    let mut indices: Vec<u64> = results.iter().map(|r| r.index).collect();
+    indices.sort();
+    assert_eq!(indices, (0..total as u64).collect::<Vec<_>>());
+
+    let mut commits: Vec<String> = results.iter().map(|r| r.commit.clone()).collect();
+    commits.sort();
+    commits.dedup();
+    assert_eq!(commits.len(), total, "no two commits may collide");
+
+    // Final head == highest index's commit.
+    let head = store.head("race").await.unwrap().unwrap();
+    assert_eq!(head.index, (total as u64) - 1);
+
+    // And replay yields exactly `total` submissions in a linear chain.
+    let replayed = store.replay("race").await.unwrap();
+    assert_eq!(replayed.len(), total);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn shadow_repo_tree_structure_matches_spec() {
+    let (store, _dir) = new_store();
+    let sub = turn("structure");
+    let sub_id = sub.id;
+    let bundle = StoredSubmission {
+        submission: sub,
+        emissions: vec![streaming_event(sub_id, "x"), streaming_event(sub_id, "y")],
+    };
+    let r = store.append_submission("s", &bundle).await.unwrap();
+
+    // Open the on-disk bare repo directly and assert the layout:
+    //   submission.json (blob)
+    //   emissions/0000.json (blob)
+    //   emissions/0001.json (blob)
+    let repo_path = _dir.path().join("sessions").join("s").join("git");
+    let repo = git2::Repository::open_bare(&repo_path).unwrap();
+    let commit = repo
+        .find_commit(git2::Oid::from_str(&r.commit).unwrap())
+        .unwrap();
+    let tree = commit.tree().unwrap();
+
+    assert!(
+        tree.get_name("submission.json").is_some(),
+        "submission.json must be at tree root"
+    );
+    let emissions = tree.get_name("emissions").expect("emissions subtree");
+    let emissions_tree = repo.find_tree(emissions.id()).unwrap();
+    let mut names: Vec<String> = emissions_tree
+        .iter()
+        .map(|e| e.name().unwrap().to_string())
+        .collect();
+    names.sort();
+    assert_eq!(
+        names,
+        vec!["0000.json".to_string(), "0001.json".to_string()]
+    );
+}


### PR DESCRIPTION
## Summary

Phase 1 of [SPEC-gateway §6.1b](docs/plan/specs/SPEC-gateway.md) two-layer session persistence for `sera-gateway`:

- **PartTable (SQLite)** — `session_heads` + `session_parts` tables track the current head commit, part index, and per-part metadata. Follows the existing `sera-db` `rusqlite` pattern (`Arc<Mutex<Connection>>`, `init_schema`, `async_trait`).
- **Shadow git repo** — a per-session bare repo at `<sessions_root>/<session_id>/git`. Each submission + its emitted events becomes one commit on `refs/heads/main`; tree layout is `submission.json` at the root plus `emissions/<NNNN>.json` blobs.
- **`SessionStore` trait** — exposes only what the sera-r1g8 envelope-wrapping work needs: `append_submission`, `head`, `replay`. No speculative extra methods.
- **Determinism** — fixed author/committer + fixed epoch keeps the commit SHA byte-for-byte stable across reopens; replay from the SHA reproduces the submission chain.
- **Atomic concurrent writes** — connection-level `tokio::sync::Mutex` + `BEGIN IMMEDIATE` transaction makes git HEAD and PartTable head flip together.

## Scope notes

- `git2 = "0.19"` is added to `sera-gateway` directly; workspace dep flipped to `default-features = false` so libssh2/openssl-sys aren't required on machines without system OpenSSL. Gateway doesn't need network transports for a local bare repo.
- Legacy `session_persist::PartTable` / `SessionSnapshot` stubs are left untouched — nothing else in the workspace uses them, and they belong to a separate JSON-snapshot path wired via `TranscriptPersistence`. Follow-up can delete them once callers migrate.
- Route wiring to emit into the store is sera-r1g8's responsibility (sibling worktree). This PR only lands the store + trait.

## Test plan

- [x] Unit tests (`session_store::tests`, 9 tests): schema idempotency, empty-head, head-after-append, index increment + parent chain, byte-for-byte deterministic reopen, concurrent-writer serialisation, emissions tree shape, part rows tracked per session.
- [x] Integration test (`tests/session_store_integration.rs`, 4 tests): full submit → commit → replay cycle across two turns, replay from SHA after reopen, 24 concurrent writers on a single session, on-disk tree layout matches spec.
- [x] `cargo fmt -p sera-gateway -p sera-db` — clean.
- [x] `cargo clippy -p sera-gateway -p sera-db --all-targets -- -D warnings` — no issues.
- [x] `cargo test -p sera-gateway -p sera-db` — 429 passed, 3 ignored.
- [x] `cargo check --workspace` — clean.

Closes sera-r9ed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)