### PR TITLE
fix(scripts): sera-local defaults SERA_ALLOW_MISSING_CONSTITUTIONAL_GATE=1 (sera-df7h)

### DIFF
--- a/scripts/sera-local
+++ b/scripts/sera-local
@@ -80,7 +80,12 @@ echo "sera-local: chat via: curl -s http://localhost:${PORT}/api/chat -H 'Conten
 echo
 
 cd "$DATA_DIR"
+# Local dev default: permit turns without a ConstitutionalGate HookChain.
+# Prior to sera-jo8l this was auto-set when Instance.spec.tier == "local";
+# now that tier is purged, sera-local carries the default explicitly.
+# Operators can override by exporting SERA_ALLOW_MISSING_CONSTITUTIONAL_GATE=0.
 exec env \
+  SERA_ALLOW_MISSING_CONSTITUTIONAL_GATE="${SERA_ALLOW_MISSING_CONSTITUTIONAL_GATE:-1}" \
   SERA_RUNTIME_BIN="$RUNTIME_BIN" \
   LLM_BASE_URL="$LLM_BASE_URL" \
   SERA_DATA_ROOT="$DATA_DIR" \


### PR DESCRIPTION
## Summary

Restore local-dev ergonomics broken by sera-jo8l's tier purge. sera-jo8l removed the tier-conditional auto-set of `SERA_ALLOW_MISSING_CONSTITUTIONAL_GATE` in `bin/sera.rs` but left `scripts/sera-local` without a replacement default. Result: running `scripts/sera-local` now produces `Runtime error: Broken pipe (os error 32)` on `/api/chat` because the runtime child refuses to start without a ConstitutionalGate HookChain.

## Fix

Default the env var to `1` in `scripts/sera-local`, the explicit local-dev entrypoint. Operators can override with `SERA_ALLOW_MISSING_CONSTITUTIONAL_GATE=0` if they want strict mode locally.

## Verified locally

Pre-fix (no env var set):
```
{"response":"[sera] Runtime error: Broken pipe (os error 32)","session_id":"ses_...","usage":...}
```

With env var set manually:
```
{"response":"Hello","session_id":"ses_...","usage":...}
# plus /tmp/sera-test/sessions/<id>/git/ shadow-git repo
```

This PR makes the script behave like the "with env var set manually" case by default.

## Test plan

- [x] Change is shell-only; no Rust code touched.
- [x] Manual verification: setting the env var manually produces correct behavior.
- [ ] CI: validate-rust (no-op for shell), CodeQL (no-op).

Closes sera-df7h.

🤖 Generated with [Claude Code](https://claude.com/claude-code)