### PR TITLE
fix(sera-gateway): raise default turn timeout 120s → 600s (sera-jw8o)

### DIFF
--- a/rust/crates/sera-gateway/src/bin/sera.rs
+++ b/rust/crates/sera-gateway/src/bin/sera.rs
@@ -1349,7 +1349,13 @@ enum StreamState {
 /// lane slot is released by the caller after `execute_turn` returns, so a
 /// timeout here guarantees the slot is eventually freed even if the harness
 /// never responds. Override with `SERA_TURN_TIMEOUT_SECS`.
-const DEFAULT_TURN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
+///
+/// 10 minutes accommodates thinking models (Claude extended thinking, local
+/// reasoning models like qwen3.6-35b on modest hardware) that routinely take
+/// 2–5 minutes per turn, while still bounding a truly wedged runtime. Operators
+/// needing longer bounds (e.g. long multi-step tool chains) set
+/// `SERA_TURN_TIMEOUT_SECS`.
+const DEFAULT_TURN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(600);
 
 fn turn_timeout() -> std::time::Duration {
     std::env::var("SERA_TURN_TIMEOUT_SECS")


### PR DESCRIPTION
## Summary

Raise `DEFAULT_TURN_TIMEOUT` from 120s to 600s. Observed in production 2026-04-23: `Runtime harness turn timed out; releasing lane session_key=discord:sera:1482493880841670859 timeout_secs=120` — 120s was badly tuned for thinking/local models.

## Why

120s is fine for cheap fast models but fails on:
- Cloud thinking models (Claude extended thinking): 2–10 min typical
- Local models (qwen3.6-35b, gemma-4-26b via LM Studio): 1–5 min per turn on modest hardware
- Multi-step tool chains

600s (10 minutes) accommodates typical usage while still bounding a truly wedged runtime. `SERA_TURN_TIMEOUT_SECS` env override stays for operators who need different bounds.

## Follow-up (not in this PR)

- Per-agent manifest override (`spec.turn_timeout_secs`) is a nice-to-have — file if requested. Kept out of scope per Surgical Changes.

## Test plan

- [x] `turn_timeout_defaults_when_env_unset` test still passes (compares against `DEFAULT_TURN_TIMEOUT` constant, not hardcoded 120).
- [x] `cargo test -p sera-gateway` green.

Closes sera-jw8o.

🤖 Generated with [Claude Code](https://claude.com/claude-code)