### PR TITLE
refactor(sera-gateway): unify ConnectorError on sera-types (sera-8s91/connerr)

### DIFF
--- a/rust/crates/sera-gateway/src/connector/mod.rs
+++ b/rust/crates/sera-gateway/src/connector/mod.rs
@@ -6,6 +6,8 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use tokio::sync::RwLock;
 
+pub use sera_types::connector::ConnectorError;
+
 /// Connector trait — delivers and receives messages from external channels.
 #[async_trait]
 pub trait Connector: Send + Sync {
@@ -14,15 +16,6 @@ pub trait Connector: Send + Sync {
 
     /// Human-readable name of this connector.
     fn name(&self) -> &str;
-}
-
-/// Connector errors.
-#[derive(Debug, thiserror::Error)]
-pub enum ConnectorError {
-    #[error("delivery failed: {0}")]
-    DeliveryFailed(String),
-    #[error("channel not found: {0}")]
-    ChannelNotFound(String),
 }
 
 /// Registry of active connectors.

--- a/rust/crates/sera-types/src/connector.rs
+++ b/rust/crates/sera-types/src/connector.rs
@@ -83,6 +83,8 @@ pub enum ConnectorError {
     NotConnected,
     #[error("configuration error: {0}")]
     ConfigError(String),
+    #[error("channel not found: {0}")]
+    ChannelNotFound(String),
 }
 
 // ── OutboundMessage ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Delete `sera_gateway::connector::ConnectorError` (local duplicate, 2 variants)
- Add `ChannelNotFound` variant to `sera_types::connector::ConnectorError` (additive, no semantic collision)
- Re-export `sera_types::connector::ConnectorError` from `sera_gateway::connector` to preserve the public surface

## Verification

- `cargo check -p sera-types -p sera-gateway` → Finished clean (0 errors)

## LOC delta

+4 / -9 = **-5 net**

🤖 Generated with [Claude Code](https://claude.com/claude-code)