### PR TITLE
refactor: purge tier concept from codebase (sera-jo8l)

### DIFF
--- a/rust/crates/sera-config/src/manifest_loader.rs
+++ b/rust/crates/sera-config/src/manifest_loader.rs
@@ -269,8 +269,7 @@ apiVersion: sera.dev/v1
 kind: Instance
 metadata:
   name: my-sera
-spec:
-  tier: local
+spec: {}
 ---
 apiVersion: sera.dev/v1
 kind: Provider
@@ -318,7 +317,7 @@ spec:
     fn instance_spec_extraction() {
         let set = parse_manifests(MVS_CONFIG).unwrap();
         let spec = set.instance_spec().unwrap().unwrap();
-        assert_eq!(spec.tier, "local");
+        assert!(spec.docs_dir.is_none());
     }
 
     #[test]
@@ -375,8 +374,7 @@ apiVersion: sera.dev/v1
 kind: Instance
 metadata:
   name: test
-spec:
-  tier: local
+spec: {}
 "#;
         let set = parse_manifests(yaml).unwrap();
         assert_eq!(set.instances.len(), 1);
@@ -422,8 +420,7 @@ apiVersion: noslash
 kind: Instance
 metadata:
   name: test
-spec:
-  tier: local
+spec: {}
 "#;
         let err = parse_manifests(yaml).unwrap_err();
         assert!(err.to_string().contains("invalid apiVersion"));

--- a/rust/crates/sera-e2e-harness/src/lib.rs
+++ b/rust/crates/sera-e2e-harness/src/lib.rs
@@ -320,8 +320,7 @@ fn minimal_sera_yaml(llm_base_url: &str, model: &str) -> String {
 kind: Instance
 metadata:
   name: sera-e2e
-spec:
-  tier: local
+spec: {{}}
 ---
 apiVersion: sera.dev/v1
 kind: Provider

--- a/rust/crates/sera-gateway/src/bin/sera.rs
+++ b/rust/crates/sera-gateway/src/bin/sera.rs
@@ -2112,7 +2112,6 @@ kind: Instance
 metadata:
   name: my-sera
 spec:
-  tier: local
 ---
 apiVersion: sera.dev/v1
 kind: Provider
@@ -2645,20 +2644,6 @@ async fn run_start(config: PathBuf, port: u16) -> anyhow::Result<()> {
         exe_dir.join("sera-runtime").to_string_lossy().to_string()
     });
 
