### PR TITLE
refactor(sera-memory): delete duplicate MemoryId, re-export from sera-types (sera-8s91/memid)

### DIFF
--- a/rust/crates/sera-memory/src/store.rs
+++ b/rust/crates/sera-memory/src/store.rs
@@ -220,44 +220,7 @@ pub struct MemoryHit {
     pub raw_score: f32,
 }
 
-/// Stable identifier for a semantic-memory row.
-///
-/// Backends are free to choose the id space (UUIDv4 in `PgVectorStore`;
-/// hash-derived in `InMemorySemanticStore`); the wrapper keeps the public
-/// surface opaque so callers don't accidentally couple to a specific
-/// backing representation.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct MemoryId(pub String);
-
-impl MemoryId {
-    /// Wrap any string-like into a [`MemoryId`].
-    pub fn new(id: impl Into<String>) -> Self {
-        Self(id.into())
-    }
-
-    /// Borrow the inner id as a string slice.
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-}
-
-impl std::fmt::Display for MemoryId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.0)
-    }
-}
-
-impl From<String> for MemoryId {
-    fn from(s: String) -> Self {
-        Self(s)
-    }
-}
-
-impl From<&str> for MemoryId {
-    fn from(s: &str) -> Self {
-        Self(s.to_string())
-    }
-}
+pub use sera_types::memory::MemoryId;
 
 /// A single semantic-memory row — content + embedding + metadata.
 ///

--- a/rust/crates/sera-types/src/memory.rs
+++ b/rust/crates/sera-types/src/memory.rs
@@ -243,11 +243,27 @@ impl MemoryId {
     pub fn generate() -> Self {
         Self(uuid::Uuid::new_v4().to_string())
     }
+    /// Borrow the inner id as a string slice.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
 }
 
 impl std::fmt::Display for MemoryId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)
+    }
+}
+
+impl From<String> for MemoryId {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl From<&str> for MemoryId {
+    fn from(s: &str) -> Self {
+        Self(s.to_string())
     }
 }
 


### PR DESCRIPTION
Removes duplicate `MemoryId` definition from `sera-memory::store`, replaces with `pub use sera_types::memory::MemoryId`.