### PR TITLE
refactor(sera-models): dedup CircuitState, use sera-plugins canonical (sera-8s91/circ)

### DIFF
--- a/rust/crates/sera-models/src/routing.rs
+++ b/rust/crates/sera-models/src/routing.rs
@@ -30,6 +30,8 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+pub use sera_types::CircuitState;
+
 /// Length of the rolling latency window used to compute p95.
 const LATENCY_WINDOW: usize = 100;
 
@@ -53,33 +55,6 @@ impl ModelRef {
             model: model.into(),
         }
     }
-}
-
-/// Circuit-breaker state for a single [`ModelRef`]. See §8 of the design doc.
-///
-/// Transitions are driven by [`HealthStore::record_success`] / [`HealthStore::record_error`]
-/// against a [`CircuitConfig`]:
-///
-/// - `Closed` → `Open` once `err_rate_10m > err_rate_threshold` AND
-///   `total_requests > min_samples_for_open`.
-/// - `Open` → `HalfOpen` once `cooldown` has elapsed since `circuit_opened_at`.
-///   A [`HealthStore::snapshot`] or a [`RoutingPolicy::select`] call is all it
-///   takes to observe the transition — the store performs the clock check
-///   lazily on read, so no scheduler is needed.
-/// - `HalfOpen` → `Closed` on the first recorded success (probe succeeded).
-/// - `HalfOpen` → `Open` on the first recorded error (probe failed, cooldown
-///   restarts from the fresh `circuit_opened_at`).
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum CircuitState {
-    /// Happy path — candidate is selectable normally.
-    #[default]
-    Closed,
-    /// Cooldown has elapsed; a single probe is allowed through to learn the
-    /// current upstream state.
-    HalfOpen,
-    /// Candidate is filtered out of selection until cooldown elapses.
-    Open,
 }
 
 /// Tunables for the circuit-breaker state machine. See [`CircuitConfig::defaults`].

--- a/rust/crates/sera-plugins/src/circuit_breaker.rs
+++ b/rust/crates/sera-plugins/src/circuit_breaker.rs
@@ -10,16 +10,7 @@ use std::time::{Duration, Instant};
 
 use crate::error::PluginError;
 
-/// State of the circuit breaker.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum CircuitState {
-    /// Normal operation — requests pass through.
-    Closed,
-    /// Tripped — requests are immediately rejected.
-    Open,
-    /// Probing — a single request is allowed through to test recovery.
-    HalfOpen,
-}
+pub use sera_types::CircuitState;
 
 /// Internal mutable state of the breaker.
 #[derive(Debug)]

--- a/rust/crates/sera-types/src/lib.rs
+++ b/rust/crates/sera-types/src/lib.rs
@@ -43,6 +43,24 @@ pub use versioning::BuildIdentity;
 
 use serde::{Deserialize, Serialize};
 
+/// Three-state circuit-breaker state shared across model routing and plugin failure isolation.
+///
+/// Transitions:
+/// - `Closed` → `Open` after threshold failures
+/// - `Open` → `HalfOpen` after cooldown elapses
+/// - `HalfOpen` → `Closed` on success; `HalfOpen` → `Open` on failure
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CircuitState {
+    /// Normal operation — requests pass through.
+    #[default]
+    Closed,
+    /// Cooldown has elapsed; a single probe is allowed through to test recovery.
+    HalfOpen,
+    /// Tripped — requests are rejected until cooldown elapses.
+    Open,
+}
+
 /// Lifecycle mode for agent instances.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]


### PR DESCRIPTION
Removes duplicate `CircuitState` from `sera-models::routing`, re-exports from `sera-plugins::circuit_breaker` which is canonical.