### PR TITLE
fix(sera-hooks): update wasmtime preview1 imports for v44 API (sera-y3fd)

### DIFF
--- a/rust/crates/sera-hooks/src/component_adapter.rs
+++ b/rust/crates/sera-hooks/src/component_adapter.rs
@@ -172,8 +172,8 @@ fn host_state_set(caps: &ComponentCapabilities, key: String, mut value: String) 
 }
 
 fn host_emit_audit(caps: &ComponentCapabilities, event_type: String, payload_json: String) {
-    let payload = serde_json::from_str::<JsonValue>(&payload_json)
-        .unwrap_or_else(|_| JsonValue::String(payload_json));
+    let payload =
+        serde_json::from_str::<JsonValue>(&payload_json).unwrap_or(JsonValue::String(payload_json));
     caps.audit_events
         .lock()
         .expect("audit lock poisoned")
@@ -557,7 +557,7 @@ mod tests {
 
     #[test]
     fn rejects_malformed_bytes() {
-        let err = ComponentAdapter::from_bytes(&[0u8, 1, 2], meta("bad"), WasmConfig::default())
+        let err = ComponentAdapter::from_bytes([0u8, 1, 2], meta("bad"), WasmConfig::default())
             .unwrap_err();
         assert!(matches!(err, ComponentError::Load(_)));
     }

--- a/rust/crates/sera-hooks/src/wasm_adapter.rs
+++ b/rust/crates/sera-hooks/src/wasm_adapter.rs
@@ -98,7 +98,7 @@ pub struct WasmHookMetadata {
 #[cfg(feature = "wasm")]
 struct StoreData {
     limits: wasmtime::StoreLimits,
-    wasi: wasmtime_wasi::preview1::WasiP1Ctx,
+    wasi: wasmtime_wasi::p1::WasiP1Ctx,
 }
 
 // ── WASM Hook Adapter ─────────────────────────────────────────────────────────
@@ -212,7 +212,7 @@ impl WasmHookAdapter {
 
                 // Link WASI preview-1.
                 let mut linker: Linker<StoreData> = Linker::new(&engine);
-                wasmtime_wasi::preview1::add_to_linker_sync(&mut linker, |data| &mut data.wasi)
+                wasmtime_wasi::p1::add_to_linker_sync(&mut linker, |data| &mut data.wasi)
                     .map_err(|e| WasmError::Linking(e.to_string()))?;
 
                 let instance = linker


### PR DESCRIPTION
## Summary

- `wasmtime_wasi::preview1` was renamed to `wasmtime_wasi::p1` in wasmtime v44
- Updated two import paths in `wasm_adapter.rs`: `WasiP1Ctx` and `add_to_linker_sync`
- Fixed two pre-existing clippy lints in `component_adapter.rs` surfaced by `-D warnings`: `unnecessary_lazy_evaluations` and `needless_borrows_for_generic_args`

## Import change (before → after)

```rust
// wasm_adapter.rs:101
- wasi: wasmtime_wasi::preview1::WasiP1Ctx,
+ wasi: wasmtime_wasi::p1::WasiP1Ctx,

// wasm_adapter.rs:215
- wasmtime_wasi::preview1::add_to_linker_sync(&mut linker, |data| &mut data.wasi)
+ wasmtime_wasi::p1::add_to_linker_sync(&mut linker, |data| &mut data.wasi)
```

## Quality gates

- `cargo check -p sera-hooks --features wasm` → **green** ✓
- `cargo clippy -p sera-hooks --all-targets --features wasm -- -D warnings` → **green** ✓
- `cargo test -p sera-hooks` → **63 passed, 2 ignored** ✓
- `cargo check --workspace` → **green** ✓

## Notes

The wasmtime workspace version constraint is `>=43, <50`, so this fix works for both v43 (where `preview1` still existed) and v44+ (where it became `p1`). Confirmed: `wasmtime-wasi` v44.0.0 exports `p1::WasiP1Ctx` and `p1::add_to_linker_sync` identically to the former `preview1` names.

Closes sera-y3fd