### PR TITLE
fix(sera-gateway): wire SqliteGitSessionStore into production boot path (sera-4i4i)

### DIFF
--- a/rust/crates/sera-gateway/src/bin/sera.rs
+++ b/rust/crates/sera-gateway/src/bin/sera.rs
@@ -46,7 +46,9 @@ use sera_runtime::skill_dispatch::SkillDispatchEngine;
 // sera-uwk0: Mail gate ingress correlator (Design B — RFC 5322 headers +
 // SERA-issued nonce fallback). Wired into AppState + `/api/mail/inbound`.
 use sera_gateway::kill_switch::{KillSwitch, admin_sock_path, spawn_admin_socket};
-use sera_gateway::session_store::{InMemorySessionStore, SessionStore as _};
+use sera_gateway::session_store::{SessionStore, SqliteGitSessionStore};
+#[cfg(test)]
+use sera_gateway::session_store::InMemorySessionStore;
 use sera_hooks::{ChainExecutor, HookRegistry};
 use sera_mail::{
     CorrelationOutcome, HeaderMailCorrelator, InMemoryEnvelopeIndex, InMemoryMailLookup,
@@ -561,8 +563,9 @@ struct AppState {
     kill_switch: Arc<KillSwitch>,
     /// Submission envelope store — every agent-facing route appends a
     /// Submission here before calling the underlying service (sera-r1g8).
-    /// In-memory stub until sera-r9ed lands with the PartTable+git backing.
-    session_store: Arc<InMemorySessionStore>,
+    /// Production boot uses SqliteGitSessionStore (sera-4i4i); tests keep
+    /// InMemorySessionStore to avoid writing shadow-git dirs to disk.
+    session_store: Arc<dyn SessionStore>,
 }
 
 // ── Phase-3 trait impls ──────────────────────────────────────────────────────
@@ -2396,7 +2399,16 @@ async fn run_start(config: PathBuf, port: u16) -> anyhow::Result<()> {
     );
 
     // 2. Open SQLite database.
-    let db_path = PathBuf::from("sera.db");
+    //
+    // sera-4i4i: data_root is the directory that holds all local-first
+    // persistence (sera.db, parts.sqlite, sessions/). Defaults to cwd so
+    // existing deployments keep working; override via SERA_DATA_ROOT.
+    let data_root = std::env::var("SERA_DATA_ROOT")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("."));
+    let db_path = data_root.join("sera.db");
     tracing::info!(path = %db_path.display(), "Opening SQLite database");
     let db = SqliteDb::open(&db_path)?;
 
@@ -2731,7 +2743,16 @@ async fn run_start(config: PathBuf, port: u16) -> anyhow::Result<()> {
         skill_engine,
         semantic_store,
         kill_switch: Arc::new(KillSwitch::new()),
-        session_store: Arc::new(InMemorySessionStore::new()),
+        // sera-4i4i: use SqliteGitSessionStore so envelopes survive restarts.
+        // db_path = <data_root>/parts.sqlite; sessions_root = <data_root>/sessions/.
+        session_store: {
+            let parts_db = data_root.join("parts.sqlite");
+            let sessions_root = data_root.join("sessions");
+            Arc::new(
+                SqliteGitSessionStore::open(&parts_db, &sessions_root)
+                    .expect("failed to initialize SqliteGitSessionStore"),
+            )
+        },
     });
 
     // 4. Start event processing loop.
@@ -3171,6 +3192,8 @@ mod tests {
                 SqliteMemoryStore::open_in_memory(None).expect("open in-memory semantic store"),
             ),
             kill_switch: Arc::new(KillSwitch::new()),
+            // sera-4i4i: intentional test-fixture — InMemorySessionStore avoids
+            // writing shadow-git dirs to the filesystem during tests.
             session_store: Arc::new(InMemorySessionStore::new()),
         })
     }
@@ -3205,6 +3228,8 @@ mod tests {
                 SqliteMemoryStore::open_in_memory(None).expect("open in-memory semantic store"),
             ),
             kill_switch: Arc::new(KillSwitch::new()),
+            // sera-4i4i: intentional test-fixture — InMemorySessionStore avoids
+            // writing shadow-git dirs to the filesystem during tests.
             session_store: Arc::new(InMemorySessionStore::new()),
         })
     }
@@ -3239,6 +3264,8 @@ mod tests {
                 SqliteMemoryStore::open_in_memory(None).expect("open in-memory semantic store"),
             ),
             kill_switch: Arc::new(KillSwitch::new()),
+            // sera-4i4i: intentional test-fixture — InMemorySessionStore avoids
+            // writing shadow-git dirs to the filesystem during tests.
             session_store: Arc::new(InMemorySessionStore::new()),
         })
     }
@@ -3273,6 +3300,8 @@ mod tests {
                 SqliteMemoryStore::open_in_memory(None).expect("open in-memory semantic store"),
             ),
             kill_switch: Arc::new(KillSwitch::new()),
+            // sera-4i4i: intentional test-fixture — InMemorySessionStore avoids
+            // writing shadow-git dirs to the filesystem during tests.
             session_store: Arc::new(InMemorySessionStore::new()),
         })
     }
@@ -4071,6 +4100,8 @@ mod tests {
                 SqliteMemoryStore::open_in_memory(None).expect("open in-memory semantic store"),
             ),
             kill_switch: Arc::new(KillSwitch::new()),
+            // sera-4i4i: intentional test-fixture — InMemorySessionStore avoids
+            // writing shadow-git dirs to the filesystem during tests.
             session_store: Arc::new(InMemorySessionStore::new()),
         };
         let headers = HeaderMap::new();
