### PR TITLE
refactor(sera-tui): rename Session → SessionSummary (sera-8s91/tuisess)

### DIFF
--- a/rust/crates/sera-tui/src/app/mod.rs
+++ b/rust/crates/sera-tui/src/app/mod.rs
@@ -410,7 +410,7 @@ impl Runtime {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::client::{Agent, GatewayClient, HitlRequest, Session, StreamEvent, SseUpdate};
+    use crate::client::{Agent, GatewayClient, HitlRequest, SessionSummary, StreamEvent, SseUpdate};
 
     fn client() -> GatewayClient {
         GatewayClient::new("http://127.0.0.1:1", "test", std::time::Duration::from_millis(1))
@@ -526,7 +526,7 @@ mod tests {
     #[test]
     fn apply_sse_event_lands_on_session_view() {
         let mut app = App::new(client(), TuiKeybindings::defaults());
-        app.session.set_session(Session {
+        app.session.set_session(SessionSummary {
             id: "s1".into(),
             agent_id: "a1".into(),
             created_at: String::new(),

--- a/rust/crates/sera-tui/src/client.rs
+++ b/rust/crates/sera-tui/src/client.rs
@@ -121,7 +121,7 @@ impl Agent {
 
 /// Session summary.
 #[derive(Debug, Clone)]
-pub struct Session {
+pub struct SessionSummary {
     pub id: String,
     pub agent_id: String,
     /// ISO-8601 timestamp of session creation.  Not yet rendered in the
@@ -132,7 +132,7 @@ pub struct Session {
     pub state: String,
 }
 
-impl Session {
+impl SessionSummary {
     fn from_json(v: &serde_json::Value) -> Self {
         let s = |k: &str| {
             v.get(k)
@@ -429,7 +429,7 @@ impl GatewayClient {
     pub async fn list_sessions(
         &self,
         agent_id: Option<&str>,
-    ) -> Result<Vec<Session>, ClientError> {
+    ) -> Result<Vec<SessionSummary>, ClientError> {
         let mut path = "/api/sessions".to_owned();
         if let Some(a) = agent_id {
             path.push_str(&format!("?agent_id={a}"));
@@ -437,7 +437,7 @@ impl GatewayClient {
         match self.get_json(&path).await {
             Ok(body) => Ok(body
                 .as_array()
-                .map(|arr| arr.iter().map(Session::from_json).collect())
+                .map(|arr| arr.iter().map(SessionSummary::from_json).collect())
                 .unwrap_or_default()),
             Err(ClientError::NotAvailable(_)) => Ok(Vec::new()),
             Err(e) => Err(e),
@@ -674,13 +674,13 @@ mod tests {
     #[test]
     fn session_from_json_handles_both_field_names() {
         let v = serde_json::json!({"id": "s1", "agent_id": "a1", "state": "active"});
-        let s = Session::from_json(&v);
+        let s = SessionSummary::from_json(&v);
         assert_eq!(s.id, "s1");
         assert_eq!(s.agent_id, "a1");
         assert_eq!(s.state, "active");
 
         let v2 = serde_json::json!({"id": "s2", "agent_instance_id": "a2", "status": "idle"});
-        let s2 = Session::from_json(&v2);
+        let s2 = SessionSummary::from_json(&v2);
         assert_eq!(s2.agent_id, "a2");
         assert_eq!(s2.state, "idle");
     }

--- a/rust/crates/sera-tui/src/views/session.rs
+++ b/rust/crates/sera-tui/src/views/session.rs
@@ -7,7 +7,7 @@ use ratatui::widgets::{List, ListItem, Paragraph};
 use ratatui::Frame;
 
 use super::agent_list::make_block;
-use crate::client::{ConnectionState, Session, StreamEvent, TranscriptEntry};
+use crate::client::{ConnectionState, SessionSummary, StreamEvent, TranscriptEntry};
 
 /// Viewer state for a single session.  Owns:
 /// * metadata (agent id, session id, state)
@@ -15,7 +15,7 @@ use crate::client::{ConnectionState, Session, StreamEvent, TranscriptEntry};
 /// * tool events (SSE only, non-message events)
 /// * scroll bookkeeping — auto-scrolls to tail unless the user has paused
 pub struct SessionView {
-    pub session: Option<Session>,
+    pub session: Option<SessionSummary>,
     pub transcript: Vec<TranscriptEntry>,
     pub tool_log: Vec<String>,
     pub scroll_offset: u16,
@@ -35,7 +35,7 @@ impl SessionView {
         }
     }
 
-    pub fn set_session(&mut self, session: Session) {
+    pub fn set_session(&mut self, session: SessionSummary) {
         self.session = Some(session);
         self.transcript.clear();
         self.tool_log.clear();
@@ -241,8 +241,8 @@ fn truncate_or_dash(s: &str, max: usize) -> String {
 mod tests {
     use super::*;
 
-    fn sess(id: &str) -> Session {
-        Session {
+    fn sess(id: &str) -> SessionSummary {
+        SessionSummary {
             id: id.to_owned(),
             agent_id: "agent-1".to_owned(),
             created_at: "2026-04-18T00:00:00Z".to_owned(),


### PR DESCRIPTION
Pure rename: `sera-tui::client::Session` → `SessionSummary` to disambiguate from other Session types. Affects `client.rs` and `views/session.rs`.