### PR TITLE
cleanup(sera-types): delete duplicate AgentCapability

### DIFF
--- a/rust/crates/sera-auth/tests/auth_tests.rs
+++ b/rust/crates/sera-auth/tests/auth_tests.rs
@@ -6,7 +6,8 @@ use sera_auth::{
     capability::{CapabilityToken, CapabilityTokenError},
     casbin_adapter::CasbinAuthzAdapter,
 };
-use sera_types::evolution::{AgentCapability, BlastRadius, ChangeArtifactId};
+use sera_types::AgentCapability;
+use sera_types::evolution::{BlastRadius, ChangeArtifactId};
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/rust/crates/sera-meta/src/lib.rs
+++ b/rust/crates/sera-meta/src/lib.rs
@@ -53,9 +53,10 @@ pub use validation::{
 // live in sera-auth (the canonical home for capability-related types); the
 // rest remain in sera-types.
 pub use sera_auth::{CapabilityToken, ChangeProposer};
+pub use sera_types::{AgentCapability};
 pub use sera_types::evolution::{
-    AgentCapability, BlastRadius, ChangeArtifactId, ConstitutionalEnforcementPoint,
-    ConstitutionalRule, EvolutionTier,
+    BlastRadius, ChangeArtifactId, ConstitutionalEnforcementPoint, ConstitutionalRule,
+    EvolutionTier,
 };
 
 /// Lifecycle status of a change artifact.

--- a/rust/crates/sera-types/src/capability.rs
+++ b/rust/crates/sera-types/src/capability.rs
@@ -160,7 +160,11 @@ mod tests {
     #[test]
     fn exec_capability_commands() {
         let cap = ExecCapability {
-            commands: Some(vec!["ls".to_string(), "cat".to_string(), "echo".to_string()]),
+            commands: Some(vec![
+                "ls".to_string(),
+                "cat".to_string(),
+                "echo".to_string(),
+            ]),
         };
         let json = serde_json::to_string(&cap).unwrap();
         let parsed: ExecCapability = serde_json::from_str(&json).unwrap();

--- a/rust/crates/sera-types/src/chat.rs
+++ b/rust/crates/sera-types/src/chat.rs
@@ -67,10 +67,7 @@ pub enum AgentAction {
         args: serde_json::Value,
     },
     #[serde(rename = "delegation")]
-    Delegation {
-        agent_role: String,
-        task: String,
-    },
+    Delegation { agent_role: String, task: String },
     #[serde(rename = "final_answer")]
     FinalAnswer {
         answer: String,
@@ -85,7 +82,12 @@ mod tests {
 
     #[test]
     fn chat_role_roundtrip() {
-        for role in [ChatRole::User, ChatRole::Assistant, ChatRole::System, ChatRole::Tool] {
+        for role in [
+            ChatRole::User,
+            ChatRole::Assistant,
+            ChatRole::System,
+            ChatRole::Tool,
+        ] {
             let json = serde_json::to_string(&role).unwrap();
             let parsed: ChatRole = serde_json::from_str(&json).unwrap();
             assert_eq!(role, parsed);

--- a/rust/crates/sera-types/src/circle.rs
+++ b/rust/crates/sera-types/src/circle.rs
@@ -322,7 +322,9 @@ mod tests {
                     *a,
                     TerminationCondition::MaxMessages(DEFAULT_TERMINATION_MAX_MESSAGES)
                 ));
-                assert!(matches!(*b, TerminationCondition::Timeout(d) if d.as_secs() == DEFAULT_TERMINATION_TIMEOUT_SECS));
+                assert!(
+                    matches!(*b, TerminationCondition::Timeout(d) if d.as_secs() == DEFAULT_TERMINATION_TIMEOUT_SECS)
+                );
             }
             other => panic!("unexpected default: {other:?}"),
         }
@@ -354,10 +356,7 @@ mod tests {
 
     #[test]
     fn retention_serde_round_trip() {
-        let r = BlackboardRetention::new(
-            NonZeroUsize::new(8),
-            Some(Duration::from_secs(60)),
-        );
+        let r = BlackboardRetention::new(NonZeroUsize::new(8), Some(Duration::from_secs(60)));
         let yaml = serde_yaml::to_string(&r).unwrap();
         let parsed: BlackboardRetention = serde_yaml::from_str(&yaml).unwrap();
         assert_eq!(parsed, r);
@@ -367,7 +366,9 @@ mod tests {
 
     #[test]
     fn constitution_ref_inline_yaml_round_trip() {
-        let c = ConstitutionRef::Inline { text: "# Conventions\n- Use Rust\n".to_string() };
+        let c = ConstitutionRef::Inline {
+            text: "# Conventions\n- Use Rust\n".to_string(),
+        };
         let yaml = serde_yaml::to_string(&c).unwrap();
         assert!(yaml.contains("text:"), "expected 'text:' key, got: {yaml}");
         let parsed: ConstitutionRef = serde_yaml::from_str(&yaml).unwrap();
@@ -376,7 +377,9 @@ mod tests {
 
     #[test]
     fn constitution_ref_file_yaml_round_trip() {
-        let c = ConstitutionRef::File { file: std::path::PathBuf::from("circles/eng/constitution.md") };
+        let c = ConstitutionRef::File {
+            file: std::path::PathBuf::from("circles/eng/constitution.md"),
+        };
         let yaml = serde_yaml::to_string(&c).unwrap();
         assert!(yaml.contains("file:"), "expected 'file:' key, got: {yaml}");
         let parsed: ConstitutionRef = serde_yaml::from_str(&yaml).unwrap();
@@ -385,18 +388,28 @@ mod tests {
 
     #[test]
     fn constitution_ref_inline_json_round_trip() {
-        let c = ConstitutionRef::Inline { text: "hello world".to_string() };
+        let c = ConstitutionRef::Inline {
+            text: "hello world".to_string(),
+        };
         let json = serde_json::to_string(&c).unwrap();
-        assert!(json.contains(r#""text""#), "expected 'text' key, got: {json}");
+        assert!(
+            json.contains(r#""text""#),
+            "expected 'text' key, got: {json}"
+        );
         let parsed: ConstitutionRef = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed, c);
     }
 
     #[test]
     fn constitution_ref_file_json_round_trip() {
-        let c = ConstitutionRef::File { file: std::path::PathBuf::from("path/to/doc.md") };
+        let c = ConstitutionRef::File {
+            file: std::path::PathBuf::from("path/to/doc.md"),
+        };
         let json = serde_json::to_string(&c).unwrap();
-        assert!(json.contains(r#""file""#), "expected 'file' key, got: {json}");
+        assert!(
+            json.contains(r#""file""#),
+            "expected 'file' key, got: {json}"
+        );
         let parsed: ConstitutionRef = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed, c);
     }
@@ -408,12 +421,17 @@ mod tests {
             name: "engineering".to_string(),
             display_name: "Engineering Circle".to_string(),
             description: Some("Main eng team".to_string()),
-            constitution: Some(ConstitutionRef::Inline { text: "# Stack\n- Rust".to_string() }),
+            constitution: Some(ConstitutionRef::Inline {
+                text: "# Stack\n- Rust".to_string(),
+            }),
         };
         let yaml = serde_yaml::to_string(&circle).unwrap();
         let parsed: Circle = serde_yaml::from_str(&yaml).unwrap();
         assert_eq!(parsed.name, "engineering");
-        assert!(matches!(parsed.constitution, Some(ConstitutionRef::Inline { .. })));
+        assert!(matches!(
+            parsed.constitution,
+            Some(ConstitutionRef::Inline { .. })
+        ));
     }
 
     // ── Party mode serde tests (sera-8d1.2) ──────────────────────────────────
@@ -518,6 +536,9 @@ mod tests {
             constitution: None,
         };
         let json = serde_json::to_string(&circle).unwrap();
-        assert!(!json.contains("constitution"), "field should be omitted: {json}");
+        assert!(
+            !json.contains("constitution"),
+            "field should be omitted: {json}"
+        );
     }
 }

--- a/rust/crates/sera-types/src/circle_activity.rs
+++ b/rust/crates/sera-types/src/circle_activity.rs
@@ -27,7 +27,11 @@ pub struct CircleActivityEntry {
 
 impl CircleActivityEntry {
     /// Create a new entry using the current wall-clock time.
-    pub fn new(agent_id: impl Into<String>, circle_id: impl Into<String>, summary: impl Into<String>) -> Self {
+    pub fn new(
+        agent_id: impl Into<String>,
+        circle_id: impl Into<String>,
+        summary: impl Into<String>,
+    ) -> Self {
         let timestamp = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
             .map(|d| d.as_secs())
@@ -58,7 +62,10 @@ impl CircleActivityEntry {
     /// Format the entry as a prompt bullet:
     /// `- [agent-id @ ISO-like-timestamp] summary`
     pub fn format_for_prompt(&self) -> String {
-        format!("- [{} @ {}] {}", self.agent_id, self.timestamp, self.summary)
+        format!(
+            "- [{} @ {}] {}",
+            self.agent_id, self.timestamp, self.summary
+        )
     }
 }
 
@@ -81,8 +88,14 @@ impl InMemoryCircleActivityLog {
     }
 
     /// Record a new entry.
-    pub fn record(&mut self, agent_id: impl Into<String>, circle_id: impl Into<String>, summary: impl Into<String>) {
-        self.entries.push(CircleActivityEntry::new(agent_id, circle_id, summary));
+    pub fn record(
+        &mut self,
+        agent_id: impl Into<String>,
+        circle_id: impl Into<String>,
+        summary: impl Into<String>,
+    ) {
+        self.entries
+            .push(CircleActivityEntry::new(agent_id, circle_id, summary));
     }
 
     /// Record an entry with an explicit timestamp (useful for deterministic tests).
@@ -93,7 +106,9 @@ impl InMemoryCircleActivityLog {
         summary: impl Into<String>,
         timestamp: u64,
     ) {
-        self.entries.push(CircleActivityEntry::with_timestamp(agent_id, circle_id, summary, timestamp));
+        self.entries.push(CircleActivityEntry::with_timestamp(
+            agent_id, circle_id, summary, timestamp,
+        ));
     }
 
     /// Return up to `limit` most-recent entries for `circle_id`, excluding `exclude_agent`.

--- a/rust/crates/sera-types/src/config_manifest.rs
+++ b/rust/crates/sera-types/src/config_manifest.rs
@@ -136,11 +136,12 @@ pub struct ConfigManifest {
 impl ConfigManifest {
     /// Parse and validate a RawManifest into a ConfigManifest.
     pub fn from_raw(raw: RawManifest) -> Result<Self, ConfigManifestError> {
-        let api_version = ApiVersion::parse(&raw.api_version).ok_or_else(|| {
-            ConfigManifestError::InvalidApiVersion(raw.api_version.clone())
-        })?;
+        let api_version = ApiVersion::parse(&raw.api_version)
+            .ok_or_else(|| ConfigManifestError::InvalidApiVersion(raw.api_version.clone()))?;
 
-        let kind = raw.kind.parse::<ResourceKind>()
+        let kind = raw
+            .kind
+            .parse::<ResourceKind>()
             .map_err(|_| ConfigManifestError::UnknownKind(raw.kind.clone()))?;
 
         Ok(Self {
@@ -343,7 +344,13 @@ spec:
         let spec: AgentSpec = serde_json::from_value(manifest.spec).unwrap();
         assert_eq!(spec.provider, "lm-studio");
         assert_eq!(spec.model.as_deref(), Some("gemma-4-12b"));
-        assert!(spec.persona.unwrap().immutable_anchor.unwrap().contains("Sera"));
+        assert!(
+            spec.persona
+                .unwrap()
+                .immutable_anchor
+                .unwrap()
+                .contains("Sera")
+        );
         assert_eq!(spec.tools.unwrap().allow.len(), 4);
     }
 
@@ -422,6 +429,9 @@ spec: {}
 "#;
         let raw: RawManifest = serde_yaml::from_str(yaml).unwrap();
         assert_eq!(raw.metadata.labels.get("env").unwrap(), "local");
-        assert_eq!(raw.metadata.annotations.get("description").unwrap(), "Test instance");
+        assert_eq!(
+            raw.metadata.annotations.get("description").unwrap(),
+            "Test instance"
+        );
     }
 }

--- a/rust/crates/sera-types/src/connector.rs
+++ b/rust/crates/sera-types/src/connector.rs
@@ -413,7 +413,10 @@ mod tests {
         };
 
         let json = serde_json::to_string(&identity).unwrap();
-        assert!(!json.contains("account_id"), "None fields should be skipped");
+        assert!(
+            !json.contains("account_id"),
+            "None fields should be skipped"
+        );
 
         let parsed: ConnectorIdentity = serde_json::from_str(&json).unwrap();
         assert!(parsed.account_id.is_none());
@@ -435,7 +438,10 @@ mod tests {
             ConnectorError::AuthError("invalid token".to_string()).to_string(),
             "authentication error: invalid token"
         );
-        assert_eq!(ConnectorError::NotConnected.to_string(), "connector is not connected");
+        assert_eq!(
+            ConnectorError::NotConnected.to_string(),
+            "connector is not connected"
+        );
         assert_eq!(
             ConnectorError::ConfigError("missing token".to_string()).to_string(),
             "configuration error: missing token"

--- a/rust/crates/sera-types/src/envelope.rs
+++ b/rust/crates/sera-types/src/envelope.rs
@@ -263,7 +263,11 @@ mod tests {
     #[test]
     fn supports_returns_true_for_known_feature() {
         let caps = ProtocolCapabilities {
-            features: vec!["steer".to_string(), "hitl".to_string(), "hooks@v2".to_string()],
+            features: vec![
+                "steer".to_string(),
+                "hitl".to_string(),
+                "hooks@v2".to_string(),
+            ],
         };
         assert!(caps.supports("steer"));
         assert!(caps.supports("hitl"));
@@ -298,7 +302,10 @@ mod tests {
         assert_eq!(parsed.protocol_version, "2.0");
         assert_eq!(parsed.frame_type, "handshake");
         assert_eq!(parsed.agent_id.as_deref(), Some("agent-001"));
-        assert_eq!(parsed.parent_session_key.as_deref(), Some("parent-sess-xyz"));
+        assert_eq!(
+            parsed.parent_session_key.as_deref(),
+            Some("parent-sess-xyz")
+        );
         assert!(parsed.capabilities.supports("steer"));
         assert!(parsed.capabilities.supports("hitl"));
         assert!(parsed.capabilities.supports("hooks@v2"));

--- a/rust/crates/sera-types/src/event.rs
+++ b/rust/crates/sera-types/src/event.rs
@@ -79,7 +79,7 @@ pub enum EventSource {
 /// MVS scope: Message and System events only. No webhooks, no cron triggers,
 /// no approval events. Queue modes are simple FIFO.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Event {
+pub struct IncomingEvent {
     pub id: EventId,
     pub kind: EventKind,
     pub source: EventSource,
@@ -108,7 +108,7 @@ pub struct Event {
     pub metadata: serde_json::Value,
 }
 
-impl Event {
+impl IncomingEvent {
     /// Create a new message event from a channel.
     pub fn message(agent_id: &str, session_key: &str, principal: PrincipalRef, text: &str) -> Self {
         Self {
@@ -221,7 +221,7 @@ mod tests {
 
     #[test]
     fn message_event_construction() {
-        let event = Event::message("sera", "agent:sera:main", test_principal(), "Hello");
+        let event = IncomingEvent::message("sera", "agent:sera:main", test_principal(), "Hello");
         assert_eq!(event.kind, EventKind::Message);
         assert_eq!(event.source, EventSource::Channel);
         assert_eq!(event.agent_id, "sera");
@@ -231,15 +231,15 @@ mod tests {
 
     #[test]
     fn api_message_event() {
-        let event = Event::api_message("sera", "agent:sera:main", test_principal(), "Hi");
+        let event = IncomingEvent::api_message("sera", "agent:sera:main", test_principal(), "Hi");
         assert_eq!(event.source, EventSource::Api);
     }
 
     #[test]
     fn event_roundtrip() {
-        let event = Event::message("sera", "agent:sera:main", test_principal(), "test");
+        let event = IncomingEvent::message("sera", "agent:sera:main", test_principal(), "test");
         let json = serde_json::to_string(&event).unwrap();
-        let parsed: Event = serde_json::from_str(&json).unwrap();
+        let parsed: IncomingEvent = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.agent_id, "sera");
         assert_eq!(parsed.text.as_deref(), Some("test"));
     }
@@ -297,7 +297,7 @@ mod tests {
 
     #[test]
     fn heartbeat_event() {
-        let event = Event::heartbeat("sera", "agent:sera:main");
+        let event = IncomingEvent::heartbeat("sera", "agent:sera:main");
         assert_eq!(event.kind, EventKind::Heartbeat);
         assert_eq!(event.source, EventSource::Internal);
         assert!(event.text.is_none());
@@ -305,7 +305,7 @@ mod tests {
 
     #[test]
     fn cron_event() {
-        let event = Event::cron("sera", "agent:sera:main", test_principal(), "dreaming");
+        let event = IncomingEvent::cron("sera", "agent:sera:main", test_principal(), "dreaming");
         assert_eq!(event.kind, EventKind::Cron);
         assert_eq!(event.source, EventSource::Scheduler);
         assert_eq!(event.text.as_deref(), Some("dreaming"));
@@ -314,7 +314,7 @@ mod tests {
     #[test]
     fn webhook_event() {
         let payload = serde_json::json!({"action": "push", "repo": "sera"});
-        let event = Event::webhook("sera", "agent:sera:main", test_principal(), payload);
+        let event = IncomingEvent::webhook("sera", "agent:sera:main", test_principal(), payload);
         assert_eq!(event.kind, EventKind::Webhook);
         assert_eq!(event.source, EventSource::Api);
         assert!(event.text.is_none());
@@ -323,21 +323,23 @@ mod tests {
 
     #[test]
     fn event_with_recipient() {
-        let mut event = Event::message("sera", "agent:sera:main", test_principal(), "Hello");
+        let mut event =
+            IncomingEvent::message("sera", "agent:sera:main", test_principal(), "Hello");
         event.recipient = Some("agent:reviewer".to_string());
         let json = serde_json::to_string(&event).unwrap();
         assert!(json.contains("recipient"));
-        let parsed: Event = serde_json::from_str(&json).unwrap();
+        let parsed: IncomingEvent = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.recipient.as_deref(), Some("agent:reviewer"));
     }
 
     #[test]
     fn event_with_approval() {
-        let mut event = Event::message("sera", "agent:sera:main", test_principal(), "rm -rf /");
+        let mut event =
+            IncomingEvent::message("sera", "agent:sera:main", test_principal(), "rm -rf /");
         event.requires_approval =
             Some(serde_json::json!({"scope": "tool_call", "urgency": "high"}));
         let json = serde_json::to_string(&event).unwrap();
-        let parsed: Event = serde_json::from_str(&json).unwrap();
+        let parsed: IncomingEvent = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.requires_approval.unwrap()["urgency"], "high");
     }
 }

--- a/rust/crates/sera-types/src/event.rs
+++ b/rust/crates/sera-types/src/event.rs
@@ -79,7 +79,7 @@ pub enum EventSource {
 /// MVS scope: Message and System events only. No webhooks, no cron triggers,
 /// no approval events. Queue modes are simple FIFO.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct IncomingEvent {
+pub struct Event {
     pub id: EventId,
     pub kind: EventKind,
     pub source: EventSource,
@@ -108,7 +108,7 @@ pub struct IncomingEvent {
     pub metadata: serde_json::Value,
 }
 
-impl IncomingEvent {
+impl Event {
     /// Create a new message event from a channel.
     pub fn message(agent_id: &str, session_key: &str, principal: PrincipalRef, text: &str) -> Self {
         Self {
@@ -221,7 +221,7 @@ mod tests {
 
     #[test]
     fn message_event_construction() {
-        let event = IncomingEvent::message("sera", "agent:sera:main", test_principal(), "Hello");
+        let event = Event::message("sera", "agent:sera:main", test_principal(), "Hello");
         assert_eq!(event.kind, EventKind::Message);
         assert_eq!(event.source, EventSource::Channel);
         assert_eq!(event.agent_id, "sera");
@@ -231,15 +231,15 @@ mod tests {
 
     #[test]
     fn api_message_event() {
-        let event = IncomingEvent::api_message("sera", "agent:sera:main", test_principal(), "Hi");
+        let event = Event::api_message("sera", "agent:sera:main", test_principal(), "Hi");
         assert_eq!(event.source, EventSource::Api);
     }
 
     #[test]
     fn event_roundtrip() {
-        let event = IncomingEvent::message("sera", "agent:sera:main", test_principal(), "test");
+        let event = Event::message("sera", "agent:sera:main", test_principal(), "test");
         let json = serde_json::to_string(&event).unwrap();
-        let parsed: IncomingEvent = serde_json::from_str(&json).unwrap();
+        let parsed: Event = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.agent_id, "sera");
         assert_eq!(parsed.text.as_deref(), Some("test"));
     }
@@ -297,7 +297,7 @@ mod tests {
 
     #[test]
     fn heartbeat_event() {
-        let event = IncomingEvent::heartbeat("sera", "agent:sera:main");
+        let event = Event::heartbeat("sera", "agent:sera:main");
         assert_eq!(event.kind, EventKind::Heartbeat);
         assert_eq!(event.source, EventSource::Internal);
         assert!(event.text.is_none());
@@ -305,7 +305,7 @@ mod tests {
 
     #[test]
     fn cron_event() {
-        let event = IncomingEvent::cron("sera", "agent:sera:main", test_principal(), "dreaming");
+        let event = Event::cron("sera", "agent:sera:main", test_principal(), "dreaming");
         assert_eq!(event.kind, EventKind::Cron);
         assert_eq!(event.source, EventSource::Scheduler);
         assert_eq!(event.text.as_deref(), Some("dreaming"));
@@ -314,7 +314,7 @@ mod tests {
     #[test]
     fn webhook_event() {
         let payload = serde_json::json!({"action": "push", "repo": "sera"});
-        let event = IncomingEvent::webhook("sera", "agent:sera:main", test_principal(), payload);
+        let event = Event::webhook("sera", "agent:sera:main", test_principal(), payload);
         assert_eq!(event.kind, EventKind::Webhook);
         assert_eq!(event.source, EventSource::Api);
         assert!(event.text.is_none());
@@ -323,23 +323,21 @@ mod tests {
 
     #[test]
     fn event_with_recipient() {
-        let mut event =
-            IncomingEvent::message("sera", "agent:sera:main", test_principal(), "Hello");
+        let mut event = Event::message("sera", "agent:sera:main", test_principal(), "Hello");
         event.recipient = Some("agent:reviewer".to_string());
         let json = serde_json::to_string(&event).unwrap();
         assert!(json.contains("recipient"));
-        let parsed: IncomingEvent = serde_json::from_str(&json).unwrap();
+        let parsed: Event = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.recipient.as_deref(), Some("agent:reviewer"));
     }
 
     #[test]
     fn event_with_approval() {
-        let mut event =
-            IncomingEvent::message("sera", "agent:sera:main", test_principal(), "rm -rf /");
+        let mut event = Event::message("sera", "agent:sera:main", test_principal(), "rm -rf /");
         event.requires_approval =
             Some(serde_json::json!({"scope": "tool_call", "urgency": "high"}));
         let json = serde_json::to_string(&event).unwrap();
-        let parsed: IncomingEvent = serde_json::from_str(&json).unwrap();
+        let parsed: Event = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.requires_approval.unwrap()["urgency"], "high");
     }
 }

--- a/rust/crates/sera-types/src/evolution.rs
+++ b/rust/crates/sera-types/src/evolution.rs
@@ -78,12 +78,5 @@ pub enum EvolutionTier {
 // CapabilityToken field, so it lives next to the token definition. Keeps
 // sera-types free of an inverted dependency on sera-auth.
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum AgentCapability {
-    MetaChange,
-    CodeChange,
-    MetaApprover,
-    ConfigRead,
-    ConfigPropose,
-}
+// AgentCapability moved to `capability.rs` — colocated with CapabilityToken
+// and CapabilityPolicy, where it belongs semantically.

--- a/rust/crates/sera-types/src/harness.rs
+++ b/rust/crates/sera-types/src/harness.rs
@@ -101,10 +101,7 @@ pub fn new_plugin_registry() -> PluginRegistry {
 }
 
 /// Validate that a plugin event namespace matches the registered plugin.
-pub fn validate_plugin_event_namespace(
-    plugin: &PluginRegistration,
-    event: &PluginEvent,
-) -> bool {
+pub fn validate_plugin_event_namespace(plugin: &PluginRegistration, event: &PluginEvent) -> bool {
     event.event_type.starts_with(&plugin.namespace)
 }
 

--- a/rust/crates/sera-types/src/hook.rs
+++ b/rust/crates/sera-types/src/hook.rs
@@ -188,7 +188,11 @@ pub struct PermissionOverrides {
     /// Optional expiry for the granted permissions. When `Some`, the executor
     /// will prune grants older than `ttl` before invoking the next hook.
     /// Revokes are *not* subject to TTL — they are immediate and durable.
-    #[serde(default, skip_serializing_if = "Option::is_none", with = "duration_millis_opt")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "duration_millis_opt"
+    )]
     pub ttl: Option<Duration>,
 }
 
@@ -236,19 +240,14 @@ mod duration_millis_opt {
     use serde::{Deserialize, Deserializer, Serializer};
     use std::time::Duration;
 
-    pub fn serialize<S: Serializer>(
-        value: &Option<Duration>,
-        ser: S,
-    ) -> Result<S::Ok, S::Error> {
+    pub fn serialize<S: Serializer>(value: &Option<Duration>, ser: S) -> Result<S::Ok, S::Error> {
         match value {
             Some(d) => ser.serialize_some(&(d.as_millis() as u64)),
             None => ser.serialize_none(),
         }
     }
 
-    pub fn deserialize<'de, D: Deserializer<'de>>(
-        de: D,
-    ) -> Result<Option<Duration>, D::Error> {
+    pub fn deserialize<'de, D: Deserializer<'de>>(de: D) -> Result<Option<Duration>, D::Error> {
         let opt = Option::<u64>::deserialize(de)?;
         Ok(opt.map(Duration::from_millis))
     }
@@ -453,9 +452,7 @@ impl HookContext {
     /// True iff `perm` is present in the active permission set.
     pub fn has_permission(&self, perm: &str) -> bool {
         match self.metadata.get(HOOK_CTX_PERMISSIONS_KEY) {
-            Some(serde_json::Value::Array(arr)) => {
-                arr.iter().any(|v| v.as_str() == Some(perm))
-            }
+            Some(serde_json::Value::Array(arr)) => arr.iter().any(|v| v.as_str() == Some(perm)),
             _ => false,
         }
     }
@@ -698,7 +695,10 @@ mod tests {
         updates.insert("filtered".to_string(), serde_json::json!(true));
         let result = HookResult::pass_with(updates);
         assert!(result.is_continue());
-        if let HookResult::Continue { context_updates, .. } = &result {
+        if let HookResult::Continue {
+            context_updates, ..
+        } = &result
+        {
             assert!(context_updates.contains_key("filtered"));
         }
     }

--- a/rust/crates/sera-types/src/lib.rs
+++ b/rust/crates/sera-types/src/lib.rs
@@ -1,34 +1,33 @@
 //! SERA Domain Types — shared types matching the BYOH contract schemas
 //! and the full sera-core domain model.
 
-pub mod agent_tool;
-pub mod circle;
-pub mod circle_activity;
-pub mod envelope;
-pub mod llm;
-pub mod harness;
-pub mod evolution;
-pub mod versioning;
-pub mod content_block;
-pub mod embedding;
 pub mod agent;
-pub mod connector;
-pub mod runtime;
+pub mod agent_tool;
 pub mod audit;
 pub mod capability;
 pub mod chat;
+pub mod circle;
+pub mod circle_activity;
 pub mod config_manifest;
+pub mod connector;
+pub mod content_block;
+pub mod embedding;
+pub mod envelope;
 pub mod event;
+pub mod evolution;
+pub mod harness;
 pub mod hook;
 pub mod hook_aliases;
 pub mod intercom;
+pub mod llm;
 pub mod manifest;
 pub mod memory;
-pub mod model;
 pub mod metering;
+pub mod model;
 pub mod observability;
 pub mod policy;
 pub mod principal;
+pub mod runtime;
 pub mod sandbox;
 pub mod secrets;
 pub mod session;
@@ -36,12 +35,14 @@ pub mod signal;
 pub mod skill;
 pub mod tool;
 pub mod training_export;
+pub mod versioning;
 
+pub use capability::AgentCapability;
+pub use content_block::{ContentBlock, ConversationMessage, ConversationRole};
+pub use embedding::{EmbeddingError, EmbeddingHealth, EmbeddingService};
 pub use evolution::*;
 pub use llm::ThinkingLevel;
 pub use versioning::BuildIdentity;
-pub use content_block::{ContentBlock, ConversationMessage, ConversationRole};
-pub use embedding::{EmbeddingError, EmbeddingHealth, EmbeddingService};
 
 use serde::{Deserialize, Serialize};
 

--- a/rust/crates/sera-types/src/llm.rs
+++ b/rust/crates/sera-types/src/llm.rs
@@ -195,20 +195,47 @@ mod tests {
 
     #[test]
     fn from_str_all_variants() {
-        assert_eq!("none".parse::<ThinkingLevel>().unwrap(), ThinkingLevel::None);
+        assert_eq!(
+            "none".parse::<ThinkingLevel>().unwrap(),
+            ThinkingLevel::None
+        );
         assert_eq!("low".parse::<ThinkingLevel>().unwrap(), ThinkingLevel::Low);
-        assert_eq!("medium".parse::<ThinkingLevel>().unwrap(), ThinkingLevel::Medium);
-        assert_eq!("high".parse::<ThinkingLevel>().unwrap(), ThinkingLevel::High);
-        assert_eq!("xhigh".parse::<ThinkingLevel>().unwrap(), ThinkingLevel::XHigh);
-        assert_eq!("x_high".parse::<ThinkingLevel>().unwrap(), ThinkingLevel::XHigh);
+        assert_eq!(
+            "medium".parse::<ThinkingLevel>().unwrap(),
+            ThinkingLevel::Medium
+        );
+        assert_eq!(
+            "high".parse::<ThinkingLevel>().unwrap(),
+            ThinkingLevel::High
+        );
+        assert_eq!(
+            "xhigh".parse::<ThinkingLevel>().unwrap(),
+            ThinkingLevel::XHigh
+        );
+        assert_eq!(
+            "x_high".parse::<ThinkingLevel>().unwrap(),
+            ThinkingLevel::XHigh
+        );
     }
 
     #[test]
     fn from_str_case_insensitive() {
-        assert_eq!("NONE".parse::<ThinkingLevel>().unwrap(), ThinkingLevel::None);
-        assert_eq!("HIGH".parse::<ThinkingLevel>().unwrap(), ThinkingLevel::High);
-        assert_eq!("XHigh".parse::<ThinkingLevel>().unwrap(), ThinkingLevel::XHigh);
-        assert_eq!("Medium".parse::<ThinkingLevel>().unwrap(), ThinkingLevel::Medium);
+        assert_eq!(
+            "NONE".parse::<ThinkingLevel>().unwrap(),
+            ThinkingLevel::None
+        );
+        assert_eq!(
+            "HIGH".parse::<ThinkingLevel>().unwrap(),
+            ThinkingLevel::High
+        );
+        assert_eq!(
+            "XHigh".parse::<ThinkingLevel>().unwrap(),
+            ThinkingLevel::XHigh
+        );
+        assert_eq!(
+            "Medium".parse::<ThinkingLevel>().unwrap(),
+            ThinkingLevel::Medium
+        );
     }
 
     #[test]
@@ -239,9 +266,18 @@ mod tests {
     fn openai_reasoning_effort_mapping() {
         assert_eq!(ThinkingLevel::None.to_openai_reasoning_effort(), None);
         assert_eq!(ThinkingLevel::Low.to_openai_reasoning_effort(), Some("low"));
-        assert_eq!(ThinkingLevel::Medium.to_openai_reasoning_effort(), Some("medium"));
-        assert_eq!(ThinkingLevel::High.to_openai_reasoning_effort(), Some("high"));
-        assert_eq!(ThinkingLevel::XHigh.to_openai_reasoning_effort(), Some("high"));
+        assert_eq!(
+            ThinkingLevel::Medium.to_openai_reasoning_effort(),
+            Some("medium")
+        );
+        assert_eq!(
+            ThinkingLevel::High.to_openai_reasoning_effort(),
+            Some("high")
+        );
+        assert_eq!(
+            ThinkingLevel::XHigh.to_openai_reasoning_effort(),
+            Some("high")
+        );
     }
 
     #[test]

--- a/rust/crates/sera-types/src/manifest.rs
+++ b/rust/crates/sera-types/src/manifest.rs
@@ -292,7 +292,10 @@ spec:
         assert_eq!(parsed.name, "daily-summary");
         assert_eq!(parsed.schedule_type, "cron");
         assert_eq!(parsed.expression, "0 9 * * *");
-        assert_eq!(parsed.description.as_deref(), Some("Summarize activity daily"));
+        assert_eq!(
+            parsed.description.as_deref(),
+            Some("Summarize activity daily")
+        );
         assert_eq!(parsed.status.as_deref(), Some("active"));
         assert_eq!(parsed.category.as_deref(), Some("reporting"));
     }
@@ -489,6 +492,9 @@ spec:
         assert_eq!(template.metadata.name, "byoh-rust-example");
         assert!(!template.metadata.builtin);
         let sandbox = template.spec.sandbox.as_ref().unwrap();
-        assert_eq!(sandbox.image.as_deref(), Some("sera-byoh-rust-agent:latest"));
+        assert_eq!(
+            sandbox.image.as_deref(),
+            Some("sera-byoh-rust-agent:latest")
+        );
     }
 }

--- a/rust/crates/sera-types/src/memory.rs
+++ b/rust/crates/sera-types/src/memory.rs
@@ -128,7 +128,8 @@ impl FileMemory {
             if path.is_dir() {
                 self.collect_md_files(&path, out)?;
             } else if path.extension().and_then(|e| e.to_str()) == Some("md")
-                && let Ok(rel) = path.strip_prefix(&self.workspace) {
+                && let Ok(rel) = path.strip_prefix(&self.workspace)
+            {
                 // Normalise to forward slashes for cross-platform consistency.
                 let rel_str = rel.to_string_lossy().replace('\\', "/");
                 out.push(rel_str);
@@ -406,7 +407,9 @@ pub enum MemoryError {
 
 impl From<std::io::Error> for MemoryError {
     fn from(e: std::io::Error) -> Self {
-        MemoryError::IoError { reason: e.to_string() }
+        MemoryError::IoError {
+            reason: e.to_string(),
+        }
     }
 }
 
@@ -428,8 +431,13 @@ pub struct MemoryContext {
 /// SPEC-memory: all backend implementations must be Send + Sync.
 #[async_trait::async_trait]
 pub trait MemoryBackend: Send + Sync {
-    async fn write(&self, entry: MemoryEntry, ctx: &MemoryContext) -> Result<MemoryId, MemoryError>;
-    async fn search(&self, query: &MemoryQuery, ctx: &MemoryContext) -> Result<Vec<MemorySearchResult>, MemoryError>;
+    async fn write(&self, entry: MemoryEntry, ctx: &MemoryContext)
+    -> Result<MemoryId, MemoryError>;
+    async fn search(
+        &self,
+        query: &MemoryQuery,
+        ctx: &MemoryContext,
+    ) -> Result<Vec<MemorySearchResult>, MemoryError>;
     async fn get(&self, id: &MemoryId) -> Result<MemoryEntry, MemoryError>;
     async fn delete(&self, id: &MemoryId) -> Result<(), MemoryError>;
     async fn compact(&self, scope: &CompactionScope) -> Result<CompactionResult, MemoryError>;
@@ -453,14 +461,22 @@ impl FileMemoryBackend {
 
 #[async_trait::async_trait]
 impl MemoryBackend for FileMemoryBackend {
-    async fn write(&self, entry: MemoryEntry, _ctx: &MemoryContext) -> Result<MemoryId, MemoryError> {
+    async fn write(
+        &self,
+        entry: MemoryEntry,
+        _ctx: &MemoryContext,
+    ) -> Result<MemoryId, MemoryError> {
         let id = MemoryId::generate();
         let path = format!("{}.md", id.0);
         self.inner.write(&path, &entry.content)?;
         Ok(id)
     }
 
-    async fn search(&self, query: &MemoryQuery, _ctx: &MemoryContext) -> Result<Vec<MemorySearchResult>, MemoryError> {
+    async fn search(
+        &self,
+        query: &MemoryQuery,
+        _ctx: &MemoryContext,
+    ) -> Result<Vec<MemorySearchResult>, MemoryError> {
         let results = self.inner.search(&query.text)?;
         let out = results
             .into_iter()
@@ -481,7 +497,10 @@ impl MemoryBackend for FileMemoryBackend {
 
     async fn get(&self, id: &MemoryId) -> Result<MemoryEntry, MemoryError> {
         let path = format!("{}.md", id.0);
-        let content = self.inner.read(&path).map_err(|_| MemoryError::NotFound { id: id.0.clone() })?;
+        let content = self
+            .inner
+            .read(&path)
+            .map_err(|_| MemoryError::NotFound { id: id.0.clone() })?;
         Ok(MemoryEntry {
             id: id.clone(),
             content,
@@ -595,7 +614,9 @@ pub struct RecallStore {
 impl RecallStore {
     /// Create an empty store.
     pub fn new() -> Self {
-        Self { signals: Vec::new() }
+        Self {
+            signals: Vec::new(),
+        }
     }
 
     /// Record a new recall signal.
@@ -605,8 +626,11 @@ impl RecallStore {
 
     /// Compute aggregate `RecallStats` for a single memory entry.
     pub fn stats_for(&self, memory_id: &MemoryId) -> RecallStats {
-        let relevant: Vec<&RecallSignal> =
-            self.signals.iter().filter(|s| &s.memory_id == memory_id).collect();
+        let relevant: Vec<&RecallSignal> = self
+            .signals
+            .iter()
+            .filter(|s| &s.memory_id == memory_id)
+            .collect();
 
         let recall_count = relevant.len() as u32;
 
@@ -629,7 +653,13 @@ impl RecallStore {
             relevant.iter().map(|s| s.score).sum::<f64>() / recall_count as f64
         };
 
-        RecallStats { memory_id: memory_id.clone(), recall_count, unique_queries, last_recalled, average_score }
+        RecallStats {
+            memory_id: memory_id.clone(),
+            recall_count,
+            unique_queries,
+            last_recalled,
+            average_score,
+        }
     }
 
     /// Compute `RecallStats` for every memory entry that has at least one signal.
@@ -757,7 +787,9 @@ impl MemoryBlock {
         evictable.sort_by(|a, b| {
             let eff_a = a.priority as f32 / a.recency_boost.max(f32::EPSILON);
             let eff_b = b.priority as f32 / b.recency_boost.max(f32::EPSILON);
-            eff_a.partial_cmp(&eff_b).unwrap_or(std::cmp::Ordering::Equal)
+            eff_a
+                .partial_cmp(&eff_b)
+                .unwrap_or(std::cmp::Ordering::Equal)
         });
 
         let mut output = String::new();
@@ -872,7 +904,10 @@ mod memory_block_tests {
         block.push(evictable_seg("lo", "Expendable.", 10, 1.0));
         let rendered = block.render();
         assert!(rendered.contains("Soul."), "soul must be present");
-        assert!(rendered.contains("Important."), "high-priority must be present");
+        assert!(
+            rendered.contains("Important."),
+            "high-priority must be present"
+        );
     }
 
     // ── soul is never trimmed even if oversized ──────────────────────────────
@@ -909,7 +944,10 @@ mod memory_block_tests {
         let rendered = block.render();
         let pos_high = rendered.find("HighBoost.").unwrap();
         let pos_low = rendered.find("LowBoost.").unwrap();
-        assert!(pos_high < pos_low, "higher recency_boost should appear earlier");
+        assert!(
+            pos_high < pos_low,
+            "higher recency_boost should appear earlier"
+        );
     }
 
     // ── record_turn returns true at flush_min_turns ──────────────────────────
@@ -918,7 +956,10 @@ mod memory_block_tests {
     fn record_turn_returns_true_at_flush_min_turns() {
         let mut block = MemoryBlock::with_flush_min_turns(5, 3); // budget=5, flush at 3
         // Soul segments are never truncated, so a long soul reliably forces is_over_budget.
-        block.push(soul_seg("soul", "This soul content is way too long for the budget."));
+        block.push(soul_seg(
+            "soul",
+            "This soul content is way too long for the budget.",
+        ));
         assert!(!block.record_turn()); // overflow_turns = 1
         assert!(!block.record_turn()); // overflow_turns = 2
         assert!(block.record_turn()); // overflow_turns = 3 = flush_min_turns → true
@@ -953,9 +994,7 @@ mod memory_block_tests {
         assert_eq!(parsed.id, "seg-abc");
         assert_eq!(parsed.priority, 3);
         assert!((parsed.recency_boost - 1.5).abs() < f32::EPSILON);
-        assert!(
-            matches!(parsed.kind, SegmentKind::MemoryRecall(ref id) if id == "recall-123")
-        );
+        assert!(matches!(parsed.kind, SegmentKind::MemoryRecall(ref id) if id == "recall-123"));
     }
 
     #[test]
@@ -1086,10 +1125,7 @@ mod tests {
         mem.write("sub/deep.md", "").unwrap();
         mem.write("sub/another.md", "").unwrap();
         let files = mem.list().unwrap();
-        assert_eq!(
-            files,
-            vec!["sub/another.md", "sub/deep.md", "top.md"]
-        );
+        assert_eq!(files, vec!["sub/another.md", "sub/deep.md", "top.md"]);
     }
 
     #[test]
@@ -1509,19 +1545,29 @@ Final keyword mention.";
 
     #[test]
     fn memory_error_display() {
-        let e = MemoryError::NotFound { id: "mem-1".to_string() };
+        let e = MemoryError::NotFound {
+            id: "mem-1".to_string(),
+        };
         assert_eq!(e.to_string(), "memory not found: mem-1");
 
-        let e = MemoryError::IoError { reason: "disk full".to_string() };
+        let e = MemoryError::IoError {
+            reason: "disk full".to_string(),
+        };
         assert_eq!(e.to_string(), "memory I/O error: disk full");
 
-        let e = MemoryError::SearchFailed { reason: "index offline".to_string() };
+        let e = MemoryError::SearchFailed {
+            reason: "index offline".to_string(),
+        };
         assert_eq!(e.to_string(), "search failed: index offline");
 
-        let e = MemoryError::CompactionFailed { reason: "timeout".to_string() };
+        let e = MemoryError::CompactionFailed {
+            reason: "timeout".to_string(),
+        };
         assert_eq!(e.to_string(), "compaction failed: timeout");
 
-        let e = MemoryError::Unavailable { reason: "backend down".to_string() };
+        let e = MemoryError::Unavailable {
+            reason: "backend down".to_string(),
+        };
         assert_eq!(e.to_string(), "memory backend unavailable: backend down");
     }
 
@@ -1557,7 +1603,10 @@ Final keyword mention.";
             entries_removed: 20,
             entries_merged: 50,
         };
-        assert_eq!(r.entries_before - r.entries_after, r.entries_removed + r.entries_merged);
+        assert_eq!(
+            r.entries_before - r.entries_after,
+            r.entries_removed + r.entries_merged
+        );
     }
 
     // ── IndexStatus serde roundtrip ─────────────────────────────────────────
@@ -1621,7 +1670,11 @@ Final keyword mention.";
         let dir = TempDir::new().unwrap();
         let backend = FileMemoryBackend::new(dir.path());
         let ctx = make_ctx("agent-1");
-        let entry = make_entry("mem-2", "rust async trait architecture", MemoryTier::LongTerm);
+        let entry = make_entry(
+            "mem-2",
+            "rust async trait architecture",
+            MemoryTier::LongTerm,
+        );
         backend.write(entry, &ctx).await.unwrap();
         let query = MemoryQuery {
             text: "async trait".to_string(),
@@ -1652,9 +1705,18 @@ Final keyword mention.";
         let dir = TempDir::new().unwrap();
         let backend = FileMemoryBackend::new(dir.path());
         let ctx = make_ctx("agent-1");
-        backend.write(make_entry("m1", "one", MemoryTier::LongTerm), &ctx).await.unwrap();
-        backend.write(make_entry("m2", "two", MemoryTier::LongTerm), &ctx).await.unwrap();
-        backend.write(make_entry("m3", "three", MemoryTier::ShortTerm), &ctx).await.unwrap();
+        backend
+            .write(make_entry("m1", "one", MemoryTier::LongTerm), &ctx)
+            .await
+            .unwrap();
+        backend
+            .write(make_entry("m2", "two", MemoryTier::LongTerm), &ctx)
+            .await
+            .unwrap();
+        backend
+            .write(make_entry("m3", "three", MemoryTier::ShortTerm), &ctx)
+            .await
+            .unwrap();
         let stats = backend.stats().await;
         assert_eq!(stats.total_entries, 3);
     }
@@ -1711,7 +1773,10 @@ Final keyword mention.";
         };
         // All components 1.0 → weights sum to 1.0.
         let total = score.total_score();
-        assert!((total - 1.0).abs() < 1e-10, "weights must sum to 1.0, got {total}");
+        assert!(
+            (total - 1.0).abs() < 1e-10,
+            "weights must sum to 1.0, got {total}"
+        );
 
         // Verify individual weights.
         let only_relevance = DreamingScore {
@@ -1725,7 +1790,11 @@ Final keyword mention.";
         };
         assert!((only_relevance.total_score() - 0.30).abs() < f64::EPSILON);
 
-        let only_frequency = DreamingScore { relevance: 0.0, frequency: 1.0, ..only_relevance.clone() };
+        let only_frequency = DreamingScore {
+            relevance: 0.0,
+            frequency: 1.0,
+            ..only_relevance.clone()
+        };
         assert!((only_frequency.total_score() - 0.24).abs() < f64::EPSILON);
     }
 

--- a/rust/crates/sera-types/src/model.rs
+++ b/rust/crates/sera-types/src/model.rs
@@ -364,17 +364,27 @@ mod tests {
         );
 
         assert_eq!(
-            ModelError::RateLimited { retry_after_ms: Some(5000) }.to_string(),
+            ModelError::RateLimited {
+                retry_after_ms: Some(5000)
+            }
+            .to_string(),
             "rate limited (retry after Some(5000) ms)"
         );
 
         assert_eq!(
-            ModelError::RateLimited { retry_after_ms: None }.to_string(),
+            ModelError::RateLimited {
+                retry_after_ms: None
+            }
+            .to_string(),
             "rate limited (retry after None ms)"
         );
 
         assert_eq!(
-            ModelError::ContextLengthExceeded { limit: 4096, requested: 5000 }.to_string(),
+            ModelError::ContextLengthExceeded {
+                limit: 4096,
+                requested: 5000
+            }
+            .to_string(),
             "context length exceeded: limit 4096, requested 5000"
         );
 

--- a/rust/crates/sera-types/src/observability.rs
+++ b/rust/crates/sera-types/src/observability.rs
@@ -112,7 +112,10 @@ mod tests {
         assert_eq!(parsed.trace_id, "trace-abc123");
         assert_eq!(parsed.span_id, "span-001");
         assert_eq!(parsed.parent_span_id, Some("span-000".to_string()));
-        assert_eq!(parsed.baggage.get("session").map(String::as_str), Some("sess-1"));
+        assert_eq!(
+            parsed.baggage.get("session").map(String::as_str),
+            Some("sess-1")
+        );
     }
 
     #[test]

--- a/rust/crates/sera-types/src/runtime.rs
+++ b/rust/crates/sera-types/src/runtime.rs
@@ -353,7 +353,10 @@ mod tests {
         let e = RuntimeError::ModelError("quota exceeded".to_string());
         assert_eq!(e.to_string(), "model error: quota exceeded");
 
-        let e = RuntimeError::ContextOverflow { limit: 4096, actual: 5000 };
+        let e = RuntimeError::ContextOverflow {
+            limit: 4096,
+            actual: 5000,
+        };
         assert_eq!(e.to_string(), "context overflow: limit 4096, actual 5000");
 
         let e = RuntimeError::ToolExecutionFailed {
@@ -393,7 +396,10 @@ mod tests {
         assert!(json.contains("parent-sess-abc"));
 
         let parsed: TurnContext = serde_json::from_str(&json).unwrap();
-        assert_eq!(parsed.parent_session_key.as_deref(), Some("parent-sess-abc"));
+        assert_eq!(
+            parsed.parent_session_key.as_deref(),
+            Some("parent-sess-abc")
+        );
     }
 
     #[test]
@@ -452,13 +458,22 @@ mod tests {
                 arguments: serde_json::json!({"cmd": "ls"}),
                 result: None,
             }],
-            tokens_used: TokenUsage { prompt_tokens: 100, completion_tokens: 20, total_tokens: 120 },
+            tokens_used: TokenUsage {
+                prompt_tokens: 100,
+                completion_tokens: 20,
+                total_tokens: 120,
+            },
             duration_ms: 350,
         };
         let json = serde_json::to_string(&outcome).unwrap();
         assert!(json.contains("\"outcome\":\"run_again\""));
         let parsed: TurnOutcome = serde_json::from_str(&json).unwrap();
-        if let TurnOutcome::RunAgain { tool_calls, tokens_used, duration_ms } = parsed {
+        if let TurnOutcome::RunAgain {
+            tool_calls,
+            tokens_used,
+            duration_ms,
+        } = parsed
+        {
             assert_eq!(tool_calls.len(), 1);
             assert_eq!(tool_calls[0].name, "bash");
             assert_eq!(tokens_used.total_tokens, 120);
@@ -473,14 +488,25 @@ mod tests {
         let outcome = TurnOutcome::FinalOutput {
             response: "Here is the answer.".to_string(),
             tool_calls: vec![],
-            tokens_used: TokenUsage { prompt_tokens: 200, completion_tokens: 80, total_tokens: 280 },
+            tokens_used: TokenUsage {
+                prompt_tokens: 200,
+                completion_tokens: 80,
+                total_tokens: 280,
+            },
             duration_ms: 1200,
             transcript: vec![serde_json::json!({"role": "assistant", "content": "done"})],
         };
         let json = serde_json::to_string(&outcome).unwrap();
         assert!(json.contains("\"outcome\":\"final_output\""));
         let parsed: TurnOutcome = serde_json::from_str(&json).unwrap();
-        if let TurnOutcome::FinalOutput { response, tool_calls, tokens_used, duration_ms, transcript } = parsed {
+        if let TurnOutcome::FinalOutput {
+            response,
+            tool_calls,
+            tokens_used,
+            duration_ms,
+            transcript,
+        } = parsed
+        {
             assert_eq!(response, "Here is the answer.");
             assert!(tool_calls.is_empty());
             assert_eq!(tokens_used.total_tokens, 280);
@@ -510,13 +536,20 @@ mod tests {
         let outcome = TurnOutcome::Handoff {
             target_agent_id: "agent-reviewer".to_string(),
             context: serde_json::json!({"task": "review PR"}),
-            tokens_used: TokenUsage { prompt_tokens: 50, completion_tokens: 10, total_tokens: 60 },
+            tokens_used: TokenUsage {
+                prompt_tokens: 50,
+                completion_tokens: 10,
+                total_tokens: 60,
+            },
             duration_ms: 200,
         };
         let json = serde_json::to_string(&outcome).unwrap();
         assert!(json.contains("\"outcome\":\"handoff\""));
         let parsed: TurnOutcome = serde_json::from_str(&json).unwrap();
-        if let TurnOutcome::Handoff { target_agent_id, .. } = parsed {
+        if let TurnOutcome::Handoff {
+            target_agent_id, ..
+        } = parsed
+        {
             assert_eq!(target_agent_id, "agent-reviewer");
         } else {
             panic!("expected Handoff");
@@ -526,13 +559,21 @@ mod tests {
     #[test]
     fn turn_outcome_compact_serde_roundtrip() {
         let outcome = TurnOutcome::Compact {
-            tokens_used: TokenUsage { prompt_tokens: 5000, completion_tokens: 500, total_tokens: 5500 },
+            tokens_used: TokenUsage {
+                prompt_tokens: 5000,
+                completion_tokens: 500,
+                total_tokens: 5500,
+            },
             duration_ms: 800,
         };
         let json = serde_json::to_string(&outcome).unwrap();
         assert!(json.contains("\"outcome\":\"compact\""));
         let parsed: TurnOutcome = serde_json::from_str(&json).unwrap();
-        if let TurnOutcome::Compact { tokens_used, duration_ms } = parsed {
+        if let TurnOutcome::Compact {
+            tokens_used,
+            duration_ms,
+        } = parsed
+        {
             assert_eq!(tokens_used.total_tokens, 5500);
             assert_eq!(duration_ms, 800);
         } else {
@@ -550,7 +591,10 @@ mod tests {
         let json = serde_json::to_string(&outcome).unwrap();
         assert!(json.contains("\"outcome\":\"interruption\""));
         let parsed: TurnOutcome = serde_json::from_str(&json).unwrap();
-        if let TurnOutcome::Interruption { hook_point, reason, .. } = parsed {
+        if let TurnOutcome::Interruption {
+            hook_point, reason, ..
+        } = parsed
+        {
             assert_eq!(hook_point, "on_tool_call");
             assert_eq!(reason, "policy violation");
         } else {
@@ -563,13 +607,22 @@ mod tests {
         let outcome = TurnOutcome::WaitingForApproval {
             tool_call: serde_json::json!({"name": "deploy", "args": {}}),
             ticket_id: "ticket-99".to_string(),
-            tokens_used: TokenUsage { prompt_tokens: 300, completion_tokens: 40, total_tokens: 340 },
+            tokens_used: TokenUsage {
+                prompt_tokens: 300,
+                completion_tokens: 40,
+                total_tokens: 340,
+            },
             duration_ms: 100,
         };
         let json = serde_json::to_string(&outcome).unwrap();
         assert!(json.contains("\"outcome\":\"waiting_for_approval\""));
         let parsed: TurnOutcome = serde_json::from_str(&json).unwrap();
-        if let TurnOutcome::WaitingForApproval { ticket_id, tokens_used, .. } = parsed {
+        if let TurnOutcome::WaitingForApproval {
+            ticket_id,
+            tokens_used,
+            ..
+        } = parsed
+        {
             assert_eq!(ticket_id, "ticket-99");
             assert_eq!(tokens_used.total_tokens, 340);
         } else {
@@ -581,13 +634,22 @@ mod tests {
     fn turn_outcome_stop_serde_roundtrip() {
         let outcome = TurnOutcome::Stop {
             summary: "Task complete, no further action needed.".to_string(),
-            tokens_used: TokenUsage { prompt_tokens: 400, completion_tokens: 60, total_tokens: 460 },
+            tokens_used: TokenUsage {
+                prompt_tokens: 400,
+                completion_tokens: 60,
+                total_tokens: 460,
+            },
             duration_ms: 600,
         };
         let json = serde_json::to_string(&outcome).unwrap();
         assert!(json.contains("\"outcome\":\"stop\""));
         let parsed: TurnOutcome = serde_json::from_str(&json).unwrap();
-        if let TurnOutcome::Stop { summary, tokens_used, duration_ms } = parsed {
+        if let TurnOutcome::Stop {
+            summary,
+            tokens_used,
+            duration_ms,
+        } = parsed
+        {
             assert_eq!(summary, "Task complete, no further action needed.");
             assert_eq!(tokens_used.total_tokens, 460);
             assert_eq!(duration_ms, 600);
@@ -627,5 +689,4 @@ mod tests {
             assert_eq!(parsed, variant);
         }
     }
-
 }

--- a/rust/crates/sera-types/src/session.rs
+++ b/rust/crates/sera-types/src/session.rs
@@ -100,8 +100,7 @@ impl SessionState {
             | (SessionState::Paused, SessionState::Archived)
             | (SessionState::Paused, SessionState::Destroyed)
             // Shadow sessions can only be destroyed
-            | (SessionState::Shadow, SessionState::Destroyed)
-            // Destroyed is terminal — no transitions
+            | (SessionState::Shadow, SessionState::Destroyed) // Destroyed is terminal — no transitions
         )
     }
 
@@ -298,10 +297,7 @@ impl SessionStateMachine {
     /// On success, records the transition in history and returns the hook chain
     /// name if one is configured for this transition. Returns an error if the
     /// transition is not in the allowed table or the machine is already in `to`.
-    pub fn transition(
-        &mut self,
-        to: SessionState,
-    ) -> Result<Option<String>, SessionError> {
+    pub fn transition(&mut self, to: SessionState) -> Result<Option<String>, SessionError> {
         if self.current_state == to {
             return Err(SessionError::AlreadyInState(to));
         }

--- a/rust/crates/sera-types/src/signal.rs
+++ b/rust/crates/sera-types/src/signal.rs
@@ -44,10 +44,7 @@ pub enum Signal {
         requires: Vec<AgentCapability>,
     },
     /// Human review requested. Always routed to HITL.
-    Review {
-        artifact_id: String,
-        prompt: String,
-    },
+    Review { artifact_id: String, prompt: String },
     /// Agent started working on a task.
     Started {
         task_id: String,
@@ -169,7 +166,11 @@ pub struct Dispatch {
     #[serde(default)]
     pub signal_on: Vec<SignalType>,
     /// Optional timeout for the whole dispatch.
-    #[serde(default, with = "duration_ms_opt", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        with = "duration_ms_opt",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub timeout: Option<Duration>,
     #[serde(default)]
     pub retry_policy: RetryPolicy,
@@ -189,10 +190,7 @@ impl Dispatch {
 mod duration_ms_opt {
     use super::*;
 
-    pub fn serialize<S: serde::Serializer>(
-        v: &Option<Duration>,
-        s: S,
-    ) -> Result<S::Ok, S::Error> {
+    pub fn serialize<S: serde::Serializer>(v: &Option<Duration>, s: S) -> Result<S::Ok, S::Error> {
         match v {
             Some(d) => s.serialize_some(&(d.as_millis() as u64)),
             None => s.serialize_none(),

--- a/rust/crates/sera-types/src/tool.rs
+++ b/rust/crates/sera-types/src/tool.rs
@@ -99,7 +99,9 @@ pub fn tool_is_allowed(tool_name: &str, allow_patterns: &[String]) -> bool {
     if allow_patterns.is_empty() {
         return true; // Empty allow list = allow all
     }
-    allow_patterns.iter().any(|p| tool_matches_pattern(tool_name, p))
+    allow_patterns
+        .iter()
+        .any(|p| tool_matches_pattern(tool_name, p))
 }
 
 // ── Spec-aligned Tool architecture (SPEC-tools) ─────────────────────────────
@@ -185,7 +187,11 @@ impl ToolPolicy {
     /// Check if a tool is allowed by this policy.
     /// Deny patterns take precedence over allow patterns.
     pub fn allows(&self, tool_name: &str) -> bool {
-        if self.deny_patterns.iter().any(|p| tool_matches_pattern(tool_name, p)) {
+        if self
+            .deny_patterns
+            .iter()
+            .any(|p| tool_matches_pattern(tool_name, p))
+        {
             return false;
         }
         tool_is_allowed(tool_name, &self.allow_patterns)
@@ -1026,7 +1032,9 @@ mod tests {
         assert!(!ToolUseBehavior::Required.forbids_tools());
         assert!(ToolUseBehavior::Required.forced_name().is_none());
 
-        let specific = ToolUseBehavior::Specific { name: "read_file".to_string() };
+        let specific = ToolUseBehavior::Specific {
+            name: "read_file".to_string(),
+        };
         assert!(specific.is_forced());
         assert!(!specific.forbids_tools());
         assert_eq!(specific.forced_name(), Some("read_file"));
@@ -1038,7 +1046,9 @@ mod tests {
             ToolUseBehavior::Auto,
             ToolUseBehavior::None,
             ToolUseBehavior::Required,
-            ToolUseBehavior::Specific { name: "shell".to_string() },
+            ToolUseBehavior::Specific {
+                name: "shell".to_string(),
+            },
         ];
         for behavior in cases {
             let json = serde_json::to_string(&behavior).unwrap();
@@ -1061,16 +1071,32 @@ mod tests {
 
         let specific: ToolUseBehavior =
             serde_json::from_str(r#"{"mode":"specific","name":"read_file"}"#).unwrap();
-        assert_eq!(specific, ToolUseBehavior::Specific { name: "read_file".to_string() });
+        assert_eq!(
+            specific,
+            ToolUseBehavior::Specific {
+                name: "read_file".to_string()
+            }
+        );
     }
 
     #[test]
     fn tool_use_behavior_openai_translator() {
-        assert_eq!(ToolUseBehavior::Auto.to_openai_tool_choice(), serde_json::json!("auto"));
-        assert_eq!(ToolUseBehavior::None.to_openai_tool_choice(), serde_json::json!("none"));
-        assert_eq!(ToolUseBehavior::Required.to_openai_tool_choice(), serde_json::json!("required"));
-        let tc = ToolUseBehavior::Specific { name: "read_file".to_string() }
-            .to_openai_tool_choice();
+        assert_eq!(
+            ToolUseBehavior::Auto.to_openai_tool_choice(),
+            serde_json::json!("auto")
+        );
+        assert_eq!(
+            ToolUseBehavior::None.to_openai_tool_choice(),
+            serde_json::json!("none")
+        );
+        assert_eq!(
+            ToolUseBehavior::Required.to_openai_tool_choice(),
+            serde_json::json!("required")
+        );
+        let tc = ToolUseBehavior::Specific {
+            name: "read_file".to_string(),
+        }
+        .to_openai_tool_choice();
         assert_eq!(tc["type"], "function");
         assert_eq!(tc["function"]["name"], "read_file");
     }
@@ -1089,8 +1115,10 @@ mod tests {
             ToolUseBehavior::Required.to_anthropic_tool_choice(),
             serde_json::json!({"type": "any"})
         );
-        let tc = ToolUseBehavior::Specific { name: "shell".to_string() }
-            .to_anthropic_tool_choice();
+        let tc = ToolUseBehavior::Specific {
+            name: "shell".to_string(),
+        }
+        .to_anthropic_tool_choice();
         assert_eq!(tc["type"], "tool");
         assert_eq!(tc["name"], "shell");
     }
@@ -1098,13 +1126,21 @@ mod tests {
     #[test]
     fn tool_use_behavior_validation_auto_always_valid() {
         assert!(ToolUseBehavior::Auto.validate(&[]).is_ok());
-        assert!(ToolUseBehavior::Auto.validate(&["any_tool".to_string()]).is_ok());
+        assert!(
+            ToolUseBehavior::Auto
+                .validate(&["any_tool".to_string()])
+                .is_ok()
+        );
     }
 
     #[test]
     fn tool_use_behavior_validation_none_always_valid() {
         assert!(ToolUseBehavior::None.validate(&[]).is_ok());
-        assert!(ToolUseBehavior::None.validate(&["any_tool".to_string()]).is_ok());
+        assert!(
+            ToolUseBehavior::None
+                .validate(&["any_tool".to_string()])
+                .is_ok()
+        );
     }
 
     #[test]
@@ -1127,18 +1163,22 @@ mod tests {
     fn tool_use_behavior_validation_specific_known_tool_ok() {
         let tools = vec!["read_file".to_string(), "write_file".to_string()];
         assert!(
-            ToolUseBehavior::Specific { name: "read_file".to_string() }
-                .validate(&tools)
-                .is_ok()
+            ToolUseBehavior::Specific {
+                name: "read_file".to_string()
+            }
+            .validate(&tools)
+            .is_ok()
         );
     }
 
     #[test]
     fn tool_use_behavior_validation_specific_unknown_tool_fails() {
         let tools = vec!["read_file".to_string()];
-        let err = ToolUseBehavior::Specific { name: "shell".to_string() }
-            .validate(&tools)
-            .unwrap_err();
+        let err = ToolUseBehavior::Specific {
+            name: "shell".to_string(),
+        }
+        .validate(&tools)
+        .unwrap_err();
         match &err {
             ToolUseValidationError::UnknownTool { name, available } => {
                 assert_eq!(name, "shell");
@@ -1152,9 +1192,11 @@ mod tests {
 
     #[test]
     fn tool_use_behavior_validation_specific_empty_tools_fails() {
-        let err = ToolUseBehavior::Specific { name: "shell".to_string() }
-            .validate(&[])
-            .unwrap_err();
+        let err = ToolUseBehavior::Specific {
+            name: "shell".to_string(),
+        }
+        .validate(&[])
+        .unwrap_err();
         assert!(matches!(err, ToolUseValidationError::UnknownTool { .. }));
     }
 }

--- a/rust/crates/sera-types/tests/content_block.rs
+++ b/rust/crates/sera-types/tests/content_block.rs
@@ -5,21 +5,32 @@ use sera_types::runtime::TokenUsage;
 fn content_block_type_tag_in_json() {
     let block = ContentBlock::Text { text: "hi".into() };
     let json = serde_json::to_string(&block).unwrap();
-    assert!(json.contains("\"type\":\"text\""), "missing type tag: {json}");
-    assert!(json.contains("\"text\":\"hi\""), "missing text field: {json}");
+    assert!(
+        json.contains("\"type\":\"text\""),
+        "missing type tag: {json}"
+    );
+    assert!(
+        json.contains("\"text\":\"hi\""),
+        "missing text field: {json}"
+    );
 }
 
 #[test]
 fn conversation_message_cause_by_roundtrip() {
     let msg = ConversationMessage {
         role: ConversationRole::User,
-        content: vec![ContentBlock::Text { text: "hello".into() }],
+        content: vec![ContentBlock::Text {
+            text: "hello".into(),
+        }],
         usage: None,
         cause_by: Some(ActionId::from("act-1")),
     };
     let json = serde_json::to_string(&msg).unwrap();
     let parsed: ConversationMessage = serde_json::from_str(&json).unwrap();
-    assert_eq!(parsed.cause_by.as_ref().map(|a| a.0.as_str()), Some("act-1"));
+    assert_eq!(
+        parsed.cause_by.as_ref().map(|a| a.0.as_str()),
+        Some("act-1")
+    );
 }
 
 #[test]
@@ -49,6 +60,10 @@ fn conversation_message_tool_use_tool_result_pairing() {
     let json = serde_json::to_string(&msg).unwrap();
     let parsed: ConversationMessage = serde_json::from_str(&json).unwrap();
     assert_eq!(parsed.content.len(), 2);
-    assert!(matches!(&parsed.content[0], ContentBlock::ToolUse { name, .. } if name == "memory_read"));
-    assert!(matches!(&parsed.content[1], ContentBlock::ToolResult { tool_use_id, .. } if tool_use_id == "call-1"));
+    assert!(
+        matches!(&parsed.content[0], ContentBlock::ToolUse { name, .. } if name == "memory_read")
+    );
+    assert!(
+        matches!(&parsed.content[1], ContentBlock::ToolResult { tool_use_id, .. } if tool_use_id == "call-1")
+    );
 }

--- a/rust/crates/sera-types/tests/evolution.rs
+++ b/rust/crates/sera-types/tests/evolution.rs
@@ -1,3 +1,4 @@
+use sera_types::AgentCapability;
 use sera_types::evolution::*;
 use std::collections::HashSet;
 

--- a/rust/crates/sera-types/tests/golden_manifests.rs
+++ b/rust/crates/sera-types/tests/golden_manifests.rs
@@ -15,7 +15,10 @@ fn contracts_dir() -> &'static Path {
 #[test]
 fn parse_all_agent_templates() {
     let dir = contracts_dir();
-    assert!(dir.exists(), "contracts/manifests/ directory not found at {dir:?}");
+    assert!(
+        dir.exists(),
+        "contracts/manifests/ directory not found at {dir:?}"
+    );
 
     let mut count = 0;
     for entry in fs::read_dir(dir).unwrap() {
@@ -32,20 +35,26 @@ fn parse_all_agent_templates() {
             continue;
         }
 
-        let contents = fs::read_to_string(&path)
-            .unwrap_or_else(|e| panic!("Failed to read {filename}: {e}"));
+        let contents =
+            fs::read_to_string(&path).unwrap_or_else(|e| panic!("Failed to read {filename}: {e}"));
 
         let template: AgentTemplate = serde_yaml::from_str(&contents)
             .unwrap_or_else(|e| panic!("Failed to parse {filename}: {e}"));
 
-        assert_eq!(template.api_version, "sera/v1", "{filename}: wrong apiVersion");
+        assert_eq!(
+            template.api_version, "sera/v1",
+            "{filename}: wrong apiVersion"
+        );
         assert_eq!(template.kind, "AgentTemplate", "{filename}: wrong kind");
         assert!(!template.metadata.name.is_empty(), "{filename}: empty name");
 
         count += 1;
     }
 
-    assert!(count >= 3, "Expected at least 3 template files, found {count}");
+    assert!(
+        count >= 3,
+        "Expected at least 3 template files, found {count}"
+    );
 }
 
 #[test]
@@ -67,20 +76,26 @@ fn parse_all_sandbox_boundaries() {
             continue;
         }
 
-        let contents = fs::read_to_string(&path)
-            .unwrap_or_else(|e| panic!("Failed to read {filename}: {e}"));
+        let contents =
+            fs::read_to_string(&path).unwrap_or_else(|e| panic!("Failed to read {filename}: {e}"));
 
         let boundary: SandboxBoundary = serde_yaml::from_str(&contents)
             .unwrap_or_else(|e| panic!("Failed to parse {filename}: {e}"));
 
-        assert_eq!(boundary.api_version, "sera/v1", "{filename}: wrong apiVersion");
+        assert_eq!(
+            boundary.api_version, "sera/v1",
+            "{filename}: wrong apiVersion"
+        );
         assert_eq!(boundary.kind, "SandboxBoundary", "{filename}: wrong kind");
         assert!(!boundary.metadata.name.is_empty(), "{filename}: empty name");
 
         count += 1;
     }
 
-    assert!(count >= 3, "Expected at least 3 sandbox boundary files, found {count}");
+    assert!(
+        count >= 3,
+        "Expected at least 3 sandbox boundary files, found {count}"
+    );
 }
 
 #[test]

--- a/rust/crates/sera-types/tests/hooks.rs
+++ b/rust/crates/sera-types/tests/hooks.rs
@@ -68,7 +68,10 @@ fn context_memory_alias_yaml_roundtrip() {
 #[test]
 fn unknown_hook_point_name_fails() {
     let result = serde_json::from_str::<HookPoint>("\"not_a_real_point\"");
-    assert!(result.is_err(), "unknown hook point name should fail to parse");
+    assert!(
+        result.is_err(),
+        "unknown hook point name should fail to parse"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Removes duplicate `pub enum AgentCapability` from evolution.rs (line 83). The canonical definition remains in capability.rs (line 82), colocated with `CapabilityToken` and `CapabilityPolicy`.

## Changes
- Deleted duplicate enum from evolution.rs
- Added re-export in lib.rs: `pub use capability::AgentCapability`
- Updated sera-meta to import from top-level re-export

## Verification
- `cargo check --workspace`: PASS
- `cargo test -p sera-types --lib`: 405 tests passed
- `cargo clippy -p sera-types`: No issues
- `cargo fmt`: Applied