@@ -4108,6 +4139,8 @@ mod tests {
                 SqliteMemoryStore::open_in_memory(None).expect("open in-memory semantic store"),
             ),
             kill_switch: Arc::new(KillSwitch::new()),
+            // sera-4i4i: intentional test-fixture — InMemorySessionStore avoids
+            // writing shadow-git dirs to the filesystem during tests.
             session_store: Arc::new(InMemorySessionStore::new()),
         };
         let mut headers = HeaderMap::new();
@@ -4146,6 +4179,8 @@ mod tests {
                 SqliteMemoryStore::open_in_memory(None).expect("open in-memory semantic store"),
             ),
             kill_switch: Arc::new(KillSwitch::new()),
+            // sera-4i4i: intentional test-fixture — InMemorySessionStore avoids
+            // writing shadow-git dirs to the filesystem during tests.
             session_store: Arc::new(InMemorySessionStore::new()),
         };
         let mut headers = HeaderMap::new();
@@ -4187,6 +4222,8 @@ mod tests {
                 SqliteMemoryStore::open_in_memory(None).expect("open in-memory semantic store"),
             ),
             kill_switch: Arc::new(KillSwitch::new()),
+            // sera-4i4i: intentional test-fixture — InMemorySessionStore avoids
+            // writing shadow-git dirs to the filesystem during tests.
             session_store: Arc::new(InMemorySessionStore::new()),
         };
         let headers = HeaderMap::new();
@@ -4735,6 +4772,8 @@ mod tests {
                 SqliteMemoryStore::open_in_memory(None).expect("open in-memory semantic store"),
             ),
             kill_switch: Arc::new(KillSwitch::new()),
+            // sera-4i4i: intentional test-fixture — InMemorySessionStore avoids
+            // writing shadow-git dirs to the filesystem during tests.
             session_store: Arc::new(InMemorySessionStore::new()),
         });
 
@@ -4811,6 +4850,8 @@ mod tests {
                     SqliteMemoryStore::open_in_memory(None).expect("open in-memory semantic store"),
                 ),
                 kill_switch: Arc::new(KillSwitch::new()),
+                // sera-4i4i: intentional test-fixture — InMemorySessionStore avoids
+                // writing shadow-git dirs to the filesystem during tests.
                 session_store: Arc::new(InMemorySessionStore::new()),
             })
         };

--- a/scripts/sera-local
+++ b/scripts/sera-local
@@ -84,5 +84,6 @@ cd "$DATA_DIR"
 exec env \
   SERA_RUNTIME_BIN="$RUNTIME_BIN" \
   LLM_BASE_URL="$LLM_BASE_URL" \
+  SERA_DATA_ROOT="$DATA_DIR" \
   RUST_LOG="${RUST_LOG:-sera_gateway=info,sera_runtime=info}" \
   "$GATEWAY_BIN" start --config "$CONFIG" --port "$PORT"


### PR DESCRIPTION
## Summary

- Replaces `Arc<InMemorySessionStore>` with `Arc<dyn SessionStore>` in `AppState` — production boot now uses `SqliteGitSessionStore`
- Derives `data_root` from `SERA_DATA_ROOT` env var (default: cwd) for zero-breaking-change backward compat
- `scripts/sera-local` now passes `SERA_DATA_ROOT=$DATA_DIR` so `--data-dir` propagates into the binary
- All test AppState fixtures intentionally keep `InMemorySessionStore` — comments added at each site

Closes sera-4i4i

## Verification output

```
$ rm -rf /tmp/sera-4i4i-test
$ scripts/sera-local --data-dir /tmp/sera-4i4i-test &
$ curl -s http://localhost:42540/api/chat -H 'Content-Type: application/json' -d '{"agent":"sera","message":"hi","stream":false}'
{"response":"Hello! How can I help you today?","session_id":"ses_18a8febd770e289e00015635",...}

$ find /tmp/sera-4i4i-test -type f | sort
/tmp/sera-4i4i-test/parts.sqlite
/tmp/sera-4i4i-test/sera.db
/tmp/sera-4i4i-test/sera.yaml
/tmp/sera-4i4i-test/sessions/http:sera:ses_18a8febd770e289e00015635/git/HEAD
/tmp/sera-4i4i-test/sessions/http:sera:ses_18a8febd770e289e00015635/git/config
/tmp/sera-4i4i-test/sessions/http:sera:ses_18a8febd770e289e00015635/git/objects/28/39dea4e2d3ad851776690dd61a4930901673e8
/tmp/sera-4i4i-test/sessions/http:sera:ses_18a8febd770e289e00015635/git/objects/33/24d72fac83a38d53d79c2451eaba139839a932
/tmp/sera-4i4i-test/sessions/http:sera:ses_18a8febd770e289e00015635/git/objects/4b/825dc642cb6eb9a060e54bf8d69288fbee4904
/tmp/sera-4i4i-test/sessions/http:sera:ses_18a8febd770e289e00015635/git/objects/d2/805dacf9fe11c0947a556b6e289d7187bb47bd
/tmp/sera-4i4i-test/sessions/http:sera:ses_18a8febd770e289e00015635/git/refs/heads/main
```

- `parts.sqlite` created
- `sessions/<id>/git/HEAD` exists
- `sessions/<id>/git/refs/heads/main` exists (shadow git commit persisted)

## Test plan

- [x] `cargo fmt -p sera-gateway` — clean
- [x] `cargo clippy -p sera-gateway --all-targets -- -D warnings` — no issues
- [x] `cargo test -p sera-gateway` — 270 passed, 0 failed
- [x] `cargo check --workspace` — clean
- [x] `cargo build -p sera-gateway -p sera-runtime` — clean
- [x] Live verification: sera-local + chat turn + data dir inspection (see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)