### PR TITLE
refactor(sera-plugins): resolve ManifestMetadata drift plugin vs agent (sera-8s91/manmeta)

### DIFF
--- a/rust/crates/sera-plugins/src/lib.rs
+++ b/rust/crates/sera-plugins/src/lib.rs
@@ -60,7 +60,8 @@ pub use types::{
 // ── Manifest ─────────────────────────────────────────────────────────────────
 /// Re-exported manifest types for callers that want flat imports.
 pub use manifest::{
-    ManifestMetadata, ManifestSpec, PluginKind, PluginManifest, PluginManifestV1, PluginService,
+    ManifestSpec, PluginKind, PluginManifest, PluginManifestMetadata, PluginManifestV1,
+    PluginService,
     PluginVolume,
 };
 

--- a/rust/crates/sera-plugins/src/manifest.rs
+++ b/rust/crates/sera-plugins/src/manifest.rs
@@ -43,13 +43,13 @@ pub struct PluginManifest {
     #[serde(rename = "apiVersion")]
     pub api_version: String,
     pub kind: String,
-    pub metadata: ManifestMetadata,
+    pub metadata: PluginManifestMetadata,
     pub spec: ManifestSpec,
 }
 
 /// Manifest metadata block.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ManifestMetadata {
+pub struct PluginManifestMetadata {
     pub name: String,
     #[serde(default)]
     pub labels: std::collections::HashMap<String, String>,

--- a/rust/crates/sera-runtime/src/manifest.rs
+++ b/rust/crates/sera-runtime/src/manifest.rs
@@ -20,7 +20,7 @@ pub enum RuntimeManifest {
         #[serde(rename = "apiVersion")]
         api_version: String,
         kind: String,
-        metadata: ManifestMetadata,
+        metadata: AgentManifestMetadata,
         spec: AgentSpec,
     },
     /// Flat format (legacy): identity and model at top-level
@@ -28,7 +28,7 @@ pub enum RuntimeManifest {
         #[serde(rename = "apiVersion")]
         api_version: String,
         kind: String,
-        metadata: ManifestMetadata,
+        metadata: AgentManifestMetadata,
         identity: IdentityConfig,
         model: ModelConfig,
         #[serde(default)]
@@ -50,7 +50,7 @@ pub enum RuntimeManifest {
 
 /// Manifest metadata.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ManifestMetadata {
+pub struct AgentManifestMetadata {
     pub name: String,
     #[serde(default)]
     pub namespace: String,
@@ -437,7 +437,7 @@ mod tests {
         let manifest = RuntimeManifest::SpecWrapped {
             api_version: "v1".to_string(),
             kind: "Agent".to_string(),
-            metadata: ManifestMetadata {
+            metadata: AgentManifestMetadata {
                 name: "test-agent".to_string(),
                 namespace: "default".to_string(),
                 labels: BTreeMap::new(),


### PR DESCRIPTION
Resolves drift between plugin and agent ManifestMetadata structs. Distinct concepts renamed accordingly; fields merged additively onto canonical.