-    // Determine whether the manifest declares a local-tier instance.  When
-    // `Instance.spec.tier == "local"` the runtime has no ConstitutionalGate
-    // HookChain wired, so we forward the permissive flag via env so operators
-    // running a local sera.yaml can complete turns without a policy install.
-    let tier_is_local = manifests
-        .instance_spec()
-        .ok()
-        .flatten()
-        .map(|s| s.tier.eq_ignore_ascii_case("local"))
-        .unwrap_or(false);
-    if tier_is_local {
-        tracing::info!("constitutional gate permissive: reason=tier-local");
-    }
-
     let mut harnesses = std::collections::HashMap::new();
 
     for agent_name in manifests.agent_names() {
@@ -2692,9 +2677,12 @@ async fn run_start(config: PathBuf, port: u16) -> anyhow::Result<()> {
         env.insert("LLM_MODEL".to_string(), model.clone());
         env.insert("LLM_API_KEY".to_string(), api_key_val);
         env.insert("AGENT_ID".to_string(), agent_name.to_string());
-        // Forward permissive-gate flag to the runtime process so it can skip
-        // the ConstitutionalGate check on local-tier deployments.
-        if tier_is_local {
+        // Forward permissive-gate flag to the runtime process when the operator
+        // has set SERA_ALLOW_MISSING_CONSTITUTIONAL_GATE in the environment.
+        if std::env::var("SERA_ALLOW_MISSING_CONSTITUTIONAL_GATE")
+            .map(|v| v.eq_ignore_ascii_case("true") || v == "1")
+            .unwrap_or(false)
+        {
             env.insert(
                 "SERA_ALLOW_MISSING_CONSTITUTIONAL_GATE".to_string(),
                 "true".to_string(),

--- a/rust/crates/sera-runtime/src/main.rs
+++ b/rust/crates/sera-runtime/src/main.rs
@@ -235,11 +235,10 @@ async fn main() -> anyhow::Result<()> {
     // behaviour byte-for-byte.
 
     // Determine whether to permit turns when no ConstitutionalGate HookChain
-    // is installed.  Two opt-in paths; env takes precedence over tier-local.
-    //
-    // 1. `SERA_ALLOW_MISSING_CONSTITUTIONAL_GATE=1|true` (explicit operator opt-in)
-    // 2. Injected by the gateway when `Instance.spec.tier == "local"` (the
-    //    gateway sets the same env var, so the runtime only needs one read path).
+    // is installed.  Opt-in via env var:
+    //   SERA_ALLOW_MISSING_CONSTITUTIONAL_GATE=1|true  (explicit operator opt-in)
+    // The gateway forwards this env var when the operator has set it, so the
+    // runtime only needs one read path.
     let permissive_gate = resolve_allow_missing_gate();
 
     let context_engine = Box::new(ContextPipeline::new());
@@ -428,10 +427,8 @@ fn build_llm_client(config: &RuntimeConfig) -> LlmClient {
 /// Read `SERA_ALLOW_MISSING_CONSTITUTIONAL_GATE` and return `true` when the
 /// operator has explicitly opted in (value `"1"` or `"true"`, case-insensitive).
 ///
-/// The gateway forwards this env var into the runtime process when it detects
-/// `Instance.spec.tier == "local"` in the manifest, so the runtime sees only
-/// one read path regardless of whether the trigger was explicit env or
-/// tier-auto-permit.
+/// The gateway forwards this env var when the operator has set it, so the
+/// runtime sees a single read path.
 fn resolve_allow_missing_gate() -> bool {
     let val = std::env::var("SERA_ALLOW_MISSING_CONSTITUTIONAL_GATE")
         .map(|v| v.eq_ignore_ascii_case("true") || v == "1")

--- a/rust/crates/sera-types/src/config_manifest.rs
+++ b/rust/crates/sera-types/src/config_manifest.rs
@@ -172,10 +172,9 @@ pub enum ConfigManifestError {
 // ── MVS Kind-Specific Spec Types ────────────────────────────────────────────
 
 /// Instance spec — top-level SERA instance configuration.
-/// MVS scope: tier and basic settings only.
+/// MVS scope: basic settings only.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InstanceSpec {
-    pub tier: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub docs_dir: Option<String>,
 }
@@ -286,8 +285,7 @@ apiVersion: sera.dev/v1
 kind: Instance
 metadata:
   name: my-sera
-spec:
-  tier: local
+spec: {}
 "#;
         let raw: RawManifest = serde_yaml::from_str(yaml).unwrap();
         assert_eq!(raw.api_version, "sera.dev/v1");
@@ -297,8 +295,7 @@ spec:
         let manifest = ConfigManifest::from_raw(raw).unwrap();
         assert_eq!(manifest.kind, ResourceKind::Instance);
 
-        let spec: InstanceSpec = serde_json::from_value(manifest.spec).unwrap();
-        assert_eq!(spec.tier, "local");
+        let _spec: InstanceSpec = serde_json::from_value(manifest.spec).unwrap();
     }
 
     #[test]
@@ -417,15 +414,14 @@ kind: Instance
 metadata:
   name: test
   labels:
-    tier: local
+    env: local
     team: platform
   annotations:
     description: Test instance
-spec:
-  tier: local
+spec: {}
 "#;
         let raw: RawManifest = serde_yaml::from_str(yaml).unwrap();
-        assert_eq!(raw.metadata.labels.get("tier").unwrap(), "local");
+        assert_eq!(raw.metadata.labels.get("env").unwrap(), "local");
         assert_eq!(raw.metadata.annotations.get("description").unwrap(), "Test instance");
     }
 }

--- a/rust/sera.yaml.example
+++ b/rust/sera.yaml.example
@@ -10,8 +10,7 @@ apiVersion: sera.dev/v1
 kind: Instance
 metadata:
   name: my-sera
-spec:
-  tier: local
+spec: {}
 ---
 apiVersion: sera.dev/v1
 kind: Provider

--- a/scripts/sera-local
+++ b/scripts/sera-local
@@ -10,8 +10,8 @@
 #   sera-local --help               Show this help
 #
 # Defaults target a host-local LM Studio on :1234 with google/gemma-4-e2b loaded.
-# The manifest sets tier=local so the runtime's constitutional gate is permissive
-# (no HookChain required). Ctrl-C stops the gateway.
+# Set SERA_ALLOW_MISSING_CONSTITUTIONAL_GATE=1 to run without a HookChain.
+# Ctrl-C stops the gateway.
 
 set -euo pipefail
 
@@ -50,8 +50,7 @@ apiVersion: sera.dev/v1
 kind: Instance
 metadata:
   name: sera-local
-spec:
-  tier: local
+spec: {}
 ---
 apiVersion: sera.dev/v1
 kind: Provider


### PR DESCRIPTION
## Summary

Remove the `Instance.spec.tier` manifest field and all runtime code that branches on it. Local vs enterprise is now purely config-driven — operators set `SERA_ALLOW_MISSING_CONSTITUTIONAL_GATE=1` to run without a ConstitutionalGate HookChain.

## Files modified

- `rust/crates/sera-types/src/config_manifest.rs` — removed `pub tier: String` from `InstanceSpec`; updated tests
- `rust/crates/sera-config/src/manifest_loader.rs` — removed `tier: local` from YAML fixtures; fixed `instance_spec_extraction` test
- `rust/crates/sera-gateway/src/bin/sera.rs` — removed `tier_is_local` detection block; replaced conditional env-forward with direct `SERA_ALLOW_MISSING_CONSTITUTIONAL_GATE` passthrough; removed `tier: local` from `TEMPLATE_YAML`
- `rust/crates/sera-runtime/src/main.rs` — updated stale comments referencing `tier == "local"` auto-permit
- `rust/crates/sera-e2e-harness/src/lib.rs` — removed `tier: local` from inline manifest template
- `rust/sera.yaml.example` — removed `tier: local` from example Instance spec
- `scripts/sera-local` — removed `tier: local` from generated manifest; updated comment

## Before / after grep count

- Before: 97 `tier:` hits in `rust/` (14 were Instance.spec.tier references)
- After: 0 Instance.spec.tier references; remaining hits are unrelated domain-specific tier concepts (MemoryTier, SandboxTier, CorrelationTier, HookTier, EvolutionTier, skill tier, etc.)

## Config decision

Operators who need permissive mode (no ConstitutionalGate required) set:
```
SERA_ALLOW_MISSING_CONSTITUTIONAL_GATE=1
```
The gateway forwards this env var to spawned runtime processes. No manifest field needed.

Closes sera-jo8l