### PR TITLE
fix(compose): drop invalid build.cache + add constitutional gate default (sera-a1oq)

### DIFF
--- a/rust/docker-compose.sera.yml
+++ b/rust/docker-compose.sera.yml
@@ -13,16 +13,6 @@ services:
     build:
       context: ..
       dockerfile: rust/Dockerfile.sera
-      cache:
-        - type: volume
-          source: sera-cargo-registry
-          target: /root/.cargo/registry
-        - type: volume
-          source: sera-cargo-cache
-          target: /root/.cargo/cache
-        - type: volume
-          source: sera-sccache-cache
-          target: /build/.sccache
     volumes:
       - ./sera.yaml:/app/sera.yaml:ro
       - sera-data:/app/data
@@ -31,6 +21,7 @@ services:
       - SERA_API_KEY=${SERA_API_KEY:-}
       - RUST_LOG=${RUST_LOG:-info}
       - SERA_RUNTIME_BIN=/usr/local/bin/sera-runtime
+      - SERA_ALLOW_MISSING_CONSTITUTIONAL_GATE=${SERA_ALLOW_MISSING_CONSTITUTIONAL_GATE:-1}
     # Bridge networking so published ports reach the host on WSL2 Docker Desktop.
     # (network_mode: host binds to the Docker Desktop VM netns, not the WSL2
     # distro, so `ports:` is ignored and host curl to localhost:3001 times out.)


### PR DESCRIPTION
Closes sera-a1oq.

Surfaced during minimal docker e2e against current main:

1. `services.sera.build.cache` isn't in the Docker Compose spec and gets rejected by compose v5.1.0. Removed.
2. `SERA_ALLOW_MISSING_CONSTITUTIONAL_GATE` not defaulted → `/api/chat` returns `"[interrupted: no ConstitutionalGate policy installed]"`. Same fix as #1017 df7h but for the docker path.

## E2E smoke post-fix

- `GET /api/health` → `200 {"status":"ok"}`
- `POST /api/chat` non-stream → real LLM reply
- `POST /api/chat` stream → SSE message deltas + `done`
- Two-turn session continuity → agent recalls prior turn