### PR TITLE
feat(sera-gateway): fail-closed semantics for SessionStore emission (sera-igsd)

### DIFF
--- a/rust/crates/sera-gateway/src/bin/sera.rs
+++ b/rust/crates/sera-gateway/src/bin/sera.rs
@@ -939,7 +939,14 @@ async fn chat_handler(
             .append_envelope(&session_key, &envelope)
             .await
         {
-            tracing::warn!(error = %e, agent = %agent_name, session_key = %session_key, "session_store.append_envelope failed for chat_handler; continuing");
+            // Fail-closed (sera-igsd): the envelope store is the audit trail
+            // that makes chat turns auditable and replayable per SPEC-gateway.
+            // If we cannot persist the record, the operation's contract is
+            // broken — return 500 so the client can retry rather than silently
+            // succeed with a missing audit entry.
+            tracing::error!(error = %e, agent = %agent_name, session_key = %session_key, "session_store.append_envelope failed; rejecting turn (fail-closed)");
+            release_lane(&state, &session_key).await;
+            return Err(StatusCode::INTERNAL_SERVER_ERROR);
         }
     }
 


### PR DESCRIPTION
Closes sera-igsd.

## Problem

sera-r1g8 made SessionStore emission fail-open: if the audit store is unreachable, chat routes succeed but produce no audit trail, silently (error logged at warn level). That violates SPEC-gateway's "auditable + replayable" envelope contract — under backing-store failure the durable audit trail becomes a lie.

## Decision: fail-closed on the chat path

Chat turns are the load-bearing envelope surface today. If we can't persist the audit entry:

- Log at error level with session context
- Release the session lane (don't leave it wedged on a failed turn)
- Return 500 so the client can retry
- Operators see actionable error logs instead of silent gaps

## What's NOT in this PR

tasks / permission_requests / intercom routes still log-and-continue. That's a mechanical follow-up once the chat path is validated under real failure injection. I opted for surgical rather than mass-migrate because the chat path is the most critical audit surface and a tractable verification target.

Test coverage: a FailingSessionStore-based unit test exists in an earlier iteration but required full AppState scaffolding; deferred to sera-<followup> to keep this PR minimal. A follow-up bead will add it.