### PR TITLE
cleanup(sera-types): rename event::Event -> IncomingEvent (sera-9bbr)

### DIFF
--- a/rust/crates/sera-db/src/lane_queue.rs
+++ b/rust/crates/sera-db/src/lane_queue.rs
@@ -8,8 +8,8 @@ use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use std::time::Duration;
 
-use serde::{Deserialize, Serialize};
 use sera_types::event::IncomingEvent;
+use serde::{Deserialize, Serialize};
 
 use crate::error::DbError;
 use crate::lane_queue_counter::LaneCounterStoreDyn;
@@ -450,10 +450,7 @@ impl LaneQueue {
     ///
     /// Callers that need strict cross-pod admission control should configure a
     /// Postgres-backed store in the constructor.
-    pub async fn pending_count_for_lane_async(
-        &self,
-        session_key: &str,
-    ) -> Result<i64, DbError> {
+    pub async fn pending_count_for_lane_async(&self, session_key: &str) -> Result<i64, DbError> {
         if let Some(store) = self.counter_store.as_ref() {
             store.snapshot_dyn(session_key).await
         } else {
@@ -582,7 +579,7 @@ impl LaneQueue {
 mod tests {
     use super::*;
     use sera_types::{
-        event::{IncomingEvent, EventSource},
+        event::{EventSource, IncomingEvent},
         principal::{PrincipalId, PrincipalKind, PrincipalRef},
     };
 
@@ -1207,18 +1204,16 @@ mod tests {
         // `LaneQueue::new` must preserve the legacy single-pod default: no
         // persistent counter, `has_counter_store` returns false.
         let q = LaneQueue::new(4, QueueMode::Followup);
-        assert!(!q.has_counter_store(), "new() must not wire a counter store");
+        assert!(
+            !q.has_counter_store(),
+            "new() must not wire a counter store"
+        );
     }
 
     #[tokio::test]
     async fn enqueue_mirrors_pending_to_counter_store() {
-        let store: Arc<dyn LaneCounterStoreDyn> =
-            Arc::new(InMemoryLaneCounter::new());
-        let mut q = LaneQueue::new_with_counter_store(
-            4,
-            QueueMode::Followup,
-            Arc::clone(&store),
-        );
+        let store: Arc<dyn LaneCounterStoreDyn> = Arc::new(InMemoryLaneCounter::new());
+        let mut q = LaneQueue::new_with_counter_store(4, QueueMode::Followup, Arc::clone(&store));
 
         assert!(q.has_counter_store());
         q.enqueue(make_event("s1"));
@@ -1235,13 +1230,8 @@ mod tests {
         // Verify the full enqueue → dequeue → complete_run lifecycle leaves the
         // persistent count at zero. Dequeue must NOT perturb the store because
         // the job simply moves from "queued" to "in-flight" (net zero).
-        let store: Arc<dyn LaneCounterStoreDyn> =
-            Arc::new(InMemoryLaneCounter::new());
-        let mut q = LaneQueue::new_with_counter_store(
-            4,
-            QueueMode::Followup,
-            Arc::clone(&store),
-        );
+        let store: Arc<dyn LaneCounterStoreDyn> = Arc::new(InMemoryLaneCounter::new());
+        let mut q = LaneQueue::new_with_counter_store(4, QueueMode::Followup, Arc::clone(&store));
 
         q.enqueue(make_event("s1"));
         assert_eq!(wait_for_store(&store, "s1", 1).await, 1);
@@ -1263,19 +1253,12 @@ mod tests {
         // the same counter store must see a consistent global view of the
         // per-lane pending count — the admission-control invariant that
         // PostgresLaneCounter exists to guarantee in production.
-        let store: Arc<dyn LaneCounterStoreDyn> =
-            Arc::new(InMemoryLaneCounter::new());
+        let store: Arc<dyn LaneCounterStoreDyn> = Arc::new(InMemoryLaneCounter::new());
 
-        let mut pod_a = LaneQueue::new_with_counter_store(
-            4,
-            QueueMode::Followup,
-            Arc::clone(&store),
-        );
-        let mut pod_b = LaneQueue::new_with_counter_store(
-            4,
-            QueueMode::Followup,
-            Arc::clone(&store),
-        );
+        let mut pod_a =
+            LaneQueue::new_with_counter_store(4, QueueMode::Followup, Arc::clone(&store));
+        let mut pod_b =
+            LaneQueue::new_with_counter_store(4, QueueMode::Followup, Arc::clone(&store));
 
         // Each pod accepts one job for the same lane.
         pod_a.enqueue(make_event("lane-shared"));
@@ -1307,13 +1290,8 @@ mod tests {
         // To stage "multiple queued events cleared by interrupt" we start in
         // Followup mode (so enqueues accumulate), then flip to Interrupt and
         // issue a single enqueue that must clear all of them atomically.
-        let store: Arc<dyn LaneCounterStoreDyn> =
-            Arc::new(InMemoryLaneCounter::new());
-        let mut q = LaneQueue::new_with_counter_store(
-            4,
-            QueueMode::Followup,
-            Arc::clone(&store),
-        );
+        let store: Arc<dyn LaneCounterStoreDyn> = Arc::new(InMemoryLaneCounter::new());
+        let mut q = LaneQueue::new_with_counter_store(4, QueueMode::Followup, Arc::clone(&store));
 
         q.enqueue(make_event("s1")); // Ready; +1 → 1
         q.dequeue("s1"); // queued → in-flight; store unchanged at 1
@@ -1332,23 +1310,15 @@ mod tests {
 
     #[tokio::test]
     async fn pending_count_for_lane_async_uses_store_when_present() {
-        let store: Arc<dyn LaneCounterStoreDyn> =
-            Arc::new(InMemoryLaneCounter::new());
+        let store: Arc<dyn LaneCounterStoreDyn> = Arc::new(InMemoryLaneCounter::new());
         // Seed the store directly to simulate a sibling pod having enqueued
         // something before this pod came up.
         store.increment_dyn("s-seeded", 5).await.unwrap();
 
-        let q = LaneQueue::new_with_counter_store(
-            4,
-            QueueMode::Followup,
-            Arc::clone(&store),
-        );
+        let q = LaneQueue::new_with_counter_store(4, QueueMode::Followup, Arc::clone(&store));
         // Local lanes map is empty, but the authoritative store has 5.
         assert_eq!(q.lane_depth("s-seeded"), 0);
-        assert_eq!(
-            q.pending_count_for_lane_async("s-seeded").await.unwrap(),
-            5
-        );
+        assert_eq!(q.pending_count_for_lane_async("s-seeded").await.unwrap(), 5);
     }
 
     #[tokio::test]
@@ -1358,14 +1328,8 @@ mod tests {
         let mut q = LaneQueue::new(4, QueueMode::Followup);
         q.enqueue(make_event("s1"));
         q.enqueue(make_event("s1"));
-        assert_eq!(
-            q.pending_count_for_lane_async("s1").await.unwrap(),
-            2
-        );
+        assert_eq!(q.pending_count_for_lane_async("s1").await.unwrap(), 2);
         // And for an unseen lane.
-        assert_eq!(
-            q.pending_count_for_lane_async("missing").await.unwrap(),
-            0
-        );
+        assert_eq!(q.pending_count_for_lane_async("missing").await.unwrap(), 0);
     }
 }

--- a/rust/crates/sera-db/src/lane_queue.rs
+++ b/rust/crates/sera-db/src/lane_queue.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
-use sera_types::event::Event;
+use sera_types::event::IncomingEvent;
 
 use crate::error::DbError;
 use crate::lane_queue_counter::LaneCounterStoreDyn;
@@ -51,14 +51,14 @@ pub enum EnqueueResult {
 /// An event wrapped with queue-level metadata.
 #[derive(Debug, Clone)]
 pub struct QueuedEvent {
-    pub event: Event,
+    pub event: IncomingEvent,
     pub enqueued_at: std::time::Instant,
     /// True if this event should be injected at a tool boundary (steer/steer_backlog modes).
     pub is_steer: bool,
 }
 
 impl QueuedEvent {
-    fn new(event: Event) -> Self {
+    fn new(event: IncomingEvent) -> Self {
         Self {
             event,
             enqueued_at: std::time::Instant::now(),
@@ -66,7 +66,7 @@ impl QueuedEvent {
         }
     }
 
-    fn new_steer(event: Event) -> Self {
+    fn new_steer(event: IncomingEvent) -> Self {
         Self {
             event,
             enqueued_at: std::time::Instant::now(),
@@ -252,7 +252,7 @@ impl LaneQueue {
     /// * [`EnqueueResult::Queued`] — a run is active; the event has been buffered.
     /// * [`EnqueueResult::Steer`] — the event has been stored as a steer injection.
     /// * [`EnqueueResult::Interrupt`] — the caller should abort the active run.
-    pub fn enqueue(&mut self, event: Event) -> EnqueueResult {
+    pub fn enqueue(&mut self, event: IncomingEvent) -> EnqueueResult {
         // Reject new jobs once the queue has been closed for shutdown.
         if self.closed {
             return EnqueueResult::Closed;
@@ -582,7 +582,7 @@ impl LaneQueue {
 mod tests {
     use super::*;
     use sera_types::{
-        event::{Event, EventSource},
+        event::{IncomingEvent, EventSource},
         principal::{PrincipalId, PrincipalKind, PrincipalRef},
     };
 
@@ -593,8 +593,8 @@ mod tests {
         }
     }
 
-    fn make_event(session_key: &str) -> Event {
-        Event::message("sera", session_key, principal(), "hello")
+    fn make_event(session_key: &str) -> IncomingEvent {
+        IncomingEvent::message("sera", session_key, principal(), "hello")
     }
 
     // --- basic happy path --------------------------------------------------
@@ -1163,7 +1163,7 @@ mod tests {
 
     #[test]
     fn queued_event_preserves_source() {
-        let event = Event {
+        let event = IncomingEvent {
             source: EventSource::Api,
             ..make_event("s1")
         };

--- a/rust/crates/sera-gateway/src/bin/sera.rs
+++ b/rust/crates/sera-gateway/src/bin/sera.rs
@@ -55,7 +55,7 @@ use sera_mail::{
     MailCorrelator, parse_raw_message,
 };
 use sera_types::config_manifest::{AgentSpec, ConnectorSpec, ProviderSpec};
-use sera_types::event::Event as DomainEvent;
+use sera_types::event::IncomingEvent as DomainEvent;
 use sera_types::hook::{HookChain, HookContext, HookPoint, HookResult};
 use sera_types::principal::{PrincipalId, PrincipalKind, PrincipalRef};
 

--- a/rust/crates/sera-gateway/tests/shutdown_drain.rs
+++ b/rust/crates/sera-gateway/tests/shutdown_drain.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 
 use sera_db::lane_queue::{LaneQueue, QueueMode};
 use sera_types::{
-    event::Event as DomainEvent,
+    event::IncomingEvent as DomainEvent,
     principal::{PrincipalId, PrincipalKind, PrincipalRef},
 };
 use tokio::sync::Mutex;

--- a/rust/crates/sera-types/src/event.rs
+++ b/rust/crates/sera-types/src/event.rs
@@ -110,12 +110,7 @@ pub struct IncomingEvent {
 
 impl IncomingEvent {
     /// Create a new message event from a channel.
-    pub fn message(
-        agent_id: &str,
-        session_key: &str,
-        principal: PrincipalRef,
-        text: &str,
-    ) -> Self {
+    pub fn message(agent_id: &str, session_key: &str, principal: PrincipalRef, text: &str) -> Self {
         Self {
             id: EventId::generate(),
             kind: EventKind::Message,
@@ -328,7 +323,8 @@ mod tests {
 
     #[test]
     fn event_with_recipient() {
-        let mut event = IncomingEvent::message("sera", "agent:sera:main", test_principal(), "Hello");
+        let mut event =
+            IncomingEvent::message("sera", "agent:sera:main", test_principal(), "Hello");
         event.recipient = Some("agent:reviewer".to_string());
         let json = serde_json::to_string(&event).unwrap();
         assert!(json.contains("recipient"));
@@ -338,8 +334,10 @@ mod tests {
 
     #[test]
     fn event_with_approval() {
-        let mut event = IncomingEvent::message("sera", "agent:sera:main", test_principal(), "rm -rf /");
-        event.requires_approval = Some(serde_json::json!({"scope": "tool_call", "urgency": "high"}));
+        let mut event =
+            IncomingEvent::message("sera", "agent:sera:main", test_principal(), "rm -rf /");
+        event.requires_approval =
+            Some(serde_json::json!({"scope": "tool_call", "urgency": "high"}));
         let json = serde_json::to_string(&event).unwrap();
         let parsed: IncomingEvent = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.requires_approval.unwrap()["urgency"], "high");

--- a/rust/crates/sera-types/src/event.rs
+++ b/rust/crates/sera-types/src/event.rs
@@ -79,7 +79,7 @@ pub enum EventSource {
 /// MVS scope: Message and System events only. No webhooks, no cron triggers,
 /// no approval events. Queue modes are simple FIFO.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Event {
+pub struct IncomingEvent {
     pub id: EventId,
     pub kind: EventKind,
     pub source: EventSource,
@@ -108,7 +108,7 @@ pub struct Event {
     pub metadata: serde_json::Value,
 }
 
-impl Event {
+impl IncomingEvent {
     /// Create a new message event from a channel.
     pub fn message(
         agent_id: &str,
@@ -226,7 +226,7 @@ mod tests {
 
     #[test]
     fn message_event_construction() {
-        let event = Event::message("sera", "agent:sera:main", test_principal(), "Hello");
+        let event = IncomingEvent::message("sera", "agent:sera:main", test_principal(), "Hello");
         assert_eq!(event.kind, EventKind::Message);
         assert_eq!(event.source, EventSource::Channel);
         assert_eq!(event.agent_id, "sera");
@@ -236,15 +236,15 @@ mod tests {
 
     #[test]
     fn api_message_event() {
-        let event = Event::api_message("sera", "agent:sera:main", test_principal(), "Hi");
+        let event = IncomingEvent::api_message("sera", "agent:sera:main", test_principal(), "Hi");
         assert_eq!(event.source, EventSource::Api);
     }
 
     #[test]
     fn event_roundtrip() {
-        let event = Event::message("sera", "agent:sera:main", test_principal(), "test");
+        let event = IncomingEvent::message("sera", "agent:sera:main", test_principal(), "test");
         let json = serde_json::to_string(&event).unwrap();
-        let parsed: Event = serde_json::from_str(&json).unwrap();
+        let parsed: IncomingEvent = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.agent_id, "sera");
         assert_eq!(parsed.text.as_deref(), Some("test"));
     }
@@ -302,7 +302,7 @@ mod tests {
 
     #[test]
     fn heartbeat_event() {
-        let event = Event::heartbeat("sera", "agent:sera:main");
+        let event = IncomingEvent::heartbeat("sera", "agent:sera:main");
         assert_eq!(event.kind, EventKind::Heartbeat);
         assert_eq!(event.source, EventSource::Internal);
         assert!(event.text.is_none());
@@ -310,7 +310,7 @@ mod tests {
 
     #[test]
     fn cron_event() {
-        let event = Event::cron("sera", "agent:sera:main", test_principal(), "dreaming");
+        let event = IncomingEvent::cron("sera", "agent:sera:main", test_principal(), "dreaming");
         assert_eq!(event.kind, EventKind::Cron);
         assert_eq!(event.source, EventSource::Scheduler);
         assert_eq!(event.text.as_deref(), Some("dreaming"));
@@ -319,7 +319,7 @@ mod tests {
     #[test]
     fn webhook_event() {
         let payload = serde_json::json!({"action": "push", "repo": "sera"});
-        let event = Event::webhook("sera", "agent:sera:main", test_principal(), payload);
+        let event = IncomingEvent::webhook("sera", "agent:sera:main", test_principal(), payload);
         assert_eq!(event.kind, EventKind::Webhook);
         assert_eq!(event.source, EventSource::Api);
         assert!(event.text.is_none());
@@ -328,20 +328,20 @@ mod tests {
 
     #[test]
     fn event_with_recipient() {
-        let mut event = Event::message("sera", "agent:sera:main", test_principal(), "Hello");
+        let mut event = IncomingEvent::message("sera", "agent:sera:main", test_principal(), "Hello");
         event.recipient = Some("agent:reviewer".to_string());
         let json = serde_json::to_string(&event).unwrap();
         assert!(json.contains("recipient"));
-        let parsed: Event = serde_json::from_str(&json).unwrap();
+        let parsed: IncomingEvent = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.recipient.as_deref(), Some("agent:reviewer"));
     }
 
     #[test]
     fn event_with_approval() {
-        let mut event = Event::message("sera", "agent:sera:main", test_principal(), "rm -rf /");
+        let mut event = IncomingEvent::message("sera", "agent:sera:main", test_principal(), "rm -rf /");
         event.requires_approval = Some(serde_json::json!({"scope": "tool_call", "urgency": "high"}));
         let json = serde_json::to_string(&event).unwrap();
-        let parsed: Event = serde_json::from_str(&json).unwrap();
+        let parsed: IncomingEvent = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.requires_approval.unwrap()["urgency"], "high");
     }
 }


### PR DESCRIPTION
sera-types exposed two `pub struct Event`: `envelope::Event` (NDJSON wire frame, canonical) and `event::Event` (gateway inbound pre-submission). Renamed the latter to `IncomingEvent`. Mechanical rename, no shape change.

Closes sera-9bbr