### PR TITLE
cleanup: unify ContentBlock on sera-session (sera-38r6)

### DIFF
--- a/rust/crates/sera-session/src/transcript.rs
+++ b/rust/crates/sera-session/src/transcript.rs
@@ -3,16 +3,7 @@
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-/// A content block in the transcript.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
-pub enum ContentBlock {
-    Text { text: String },
-    ToolUse { id: String, name: String, input: serde_json::Value },
-    ToolResult { tool_use_id: String, content: String, is_error: bool },
-    Image { media_type: String, data: String },
-    Thinking { thinking: String },
-}
+pub use sera_types::ContentBlock;
 
 /// Role of a transcript entry.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/rust/crates/sera-types/src/content_block.rs
+++ b/rust/crates/sera-types/src/content_block.rs
@@ -29,25 +29,15 @@ impl From<&str> for ActionId {
     }
 }
 
-/// A single block of content within a conversation message.
+/// A single block of content within a conversation message or transcript.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ContentBlock {
-    Text {
-        text: String,
-    },
-    ToolUse {
-        id: String,
-        name: String,
-        input: serde_json::Value,
-    },
-    ToolResult {
-        tool_use_id: String,
-        tool_name: String,
-        output: String,
-        #[serde(default)]
-        error: bool,
-    },
+    Text { text: String },
+    ToolUse { id: String, name: String, input: serde_json::Value },
+    ToolResult { tool_use_id: String, content: String, is_error: bool },
+    Image { media_type: String, data: String },
+    Thinking { thinking: String },
 }
 
 /// Role of a participant in a conversation.

--- a/rust/crates/sera-types/tests/content_block.rs
+++ b/rust/crates/sera-types/tests/content_block.rs
@@ -34,9 +34,8 @@ fn conversation_message_tool_use_tool_result_pairing() {
             },
             ContentBlock::ToolResult {
                 tool_use_id: "call-1".into(),
-                tool_name: "memory_read".into(),
-                output: "# Notes".into(),
-                error: false,
+                content: "# Notes".into(),
+                is_error: false,
             },
         ],
         usage: Some(TokenUsage {


### PR DESCRIPTION
sera-types::content_block::ContentBlock duplicated sera-session's richer transcript ContentBlock with wire-incompatible ToolResult shapes. sera-session is the architectural home (transcript layer). Closes sera-38r6.