### PR TITLE
cleanup: consolidate LaneQueue / QueuedEvent / QueueMode on sera-queue (sera-ifkf)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5065,6 +5065,7 @@ dependencies = [
  "rusqlite",
  "sera-errors",
  "sera-memory",
+ "sera-queue",
  "sera-types",
  "serde",
  "serde_json",

--- a/rust/crates/sera-db/Cargo.toml
+++ b/rust/crates/sera-db/Cargo.toml
@@ -10,6 +10,7 @@ sqlite-vec = ["dep:sqlite-vec"]
 
 [dependencies]
 sera-memory = { workspace = true, features = ["pgvector", "sqlite", "sqlite-vec"] }
+sera-queue.workspace = true
 sera-types.workspace = true
 sera-errors.workspace = true
 rusqlite.workspace = true

--- a/rust/crates/sera-db/src/lane_queue.rs
+++ b/rust/crates/sera-db/src/lane_queue.rs
@@ -8,29 +8,12 @@ use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use std::time::Duration;
 
+use sera_queue::QueueMode;
 use sera_types::event::IncomingEvent;
 use serde::{Deserialize, Serialize};
 
 use crate::error::DbError;
 use crate::lane_queue_counter::LaneCounterStoreDyn;
-
-/// How queued messages are handled while a run is active for this session.
-///
-/// SPEC-gateway §5.2
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum QueueMode {
-    /// Coalesce queued messages into one follow-up turn after current run completes.
-    Collect,
-    /// Wait until current run ends, process queued messages as sequential follow-up turns.
-    Followup,
-    /// Inject incoming message at next tool boundary in current run.
-    Steer,
-    /// Steer now AND preserve for follow-up after current run.
-    SteerBacklog,
-    /// Abort active run, start new run with newest message.
-    Interrupt,
-}
 
 /// Result of an enqueue operation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/rust/crates/sera-gateway/src/bin/sera.rs
+++ b/rust/crates/sera-gateway/src/bin/sera.rs
@@ -31,7 +31,8 @@ use sera_config::manifest_loader::{
     ManifestSet, load_manifest_file, parse_manifests, resolve_provider_api_key,
 };
 use sera_config::secrets::SecretResolver;
-use sera_db::lane_queue::{LaneQueue, QueueMode};
+use sera_db::lane_queue::LaneQueue;
+use sera_queue::QueueMode;
 use sera_db::lane_queue_counter::{InMemoryLaneCounter, LaneCounterStoreDyn, PostgresLaneCounter};
 use sera_db::sqlite::SqliteDb;
 // sera-vzce: SqliteMemoryStore is the zero-infra SemanticMemoryStore tier

--- a/rust/crates/sera-gateway/src/envelope.rs
+++ b/rust/crates/sera-gateway/src/envelope.rs
@@ -55,17 +55,6 @@ pub struct DedupeKey {
     pub message_id: String,
 }
 
-/// Queue processing mode.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum QueueMode {
-    Collect,
-    Followup,
-    Steer,
-    SteerBacklog,
-    Interrupt,
-}
-
 /// Worker failure classification.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]

--- a/rust/crates/sera-gateway/tests/shutdown_drain.rs
+++ b/rust/crates/sera-gateway/tests/shutdown_drain.rs
@@ -8,7 +8,8 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use sera_db::lane_queue::{LaneQueue, QueueMode};
+use sera_db::lane_queue::LaneQueue;
+use sera_queue::QueueMode;
 use sera_types::{
     event::IncomingEvent as DomainEvent,
     principal::{PrincipalId, PrincipalKind, PrincipalRef},

--- a/rust/crates/sera-queue/src/lane.rs
+++ b/rust/crates/sera-queue/src/lane.rs
@@ -4,7 +4,8 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 /// Controls how an event is placed into the lane queue.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum QueueMode {
     /// Normal FIFO accumulation.
     Collect,

--- a/rust/crates/sera-queue/src/lane.rs
+++ b/rust/crates/sera-queue/src/lane.rs
@@ -63,7 +63,7 @@ impl LaneQueue {
             lane: lane.clone(),
             payload,
             enqueued_at: Utc::now(),
-            mode: mode.clone(),
+            mode,
         };
 
         match mode {


### PR DESCRIPTION
sera-queue is canonical per rust/CLAUDE.md. Consolidated the shared types; sera-db exposes only its backend-specific impl types. Gateway imports from sera-queue. Closes sera-ifkf.