### PR TITLE
cleanup(sera-tools): rename registry::Tool -> ToolDescriptor (sera-vdu5)

### DIFF
--- a/rust/crates/sera-tools/src/knowledge_ingest.rs
+++ b/rust/crates/sera-tools/src/knowledge_ingest.rs
@@ -514,13 +514,13 @@ impl KnowledgeIngestPipeline {
 
 // ── Tool trait integration ────────────────────────────────────────────────────
 
-use crate::registry::Tool;
+use crate::registry::ToolDescriptor;
 
 /// `knowledge-ingest` tool — registered with `ToolRegistry` so the agent
 /// runtime can discover it by name.
 pub struct KnowledgeIngestTool;
 
-impl Tool for KnowledgeIngestTool {
+impl ToolDescriptor for KnowledgeIngestTool {
     fn name(&self) -> &str {
         "knowledge-ingest"
     }

--- a/rust/crates/sera-tools/src/lsp/tools/find_referencing_symbols.rs
+++ b/rust/crates/sera-tools/src/lsp/tools/find_referencing_symbols.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use crate::lsp::error::{LspError, ToolError};
 use crate::lsp::name_path::NamePath;
 use crate::lsp::state::{normalize_path, LspToolsState};
-use crate::registry::Tool;
+use crate::registry::ToolDescriptor;
 
 use super::find_symbol::{uri_to_path, SymbolMatch};
 use super::{ByteRange, SymbolEntry, SymbolKind};
@@ -62,7 +62,7 @@ impl Default for FindReferencingSymbolsTool {
     }
 }
 
-impl Tool for FindReferencingSymbolsTool {
+impl ToolDescriptor for FindReferencingSymbolsTool {
     fn name(&self) -> &str {
         Self::NAME
     }

--- a/rust/crates/sera-tools/src/lsp/tools/find_symbol.rs
+++ b/rust/crates/sera-tools/src/lsp/tools/find_symbol.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use crate::lsp::error::{LspError, ToolError};
 use crate::lsp::name_path::{NamePath, NamePathSegment};
 use crate::lsp::state::{normalize_path, LspToolsState};
-use crate::registry::Tool;
+use crate::registry::ToolDescriptor;
 
 use super::{ByteRange, SymbolEntry, SymbolKind};
 
@@ -78,7 +78,7 @@ impl Default for FindSymbolTool {
     }
 }
 
-impl Tool for FindSymbolTool {
+impl ToolDescriptor for FindSymbolTool {
     fn name(&self) -> &str {
         Self::NAME
     }

--- a/rust/crates/sera-tools/src/lsp/tools/get_symbols_overview.rs
+++ b/rust/crates/sera-tools/src/lsp/tools/get_symbols_overview.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use crate::lsp::cache::CacheKey;
 use crate::lsp::error::{LspError, ToolError};
 use crate::lsp::state::{normalize_path, LspToolsState};
-use crate::registry::Tool;
+use crate::registry::ToolDescriptor;
 
 #[cfg(test)]
 use std::sync::Arc;
@@ -56,7 +56,7 @@ impl Default for GetSymbolsOverviewTool {
     }
 }
 
-impl Tool for GetSymbolsOverviewTool {
+impl ToolDescriptor for GetSymbolsOverviewTool {
     fn name(&self) -> &str {
         Self::NAME
     }

--- a/rust/crates/sera-tools/src/registry.rs
+++ b/rust/crates/sera-tools/src/registry.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 /// A tool that can be registered and retrieved by name.
-pub trait Tool: Send + Sync {
+pub trait ToolDescriptor: Send + Sync {
     fn name(&self) -> &str;
     fn description(&self) -> &str;
 }
@@ -12,7 +12,7 @@ pub trait Tool: Send + Sync {
 /// Registry for managing tools by name.
 #[derive(Default)]
 pub struct ToolRegistry {
-    tools: HashMap<String, Arc<dyn Tool>>,
+    tools: HashMap<String, Arc<dyn ToolDescriptor>>,
 }
 
 impl ToolRegistry {
@@ -24,12 +24,12 @@ impl ToolRegistry {
     }
 
     /// Register a tool. Replaces any existing tool with the same name.
-    pub fn register(&mut self, tool: Arc<dyn Tool>) {
+    pub fn register(&mut self, tool: Arc<dyn ToolDescriptor>) {
         self.tools.insert(tool.name().to_string(), tool);
     }
 
     /// Get a tool by name.
-    pub fn get(&self, name: &str) -> Option<Arc<dyn Tool>> {
+    pub fn get(&self, name: &str) -> Option<Arc<dyn ToolDescriptor>> {
         self.tools.get(name).cloned()
     }
 

--- a/rust/crates/sera-tools/tests/tools_tests.rs
+++ b/rust/crates/sera-tools/tests/tools_tests.rs
@@ -199,11 +199,11 @@ fn queue_mode_serde_roundtrip() {
 // ---------------------------------------------------------------------------
 // 14. Tool registry register and get
 // ---------------------------------------------------------------------------
-use sera_tools::registry::{Tool, ToolRegistry};
+use sera_tools::registry::{ToolDescriptor, ToolRegistry};
 
 struct EchoTool;
 
-impl Tool for EchoTool {
+impl ToolDescriptor for EchoTool {
     fn name(&self) -> &str {
         "echo"
     }


### PR DESCRIPTION
`sera-tools::registry::Tool` (metadata shim) and `sera-types::tool::Tool` (dispatchable async trait) shared a name, causing import ambiguity. Renamed the catalog-descriptor trait. No semantic change.

Closes sera-vdu5