### PR TITLE
refactor(sera-config): rename ChangeArtifactId → ArtifactRef (sera-8s91/changeart)

### DIFF
--- a/rust/crates/sera-config/src/lib.rs
+++ b/rust/crates/sera-config/src/lib.rs
@@ -30,7 +30,7 @@ pub use config_store::{ConfigStore, ConfigStoreError, ManifestValue};
 pub use layer_merge::{LayeredManifestSet, ManifestLayer};
 pub use schema_registry::SchemaRegistry;
 pub use shadow_store::ShadowConfigStore;
-pub use version_log::{ChangeArtifactId, ConfigVersionEntry, ConfigVersionLog};
+pub use version_log::{ArtifactRef, ConfigVersionEntry, ConfigVersionLog};
 
 use std::env;
 

--- a/rust/crates/sera-config/src/version_log.rs
+++ b/rust/crates/sera-config/src/version_log.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 /// Opaque identifier for a change artifact.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct ChangeArtifactId(pub String);
+pub struct ArtifactRef(pub String);
 
 /// A single entry in the version log.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -13,7 +13,7 @@ pub struct ConfigVersionEntry {
     /// Monotonically increasing version number (1-based after first append).
     pub version: u64,
     /// The change artifact that produced this entry.
-    pub change_artifact: ChangeArtifactId,
+    pub change_artifact: ArtifactRef,
     /// Optional opaque signature bytes (hex-encoded).
     pub signature: Option<String>,
     /// Hash of the previous entry (all-zeros hex string for genesis).
@@ -62,7 +62,7 @@ impl ConfigVersionLog {
     /// The `prev_hash` is taken from `tail_hash()` automatically.
     pub fn append(
         &mut self,
-        change_artifact: ChangeArtifactId,
+        change_artifact: ArtifactRef,
         signature: Option<String>,
         payload: serde_json::Value,
     ) -> &ConfigVersionEntry {
@@ -119,7 +119,7 @@ impl Default for ConfigVersionLog {
 /// Compute the SHA-256 hash for a log entry.
 fn compute_hash(
     version: u64,
-    change_artifact: &ChangeArtifactId,
+    change_artifact: &ArtifactRef,
     prev_hash: &str,
     payload: &serde_json::Value,
 ) -> String {

--- a/rust/crates/sera-config/tests/test_version_log.rs
+++ b/rust/crates/sera-config/tests/test_version_log.rs
@@ -1,5 +1,5 @@
 use serde_json::json;
-use sera_config::version_log::{ChangeArtifactId, ConfigVersionLog};
+use sera_config::version_log::{ArtifactRef, ConfigVersionLog};
 
 #[test]
 fn version_log_starts_empty() {
@@ -15,26 +15,26 @@ fn version_log_starts_empty() {
 #[test]
 fn version_log_append_increments_version() {
     let mut log = ConfigVersionLog::new();
-    log.append(ChangeArtifactId("ca-1".to_string()), None, json!({"a": 1}));
+    log.append(ArtifactRef("ca-1".to_string()), None, json!({"a": 1}));
     assert_eq!(log.version(), 1);
-    log.append(ChangeArtifactId("ca-2".to_string()), None, json!({"b": 2}));
+    log.append(ArtifactRef("ca-2".to_string()), None, json!({"b": 2}));
     assert_eq!(log.version(), 2);
 }
 
 #[test]
 fn version_log_chain_verifies_after_appends() {
     let mut log = ConfigVersionLog::new();
-    log.append(ChangeArtifactId("ca-1".to_string()), None, json!({"x": 1}));
-    log.append(ChangeArtifactId("ca-2".to_string()), None, json!({"x": 2}));
-    log.append(ChangeArtifactId("ca-3".to_string()), None, json!({"x": 3}));
+    log.append(ArtifactRef("ca-1".to_string()), None, json!({"x": 1}));
+    log.append(ArtifactRef("ca-2".to_string()), None, json!({"x": 2}));
+    log.append(ArtifactRef("ca-3".to_string()), None, json!({"x": 3}));
     assert!(log.verify_chain().is_ok());
 }
 
 #[test]
 fn version_log_prev_hash_chain_is_linked() {
     let mut log = ConfigVersionLog::new();
-    log.append(ChangeArtifactId("ca-1".to_string()), None, json!(1));
-    log.append(ChangeArtifactId("ca-2".to_string()), None, json!(2));
+    log.append(ArtifactRef("ca-1".to_string()), None, json!(1));
+    log.append(ArtifactRef("ca-2".to_string()), None, json!(2));
 
     let entries = log.entries();
     // entry[1].prev_hash must equal entry[0].this_hash
@@ -44,7 +44,7 @@ fn version_log_prev_hash_chain_is_linked() {
 #[test]
 fn version_log_genesis_prev_hash_is_zero() {
     let mut log = ConfigVersionLog::new();
-    log.append(ChangeArtifactId("ca-1".to_string()), None, json!("genesis"));
+    log.append(ArtifactRef("ca-1".to_string()), None, json!("genesis"));
 
     let entries = log.entries();
     assert_eq!(

--- a/rust/crates/sera-gateway/src/constitutional_config.rs
+++ b/rust/crates/sera-gateway/src/constitutional_config.rs
@@ -26,7 +26,7 @@ use std::collections::HashSet;
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 
-use sera_meta::constitutional::{ConstitutionalRegistry, ConstitutionalRule};
+use sera_meta::constitutional::{ConstitutionalRegistry, ConstitutionalRuleEntry};
 use sera_meta::ChangeArtifactScope;
 use sera_types::evolution::{BlastRadius, ConstitutionalEnforcementPoint};
 use sera_types::evolution::ConstitutionalRule as ConstitutionalRuleBase;
@@ -49,7 +49,7 @@ pub struct RuleEntry {
 }
 
 impl RuleEntry {
-    /// Convert into a [`ConstitutionalRule`].
+    /// Convert into a [`ConstitutionalRuleEntry`].
     ///
     /// The `content_hash` is derived from `id || description` so that the
     /// hash changes whenever either field changes, giving a stable but
@@ -57,7 +57,7 @@ impl RuleEntry {
     /// bytes in the config file.
     ///
     /// Returns `Err` if `id` is empty or whitespace-only.
-    fn into_rule(self) -> Result<ConstitutionalRule, String> {
+    fn into_rule(self) -> Result<ConstitutionalRuleEntry, String> {
         if self.id.trim().is_empty() {
             return Err("rule id must be non-empty".to_string());
         }
@@ -69,7 +69,7 @@ impl RuleEntry {
         let mut content_hash = [0u8; 32];
         content_hash.copy_from_slice(&digest[..32]);
 
-        Ok(ConstitutionalRule::new(
+        Ok(ConstitutionalRuleEntry::new(
             ConstitutionalRuleBase {
                 id: self.id,
                 description: self.description,


### PR DESCRIPTION
Pure rename of the String-typed `ChangeArtifactId` → `ArtifactRef` in sera-config::version_log. Updated sera-gateway references.