### PR TITLE
feat(sera-context-lcm): Python LCM wrapped as ContextEngine plugin (sera-yf9r)

### DIFF
--- a/.github/workflows/validate-context-lcm.yml
+++ b/.github/workflows/validate-context-lcm.yml
@@ -1,0 +1,58 @@
+name: CI — Validate context-lcm plugin
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "sdk/python/sera-context-lcm/**"
+      - "sdk/python/sera-plugin-sdk/**"
+      - "rust/proto/plugin/**"
+      - ".github/workflows/validate-context-lcm.yml"
+  push:
+    branches: [main]
+    paths:
+      - "sdk/python/sera-context-lcm/**"
+      - "sdk/python/sera-plugin-sdk/**"
+      - "rust/proto/plugin/**"
+      - ".github/workflows/validate-context-lcm.yml"
+
+jobs:
+  validate-context-lcm:
+    name: validate-context-lcm
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install build tooling
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install hatch
+
+      - name: Install sera-plugin-sdk (editable)
+        working-directory: sdk/python/sera-plugin-sdk
+        run: python -m pip install -e '.[dev]'
+
+      - name: Install sera-context-lcm (editable + dev)
+        working-directory: sdk/python/sera-context-lcm
+        run: python -m pip install -e '.[dev]'
+
+      - name: Ruff
+        working-directory: sdk/python/sera-context-lcm
+        run: ruff check src tests
+
+      - name: Mypy
+        working-directory: sdk/python/sera-context-lcm
+        run: mypy src
+
+      - name: Pytest
+        working-directory: sdk/python/sera-context-lcm
+        run: pytest -q
+
+      - name: Build wheel
+        working-directory: sdk/python/sera-context-lcm
+        run: hatch build

--- a/sdk/python/sera-context-lcm/.gitignore
+++ b/sdk/python/sera-context-lcm/.gitignore
@@ -1,0 +1,11 @@
+__pycache__/
+*.pyc
+*.pyo
+dist/
+build/
+.tox/
+.venv/
+*.egg-info/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/

--- a/sdk/python/sera-context-lcm/LICENSE
+++ b/sdk/python/sera-context-lcm/LICENSE
@@ -1,0 +1,17 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+   Copyright 2026 SERA Contributors

--- a/sdk/python/sera-context-lcm/README.md
+++ b/sdk/python/sera-context-lcm/README.md
@@ -1,0 +1,79 @@
+# sera-context-lcm
+
+SERA `ContextEngine` plugin that wraps hermes-agent's **Lossless Context
+Management (LCM)** engine. First out-of-process consumer of
+[`sera-plugin-sdk`](../sera-plugin-sdk/) — demonstrates the stdio transport,
+the `ContextEngine` capability, and the full trait triad
+(`ContextEngine` + `ContextQuery` + `ContextDiagnostics`) described in
+[SPEC-context-engine-pluggability](../../../docs/plan/specs/SPEC-context-engine-pluggability.md).
+
+## What it does
+
+LCM persists every message to SQLite, summarises older turns into a
+depth-stratified DAG, and gives the agent drill tools (`lcm_grep`,
+`lcm_describe`, `lcm_expand`, …) to reach back into compacted history. This
+plugin binds LCM's internal `MessageStore` + `SummaryDAG` + `LCMEngine`
+directly to SERA's `ContextEngine` / `ContextQuery` / `ContextDiagnostics`
+trait surface per the SPEC §4 mapping table.
+
+The plugin does **not** subclass hermes's public `ContextEngine` base class —
+that class models one-shot `compress(messages, tokens)` compaction, which has
+a fundamentally different shape from SERA's per-session stateful
+`ingest / assemble / compact / maintain / describe` trait. The wire translation
+happens in this adapter, not in the SDK ABC (see
+`src/sera_context_lcm/plugin.py` docstring for detail).
+
+## How hermes-agent code is pulled in
+
+Only the minimal LCM storage + search subset
+(`store.py`, `dag.py`, `tokens.py`, `db_bootstrap.py`, `search_query.py`)
+is vendored in
+[`src/sera_context_lcm/_lcm_core/`](src/sera_context_lcm/_lcm_core/__init__.py).
+That subset has zero external `hermes-agent` imports — it depends only on the
+standard library — so the plugin ships as a self-contained wheel with no
+submodule dance.
+
+We do **not** vendor the summarisation pipeline (`engine.py`,
+`escalation.py`, `extraction.py`, `tools.py`) because those modules import
+`agent.*` from hermes-agent (auxiliary LLM client, etc.), and the sdk-py
+`ContextEngine` ABC models `ingest` / `assemble` / `compact` — the adapter
+only needs storage + search surfaces. Compaction belongs behind the runtime
+seam described in SPEC §2.1 and is not part of the sdk-py surface today.
+
+The original LCM sources live in
+`hermes-agent/plugins/context_engine/lcm/` and are not currently upstreamed
+in the public NousResearch/hermes-agent repo. If that changes, the vendored
+subdirectory can be replaced with a git submodule pin without touching the
+adapter.
+
+## Install and test
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install -e '../sera-plugin-sdk'
+python -m pip install -e '.[dev]'
+python -m pytest -q
+ruff check src tests
+```
+
+## Running as a SERA plugin
+
+The shipped `plugin.yaml` advertises the stdio transport with `ContextEngine`
+capability. SERA's plugin registry spawns the subprocess and drives it over
+NDJSON JSON-RPC per `SPEC-plugins` §8.
+
+```bash
+python -m sera_context_lcm  # starts the stdio server
+```
+
+## Fresh SQLite schema
+
+This plugin writes to a **new** SQLite file (`~/.sera/plugins/lcm/lcm.db`
+by default; override with `SERA_LCM_DATABASE_PATH`). There is no migration
+from an existing hermes LCM database — if users need byte compatibility, that
+becomes a separate bead.
+
+## License
+
+Apache-2.0. See `LICENSE`.

--- a/sdk/python/sera-context-lcm/plugin.yaml
+++ b/sdk/python/sera-context-lcm/plugin.yaml
@@ -1,0 +1,19 @@
+apiVersion: sera.dev/v1
+kind: Plugin
+metadata:
+  name: sera-context-lcm
+  labels:
+    origin: "sera-yf9r"
+spec:
+  capabilities:
+    - ContextEngine
+  transport: stdio
+  stdio:
+    # command[0] must be an absolute path — sera never does $PATH resolution at
+    # spawn time (see rust/crates/sera-plugins/src/manifest.rs validate_stdio_command).
+    # Operators should adjust the interpreter path to the venv that owns the
+    # installed `sera-context-lcm` package.
+    command: ["/usr/bin/python3", "-m", "sera_context_lcm"]
+    env: {}
+  health_check_interval: 30s
+  version: "0.1.0"

--- a/sdk/python/sera-context-lcm/pyproject.toml
+++ b/sdk/python/sera-context-lcm/pyproject.toml
@@ -1,0 +1,95 @@
+[build-system]
+requires = ["hatchling>=1.22"]
+build-backend = "hatchling.build"
+
+[project]
+name = "sera-context-lcm"
+version = "0.1.0"
+description = "SERA ContextEngine plugin — wraps hermes-agent's Lossless Context Management"
+readme = "README.md"
+license = "Apache-2.0"
+requires-python = ">=3.11"
+authors = [{ name = "SERA Contributors" }]
+keywords = ["sera", "plugin", "context-engine", "lcm", "hermes"]
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: Apache Software License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Topic :: Software Development :: Libraries :: Python Modules",
+]
+dependencies = [
+  "sera-plugin-sdk",
+  "pyyaml>=6.0",
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=8",
+  "pytest-asyncio>=0.23",
+  "mypy>=1.10",
+  "ruff>=0.5",
+]
+
+[project.urls]
+Homepage = "https://github.com/sera-project/sera"
+Issues = "https://github.com/sera-project/sera/issues"
+
+[project.scripts]
+sera-context-lcm = "sera_context_lcm.__main__:main"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/sera_context_lcm"]
+
+[tool.hatch.build.targets.sdist]
+include = [
+  "src",
+  "README.md",
+  "LICENSE",
+  "plugin.yaml",
+  "pyproject.toml",
+]
+
+[tool.hatch.envs.default]
+dependencies = [
+  "pytest>=8",
+  "pytest-asyncio>=0.23",
+  "mypy>=1.10",
+  "ruff>=0.5",
+]
+
+[tool.hatch.envs.default.scripts]
+test = "pytest -q {args:tests}"
+lint = "ruff check src tests"
+typecheck = "mypy src"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+extend-exclude = ["src/sera_context_lcm/_lcm_core"]
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "UP", "B", "SIM", "RUF"]
+ignore = ["E501"]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["B018"]
+
+[tool.mypy]
+python_version = "3.11"
+strict = false
+packages = ["sera_context_lcm"]
+mypy_path = "src"
+ignore_missing_imports = true
+exclude = ["_lcm_core/"]
+
+[[tool.mypy.overrides]]
+module = "sera_context_lcm._lcm_core.*"
+ignore_errors = true
+ignore_missing_imports = true

--- a/sdk/python/sera-context-lcm/src/sera_context_lcm/__init__.py
+++ b/sdk/python/sera-context-lcm/src/sera_context_lcm/__init__.py
@@ -1,0 +1,16 @@
+"""sera-context-lcm — SERA ContextEngine plugin wrapping hermes-agent's LCM.
+
+First out-of-process consumer of the Python plugin SDK. Implements the full
+trait triad (``ContextEngine`` + ``ContextQuery`` + ``ContextDiagnostics``) by
+binding directly to LCM's internal ``MessageStore`` / ``SummaryDAG`` /
+``LCMEngine`` components — see
+:mod:`sera_context_lcm.plugin` for the shape-translation rationale.
+"""
+
+from __future__ import annotations
+
+from .plugin import LcmPlugin
+
+__version__ = "0.1.0"
+
+__all__ = ["LcmPlugin", "__version__"]

--- a/sdk/python/sera-context-lcm/src/sera_context_lcm/__main__.py
+++ b/sdk/python/sera-context-lcm/src/sera_context_lcm/__main__.py
@@ -1,0 +1,19 @@
+"""Stdio entrypoint — ``python -m sera_context_lcm``.
+
+Boots the LCM plugin and hands control to :func:`sera_plugin_sdk.run_stdio_plugin`
+which drives the NDJSON JSON-RPC loop over stdin/stdout.
+"""
+
+from __future__ import annotations
+
+from sera_plugin_sdk import run_stdio_plugin
+
+from .plugin import LcmPlugin
+
+
+def main() -> None:
+    run_stdio_plugin(LcmPlugin())
+
+
+if __name__ == "__main__":
+    main()

--- a/sdk/python/sera-context-lcm/src/sera_context_lcm/_lcm_core/__init__.py
+++ b/sdk/python/sera-context-lcm/src/sera_context_lcm/_lcm_core/__init__.py
@@ -1,0 +1,21 @@
+"""Vendored subset of hermes-agent's LCM engine.
+
+Origin: ``hermes-agent/plugins/context_engine/lcm/`` (NousResearch/hermes-agent).
+
+We vendor only the storage + search + tokenisation subset (``store.py``,
+``dag.py``, ``tokens.py``, ``db_bootstrap.py``, ``search_query.py``) — the
+pieces that have zero external hermes-agent dependencies. The compaction /
+summarisation pipeline (``engine.py``, ``escalation.py``, ``extraction.py``,
+``tools.py``) is **not** vendored because it depends on ``agent.*`` modules
+from hermes-agent (auxiliary LLM client) that are out of scope for the
+SERA trait surface — the shape translation happens in
+:mod:`sera_context_lcm.plugin`.
+
+Upstream tracking: the vendored files are local-only additions in the author's
+hermes-agent checkout and are not published on any NousResearch/hermes-agent
+branch at the time of writing (see bead sera-yf9r notes). If upstream lands
+these files later, this subpackage can be replaced with a git submodule pin.
+
+Do not edit the vendored files by hand — resync from the origin when the
+upstream LCM code moves.
+"""

--- a/sdk/python/sera-context-lcm/src/sera_context_lcm/_lcm_core/dag.py
+++ b/sdk/python/sera-context-lcm/src/sera_context_lcm/_lcm_core/dag.py
@@ -1,0 +1,556 @@
+"""Summary DAG — hierarchical compaction graph.
+
+Each node is a summary of source material (raw messages or lower-depth
+summaries). Nodes form a directed acyclic graph where edges point from
+a summary to its sources.
+
+Depth semantics:
+  D0 — leaf summaries of raw messages (minutes timescale)
+  D1 — condensation of D0 nodes (hours)
+  D2 — condensation of D1 nodes (days)
+  D3+ — further condensation (weeks/months)
+"""
+
+import json
+import logging
+import sqlite3
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from .db_bootstrap import (
+    ExternalContentFtsSpec,
+    configure_connection,
+    ensure_external_content_fts,
+    run_versioned_migrations,
+)
+from .search_query import (
+    compute_directness_rank_bonus_upper_bound,
+    compute_directness_score,
+    compute_search_fetch_limit,
+    contains_risky_fts_ascii,
+    count_term_matches,
+    escape_like,
+    extract_quoted_phrases,
+    extract_search_terms,
+    normalize_search_sort,
+    requires_like_fallback,
+    AGE_DECAY_RATE,
+    should_apply_directness_rank_adjustment,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _build_search_order_by(sort: str | None, recency_expr: str) -> str:
+    normalized = normalize_search_sort(sort)
+    if normalized == "relevance":
+        return f"rank ASC, {recency_expr} DESC"
+    if normalized == "hybrid":
+        return (
+            f"(rank / (1 + (MAX(0.0, ((strftime('%s','now') - {recency_expr}) / 3600.0)) * {AGE_DECAY_RATE}))) ASC, "
+            f"{recency_expr} DESC"
+        )
+    return f"{recency_expr} DESC"
+
+
+def _fallback_result_sort_key(node: "SummaryNode", sort: str | None) -> tuple[float, float, float]:
+    normalized = normalize_search_sort(sort)
+    score = float(node.search_rank or 0.0) * -1.0
+    recency = float(node.latest_at or node.created_at or 0.0)
+    directness = float(node.search_directness or 0.0)
+
+    if normalized == "relevance":
+        return (-score, -directness, -recency)
+    if normalized == "hybrid":
+        age_hours = max(0.0, (time.time() - recency) / 3600.0)
+        blended = score / (1 + (age_hours * AGE_DECAY_RATE))
+        return (-blended, -directness, -recency)
+    return (-recency, -score, -directness)
+
+
+def _fts_result_sort_key(node: "SummaryNode", sort: str | None) -> tuple[float, float, float]:
+    normalized = normalize_search_sort(sort)
+    rank = node.search_rank
+    rank_value = float(rank) if rank is not None else float("inf")
+    recency = float(node.latest_at or node.created_at or 0.0)
+    directness = float(node.search_directness or 0.0)
+
+    if normalized == "relevance":
+        return (rank_value, -directness, -recency)
+    if normalized == "hybrid":
+        age_hours = max(0.0, (time.time() - recency) / 3600.0)
+        strength = (-rank_value) if rank is not None else float("-inf")
+        blended_strength = strength / (1 + (age_hours * AGE_DECAY_RATE)) if rank is not None else float("-inf")
+        return (-blended_strength, -directness, -recency)
+    return (-recency, rank_value, 0.0)
+
+
+def _fts_primary_value(node: "SummaryNode", sort: str | None) -> float:
+    normalized = normalize_search_sort(sort)
+    rank = node.search_rank
+    rank_value = float(rank) if rank is not None else float("inf")
+    if normalized == "hybrid":
+        recency = float(node.latest_at or node.created_at or 0.0)
+        age_hours = max(0.0, (time.time() - recency) / 3600.0)
+        strength = (-rank_value) if rank is not None else float("-inf")
+        blended_strength = strength / (1 + (age_hours * AGE_DECAY_RATE)) if rank is not None else float("-inf")
+        return -blended_strength
+    return rank_value
+
+
+@dataclass
+class SummaryNode:
+    """A single node in the summary DAG."""
+    node_id: int = 0
+    session_id: str = ""
+    depth: int = 0
+    summary: str = ""
+    token_count: int = 0
+    source_token_count: int = 0  # total tokens of source material
+    source_ids: List[int] = field(default_factory=list)  # store_ids or node_ids
+    source_type: str = "messages"  # "messages" or "nodes"
+    created_at: float = 0.0
+    earliest_at: float | None = None
+    latest_at: float | None = None
+    expand_hint: str = ""  # "Expand for details about: ..."
+    search_rank: float | None = None
+    search_directness: float = 0.0
+
+
+class SummaryDAG:
+    """SQLite-backed DAG of summary nodes."""
+
+    def __init__(self, db_path: str | Path):
+        self.db_path = Path(db_path)
+        self._conn: Optional[sqlite3.Connection] = None
+        self._init_db()
+
+    def _init_db(self):
+        self._conn = sqlite3.connect(str(self.db_path), timeout=5.0, check_same_thread=False)
+        configure_connection(self._conn)
+        self._conn.executescript("""
+            CREATE TABLE IF NOT EXISTS summary_nodes (
+                node_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL,
+                depth INTEGER NOT NULL DEFAULT 0,
+                summary TEXT NOT NULL,
+                token_count INTEGER DEFAULT 0,
+                source_token_count INTEGER DEFAULT 0,
+                source_ids TEXT NOT NULL DEFAULT '[]',
+                source_type TEXT NOT NULL DEFAULT 'messages',
+                created_at REAL NOT NULL,
+                earliest_at REAL,
+                latest_at REAL,
+                expand_hint TEXT DEFAULT ''
+            );
+            CREATE INDEX IF NOT EXISTS idx_nodes_session_depth
+                ON summary_nodes(session_id, depth, created_at);
+
+            CREATE TABLE IF NOT EXISTS metadata (
+                key TEXT PRIMARY KEY,
+                value TEXT
+            );
+        """)
+        ensure_external_content_fts(
+            self._conn,
+            ExternalContentFtsSpec(
+                table_name="nodes_fts",
+                content_table="summary_nodes",
+                content_rowid="node_id",
+                indexed_column="summary",
+                trigger_sqls=(
+                    """
+                    CREATE TRIGGER IF NOT EXISTS nodes_fts_insert
+                        AFTER INSERT ON summary_nodes BEGIN
+                        INSERT INTO nodes_fts(rowid, summary)
+                            VALUES (new.node_id, new.summary);
+                    END;
+                    """,
+                    """
+                    CREATE TRIGGER IF NOT EXISTS nodes_fts_delete
+                        AFTER DELETE ON summary_nodes BEGIN
+                        INSERT INTO nodes_fts(nodes_fts, rowid, summary)
+                            VALUES('delete', old.node_id, old.summary);
+                    END;
+                    """,
+                ),
+            ),
+        )
+        run_versioned_migrations(self._conn)
+        self._ensure_source_window_columns()
+        self._conn.commit()
+
+    def _ensure_source_window_columns(self) -> None:
+        columns = {
+            row[1] for row in self._conn.execute("PRAGMA table_info(summary_nodes)").fetchall()
+        }
+        if "earliest_at" not in columns:
+            self._conn.execute("ALTER TABLE summary_nodes ADD COLUMN earliest_at REAL")
+        if "latest_at" not in columns:
+            self._conn.execute("ALTER TABLE summary_nodes ADD COLUMN latest_at REAL")
+        self._conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_nodes_session_latest ON summary_nodes(session_id, latest_at, created_at)"
+        )
+
+    # -- Write --------------------------------------------------------------
+
+    def add_node(self, node: SummaryNode) -> int:
+        """Insert a summary node and return its node_id."""
+        cur = self._conn.execute(
+            """INSERT INTO summary_nodes
+               (session_id, depth, summary, token_count, source_token_count,
+                source_ids, source_type, created_at, earliest_at, latest_at, expand_hint)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                node.session_id,
+                node.depth,
+                node.summary,
+                node.token_count,
+                node.source_token_count,
+                json.dumps(node.source_ids),
+                node.source_type,
+                node.created_at or time.time(),
+                node.earliest_at,
+                node.latest_at,
+                node.expand_hint,
+            ),
+        )
+        self._conn.commit()
+        node.node_id = cur.lastrowid
+        return node.node_id
+
+    def delete_below_depth(self, session_id: str, min_depth: int) -> int:
+        """Delete all nodes for a session with depth < min_depth.
+
+        Returns the number of deleted nodes. Used during session reset
+        to retain only high-level summaries across sessions.
+        """
+        cur = self._conn.execute(
+            """DELETE FROM summary_nodes
+               WHERE session_id = ? AND depth < ?""",
+            (session_id, min_depth),
+        )
+        deleted = cur.rowcount
+        if deleted:
+            self._conn.commit()
+        return deleted
+
+    def delete_session_nodes(self, session_id: str) -> int:
+        """Delete all nodes for a session. Returns count deleted."""
+        cur = self._conn.execute(
+            "DELETE FROM summary_nodes WHERE session_id = ?",
+            (session_id,),
+        )
+        deleted = cur.rowcount
+        if deleted:
+            self._conn.commit()
+        return deleted
+
+    def reassign_session_nodes(self, old_session_id: str, new_session_id: str) -> int:
+        """Move all nodes from one session_id to another.
+
+        Used for /new carry-over where retained summaries should become part of
+        the fresh session while preserving node IDs and node-to-node links.
+        """
+        cur = self._conn.execute(
+            "UPDATE summary_nodes SET session_id = ? WHERE session_id = ?",
+            (new_session_id, old_session_id),
+        )
+        moved = cur.rowcount
+        if moved:
+            self._conn.commit()
+        return moved
+
+    # -- Read ---------------------------------------------------------------
+
+    def get_node(self, node_id: int) -> Optional[SummaryNode]:
+        row = self._conn.execute(
+            "SELECT * FROM summary_nodes WHERE node_id = ?", (node_id,)
+        ).fetchone()
+        return self._row_to_node(row) if row else None
+
+    def get_session_nodes(self, session_id: str,
+                          depth: int | None = None,
+                          limit: int = 1000) -> List[SummaryNode]:
+        """Get nodes for a session, optionally filtered by depth."""
+        if depth is not None:
+            rows = self._conn.execute(
+                """SELECT * FROM summary_nodes
+                   WHERE session_id = ? AND depth = ?
+                   ORDER BY created_at LIMIT ?""",
+                (session_id, depth, limit),
+            ).fetchall()
+        else:
+            rows = self._conn.execute(
+                """SELECT * FROM summary_nodes
+                   WHERE session_id = ?
+                   ORDER BY depth, created_at LIMIT ?""",
+                (session_id, limit),
+            ).fetchall()
+        return [self._row_to_node(r) for r in rows]
+
+    def count_at_depth(self, session_id: str, depth: int) -> int:
+        """Count nodes at a specific depth for a session."""
+        row = self._conn.execute(
+            """SELECT COUNT(*) FROM summary_nodes
+               WHERE session_id = ? AND depth = ?""",
+            (session_id, depth),
+        ).fetchone()
+        return row[0] if row else 0
+
+    def get_uncondensed_at_depth(self, session_id: str, depth: int,
+                                  limit: int = 100) -> List[SummaryNode]:
+        """Get nodes at a depth that haven't been condensed yet.
+
+        A node is 'uncondensed' if it's not referenced as a source by
+        any higher-depth node.
+        """
+        rows = self._conn.execute(
+            """SELECT n.* FROM summary_nodes n
+               WHERE n.session_id = ? AND n.depth = ?
+               AND n.node_id NOT IN (
+                   SELECT json_each.value FROM summary_nodes p,
+                   json_each(p.source_ids)
+                   WHERE p.session_id = ? AND p.depth > ? AND p.source_type = 'nodes'
+               )
+               ORDER BY n.created_at LIMIT ?""",
+            (session_id, depth, session_id, depth, limit),
+        ).fetchall()
+        return [self._row_to_node(r) for r in rows]
+
+    # -- Search -------------------------------------------------------------
+
+    def search(self, query: str, session_id: str | None = None,
+               limit: int = 20, sort: str | None = None,
+               source: str | None = None) -> List[SummaryNode]:
+        """FTS5 search across all summary nodes."""
+        terms = extract_search_terms(query)
+        phrases = extract_quoted_phrases(query)
+        if requires_like_fallback(query):
+            return self._search_like(query, session_id=session_id, limit=limit, sort=sort, source=source)
+
+        order_by = _build_search_order_by(sort, "COALESCE(n.latest_at, n.created_at)")
+        fetch_limit = compute_search_fetch_limit(limit, terms, phrases)
+        apply_directness_adjustment = should_apply_directness_rank_adjustment(terms, phrases)
+        max_rank_bonus = compute_directness_rank_bonus_upper_bound(terms, phrases) * 2e-7
+        offset = 0
+        results: list[SummaryNode] = []
+        source_match_cache: dict[int, bool] = {}
+        while True:
+            try:
+                if session_id:
+                    rows = self._conn.execute(
+                        f"""SELECT n.*, rank as search_rank FROM nodes_fts fts
+                           JOIN summary_nodes n ON n.node_id = fts.rowid
+                           WHERE nodes_fts MATCH ? AND n.session_id = ?
+                           ORDER BY {order_by} LIMIT ? OFFSET ?""",
+                        (query, session_id, fetch_limit, offset),
+                    ).fetchall()
+                else:
+                    rows = self._conn.execute(
+                        f"""SELECT n.*, rank as search_rank FROM nodes_fts fts
+                           JOIN summary_nodes n ON n.node_id = fts.rowid
+                           WHERE nodes_fts MATCH ?
+                           ORDER BY {order_by} LIMIT ? OFFSET ?""",
+                        (query, fetch_limit, offset),
+                    ).fetchall()
+            except sqlite3.Error as exc:
+                logger.warning("FTS node search failed, falling back to LIKE: %s", exc)
+                return self._search_like(query, session_id=session_id, limit=limit, sort=sort, source=source)
+
+            raw_nodes = [self._row_to_node(r) for r in rows]
+            raw_primary_values: list[float] = []
+            for node in raw_nodes:
+                if source and not self._node_matches_source(node.node_id, source, cache=source_match_cache):
+                    continue
+                node.search_directness = compute_directness_score(node.summary, terms, phrases)
+                if apply_directness_adjustment and node.search_rank is not None:
+                    rank_adjustment = max(float(node.search_directness), 0.0)
+                    node.search_rank = float(node.search_rank) - (rank_adjustment * 2e-7)
+                raw_primary_values.append(_fts_primary_value(node, sort))
+                results.append(node)
+            results.sort(key=lambda node: _fts_result_sort_key(node, sort))
+
+            if not apply_directness_adjustment or len(rows) < fetch_limit or len(results) <= limit:
+                return results[:limit]
+
+            worst_visible_primary = _fts_primary_value(results[min(limit, len(results)) - 1], sort)
+            last_fetched_primary = raw_primary_values[-1]
+            best_unseen_primary = last_fetched_primary - max_rank_bonus
+            if best_unseen_primary > worst_visible_primary:
+                return results[:limit]
+
+            offset += len(rows)
+            fetch_limit *= 2
+
+    def _search_like(self, query: str, session_id: str | None = None,
+                     limit: int = 20, sort: str | None = None,
+                     source: str | None = None) -> List[SummaryNode]:
+        terms = extract_search_terms(query)
+        phrases = extract_quoted_phrases(query)
+        if not terms:
+            return []
+
+        where: list[str] = ["summary IS NOT NULL"]
+        args: list[Any] = []
+        if session_id:
+            where.append("session_id = ?")
+            args.append(session_id)
+        like_clauses = []
+        for term in terms:
+            like_clauses.append("summary LIKE ? ESCAPE '\\'")
+            args.append(f"%{escape_like(term)}%")
+        where.append("(" + " OR ".join(like_clauses) + ")")
+
+        rows = self._conn.execute(
+            f"SELECT * FROM summary_nodes WHERE {' AND '.join(where)}",
+            args,
+        ).fetchall()
+        collapse_risky_repeats = contains_risky_fts_ascii(query)
+        nodes: list[SummaryNode] = []
+        source_match_cache: dict[int, bool] = {}
+        for row in rows:
+            node = self._row_to_node(row)
+            if source and not self._node_matches_source(node.node_id, source, cache=source_match_cache):
+                continue
+            score = sum(
+                min(count_term_matches(node.summary, term), 1) if collapse_risky_repeats else count_term_matches(node.summary, term)
+                for term in terms
+            )
+            if score <= 0:
+                continue
+            node.search_rank = -float(score)
+            node.search_directness = compute_directness_score(node.summary, terms, phrases)
+            nodes.append(node)
+
+        nodes.sort(key=lambda node: _fallback_result_sort_key(node, sort))
+        return nodes[:limit]
+
+    # -- DAG traversal ------------------------------------------------------
+
+    def get_source_nodes(self, node: SummaryNode) -> List[SummaryNode]:
+        """Get the immediate child nodes of a summary node."""
+        if node.source_type != "nodes" or not node.source_ids:
+            return []
+        placeholders = ",".join("?" * len(node.source_ids))
+        rows = self._conn.execute(
+            f"""SELECT * FROM summary_nodes
+                WHERE node_id IN ({placeholders})
+                ORDER BY created_at""",
+            node.source_ids,
+        ).fetchall()
+        return [self._row_to_node(r) for r in rows]
+
+    def _node_matches_source(
+        self,
+        node_id: int,
+        source: str,
+        *,
+        cache: dict[int, bool] | None = None,
+    ) -> bool:
+        if not source:
+            return True
+        if cache is not None and node_id in cache:
+            return cache[node_id]
+        row = self._conn.execute(
+            """
+            WITH RECURSIVE source_walk(source_type, source_id) AS (
+                SELECT n.source_type, CAST(j.value AS INTEGER)
+                FROM summary_nodes n, json_each(n.source_ids) j
+                WHERE n.node_id = ?
+
+                UNION ALL
+
+                SELECT child.source_type, CAST(j.value AS INTEGER)
+                FROM summary_nodes child
+                JOIN source_walk walk
+                  ON walk.source_type = 'nodes'
+                 AND child.node_id = walk.source_id
+                JOIN json_each(child.source_ids) j
+            )
+            SELECT 1
+            FROM source_walk walk
+            JOIN messages m
+              ON walk.source_type = 'messages'
+             AND m.store_id = walk.source_id
+            WHERE m.source = ?
+            LIMIT 1
+            """,
+            (node_id, source),
+        ).fetchone()
+        matched = row is not None
+        if cache is not None:
+            cache[node_id] = matched
+        return matched
+
+    def get_source_time_window(self, node_ids: List[int]) -> tuple[float | None, float | None]:
+        if not node_ids:
+            return None, None
+        placeholders = ",".join("?" * len(node_ids))
+        row = self._conn.execute(
+            f"""SELECT
+                    MIN(COALESCE(earliest_at, created_at)),
+                    MAX(COALESCE(latest_at, created_at))
+                FROM summary_nodes
+                WHERE node_id IN ({placeholders})""",
+            node_ids,
+        ).fetchone()
+        if not row:
+            return None, None
+        return row[0], row[1]
+
+    def describe_subtree(self, node_id: int) -> Dict[str, Any]:
+        """Return metadata about a node's subtree without loading content."""
+        node = self.get_node(node_id)
+        if not node:
+            return {"error": f"Node {node_id} not found"}
+
+        children = []
+        if node.source_type == "nodes":
+            for child_node in self.get_source_nodes(node):
+                children.append({
+                    "node_id": child_node.node_id,
+                    "depth": child_node.depth,
+                    "token_count": child_node.token_count,
+                    "source_token_count": child_node.source_token_count,
+                    "expand_hint": child_node.expand_hint,
+                })
+
+        return {
+            "node_id": node.node_id,
+            "depth": node.depth,
+            "token_count": node.token_count,
+            "source_token_count": node.source_token_count,
+            "source_type": node.source_type,
+            "num_sources": len(node.source_ids),
+            "earliest_at": node.earliest_at,
+            "latest_at": node.latest_at,
+            "expand_hint": node.expand_hint,
+            "children": children,
+        }
+
+    # -- Helpers ------------------------------------------------------------
+
+    def _row_to_node(self, row) -> SummaryNode:
+        return SummaryNode(
+            node_id=row[0],
+            session_id=row[1],
+            depth=row[2],
+            summary=row[3],
+            token_count=row[4],
+            source_token_count=row[5],
+            source_ids=json.loads(row[6]) if row[6] else [],
+            source_type=row[7],
+            created_at=row[8],
+            earliest_at=row[9],
+            latest_at=row[10],
+            expand_hint=row[11] or "",
+            search_rank=row[12] if len(row) > 12 else None,
+        )
+
+    def close(self):
+        if self._conn:
+            self._conn.close()
+            self._conn = None

--- a/sdk/python/sera-context-lcm/src/sera_context_lcm/_lcm_core/db_bootstrap.py
+++ b/sdk/python/sera-context-lcm/src/sera_context_lcm/_lcm_core/db_bootstrap.py
@@ -1,0 +1,262 @@
+"""Shared SQLite bootstrap helpers for hermes-lcm.
+
+This module keeps startup DB initialization in one place so store/DAG use the
+same schema-version marker, PRAGMA settings, and FTS repair behavior.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Iterable, Sequence
+
+SCHEMA_VERSION = 4
+SQLITE_BUSY_TIMEOUT_MS = 30_000
+
+
+class ExternalContentFtsSpec:
+    def __init__(
+        self,
+        *,
+        table_name: str,
+        content_table: str,
+        content_rowid: str,
+        indexed_column: str,
+        trigger_sqls: Sequence[str],
+    ) -> None:
+        self.table_name = table_name
+        self.content_table = content_table
+        self.content_rowid = content_rowid
+        self.indexed_column = indexed_column
+        self.trigger_sqls = tuple(trigger_sqls)
+
+
+def configure_connection(conn: sqlite3.Connection) -> None:
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute(f"PRAGMA busy_timeout={SQLITE_BUSY_TIMEOUT_MS}")
+
+
+def ensure_metadata_table(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS metadata (
+            key TEXT PRIMARY KEY,
+            value TEXT
+        )
+        """
+    )
+
+
+def get_schema_version(conn: sqlite3.Connection) -> int:
+    ensure_metadata_table(conn)
+    row = conn.execute(
+        "SELECT value FROM metadata WHERE key = 'schema_version'"
+    ).fetchone()
+    if not row or row[0] is None:
+        return 0
+    try:
+        return int(str(row[0]))
+    except (TypeError, ValueError):
+        return 0
+
+
+def ensure_migration_state_table(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS lcm_migration_state (
+            step_name TEXT PRIMARY KEY,
+            completed_at REAL NOT NULL
+        )
+        """
+    )
+
+
+def ensure_lifecycle_state_table(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS lcm_lifecycle_state (
+            conversation_id TEXT PRIMARY KEY,
+            current_session_id TEXT,
+            last_finalized_session_id TEXT,
+            current_frontier_store_id INTEGER NOT NULL DEFAULT 0,
+            last_finalized_frontier_store_id INTEGER NOT NULL DEFAULT 0,
+            debt_kind TEXT,
+            debt_size_estimate INTEGER NOT NULL DEFAULT 0,
+            current_bound_at REAL,
+            last_finalized_at REAL,
+            debt_updated_at REAL,
+            last_maintenance_attempt_at REAL,
+            last_rollover_at REAL,
+            last_reset_at REAL,
+            updated_at REAL NOT NULL DEFAULT (strftime('%s','now'))
+        )
+        """
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_lcm_lifecycle_current_session ON lcm_lifecycle_state(current_session_id)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_lcm_lifecycle_last_finalized_session ON lcm_lifecycle_state(last_finalized_session_id)"
+    )
+
+
+def ensure_lifecycle_state_columns(conn: sqlite3.Connection) -> None:
+    ensure_lifecycle_state_table(conn)
+    columns = {
+        row[1] for row in conn.execute("PRAGMA table_info(lcm_lifecycle_state)").fetchall()
+    }
+    if "debt_kind" not in columns:
+        conn.execute("ALTER TABLE lcm_lifecycle_state ADD COLUMN debt_kind TEXT")
+    if "debt_size_estimate" not in columns:
+        conn.execute(
+            "ALTER TABLE lcm_lifecycle_state ADD COLUMN debt_size_estimate INTEGER NOT NULL DEFAULT 0"
+        )
+    if "debt_updated_at" not in columns:
+        conn.execute("ALTER TABLE lcm_lifecycle_state ADD COLUMN debt_updated_at REAL")
+    if "last_maintenance_attempt_at" not in columns:
+        conn.execute(
+            "ALTER TABLE lcm_lifecycle_state ADD COLUMN last_maintenance_attempt_at REAL"
+        )
+
+
+def mark_migration_step_complete(conn: sqlite3.Connection, step_name: str) -> None:
+    ensure_migration_state_table(conn)
+    conn.execute(
+        """
+        INSERT INTO lcm_migration_state(step_name, completed_at)
+        VALUES(?, strftime('%s','now'))
+        ON CONFLICT(step_name) DO UPDATE SET completed_at = excluded.completed_at
+        """,
+        (step_name,),
+    )
+
+
+def set_schema_version(conn: sqlite3.Connection, version: int = SCHEMA_VERSION) -> None:
+    ensure_metadata_table(conn)
+    conn.execute(
+        """
+        INSERT INTO metadata(key, value)
+        VALUES('schema_version', ?)
+        ON CONFLICT(key) DO UPDATE SET value = excluded.value
+        """,
+        (str(version),),
+    )
+
+
+def get_existing_table_names(conn: sqlite3.Connection, names: Iterable[str]) -> set[str]:
+    existing: set[str] = set()
+    for name in names:
+        row = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name = ?",
+            (name,),
+        ).fetchone()
+        if row and row[0]:
+            existing.add(row[0])
+    return existing
+
+
+def get_fts_shadow_table_names(table_name: str) -> list[str]:
+    return [
+        f"{table_name}_data",
+        f"{table_name}_idx",
+        f"{table_name}_docsize",
+        f"{table_name}_config",
+    ]
+
+
+def quote_sql_identifier(identifier: str) -> str:
+    if not identifier or not identifier.replace("_", "a").isalnum() or identifier[0].isdigit():
+        raise ValueError(f"invalid SQL identifier: {identifier}")
+    return f'"{identifier}"'
+
+
+def _fts_needs_rebuild(conn: sqlite3.Connection, spec: ExternalContentFtsSpec) -> bool:
+    shadow_tables = get_fts_shadow_table_names(spec.table_name)
+    existing_tables = get_existing_table_names(conn, [spec.table_name, *shadow_tables])
+    if spec.table_name not in existing_tables:
+        return True
+    if any(name not in existing_tables for name in shadow_tables):
+        return True
+
+    try:
+        info = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name = ?",
+            (spec.table_name,),
+        ).fetchone()
+        sql = (info[0] if info else "") or ""
+        normalized = sql.lower()
+        if "virtual table" not in normalized or "using fts5" not in normalized:
+            return True
+
+        columns = conn.execute(
+            f"PRAGMA table_info({quote_sql_identifier(spec.table_name)})"
+        ).fetchall()
+        column_names = {row[1] for row in columns if len(row) > 1}
+        if spec.indexed_column not in column_names:
+            return True
+
+        content_count = conn.execute(
+            f"SELECT COUNT(*) FROM {quote_sql_identifier(spec.content_table)}"
+        ).fetchone()[0]
+        fts_count = conn.execute(
+            f"SELECT COUNT(*) FROM {quote_sql_identifier(spec.table_name)}"
+        ).fetchone()[0]
+        if int(content_count or 0) != int(fts_count or 0):
+            return True
+
+        conn.execute(
+            f"INSERT INTO {quote_sql_identifier(spec.table_name)}({quote_sql_identifier(spec.table_name)}, rank) VALUES('integrity-check', 1)"
+        )
+    except sqlite3.DatabaseError:
+        return True
+
+    return False
+
+
+def _drop_fts_table(conn: sqlite3.Connection, table_name: str) -> None:
+    conn.execute(f"DROP TABLE IF EXISTS {quote_sql_identifier(table_name)}")
+    for shadow_name in get_fts_shadow_table_names(table_name):
+        conn.execute(f"DROP TABLE IF EXISTS {quote_sql_identifier(shadow_name)}")
+
+
+def ensure_external_content_fts(conn: sqlite3.Connection, spec: ExternalContentFtsSpec) -> None:
+    if _fts_needs_rebuild(conn, spec):
+        _drop_fts_table(conn, spec.table_name)
+        conn.execute(
+            f"""
+            CREATE VIRTUAL TABLE {quote_sql_identifier(spec.table_name)} USING fts5(
+                {quote_sql_identifier(spec.indexed_column)},
+                content={quote_sql_identifier(spec.content_table)},
+                content_rowid={quote_sql_identifier(spec.content_rowid)}
+            )
+            """
+        )
+        conn.execute(
+            f"INSERT INTO {quote_sql_identifier(spec.table_name)}({quote_sql_identifier(spec.table_name)}) VALUES('rebuild')"
+        )
+
+    for trigger_sql in spec.trigger_sqls:
+        conn.execute(trigger_sql)
+
+
+def run_versioned_migrations(conn: sqlite3.Connection) -> None:
+    ensure_metadata_table(conn)
+    ensure_migration_state_table(conn)
+
+    current_version = get_schema_version(conn)
+    if current_version < 2:
+        mark_migration_step_complete(conn, "v2_external_content_fts_triggers")
+        current_version = 2
+
+    if current_version < 3:
+        ensure_lifecycle_state_table(conn)
+        mark_migration_step_complete(conn, "v3_lifecycle_state")
+        current_version = 3
+    else:
+        ensure_lifecycle_state_table(conn)
+
+    ensure_lifecycle_state_columns(conn)
+    if current_version < 4:
+        mark_migration_step_complete(conn, "v4_lifecycle_debt_columns")
+        current_version = 4
+
+    set_schema_version(conn, current_version)

--- a/sdk/python/sera-context-lcm/src/sera_context_lcm/_lcm_core/search_query.py
+++ b/sdk/python/sera-context-lcm/src/sera_context_lcm/_lcm_core/search_query.py
@@ -1,0 +1,236 @@
+"""Helpers for search query handling across FTS and LIKE fallback paths."""
+
+from __future__ import annotations
+
+import re
+from typing import List
+
+_CJK_RE = re.compile(
+    r"["
+    r"\u3400-\u4dbf"
+    r"\u4e00-\u9fff"
+    r"\u3000-\u303f"
+    r"\u3040-\u30ff"
+    r"\uac00-\ud7af"
+    r"\uff00-\uffef"
+    r"]"
+)
+_EMOJI_RE = re.compile(
+    r"["
+    r"\u2600-\u27bf"
+    r"\U0001F300-\U0001FAFF"
+    r"]"
+)
+_QUOTED_PHRASE_RE = re.compile(r'"([^"]+)"')
+_BOOLEAN_OPERATORS = {"AND", "OR", "NOT", "NEAR"}
+_RISKY_FTS_TOKEN_RE = re.compile(r"[A-Za-z0-9][\-:/][A-Za-z0-9]")
+_SPLIT_PUNCT_RE = re.compile(r"[-:/]+")
+_STRIP_EDGE_PUNCT = "\"'()[]{}.,;"
+
+
+_WORD_RE = re.compile(r"[\w-]+", re.UNICODE)
+
+
+def contains_cjk(text: str) -> bool:
+    return bool(_CJK_RE.search(text or ""))
+
+
+def contains_emoji(text: str) -> bool:
+    return bool(_EMOJI_RE.search(text or ""))
+
+
+def contains_risky_fts_ascii(text: str) -> bool:
+    raw = (text or "").strip()
+    if not raw:
+        return False
+    if raw.count('"') % 2:
+        return True
+    text_without_phrases = _QUOTED_PHRASE_RE.sub(" ", raw)
+    return bool(_RISKY_FTS_TOKEN_RE.search(text_without_phrases))
+
+
+def requires_like_fallback(query: str) -> bool:
+    return contains_cjk(query) or contains_emoji(query) or contains_risky_fts_ascii(query)
+
+
+def _token_variants(token: str) -> List[str]:
+    cleaned = (token or "").strip().strip(_STRIP_EDGE_PUNCT)
+    if not cleaned:
+        return []
+    if cleaned.upper() in _BOOLEAN_OPERATORS:
+        return []
+
+    variants = [cleaned]
+    if _SPLIT_PUNCT_RE.search(cleaned):
+        parts = [part for part in _SPLIT_PUNCT_RE.split(cleaned) if part]
+        if len(parts) > 1:
+            variants.extend(parts)
+
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for variant in variants:
+        if variant not in seen:
+            deduped.append(variant)
+            seen.add(variant)
+    return deduped
+
+
+def extract_search_terms(query: str) -> List[str]:
+    text = (query or "").strip()
+    if not text:
+        return []
+
+    terms: list[str] = []
+    for phrase in _QUOTED_PHRASE_RE.findall(text):
+        cleaned = phrase.strip()
+        if cleaned:
+            terms.append(cleaned)
+
+    text_without_phrases = _QUOTED_PHRASE_RE.sub(" ", text)
+    for token in text_without_phrases.split():
+        terms.extend(_token_variants(token))
+
+    if not terms:
+        fallback_text = text.strip().strip(_STRIP_EDGE_PUNCT)
+        if fallback_text:
+            terms.append(fallback_text)
+
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for term in terms:
+        if term not in seen:
+            deduped.append(term)
+            seen.add(term)
+    return deduped
+
+
+def extract_quoted_phrases(query: str) -> List[str]:
+    return [phrase.strip() for phrase in _QUOTED_PHRASE_RE.findall(query or "") if phrase.strip()]
+
+
+def escape_like(term: str) -> str:
+    return term.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
+def count_term_matches(text: str, term: str) -> int:
+    haystack = (text or "")
+    needle = (term or "")
+    if not haystack or not needle:
+        return 0
+    return haystack.lower().count(needle.lower())
+
+
+def compute_directness_score(text: str, terms: List[str], phrases: List[str] | None = None) -> float:
+    content = text or ""
+    if not content:
+        return 0.0
+
+    unique_hits = 0
+    total_hits = 0
+    non_phrase_unique_hits = 0
+    non_phrase_total_hits = 0
+    normalized_phrases = {(phrase or "").strip().lower() for phrase in (phrases or []) if (phrase or "").strip()}
+    for term in terms:
+        matches = count_term_matches(content, term)
+        if matches > 0:
+            unique_hits += 1
+            total_hits += matches
+            if term.strip().lower() not in normalized_phrases:
+                non_phrase_unique_hits += 1
+                non_phrase_total_hits += matches
+
+    phrase_hits = 0
+    lowered = content.lower()
+    for phrase in phrases or []:
+        if phrase and phrase.lower() in lowered:
+            phrase_hits += 1
+
+    repetition_penalty = max(0, total_hits - unique_hits)
+    non_phrase_repetition_penalty = max(0, non_phrase_total_hits - non_phrase_unique_hits)
+    score = float((unique_hits * 5) + (phrase_hits * 8))
+    if not phrases:
+        score -= min(repetition_penalty, 6)
+    else:
+        score -= min(non_phrase_repetition_penalty, 6)
+
+    if phrases:
+        for phrase in phrases:
+            normalized_phrase = (phrase or "").strip().lower()
+            if not normalized_phrase:
+                continue
+            phrase_occurrences = lowered.count(normalized_phrase)
+            if phrase_occurrences <= 1:
+                continue
+            segments = re.split(re.escape(normalized_phrase), lowered)
+            gap_unique_counts = []
+            for segment in segments:
+                segment_tokens = [
+                    token.lower()
+                    for token in _WORD_RE.findall(segment)
+                    if any(char.isalpha() for char in token)
+                ]
+                gap_unique_counts.append(len(set(segment_tokens)))
+            interior_gap_counts = gap_unique_counts[1:-1]
+            tail_gap_count = gap_unique_counts[-1] if gap_unique_counts else 0
+            extra_occurrences = phrase_occurrences - 1
+            score -= extra_occurrences * 0.5
+            score -= sum(1.5 for count in interior_gap_counts if 0 < count <= 4)
+            if all(count == 0 for count in interior_gap_counts) and tail_gap_count <= 2:
+                score -= min(extra_occurrences, 3) * 1.0
+
+    return score
+
+
+def _is_precise_query_shape(terms: List[str], phrases: List[str] | None = None) -> bool:
+    if len(terms) == 1:
+        return True
+    return len(phrases or []) == 1 and len(terms) <= 2
+
+
+def should_widen_candidate_fetch(terms: List[str], phrases: List[str] | None = None) -> bool:
+    return _is_precise_query_shape(terms, phrases)
+
+
+def should_apply_directness_rank_adjustment(terms: List[str], phrases: List[str] | None = None) -> bool:
+    return _is_precise_query_shape(terms, phrases)
+
+
+def compute_directness_rank_bonus_upper_bound(terms: List[str], phrases: List[str] | None = None) -> float:
+    return float((len(terms) * 5) + (len(phrases or []) * 8))
+
+
+def compute_search_fetch_limit(limit: int, terms: List[str], phrases: List[str] | None = None) -> int:
+    base = max(limit * 5, limit, 20)
+    if should_widen_candidate_fetch(terms, phrases):
+        return max(base, limit * 10, 50)
+    return base
+
+
+AGE_DECAY_RATE = 0.001
+
+
+def normalize_search_sort(sort: str | None) -> str:
+    """Normalize sort parameter to one of: recency, relevance, hybrid."""
+    normalized = (sort or "recency").strip().lower()
+    return normalized if normalized in {"recency", "relevance", "hybrid"} else "recency"
+
+
+def build_snippet(text: str, terms: List[str], width: int = 80) -> str:
+    content = (text or "")
+    if not content:
+        return ""
+    lowered = content.lower()
+    for term in terms:
+        if not term:
+            continue
+        idx = lowered.find(term.lower())
+        if idx >= 0:
+            start = max(0, idx - width // 2)
+            end = min(len(content), idx + len(term) + width // 2)
+            snippet = content[start:end]
+            if start > 0:
+                snippet = "..." + snippet
+            if end < len(content):
+                snippet = snippet + "..."
+            return snippet
+    return content[:width] + ("..." if len(content) > width else "")

--- a/sdk/python/sera-context-lcm/src/sera_context_lcm/_lcm_core/store.py
+++ b/sdk/python/sera-context-lcm/src/sera_context_lcm/_lcm_core/store.py
@@ -1,0 +1,607 @@
+"""Immutable-first message store — the source of truth.
+
+Every message is persisted durably in SQLite. The normal model is append-only,
+with one narrow opt-in exception: already-externalized summarized tool-result
+rows may be rewritten to compact GC tombstones while preserving the original
+row identity (`store_id`) for DAG/source lookup.
+"""
+
+
+import json
+import logging
+import sqlite3
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from .db_bootstrap import (
+    ExternalContentFtsSpec,
+    configure_connection,
+    ensure_external_content_fts,
+    run_versioned_migrations,
+)
+from .search_query import (
+    build_snippet,
+    compute_directness_rank_bonus_upper_bound,
+    compute_directness_score,
+    compute_search_fetch_limit,
+    contains_risky_fts_ascii,
+    count_term_matches,
+    escape_like,
+    extract_quoted_phrases,
+    extract_search_terms,
+    normalize_search_sort,
+    requires_like_fallback,
+    AGE_DECAY_RATE,
+    should_apply_directness_rank_adjustment,
+)
+from .tokens import count_message_tokens
+
+logger = logging.getLogger(__name__)
+
+
+_MESSAGE_ROLE_BIAS_SQL = "CASE m.role WHEN 'user' THEN 0 WHEN 'assistant' THEN 1 WHEN 'tool' THEN 2 ELSE 1 END"
+_MESSAGE_SELECT_COLUMNS = (
+    "store_id, session_id, source, role, content, tool_call_id, "
+    "tool_calls, tool_name, timestamp, token_estimate, pinned"
+)
+
+
+def _message_role_bias(role: str | None) -> float:
+    if role == "user":
+        return 0.0
+    if role == "assistant":
+        return 1.0
+    if role == "tool":
+        return 2.0
+    return 1.0
+
+
+def _message_directness_score(role: str | None, content: str | None, terms: List[str], phrases: List[str] | None = None) -> float:
+    score = compute_directness_score(content or "", terms, phrases)
+    if role == "tool":
+        stripped = (content or "").lstrip()
+        if stripped.startswith("{") or stripped.startswith("["):
+            score -= 4.0
+    return score
+
+
+def _build_search_order_by(
+    sort: str | None,
+    timestamp_expr: str,
+    role_penalty_expr: str | None = None,
+) -> str:
+    normalized = normalize_search_sort(sort)
+    order_parts: list[str] = []
+    if normalized == "relevance":
+        if role_penalty_expr:
+            order_parts.extend(["rank ASC", f"{role_penalty_expr} ASC", f"{timestamp_expr} DESC"])
+        else:
+            order_parts.extend(["rank ASC", f"{timestamp_expr} DESC"])
+        return ", ".join(order_parts)
+    if normalized == "hybrid":
+        blended = f"(rank / (1 + (MAX(0.0, ((strftime('%s','now') - {timestamp_expr}) / 3600.0)) * {AGE_DECAY_RATE})))"
+        if role_penalty_expr:
+            order_parts.extend([f"{blended} ASC", f"{role_penalty_expr} ASC", f"{timestamp_expr} DESC"])
+        else:
+            order_parts.extend([f"{blended} ASC", f"{timestamp_expr} DESC"])
+        return ", ".join(order_parts)
+    order_parts.append(f"{timestamp_expr} DESC")
+    if role_penalty_expr:
+        order_parts.append(f"{role_penalty_expr} ASC")
+    order_parts.append("rank ASC")
+    return ", ".join(order_parts)
+
+
+def _fallback_result_sort_key(result: Dict[str, Any], sort: str | None) -> tuple[float, float, float, float]:
+    normalized = normalize_search_sort(sort)
+    score = float(result.get("_fallback_score") or 0.0)
+    directness = float(result.get("_directness_score") or 0.0)
+    timestamp = float(result.get("timestamp") or 0.0)
+    role_bias = _message_role_bias(result.get("role"))
+
+    if normalized == "relevance":
+        return (-score, -directness, role_bias, -timestamp)
+    if normalized == "hybrid":
+        age_hours = max(0.0, (time.time() - timestamp) / 3600.0)
+        blended = score / (1 + (age_hours * AGE_DECAY_RATE))
+        return (-blended, -directness, role_bias, -timestamp)
+    return (-timestamp, role_bias, -score, -directness)
+
+
+def _fts_result_sort_key(result: Dict[str, Any], sort: str | None) -> tuple[float, float, float, float]:
+    normalized = normalize_search_sort(sort)
+    rank = result.get("search_rank")
+    rank_value = float(rank) if rank is not None else float("inf")
+    directness = float(result.get("_directness_score") or 0.0)
+    timestamp = float(result.get("timestamp") or 0.0)
+    role_bias = _message_role_bias(result.get("role"))
+
+    if normalized == "relevance":
+        return (rank_value, -directness, role_bias, -timestamp)
+    if normalized == "hybrid":
+        age_hours = max(0.0, (time.time() - timestamp) / 3600.0)
+        blended = rank_value / (1 + (age_hours * AGE_DECAY_RATE)) if rank is not None else float("inf")
+        return (blended, -directness, role_bias, -timestamp)
+    return (-timestamp, role_bias, rank_value, 0.0)
+
+
+def _fts_primary_value(result: Dict[str, Any], sort: str | None) -> float:
+    normalized = normalize_search_sort(sort)
+    rank = result.get("search_rank")
+    rank_value = float(rank) if rank is not None else float("inf")
+    if normalized == "hybrid":
+        timestamp = float(result.get("timestamp") or 0.0)
+        age_hours = max(0.0, (time.time() - timestamp) / 3600.0)
+        return rank_value / (1 + (age_hours * AGE_DECAY_RATE)) if rank is not None else float("inf")
+    return rank_value
+
+
+class MessageStore:
+    """SQLite-backed immutable message store."""
+
+    def __init__(self, db_path: str | Path):
+        self.db_path = Path(db_path)
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn: Optional[sqlite3.Connection] = None
+        self._init_db()
+
+    def _init_db(self):
+        self._conn = sqlite3.connect(str(self.db_path), timeout=5.0, check_same_thread=False)
+        configure_connection(self._conn)
+        self._conn.executescript("""
+            CREATE TABLE IF NOT EXISTS messages (
+                store_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL,
+                source TEXT DEFAULT '',
+                role TEXT NOT NULL,
+                content TEXT,
+                tool_call_id TEXT,
+                tool_calls TEXT,
+                tool_name TEXT,
+                timestamp REAL NOT NULL,
+                token_estimate INTEGER DEFAULT 0,
+                pinned INTEGER DEFAULT 0
+            );
+            CREATE INDEX IF NOT EXISTS idx_msg_session
+                ON messages(session_id, store_id);
+            CREATE INDEX IF NOT EXISTS idx_msg_session_ts
+                ON messages(session_id, timestamp);
+
+            CREATE TABLE IF NOT EXISTS metadata (
+                key TEXT PRIMARY KEY,
+                value TEXT
+            );
+        """)
+        ensure_external_content_fts(
+            self._conn,
+            ExternalContentFtsSpec(
+                table_name="messages_fts",
+                content_table="messages",
+                content_rowid="store_id",
+                indexed_column="content",
+                trigger_sqls=(
+                    """
+                    CREATE TRIGGER IF NOT EXISTS msg_fts_insert
+                        AFTER INSERT ON messages BEGIN
+                        INSERT INTO messages_fts(rowid, content)
+                            VALUES (new.store_id, new.content);
+                    END;
+                    """,
+                    """
+                    CREATE TRIGGER IF NOT EXISTS msg_fts_delete
+                        AFTER DELETE ON messages BEGIN
+                        INSERT INTO messages_fts(messages_fts, rowid, content)
+                            VALUES('delete', old.store_id, old.content);
+                    END;
+                    """,
+                    """
+                    CREATE TRIGGER IF NOT EXISTS msg_fts_update
+                        AFTER UPDATE OF content ON messages BEGIN
+                        INSERT INTO messages_fts(messages_fts, rowid, content)
+                            VALUES('delete', old.store_id, old.content);
+                        INSERT INTO messages_fts(rowid, content)
+                            VALUES (new.store_id, new.content);
+                    END;
+                    """,
+                ),
+            ),
+        )
+        run_versioned_migrations(self._conn)
+        self._ensure_source_column()
+        self._conn.commit()
+
+    def _ensure_source_column(self) -> None:
+        columns = {
+            row[1] for row in self._conn.execute("PRAGMA table_info(messages)").fetchall()
+        }
+        if "source" not in columns:
+            self._conn.execute("ALTER TABLE messages ADD COLUMN source TEXT DEFAULT ''")
+        self._conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_msg_source_session ON messages(source, session_id, store_id)"
+        )
+
+    # -- Write operations ---------------------------------------------------
+
+    def append(self, session_id: str, msg: Dict[str, Any],
+               token_estimate: int = 0, source: str = "") -> int:
+        """Persist a message and return its store_id."""
+        tool_calls = msg.get("tool_calls")
+        tc_json = json.dumps(tool_calls) if tool_calls else None
+
+        cur = self._conn.execute(
+            """INSERT INTO messages
+               (session_id, source, role, content, tool_call_id, tool_calls,
+                tool_name, timestamp, token_estimate, pinned)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                session_id,
+                source or "",
+                msg.get("role", "unknown"),
+                msg.get("content"),
+                msg.get("tool_call_id"),
+                tc_json,
+                msg.get("tool_name"),
+                time.time(),
+                token_estimate,
+                0,
+            ),
+        )
+        self._conn.commit()
+        return cur.lastrowid
+
+    def append_batch(self, session_id: str,
+                     messages: List[Dict[str, Any]],
+                     token_estimates: List[int] | None = None,
+                     source: str = "") -> List[int]:
+        """Persist multiple messages in one transaction. Returns store_ids."""
+        if token_estimates is None:
+            token_estimates = [0] * len(messages)
+
+        ids = []
+        ts = time.time()
+        with self._conn:
+            for msg, est in zip(messages, token_estimates):
+                tc = msg.get("tool_calls")
+                tc_json = json.dumps(tc) if tc else None
+                cur = self._conn.execute(
+                    """INSERT INTO messages
+                       (session_id, source, role, content, tool_call_id, tool_calls,
+                        tool_name, timestamp, token_estimate, pinned)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    (
+                        session_id,
+                        source or "",
+                        msg.get("role", "unknown"),
+                        msg.get("content"),
+                        msg.get("tool_call_id"),
+                        tc_json,
+                        msg.get("tool_name"),
+                        ts,
+                        est,
+                        0,
+                    ),
+                )
+                ids.append(cur.lastrowid)
+        return ids
+
+    def delete_session_messages(self, session_id: str) -> int:
+        """Delete all messages for a session. Returns count deleted."""
+        cur = self._conn.execute(
+            "DELETE FROM messages WHERE session_id = ?",
+            (session_id,),
+        )
+        self._conn.commit()
+        deleted = cur.rowcount if cur.rowcount is not None else 0
+        return deleted
+
+    def gc_externalized_tool_result(self, store_id: int, placeholder: str) -> bool:
+        """Rewrite one unpinned tool-result row to a compact GC placeholder."""
+        row = self._conn.execute(
+            "SELECT role, pinned, content, tool_call_id FROM messages WHERE store_id = ?",
+            (store_id,),
+        ).fetchone()
+        if row is None:
+            return False
+        role, pinned, current_content, tool_call_id = row
+        if role != "tool" or bool(pinned) or current_content == placeholder:
+            return False
+        placeholder_tokens = count_message_tokens(
+            {
+                "role": "tool",
+                "content": placeholder,
+                "tool_call_id": tool_call_id,
+            }
+        )
+        self._conn.execute(
+            "UPDATE messages SET content = ?, token_estimate = ? WHERE store_id = ?",
+            (placeholder, placeholder_tokens, store_id),
+        )
+        self._conn.commit()
+        return True
+
+    def pin(self, store_id: int) -> None:
+
+        """Mark a message as pinned (protected from pruning)."""
+        self._conn.execute(
+            "UPDATE messages SET pinned = 1 WHERE store_id = ?", (store_id,)
+        )
+        self._conn.commit()
+
+    def unpin(self, store_id: int) -> None:
+        self._conn.execute(
+            "UPDATE messages SET pinned = 0 WHERE store_id = ?", (store_id,)
+        )
+        self._conn.commit()
+
+    # -- Read operations ----------------------------------------------------
+
+    def get(self, store_id: int) -> Optional[Dict[str, Any]]:
+        """Retrieve a single message by store_id."""
+        row = self._conn.execute(
+            f"SELECT {_MESSAGE_SELECT_COLUMNS} FROM messages WHERE store_id = ?", (store_id,)
+        ).fetchone()
+        return self._row_to_dict(row) if row else None
+
+    def get_batch(self, store_ids: List[int]) -> Dict[int, Dict[str, Any]]:
+        """Retrieve multiple messages by store_id in a single query.
+
+        Returns a dict mapping store_id → message dict.
+        """
+        if not store_ids:
+            return {}
+        placeholders = ",".join("?" for _ in store_ids)
+        rows = self._conn.execute(
+            f"SELECT {_MESSAGE_SELECT_COLUMNS} FROM messages WHERE store_id IN ({placeholders})",
+            store_ids,
+        ).fetchall()
+        return {row[0]: self._row_to_dict(row) for row in rows}
+
+    def get_range(self, session_id: str, start_id: int = 0,
+                  end_id: int | None = None,
+                  limit: int = 1000) -> List[Dict[str, Any]]:
+        """Get messages in a store_id range for a session."""
+        if end_id is not None:
+            rows = self._conn.execute(
+                f"""SELECT {_MESSAGE_SELECT_COLUMNS} FROM messages
+                   WHERE session_id = ? AND store_id >= ? AND store_id <= ?
+                   ORDER BY store_id LIMIT ?""",
+                (session_id, start_id, end_id, limit),
+            ).fetchall()
+        else:
+            rows = self._conn.execute(
+                f"""SELECT {_MESSAGE_SELECT_COLUMNS} FROM messages
+                   WHERE session_id = ? AND store_id >= ?
+                   ORDER BY store_id LIMIT ?""",
+                (session_id, start_id, limit),
+            ).fetchall()
+        return [self._row_to_dict(r) for r in rows]
+
+    def get_session_messages(self, session_id: str,
+                             limit: int = 10000) -> List[Dict[str, Any]]:
+        """Get all messages for a session, ordered by store_id."""
+        rows = self._conn.execute(
+            f"""SELECT {_MESSAGE_SELECT_COLUMNS} FROM messages
+               WHERE session_id = ?
+               ORDER BY store_id LIMIT ?""",
+            (session_id, limit),
+        ).fetchall()
+        return [self._row_to_dict(r) for r in rows]
+
+    def get_session_count(self, session_id: str) -> int:
+        """Count messages in a session."""
+        row = self._conn.execute(
+            "SELECT COUNT(*) FROM messages WHERE session_id = ?",
+            (session_id,),
+        ).fetchone()
+        return row[0] if row else 0
+
+    def get_session_token_total(self, session_id: str) -> int:
+        """Sum of token estimates for a session."""
+        row = self._conn.execute(
+            "SELECT COALESCE(SUM(token_estimate), 0) FROM messages WHERE session_id = ?",
+            (session_id,),
+        ).fetchone()
+        return row[0] if row else 0
+
+    def get_time_bounds(self, store_ids: List[int]) -> tuple[float | None, float | None]:
+        if not store_ids:
+            return None, None
+        placeholders = ",".join("?" * len(store_ids))
+        row = self._conn.execute(
+            f"SELECT MIN(timestamp), MAX(timestamp) FROM messages WHERE store_id IN ({placeholders})",
+            store_ids,
+        ).fetchone()
+        if not row:
+            return None, None
+        return row[0], row[1]
+
+    # -- Search -------------------------------------------------------------
+
+    def search(self, query: str, session_id: str | None = None,
+               limit: int = 20, sort: str | None = None,
+               source: str | None = None) -> List[Dict[str, Any]]:
+        """FTS5 search across messages. Returns matches with snippets."""
+        terms = extract_search_terms(query)
+        phrases = extract_quoted_phrases(query)
+        if requires_like_fallback(query):
+            return self._search_like(query, session_id=session_id, limit=limit, sort=sort, source=source)
+
+        order_by = _build_search_order_by(
+            sort,
+            "m.timestamp",
+            _MESSAGE_ROLE_BIAS_SQL,
+        )
+        fetch_limit = compute_search_fetch_limit(limit, terms, phrases)
+        apply_directness_adjustment = should_apply_directness_rank_adjustment(terms, phrases)
+        max_rank_bonus = compute_directness_rank_bonus_upper_bound(terms, phrases) * 3e-7
+        offset = 0
+        results: list[Dict[str, Any]] = []
+        while True:
+            try:
+                if session_id:
+                    if source:
+                        rows = self._conn.execute(
+                            f"""SELECT m.store_id, m.session_id, m.source, m.role, m.content, m.tool_call_id,
+                                      m.tool_calls, m.tool_name, m.timestamp, m.token_estimate, m.pinned,
+                                      rank as search_rank,
+                                      snippet(messages_fts, 0, '>>>', '<<<', '...', 40) as snippet
+                               FROM messages_fts fts
+                               JOIN messages m ON m.store_id = fts.rowid
+                               WHERE messages_fts MATCH ? AND m.session_id = ? AND m.source = ?
+                               ORDER BY {order_by} LIMIT ? OFFSET ?""",
+                            (query, session_id, source, fetch_limit, offset),
+                        ).fetchall()
+                    else:
+                        rows = self._conn.execute(
+                            f"""SELECT m.store_id, m.session_id, m.source, m.role, m.content, m.tool_call_id,
+                                      m.tool_calls, m.tool_name, m.timestamp, m.token_estimate, m.pinned,
+                                      rank as search_rank,
+                                      snippet(messages_fts, 0, '>>>', '<<<', '...', 40) as snippet
+                               FROM messages_fts fts
+                               JOIN messages m ON m.store_id = fts.rowid
+                               WHERE messages_fts MATCH ? AND m.session_id = ?
+                               ORDER BY {order_by} LIMIT ? OFFSET ?""",
+                            (query, session_id, fetch_limit, offset),
+                        ).fetchall()
+                else:
+                    if source:
+                        rows = self._conn.execute(
+                            f"""SELECT m.store_id, m.session_id, m.source, m.role, m.content, m.tool_call_id,
+                                      m.tool_calls, m.tool_name, m.timestamp, m.token_estimate, m.pinned,
+                                      rank as search_rank,
+                                      snippet(messages_fts, 0, '>>>', '<<<', '...', 40) as snippet
+                               FROM messages_fts fts
+                               JOIN messages m ON m.store_id = fts.rowid
+                               WHERE messages_fts MATCH ? AND m.source = ?
+                               ORDER BY {order_by} LIMIT ? OFFSET ?""",
+                            (query, source, fetch_limit, offset),
+                        ).fetchall()
+                    else:
+                        rows = self._conn.execute(
+                            f"""SELECT m.store_id, m.session_id, m.source, m.role, m.content, m.tool_call_id,
+                                      m.tool_calls, m.tool_name, m.timestamp, m.token_estimate, m.pinned,
+                                      rank as search_rank,
+                                      snippet(messages_fts, 0, '>>>', '<<<', '...', 40) as snippet
+                               FROM messages_fts fts
+                               JOIN messages m ON m.store_id = fts.rowid
+                               WHERE messages_fts MATCH ?
+                               ORDER BY {order_by} LIMIT ? OFFSET ?""",
+                            (query, fetch_limit, offset),
+                        ).fetchall()
+            except sqlite3.Error as exc:
+                logger.warning("FTS message search failed, falling back to LIKE: %s", exc)
+                return self._search_like(query, session_id=session_id, limit=limit, sort=sort, source=source)
+
+            raw_primary_values: list[float] = []
+            for r in rows:
+                d = self._row_to_dict(r)
+                base_columns = 11
+                d["search_rank"] = r[base_columns] if len(r) > base_columns else None
+                d["snippet"] = r[base_columns + 1] if len(r) > (base_columns + 1) else ""
+                d["_directness_score"] = _message_directness_score(d.get("role"), d.get("content"), terms, phrases)
+                if apply_directness_adjustment and d["search_rank"] is not None:
+                    rank_adjustment = max(float(d["_directness_score"]), 0.0)
+                    d["search_rank"] = float(d["search_rank"]) - (rank_adjustment * 3e-7)
+                raw_primary_values.append(_fts_primary_value(d, sort))
+                results.append(d)
+            results.sort(key=lambda result: _fts_result_sort_key(result, sort))
+
+            if not apply_directness_adjustment or len(rows) < fetch_limit or len(results) <= limit:
+                return results[:limit]
+
+            worst_visible_primary = _fts_primary_value(results[min(limit, len(results)) - 1], sort)
+            last_fetched_primary = raw_primary_values[-1]
+            best_unseen_primary = last_fetched_primary - max_rank_bonus
+            if best_unseen_primary > worst_visible_primary:
+                return results[:limit]
+
+            offset += len(rows)
+            fetch_limit *= 2
+
+    def _search_like(self, query: str, session_id: str | None = None,
+                     limit: int = 20, sort: str | None = None,
+                     source: str | None = None) -> List[Dict[str, Any]]:
+        terms = extract_search_terms(query)
+        phrases = extract_quoted_phrases(query)
+        if not terms:
+            return []
+
+        where: list[str] = ["content IS NOT NULL"]
+        args: list[Any] = []
+        if session_id:
+            where.append("session_id = ?")
+            args.append(session_id)
+        if source:
+            where.append("source = ?")
+            args.append(source)
+        like_clauses = []
+        for term in terms:
+            like_clauses.append("content LIKE ? ESCAPE '\\'")
+            args.append(f"%{escape_like(term)}%")
+        where.append("(" + " OR ".join(like_clauses) + ")")
+
+        rows = self._conn.execute(
+            f"SELECT {_MESSAGE_SELECT_COLUMNS} FROM messages WHERE {' AND '.join(where)}",
+            args,
+        ).fetchall()
+        results: List[Dict[str, Any]] = []
+        collapse_risky_repeats = contains_risky_fts_ascii(query)
+        for row in rows:
+            result = self._row_to_dict(row)
+            content = result.get("content") or ""
+            score = sum(
+                min(count_term_matches(content, term), 1) if collapse_risky_repeats else count_term_matches(content, term)
+                for term in terms
+            )
+            if score <= 0:
+                continue
+            result["search_rank"] = -float(score)
+            result["snippet"] = build_snippet(content, terms)
+            result["_fallback_score"] = float(score)
+            result["_directness_score"] = _message_directness_score(result.get("role"), content, terms, phrases)
+            results.append(result)
+
+        results.sort(key=lambda result: _fallback_result_sort_key(result, sort))
+        for result in results:
+            result.pop("_fallback_score", None)
+        return results[:limit]
+
+    # -- Helpers ------------------------------------------------------------
+
+    def _row_to_dict(self, row) -> Dict[str, Any]:
+        """Convert a sqlite3 row to a dict."""
+        if row is None:
+            return {}
+        cols = [
+            "store_id", "session_id", "source", "role", "content", "tool_call_id",
+            "tool_calls", "tool_name", "timestamp", "token_estimate", "pinned",
+        ]
+        d = dict(zip(cols, row[:len(cols)]))
+        # Deserialize tool_calls JSON
+        if d.get("tool_calls"):
+            try:
+                d["tool_calls"] = json.loads(d["tool_calls"])
+            except (json.JSONDecodeError, TypeError):
+                pass
+        return d
+
+    def to_openai_msg(self, stored: Dict[str, Any]) -> Dict[str, Any]:
+        """Convert a stored message back to OpenAI format."""
+        msg: Dict[str, Any] = {"role": stored["role"]}
+        if stored.get("content") is not None:
+            msg["content"] = stored["content"]
+        if stored.get("tool_calls"):
+            msg["tool_calls"] = stored["tool_calls"]
+        if stored.get("tool_call_id"):
+            msg["tool_call_id"] = stored["tool_call_id"]
+        if stored.get("tool_name"):
+            msg["name"] = stored["tool_name"]
+        return msg
+
+    # -- Lifecycle ----------------------------------------------------------
+
+    def close(self):
+        if self._conn:
+            self._conn.close()
+            self._conn = None

--- a/sdk/python/sera-context-lcm/src/sera_context_lcm/_lcm_core/tokens.py
+++ b/sdk/python/sera-context-lcm/src/sera_context_lcm/_lcm_core/tokens.py
@@ -1,0 +1,59 @@
+"""Token counting utilities for LCM.
+
+Uses tiktoken when available, falls back to char-based estimate.
+"""
+
+import logging
+from typing import Any, Dict, List
+
+logger = logging.getLogger(__name__)
+
+_CHARS_PER_TOKEN = 4
+_encoder = None
+_encoder_checked = False
+
+
+def _get_encoder():
+    """Lazily load tiktoken cl100k_base encoder."""
+    global _encoder, _encoder_checked
+    if _encoder_checked:
+        return _encoder
+    _encoder_checked = True
+    try:
+        import tiktoken
+        _encoder = tiktoken.get_encoding("cl100k_base")
+    except Exception:
+        logger.debug("tiktoken not available, using char-based estimates")
+    return _encoder
+
+
+def count_tokens(text: str) -> int:
+    """Count tokens in a string."""
+    if not text:
+        return 0
+    enc = _get_encoder()
+    if enc is not None:
+        try:
+            return len(enc.encode(text))
+        except Exception:
+            pass
+    return len(text) // _CHARS_PER_TOKEN + 1
+
+
+def count_message_tokens(msg: Dict[str, Any]) -> int:
+    """Estimate tokens for a single OpenAI-format message."""
+    total = 4  # role + overhead
+    content = msg.get("content") or ""
+    total += count_tokens(content)
+    for tc in msg.get("tool_calls") or []:
+        if isinstance(tc, dict):
+            fn = tc.get("function", {})
+            total += count_tokens(fn.get("name", ""))
+            total += count_tokens(fn.get("arguments", ""))
+        total += 3  # per-call overhead
+    return total
+
+
+def count_messages_tokens(messages: List[Dict[str, Any]]) -> int:
+    """Estimate total tokens for a message list."""
+    return sum(count_message_tokens(m) for m in messages)

--- a/sdk/python/sera-context-lcm/src/sera_context_lcm/plugin.py
+++ b/sdk/python/sera-context-lcm/src/sera_context_lcm/plugin.py
@@ -1,0 +1,549 @@
+"""LcmPlugin — adapter binding hermes-agent LCM internals to SERA's plugin ABCs.
+
+Design note (critical — see bead sera-yf9r):
+
+Hermes-agent's public Python ``ContextEngine`` base class models
+*one-shot stateless* compaction::
+
+    compress(messages, current_tokens) -> messages
+
+SERA's wire contract (``sera-plugin-sdk.ContextEngine`` ABC, mirroring the
+Rust ``ContextEngine`` trait in SPEC-context-engine-pluggability §2.1) is
+*per-session stateful*::
+
+    ingest(IngestMessage) -> IngestAck
+    assemble(AssembleBudget) -> AssembledContext
+
+These shapes are fundamentally different. The adapter therefore binds
+**LCM's internal components** (``MessageStore`` + ``SummaryDAG``) directly,
+mapping them onto the three trait methods in the sdk-py ABC surface
+(``ContextEngine`` / ``ContextQuery`` / ``ContextDiagnostics``). We do not
+subclass ``agent.context_engine.ContextEngine`` — that class's method
+surface would be wrong for sera's seam.
+
+Mapping (aligned with SPEC-context-engine-pluggability §4):
+
+================================  ==========================================
+sdk-py trait method                LCM call
+================================  ==========================================
+``ContextEngine.ingest``           ``MessageStore.append(...)``
+``ContextEngine.assemble``         Read store + DAG for the session, pack
+                                   segments under the token budget.
+``ContextQuery.search``            ``MessageStore.search`` + ``SummaryDAG.search``,
+                                   merged.
+``ContextQuery.describe``          ``SummaryDAG.describe_subtree``
+``ContextQuery.expand``            Walk ``SummaryDAG`` sources back to
+                                   ``MessageStore`` content, honour max
+                                   tokens.
+``ContextDiagnostics.status``      LCM store + DAG counters for the session.
+``ContextDiagnostics.doctor``      DB integrity + FTS sync + orphan check
+                                   (mirror of ``lcm_doctor``).
+================================  ==========================================
+
+``lcm_expand_query`` (LCM's sixth agent-facing tool) is intentionally not
+wrapped here — it composes search + expand + LLM synthesis, which belongs at
+the sera tool-authoring layer, not the trait surface (SPEC §4 footnote).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+from sera_plugin_sdk.capabilities import (
+    ContextDiagnostics,
+    ContextEngine,
+    ContextQuery,
+)
+from sera_plugin_sdk.errors import PluginCapabilityError
+from sera_plugin_sdk.types import (
+    AssembleBudget,
+    AssembledContext,
+    ContextSegment,
+    CtxSearchHit,
+    CtxSearchRequest,
+    CtxSearchResponse,
+    DescribeRequest,
+    DescribeResponse,
+    DoctorCheck,
+    DoctorReport,
+    ExpandRequest,
+    ExpandResponse,
+    IngestAck,
+    IngestMessage,
+    StatusResponse,
+)
+
+from ._lcm_core.dag import SummaryDAG
+from ._lcm_core.store import MessageStore
+from ._lcm_core.tokens import count_message_tokens
+
+
+def _default_db_path() -> Path:
+    override = os.environ.get("SERA_LCM_DATABASE_PATH")
+    if override:
+        return Path(override).expanduser().resolve()
+    # Fresh sera-scoped location — no byte compat with hermes LCM storage.
+    base = Path.home() / ".sera" / "plugins" / "lcm"
+    return base / "lcm.db"
+
+
+class LcmPlugin(ContextEngine, ContextQuery, ContextDiagnostics):
+    """Hermes LCM, exposed to SERA as a ``ContextEngine`` plugin.
+
+    The constructor resolves the vendored hermes-agent checkout, imports
+    ``MessageStore`` and ``SummaryDAG`` from it, and opens the sera-scoped
+    SQLite database (``~/.sera/plugins/lcm/lcm.db`` by default; override with
+    ``SERA_LCM_DATABASE_PATH``).
+    """
+
+    def __init__(self, db_path: str | Path | None = None) -> None:
+        resolved = Path(db_path) if db_path is not None else _default_db_path()
+        resolved.parent.mkdir(parents=True, exist_ok=True)
+
+        self._db_path = resolved
+        self._store = MessageStore(resolved)
+        self._dag = SummaryDAG(resolved)
+        self._count_message_tokens = count_message_tokens
+
+    # -- ContextEngine ----------------------------------------------------
+
+    async def ingest(self, msg: IngestMessage) -> IngestAck:
+        """Persist one message into LCM's ``MessageStore``.
+
+        Implements SPEC §4 ``ContextEngine::ingest`` → ``store.append``.
+        """
+        try:
+            openai_msg = _to_openai_message(msg)
+            token_estimate = self._count_message_tokens(openai_msg)
+            self._store.append(
+                msg.session_id,
+                openai_msg,
+                token_estimate=token_estimate,
+                source=msg.metadata.get("source", ""),
+            )
+        except Exception as exc:  # pragma: no cover - defensive wrap
+            raise PluginCapabilityError(
+                "LCM_INGEST_FAILED", f"failed to persist message: {exc}"
+            ) from exc
+        return IngestAck(accepted=True)
+
+    async def assemble(self, budget: AssembleBudget) -> AssembledContext:
+        """Build a context window under ``budget.budget_tokens``.
+
+        Returns:
+          - One ``ContextSegment`` per DAG summary (kind=``"longterm"``),
+            sorted by depth descending (highest-depth first — SPEC §4
+            "highest-depth summary nodes first, then lower").
+          - One ``ContextSegment`` per raw message from the tail of the
+            session (kind=``"working"``), ordered oldest → newest.
+
+        The function does **not** trigger summarisation; that lives behind
+        the ``compact`` seam which is not part of the sdk-py ABC today.
+        When budget is zero or negative, returns an empty window.
+        """
+        segments: list[ContextSegment] = []
+        used = 0
+        limit = int(budget.budget_tokens)
+        if limit <= 0:
+            return AssembledContext(segments=[], total_tokens=0)
+
+        # 1. Highest-depth summaries first (LCM's canonical assembly order).
+        nodes = self._dag.get_session_nodes(budget.session_id)
+        nodes_by_depth_desc = sorted(
+            nodes, key=lambda n: (-n.depth, -float(n.latest_at or n.created_at or 0.0))
+        )
+        for node in nodes_by_depth_desc:
+            node_tokens = int(node.token_count or 0)
+            if limit and used + node_tokens > limit and segments:
+                break
+            segments.append(
+                ContextSegment(
+                    kind="longterm",
+                    content=f"[d{node.depth} summary, node {node.node_id}]\n{node.summary}",
+                    tokens=node_tokens,
+                )
+            )
+            used += node_tokens
+
+        # 2. Raw messages, newest slice that still fits — reversed then flipped
+        #    to keep the fresh tail in chronological order.
+        messages = self._store.get_session_messages(budget.session_id)
+        tail_segments: list[ContextSegment] = []
+        for stored in reversed(messages):
+            content = stored.get("content") or ""
+            msg_tokens = int(stored.get("token_estimate") or 0)
+            if msg_tokens <= 0:
+                msg_tokens = self._count_message_tokens(
+                    {"role": stored.get("role", "user"), "content": content}
+                )
+            if limit and used + msg_tokens > limit and (segments or tail_segments):
+                break
+            tail_segments.append(
+                ContextSegment(kind="working", content=content, tokens=msg_tokens)
+            )
+            used += msg_tokens
+
+        segments.extend(reversed(tail_segments))
+        return AssembledContext(segments=segments, total_tokens=used)
+
+    # -- ContextQuery ------------------------------------------------------
+
+    async def search(self, req: CtxSearchRequest) -> CtxSearchResponse:
+        """Fan out to ``store.search`` + ``dag.search`` and merge results.
+
+        SPEC §4 ``ContextQuery::search``. The sdk-py wire shape returns
+        ``CtxSearchHit`` rows keyed by a string ``node_id`` — we stringify
+        the integer ``store_id`` / ``node_id`` per SPEC §2.2 (opaque types).
+        Messages get the ``"raw"`` depth label; summary nodes get ``"d{N}"``.
+        """
+        limit = max(1, int(req.limit or 10))
+        hits: list[CtxSearchHit] = []
+
+        try:
+            msg_rows = self._store.search(
+                req.query, session_id=req.session_id, limit=limit
+            )
+            for row in msg_rows:
+                hits.append(
+                    CtxSearchHit(
+                        node_id=f"msg:{row['store_id']}",
+                        depth_label="raw",
+                        preview=row.get("snippet") or (row.get("content") or "")[:200],
+                        rank=_maybe_float(row.get("search_rank")),
+                    )
+                )
+        except Exception as exc:
+            raise PluginCapabilityError(
+                "LCM_SEARCH_FAILED", f"store search failed: {exc}"
+            ) from exc
+
+        try:
+            node_rows = self._dag.search(
+                req.query, session_id=req.session_id, limit=limit
+            )
+            for node in node_rows:
+                hits.append(
+                    CtxSearchHit(
+                        node_id=f"node:{node.node_id}",
+                        depth_label=f"d{node.depth}",
+                        preview=(node.summary or "")[:300],
+                        rank=_maybe_float(node.search_rank),
+                    )
+                )
+        except Exception as exc:
+            raise PluginCapabilityError(
+                "LCM_SEARCH_FAILED", f"dag search failed: {exc}"
+            ) from exc
+
+        # Merge: lower rank is stronger (FTS5 convention; matches SPEC §2.2).
+        hits.sort(key=lambda h: (h.rank if h.rank is not None else float("inf")))
+        return CtxSearchResponse(hits=hits[:limit])
+
+    async def describe(self, req: DescribeRequest) -> DescribeResponse:
+        """Describe a node via ``SummaryDAG.describe_subtree`` or a raw message.
+
+        Node IDs use the prefix encoding produced by :meth:`search`:
+        ``"node:<int>"`` for DAG nodes, ``"msg:<int>"`` for raw messages.
+        A bare integer string is treated as a DAG node for convenience.
+        """
+        kind, raw_id = _parse_node_id(req.node_id)
+        if kind == "msg":
+            stored = self._store.get(raw_id)
+            if stored is None or (
+                req.session_id and stored.get("session_id") != req.session_id
+            ):
+                raise PluginCapabilityError(
+                    "LCM_NODE_NOT_FOUND",
+                    f"message {req.node_id} not found in session {req.session_id}",
+                )
+            return DescribeResponse(
+                node_id=req.node_id,
+                depth_label="raw",
+                tokens=int(stored.get("token_estimate") or 0),
+                child_node_ids=[],
+                metadata_json=json.dumps(
+                    {
+                        "role": stored.get("role"),
+                        "session_id": stored.get("session_id"),
+                        "timestamp": stored.get("timestamp"),
+                        "source": stored.get("source") or "",
+                    }
+                ),
+            )
+
+        node = self._dag.get_node(raw_id)
+        if node is None or (req.session_id and node.session_id != req.session_id):
+            raise PluginCapabilityError(
+                "LCM_NODE_NOT_FOUND",
+                f"node {req.node_id} not found in session {req.session_id}",
+            )
+        info = self._dag.describe_subtree(raw_id)
+        child_ids: list[str]
+        if node.source_type == "nodes":
+            child_ids = [f"node:{cid}" for cid in node.source_ids]
+        else:
+            child_ids = [f"msg:{cid}" for cid in node.source_ids]
+        return DescribeResponse(
+            node_id=req.node_id,
+            depth_label=f"d{node.depth}",
+            tokens=int(node.token_count or 0),
+            child_node_ids=child_ids,
+            metadata_json=json.dumps(info, default=_json_default),
+        )
+
+    async def expand(self, req: ExpandRequest) -> ExpandResponse:
+        """Expand a node or message back to concrete content.
+
+        For DAG nodes, walks ``source_ids`` back to either child summaries or
+        raw messages. For raw messages, returns the stored content.
+        """
+        max_tokens = max(0, int(req.max_tokens or 0))
+        kind, raw_id = _parse_node_id(req.node_id)
+
+        if kind == "msg":
+            stored = self._store.get(raw_id)
+            if stored is None or (
+                req.session_id and stored.get("session_id") != req.session_id
+            ):
+                raise PluginCapabilityError(
+                    "LCM_NODE_NOT_FOUND",
+                    f"message {req.node_id} not found in session {req.session_id}",
+                )
+            content = stored.get("content") or ""
+            truncated = False
+            if max_tokens and self._count_message_tokens({"role": stored.get("role", "user"), "content": content}) > max_tokens:
+                # Rough char-based clamp — matches hermes's conservative truncation.
+                approx_chars = max(1, max_tokens * 4)
+                if len(content) > approx_chars:
+                    content = content[:approx_chars]
+                    truncated = True
+            return ExpandResponse(
+                node_id=req.node_id,
+                content=content,
+                tokens=self._count_message_tokens(
+                    {"role": stored.get("role", "user"), "content": content}
+                ),
+                truncated=truncated,
+            )
+
+        node = self._dag.get_node(raw_id)
+        if node is None or (req.session_id and node.session_id != req.session_id):
+            raise PluginCapabilityError(
+                "LCM_NODE_NOT_FOUND",
+                f"node {req.node_id} not found in session {req.session_id}",
+            )
+
+        blocks: list[str] = []
+        used = 0
+        truncated = False
+
+        if node.source_type == "messages":
+            stored_by_id = self._store.get_batch(node.source_ids)
+            for sid in node.source_ids:
+                stored = stored_by_id.get(sid)
+                if not stored:
+                    continue
+                content = stored.get("content") or ""
+                msg_tokens = int(stored.get("token_estimate") or 0)
+                if msg_tokens <= 0:
+                    msg_tokens = self._count_message_tokens(
+                        {"role": stored.get("role", "user"), "content": content}
+                    )
+                if max_tokens and used + msg_tokens > max_tokens and blocks:
+                    truncated = True
+                    break
+                blocks.append(f"[{stored.get('role', 'user')} / store:{sid}] {content}")
+                used += msg_tokens
+        else:  # source_type == "nodes"
+            for child in self._dag.get_source_nodes(node):
+                child_tokens = int(child.token_count or 0)
+                if max_tokens and used + child_tokens > max_tokens and blocks:
+                    truncated = True
+                    break
+                blocks.append(
+                    f"[d{child.depth} / node:{child.node_id}] {child.summary}"
+                )
+                used += child_tokens
+
+        combined = "\n\n".join(blocks)
+        return ExpandResponse(
+            node_id=req.node_id,
+            content=combined,
+            tokens=used,
+            truncated=truncated,
+        )
+
+    # -- ContextDiagnostics ------------------------------------------------
+
+    async def status(self, session_id: str) -> StatusResponse:
+        """Return LCM counters as a JSON blob (``fields_json``).
+
+        Matches the ``lcm_status`` tool's output shape but trimmed to the
+        fields the trait surface cares about. The full metrics remain
+        available via the sera tool registry when the trait impl is wired
+        into agent-facing tools.
+        """
+        session = session_id or ""
+        store_messages = self._store.get_session_count(session) if session else 0
+        store_tokens = self._store.get_session_token_total(session) if session else 0
+        nodes = self._dag.get_session_nodes(session) if session else []
+
+        depths: dict[int, dict[str, int]] = {}
+        for node in nodes:
+            bucket = depths.setdefault(node.depth, {"count": 0, "tokens": 0})
+            bucket["count"] += 1
+            bucket["tokens"] += int(node.token_count or 0)
+
+        fields = {
+            "session_id": session,
+            "store": {
+                "messages": store_messages,
+                "estimated_tokens": store_tokens,
+            },
+            "dag": {
+                "total_nodes": len(nodes),
+                "depths": {
+                    f"d{depth}": info for depth, info in sorted(depths.items())
+                },
+            },
+        }
+        return StatusResponse(fields_json=json.dumps(fields, default=_json_default))
+
+    async def doctor(self) -> DoctorReport:
+        """Run LCM-style health checks: integrity + FTS sync + orphans."""
+        checks: list[DoctorCheck] = []
+        conn = self._store._conn
+        assert conn is not None, "MessageStore connection was closed before doctor()"
+
+        # 1. Database integrity
+        try:
+            row = conn.execute("PRAGMA integrity_check").fetchone()
+            ok_pragma = bool(row and row[0] == "ok")
+            checks.append(
+                DoctorCheck(
+                    name="database_integrity",
+                    severity="ok" if ok_pragma else "fail",
+                    message=str(row[0]) if row else "no response",
+                )
+            )
+        except sqlite3.Error as exc:
+            checks.append(
+                DoctorCheck(
+                    name="database_integrity",
+                    severity="fail",
+                    message=str(exc),
+                )
+            )
+
+        # 2. FTS index sync
+        try:
+            msg_count = conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
+            fts_count = conn.execute("SELECT COUNT(*) FROM messages_fts").fetchone()[0]
+            checks.append(
+                DoctorCheck(
+                    name="fts_index_sync",
+                    severity="ok" if fts_count >= msg_count else "warn",
+                    message=f"{fts_count} FTS rows, {msg_count} messages",
+                )
+            )
+        except sqlite3.Error as exc:
+            checks.append(
+                DoctorCheck(name="fts_index_sync", severity="fail", message=str(exc))
+            )
+
+        # 3. Node table health — count rows without deep-walking (trait doctor
+        #    has no session scope; per-session orphan detail lives in status()).
+        try:
+            node_count = conn.execute("SELECT COUNT(*) FROM summary_nodes").fetchone()[0]
+            checks.append(
+                DoctorCheck(
+                    name="summary_nodes_present",
+                    severity="ok",
+                    message=f"{node_count} summary node(s) across all sessions",
+                )
+            )
+        except sqlite3.Error as exc:
+            checks.append(
+                DoctorCheck(
+                    name="summary_nodes_present", severity="fail", message=str(exc)
+                )
+            )
+
+        return DoctorReport(checks=checks)
+
+    # -- Lifecycle ---------------------------------------------------------
+
+    async def on_shutdown(self) -> None:
+        """Close SQLite connections on graceful shutdown."""
+        try:
+            self._store.close()
+        finally:
+            self._dag.close()
+
+
+# --- helpers ---------------------------------------------------------------
+
+
+def _to_openai_message(msg: IngestMessage) -> dict[str, Any]:
+    """Project ``IngestMessage`` onto the hermes/OpenAI message shape."""
+    out: dict[str, Any] = {"role": msg.role, "content": msg.content}
+    if "tool_call_id" in msg.metadata:
+        out["tool_call_id"] = msg.metadata["tool_call_id"]
+    if "tool_name" in msg.metadata:
+        out["tool_name"] = msg.metadata["tool_name"]
+    return out
+
+
+def _parse_node_id(node_id: str) -> tuple[str, int]:
+    """Decode ``"msg:<int>"`` / ``"node:<int>"`` / bare-int node identifiers.
+
+    Raises :class:`PluginCapabilityError` if the id cannot be decoded — the
+    stdio transport turns that into a JSON-RPC capability error.
+    """
+    if not node_id:
+        raise PluginCapabilityError(
+            "LCM_INVALID_NODE_ID", "node_id must not be empty"
+        )
+    if ":" in node_id:
+        prefix, _, rest = node_id.partition(":")
+        if prefix not in ("msg", "node"):
+            raise PluginCapabilityError(
+                "LCM_INVALID_NODE_ID",
+                f"unknown node prefix '{prefix}' — expected msg:/node:",
+            )
+        try:
+            return prefix, int(rest)
+        except ValueError as exc:
+            raise PluginCapabilityError(
+                "LCM_INVALID_NODE_ID", f"invalid numeric id in '{node_id}'"
+            ) from exc
+    # Bare integer — default to DAG node id.
+    try:
+        return "node", int(node_id)
+    except ValueError as exc:
+        raise PluginCapabilityError(
+            "LCM_INVALID_NODE_ID", f"cannot parse node_id '{node_id}'"
+        ) from exc
+
+
+def _maybe_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _json_default(obj: Any) -> Any:
+    """Serialise non-JSON-native types conservatively."""
+    if isinstance(obj, bytes):
+        return obj.decode("utf-8", errors="replace")
+    return str(obj)
+
+
+__all__ = ["LcmPlugin"]

--- a/sdk/python/sera-context-lcm/tests/conftest.py
+++ b/sdk/python/sera-context-lcm/tests/conftest.py
@@ -1,0 +1,22 @@
+"""Shared pytest fixtures."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from sera_context_lcm import LcmPlugin
+
+
+@pytest.fixture
+def plugin(tmp_path: Path) -> Iterator[LcmPlugin]:
+    """Return an ``LcmPlugin`` backed by a per-test SQLite file."""
+    db_path = tmp_path / "lcm.db"
+    p = LcmPlugin(db_path=db_path)
+    try:
+        yield p
+    finally:
+        p._store.close()
+        p._dag.close()

--- a/sdk/python/sera-context-lcm/tests/test_context_diagnostics.py
+++ b/sdk/python/sera-context-lcm/tests/test_context_diagnostics.py
@@ -1,0 +1,69 @@
+"""ContextDiagnostics trait: ``status`` + ``doctor``."""
+
+from __future__ import annotations
+
+import json
+
+from sera_plugin_sdk.types import IngestMessage
+
+from sera_context_lcm import LcmPlugin
+from sera_context_lcm._lcm_core.dag import SummaryNode
+
+
+async def test_status_empty_session_reports_zero_counts(plugin: LcmPlugin) -> None:
+    resp = await plugin.status("empty-session")
+    data = json.loads(resp.fields_json)
+    assert data["session_id"] == "empty-session"
+    assert data["store"]["messages"] == 0
+    assert data["dag"]["total_nodes"] == 0
+
+
+async def test_status_reports_message_counts(plugin: LcmPlugin) -> None:
+    for i in range(4):
+        await plugin.ingest(
+            IngestMessage(session_id="s1", role="user", content=f"msg-{i}")
+        )
+    resp = await plugin.status("s1")
+    data = json.loads(resp.fields_json)
+    assert data["store"]["messages"] == 4
+    assert data["store"]["estimated_tokens"] > 0
+
+
+async def test_status_groups_dag_nodes_by_depth(plugin: LcmPlugin) -> None:
+    for depth in (0, 0, 1):
+        plugin._dag.add_node(
+            SummaryNode(
+                session_id="s1",
+                depth=depth,
+                summary="x",
+                token_count=3,
+                source_token_count=10,
+                source_ids=[],
+                source_type="messages",
+            )
+        )
+    resp = await plugin.status("s1")
+    data = json.loads(resp.fields_json)
+    assert data["dag"]["total_nodes"] == 3
+    assert data["dag"]["depths"]["d0"]["count"] == 2
+    assert data["dag"]["depths"]["d1"]["count"] == 1
+
+
+async def test_doctor_reports_core_checks(plugin: LcmPlugin) -> None:
+    report = await plugin.doctor()
+    names = {c.name for c in report.checks}
+    assert {"database_integrity", "fts_index_sync", "summary_nodes_present"} <= names
+    # Freshly-booted DB should be healthy.
+    integrity = next(c for c in report.checks if c.name == "database_integrity")
+    assert integrity.severity == "ok"
+
+
+async def test_doctor_fts_in_sync_after_ingest(plugin: LcmPlugin) -> None:
+    for i in range(3):
+        await plugin.ingest(
+            IngestMessage(session_id="s1", role="user", content=f"m-{i}")
+        )
+    report = await plugin.doctor()
+    fts = next(c for c in report.checks if c.name == "fts_index_sync")
+    assert fts.severity == "ok"
+    assert "3" in fts.message

--- a/sdk/python/sera-context-lcm/tests/test_context_engine.py
+++ b/sdk/python/sera-context-lcm/tests/test_context_engine.py
@@ -1,0 +1,131 @@
+"""ContextEngine trait: ``ingest`` + ``assemble``."""
+
+from __future__ import annotations
+
+import pytest
+from sera_plugin_sdk.capabilities import (
+    ContextDiagnostics,
+    ContextEngine,
+    ContextQuery,
+)
+from sera_plugin_sdk.types import (
+    AssembleBudget,
+    IngestMessage,
+)
+
+from sera_context_lcm import LcmPlugin
+
+
+async def test_plugin_implements_all_three_capabilities(plugin: LcmPlugin) -> None:
+    assert isinstance(plugin, ContextEngine)
+    assert isinstance(plugin, ContextQuery)
+    assert isinstance(plugin, ContextDiagnostics)
+
+
+async def test_ingest_persists_message(plugin: LcmPlugin) -> None:
+    ack = await plugin.ingest(
+        IngestMessage(session_id="s1", role="user", content="hello")
+    )
+    assert ack.accepted is True
+    assert plugin._store.get_session_count("s1") == 1
+
+
+async def test_ingest_round_trip_preserves_role_and_content(plugin: LcmPlugin) -> None:
+    await plugin.ingest(
+        IngestMessage(session_id="s1", role="assistant", content="reply one")
+    )
+    messages = plugin._store.get_session_messages("s1")
+    assert len(messages) == 1
+    assert messages[0]["role"] == "assistant"
+    assert messages[0]["content"] == "reply one"
+
+
+async def test_ingest_stores_source_from_metadata(plugin: LcmPlugin) -> None:
+    await plugin.ingest(
+        IngestMessage(
+            session_id="s2",
+            role="user",
+            content="tagged",
+            metadata={"source": "telegram"},
+        )
+    )
+    messages = plugin._store.get_session_messages("s2")
+    assert messages[0]["source"] == "telegram"
+
+
+async def test_assemble_returns_working_segments_in_order(plugin: LcmPlugin) -> None:
+    for i in range(3):
+        await plugin.ingest(
+            IngestMessage(session_id="s1", role="user", content=f"msg-{i}")
+        )
+    assembled = await plugin.assemble(AssembleBudget(session_id="s1", budget_tokens=200))
+    contents = [s.content for s in assembled.segments]
+    assert contents == ["msg-0", "msg-1", "msg-2"]
+    assert all(s.kind == "working" for s in assembled.segments)
+    assert assembled.total_tokens > 0
+
+
+async def test_assemble_respects_budget(plugin: LcmPlugin) -> None:
+    # Each ingest adds one small message (~5 tokens via char heuristic).
+    for i in range(10):
+        await plugin.ingest(
+            IngestMessage(session_id="s1", role="user", content=f"row-{i}")
+        )
+    tight = await plugin.assemble(AssembleBudget(session_id="s1", budget_tokens=20))
+    assert tight.total_tokens <= 40  # allow slack for per-message overhead
+    assert len(tight.segments) < 10
+
+
+async def test_assemble_empty_session_returns_empty_window(plugin: LcmPlugin) -> None:
+    assembled = await plugin.assemble(AssembleBudget(session_id="never", budget_tokens=1000))
+    assert assembled.segments == []
+    assert assembled.total_tokens == 0
+
+
+async def test_assemble_keeps_freshest_tail_under_tight_budget(plugin: LcmPlugin) -> None:
+    # Each message distinct so ordering is visible. Older messages should fall
+    # out first; the newest content must survive.
+    for i in range(6):
+        await plugin.ingest(
+            IngestMessage(session_id="s1", role="user", content=f"item-{i}")
+        )
+    assembled = await plugin.assemble(AssembleBudget(session_id="s1", budget_tokens=20))
+    assert assembled.segments[-1].content == "item-5"
+
+
+async def test_assemble_places_longterm_segments_before_working(plugin: LcmPlugin) -> None:
+    # Inject a synthetic DAG node so we exercise the longterm branch without
+    # needing the full summarisation pipeline.
+    from sera_context_lcm._lcm_core.dag import SummaryNode
+
+    await plugin.ingest(
+        IngestMessage(session_id="s1", role="user", content="leaf message")
+    )
+    node = SummaryNode(
+        session_id="s1",
+        depth=1,
+        summary="synthetic summary of older turns",
+        token_count=6,
+        source_token_count=50,
+        source_ids=[1],
+        source_type="messages",
+    )
+    plugin._dag.add_node(node)
+
+    assembled = await plugin.assemble(AssembleBudget(session_id="s1", budget_tokens=500))
+    kinds = [s.kind for s in assembled.segments]
+    # longterm must come first.
+    assert kinds[0] == "longterm"
+    assert "working" in kinds
+
+
+@pytest.mark.parametrize("budget", [0, -1])
+async def test_assemble_zero_or_negative_budget_is_empty(
+    plugin: LcmPlugin, budget: int
+) -> None:
+    await plugin.ingest(
+        IngestMessage(session_id="s1", role="user", content="x")
+    )
+    assembled = await plugin.assemble(AssembleBudget(session_id="s1", budget_tokens=budget))
+    assert assembled.segments == []
+    assert assembled.total_tokens == 0

--- a/sdk/python/sera-context-lcm/tests/test_context_query.py
+++ b/sdk/python/sera-context-lcm/tests/test_context_query.py
@@ -1,0 +1,218 @@
+"""ContextQuery trait: ``search`` + ``describe`` + ``expand``."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from sera_plugin_sdk.errors import PluginCapabilityError
+from sera_plugin_sdk.types import (
+    CtxSearchRequest,
+    DescribeRequest,
+    ExpandRequest,
+    IngestMessage,
+)
+
+from sera_context_lcm import LcmPlugin
+from sera_context_lcm._lcm_core.dag import SummaryNode
+
+
+async def _seed(plugin: LcmPlugin, session_id: str = "s1") -> None:
+    await plugin.ingest(
+        IngestMessage(session_id=session_id, role="user", content="hello world sera")
+    )
+    await plugin.ingest(
+        IngestMessage(
+            session_id=session_id, role="assistant", content="the sera runtime is online"
+        )
+    )
+    await plugin.ingest(
+        IngestMessage(session_id=session_id, role="user", content="wat is the plan")
+    )
+
+
+async def test_search_returns_matching_messages(plugin: LcmPlugin) -> None:
+    await _seed(plugin)
+    resp = await plugin.search(
+        CtxSearchRequest(session_id="s1", query="sera", limit=10)
+    )
+    assert len(resp.hits) >= 2
+    for hit in resp.hits:
+        assert hit.node_id.startswith("msg:")
+        assert hit.depth_label == "raw"
+        assert "sera" in hit.preview.lower()
+
+
+async def test_search_mixes_message_and_summary_hits(plugin: LcmPlugin) -> None:
+    await _seed(plugin)
+    node = SummaryNode(
+        session_id="s1",
+        depth=1,
+        summary="sera runtime summary of the conversation",
+        token_count=7,
+        source_token_count=30,
+        source_ids=[1, 2],
+        source_type="messages",
+    )
+    plugin._dag.add_node(node)
+
+    resp = await plugin.search(
+        CtxSearchRequest(session_id="s1", query="sera", limit=10)
+    )
+    node_ids = {h.node_id for h in resp.hits}
+    assert any(nid.startswith("node:") for nid in node_ids)
+    assert any(nid.startswith("msg:") for nid in node_ids)
+
+
+async def test_search_honours_limit(plugin: LcmPlugin) -> None:
+    for i in range(6):
+        await plugin.ingest(
+            IngestMessage(
+                session_id="s1", role="user", content=f"sera sera sera #{i}"
+            )
+        )
+    resp = await plugin.search(
+        CtxSearchRequest(session_id="s1", query="sera", limit=3)
+    )
+    assert len(resp.hits) <= 3
+
+
+async def test_describe_raw_message(plugin: LcmPlugin) -> None:
+    await _seed(plugin)
+    resp = await plugin.describe(DescribeRequest(session_id="s1", node_id="msg:1"))
+    assert resp.node_id == "msg:1"
+    assert resp.depth_label == "raw"
+    assert resp.child_node_ids == []
+    meta = json.loads(resp.metadata_json)
+    assert meta["role"] == "user"
+    assert meta["session_id"] == "s1"
+
+
+async def test_describe_dag_node(plugin: LcmPlugin) -> None:
+    await _seed(plugin)
+    node = SummaryNode(
+        session_id="s1",
+        depth=1,
+        summary="abc",
+        token_count=5,
+        source_token_count=30,
+        source_ids=[1, 2],
+        source_type="messages",
+    )
+    node_id = plugin._dag.add_node(node)
+
+    resp = await plugin.describe(
+        DescribeRequest(session_id="s1", node_id=f"node:{node_id}")
+    )
+    assert resp.depth_label == "d1"
+    assert resp.tokens == 5
+    assert resp.child_node_ids == ["msg:1", "msg:2"]
+
+
+async def test_describe_bare_int_defaults_to_dag_node(plugin: LcmPlugin) -> None:
+    node_id = plugin._dag.add_node(
+        SummaryNode(
+            session_id="s1",
+            depth=2,
+            summary="x",
+            token_count=1,
+            source_token_count=1,
+            source_ids=[],
+            source_type="nodes",
+        )
+    )
+    resp = await plugin.describe(
+        DescribeRequest(session_id="s1", node_id=str(node_id))
+    )
+    assert resp.depth_label == "d2"
+
+
+async def test_describe_missing_message_errors(plugin: LcmPlugin) -> None:
+    with pytest.raises(PluginCapabilityError) as excinfo:
+        await plugin.describe(DescribeRequest(session_id="s1", node_id="msg:999"))
+    assert excinfo.value.code == "LCM_NODE_NOT_FOUND"
+
+
+async def test_describe_wrong_session_errors(plugin: LcmPlugin) -> None:
+    await _seed(plugin, session_id="sA")
+    with pytest.raises(PluginCapabilityError):
+        await plugin.describe(DescribeRequest(session_id="sB", node_id="msg:1"))
+
+
+@pytest.mark.parametrize("bad", ["", "msg:", "xyz:1", "msg:abc"])
+async def test_describe_invalid_id_errors(plugin: LcmPlugin, bad: str) -> None:
+    with pytest.raises(PluginCapabilityError) as excinfo:
+        await plugin.describe(DescribeRequest(session_id="s1", node_id=bad))
+    assert excinfo.value.code == "LCM_INVALID_NODE_ID"
+
+
+async def test_expand_raw_message_returns_content(plugin: LcmPlugin) -> None:
+    await _seed(plugin)
+    resp = await plugin.expand(
+        ExpandRequest(session_id="s1", node_id="msg:1", max_tokens=200)
+    )
+    assert resp.content == "hello world sera"
+    assert resp.tokens > 0
+    assert resp.truncated is False
+
+
+async def test_expand_message_truncates_when_over_budget(plugin: LcmPlugin) -> None:
+    await plugin.ingest(
+        IngestMessage(session_id="s1", role="user", content="a" * 10_000)
+    )
+    resp = await plugin.expand(
+        ExpandRequest(session_id="s1", node_id="msg:1", max_tokens=20)
+    )
+    assert resp.truncated is True
+    assert len(resp.content) < 10_000
+
+
+async def test_expand_dag_node_with_message_sources(plugin: LcmPlugin) -> None:
+    await _seed(plugin)
+    node_id = plugin._dag.add_node(
+        SummaryNode(
+            session_id="s1",
+            depth=0,
+            summary="leaf summary",
+            token_count=4,
+            source_token_count=20,
+            source_ids=[1, 2],
+            source_type="messages",
+        )
+    )
+    resp = await plugin.expand(
+        ExpandRequest(session_id="s1", node_id=f"node:{node_id}", max_tokens=500)
+    )
+    assert "hello world sera" in resp.content
+    assert "the sera runtime is online" in resp.content
+    assert resp.tokens > 0
+
+
+async def test_expand_dag_node_with_node_sources(plugin: LcmPlugin) -> None:
+    leaf_id = plugin._dag.add_node(
+        SummaryNode(
+            session_id="s1",
+            depth=0,
+            summary="leaf-0 summary",
+            token_count=6,
+            source_token_count=20,
+            source_ids=[],
+            source_type="messages",
+        )
+    )
+    parent_id = plugin._dag.add_node(
+        SummaryNode(
+            session_id="s1",
+            depth=1,
+            summary="parent",
+            token_count=3,
+            source_token_count=6,
+            source_ids=[leaf_id],
+            source_type="nodes",
+        )
+    )
+    resp = await plugin.expand(
+        ExpandRequest(session_id="s1", node_id=f"node:{parent_id}", max_tokens=500)
+    )
+    assert "leaf-0 summary" in resp.content
+    assert resp.tokens > 0

--- a/sdk/python/sera-context-lcm/tests/test_stdio_integration.py
+++ b/sdk/python/sera-context-lcm/tests/test_stdio_integration.py
@@ -1,0 +1,182 @@
+"""End-to-end stdio integration — drive the real plugin via ``sdk-py`` stdio.
+
+Boots an ``LcmPlugin`` against an in-memory pipe, sends JSON-RPC frames for
+``ContextEngine.ingest`` + ``ContextEngine.assemble`` + ``ContextQuery.search``
++ ``ContextDiagnostics.status``, and asserts the wire responses agree with the
+direct in-process calls. This is the end-to-end canary: it proves the
+capability dispatch table wiring, the NDJSON framing, and the trait-triad
+``isinstance`` check all hold together for a real plugin.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+from sera_plugin_sdk.transport import stdio as stdio_transport
+
+from sera_context_lcm import LcmPlugin
+
+
+class _InMemoryWriteTransport(asyncio.WriteTransport):
+    def __init__(
+        self,
+        target: asyncio.StreamReader,
+        protocol: asyncio.StreamReaderProtocol,
+    ) -> None:
+        super().__init__()
+        self._target = target
+        self._protocol = protocol
+        self._closed = False
+
+    def write(self, data: bytes | bytearray | memoryview) -> None:
+        if not self._closed:
+            self._target.feed_data(bytes(data))
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        self._target.feed_eof()
+        loop = asyncio.get_event_loop()
+        loop.call_soon(self._protocol.connection_lost, None)
+
+    def is_closing(self) -> bool:
+        return self._closed
+
+    def get_write_buffer_size(self) -> int:
+        return 0
+
+    def can_write_eof(self) -> bool:
+        return True
+
+    def write_eof(self) -> None:
+        self.close()
+
+
+def _pipe_writer(target: asyncio.StreamReader) -> asyncio.StreamWriter:
+    loop = asyncio.get_event_loop()
+    dummy = asyncio.StreamReader()
+    protocol = asyncio.StreamReaderProtocol(dummy)
+    transport = _InMemoryWriteTransport(target, protocol)
+    protocol.connection_made(transport)
+    return asyncio.StreamWriter(transport, protocol, dummy, loop)
+
+
+def _frame(**payload: object) -> bytes:
+    return (json.dumps({"jsonrpc": "2.0", **payload}) + "\n").encode("utf-8")
+
+
+async def _exchange(
+    plugin: object, lines: list[bytes]
+) -> list[dict[str, object]]:
+    client_to_server = asyncio.StreamReader()
+    server_to_client = asyncio.StreamReader()
+    for line in lines:
+        client_to_server.feed_data(line)
+    client_to_server.feed_eof()
+    server_writer = _pipe_writer(server_to_client)
+    await stdio_transport.serve(plugin, client_to_server, server_writer)
+
+    responses: list[dict[str, object]] = []
+    while True:
+        line = await server_to_client.readline()
+        if not line:
+            break
+        responses.append(json.loads(line))
+    return responses
+
+
+async def test_register_response_advertises_full_capability_triad(
+    tmp_path: Path,
+) -> None:
+    plugin = LcmPlugin(db_path=tmp_path / "lcm.db")
+    try:
+        responses = await _exchange(
+            plugin, [_frame(id=1, method="PluginRegistry.Register", params={})]
+        )
+    finally:
+        plugin._store.close()
+        plugin._dag.close()
+
+    assert responses[0]["id"] == 1
+    result = responses[0]["result"]
+    assert isinstance(result, dict)
+    capabilities = result["server_capabilities"]
+    assert isinstance(capabilities, list)
+    assert set(capabilities) >= {
+        "ContextEngine",
+        "ContextQuery",
+        "ContextDiagnostics",
+    }
+
+
+async def test_stdio_full_round_trip(tmp_path: Path) -> None:
+    plugin = LcmPlugin(db_path=tmp_path / "lcm.db")
+    try:
+        responses = await _exchange(
+            plugin,
+            [
+                _frame(
+                    id=1,
+                    method="ContextEngine.ingest",
+                    params={
+                        "session_id": "sx",
+                        "role": "user",
+                        "content": "first message about sera",
+                        "metadata": {},
+                    },
+                ),
+                _frame(
+                    id=2,
+                    method="ContextEngine.ingest",
+                    params={
+                        "session_id": "sx",
+                        "role": "assistant",
+                        "content": "second reply mentions sera",
+                        "metadata": {},
+                    },
+                ),
+                _frame(
+                    id=3,
+                    method="ContextEngine.assemble",
+                    params={
+                        "session_id": "sx",
+                        "budget_tokens": 200,
+                        "constraints_json": "",
+                    },
+                ),
+                _frame(
+                    id=4,
+                    method="ContextQuery.search",
+                    params={"session_id": "sx", "query": "sera", "limit": 5},
+                ),
+                _frame(
+                    id=5,
+                    method="ContextDiagnostics.status",
+                    params={"session_id": "sx"},
+                ),
+            ],
+        )
+    finally:
+        plugin._store.close()
+        plugin._dag.close()
+
+    by_id = {r["id"]: r for r in responses}
+    assert by_id[1]["result"] == {"accepted": True}
+    assert by_id[2]["result"] == {"accepted": True}
+
+    assembled = by_id[3]["result"]
+    assert isinstance(assembled, dict)
+    assert assembled["total_tokens"] > 0
+    assert len(assembled["segments"]) == 2
+
+    search = by_id[4]["result"]
+    assert isinstance(search, dict)
+    assert len(search["hits"]) >= 2
+
+    status = by_id[5]["result"]
+    assert isinstance(status, dict)
+    status_fields = json.loads(status["fields_json"])
+    assert status_fields["store"]["messages"] == 2


### PR DESCRIPTION
## Summary

First out-of-process consumer of `sera-plugin-sdk` — wraps hermes-agent's
Lossless Context Management (LCM) engine as a stdio-transport SERA plugin
implementing the full `ContextEngine` + `ContextQuery` + `ContextDiagnostics`
trait triad from `SPEC-context-engine-pluggability`.

Per the design-pass insight baked into the bead, the adapter binds LCM's
internal `MessageStore` + `SummaryDAG` directly rather than subclassing
hermes-agent's public `ContextEngine` — their `compress(messages, tokens)`
shape is incompatible with SERA's per-session `ingest / assemble / compact`
contract.

Only the storage + search subset of LCM (`store.py`, `dag.py`, `tokens.py`,
`db_bootstrap.py`, `search_query.py`) is vendored under
`src/sera_context_lcm/_lcm_core/`. That subset has zero external hermes-agent
imports, so the plugin ships as a self-contained wheel. The summarisation
pipeline is intentionally excluded — the sdk-py ABC doesn't cover `compact()`
today and those modules depend on hermes-agent's auxiliary LLM client.

Fresh SQLite schema at `~/.sera/plugins/lcm/lcm.db` (override via
`SERA_LCM_DATABASE_PATH`). No byte-compat migration from existing hermes LCM
storage — that stays a future bead if users need it.

## What's in here

- `sdk/python/sera-context-lcm/` — new hatch-backed package (pyproject,
  plugin.yaml stdio manifest, LICENSE, README, package source).
- Vendored LCM subset under `src/sera_context_lcm/_lcm_core/` with an origin
  note in its `__init__.py`.
- 34 tests covering each trait method individually plus an end-to-end stdio
  JSON-RPC round-trip through the real sdk-py transport.
- `.github/workflows/validate-context-lcm.yml` — new CI job (ruff + mypy +
  pytest + `hatch build`), triggered on changes to
  `sdk/python/sera-context-lcm/**` or the plugin protos.

## Test plan

- [ ] `validate-context-lcm` job passes on the PR
- [ ] `validate-rust` / `ci-e2e-smoke` stay green (untouched)
- [ ] Local dev: `cd sdk/python/sera-context-lcm && pytest -q` — 34 passing

## Design doc reference

- `docs/plan/specs/SPEC-context-engine-pluggability.md` §2, §4 (trait surface
  + LCM mapping table).

Closes sera-yf9r.