### PR TITLE
refactor(sera-types): unify HarnessError, delete sera-runtime duplicate (sera-8s91/harnerr)

### DIFF
--- a/rust/crates/sera-runtime/src/harness.rs
+++ b/rust/crates/sera-runtime/src/harness.rs
@@ -76,14 +76,7 @@ pub struct ResetParams {
     pub session_key: String,
 }
 
-/// Harness errors.
-#[derive(Debug, thiserror::Error)]
-pub enum HarnessError {
-    #[error("harness error: {0}")]
-    Internal(String),
-    #[error("not supported: {0}")]
-    NotSupported(String),
-}
+pub use sera_types::harness::HarnessError;
 
 /// The default harness implementation.
 ///

--- a/rust/crates/sera-runtime/src/sera_errors.rs
+++ b/rust/crates/sera-runtime/src/sera_errors.rs
@@ -7,7 +7,6 @@
 //! - [`DelegationError`] — handoff/delegation errors
 //! - [`SubagentError`] — subagent lifecycle errors
 //! - [`LlmError`] — LLM client errors
-//! - [`HarnessError`] — test harness errors
 //! - [`ContextError`] — context engine errors
 
 use sera_errors::{SeraError, SeraErrorCode};
@@ -15,7 +14,6 @@ use sera_errors::{SeraError, SeraErrorCode};
 use crate::context_engine::ContextError;
 use crate::error::RuntimeError;
 use crate::handoff::DelegationError;
-use crate::harness::HarnessError;
 use crate::llm_client::LlmError;
 use crate::subagent::SubagentError;
 use crate::turn::{ThinkError, ToolError};
@@ -86,16 +84,6 @@ impl From<LlmError> for SeraError {
             LlmError::ProviderUnavailable(_) => SeraErrorCode::Unavailable,
             LlmError::Timeout(_) => SeraErrorCode::Timeout,
             LlmError::RequestError(_) => SeraErrorCode::Internal,
-        };
-        SeraError::with_source(code, err.to_string(), err)
-    }
-}
-
-impl From<HarnessError> for SeraError {
-    fn from(err: HarnessError) -> Self {
-        let code = match &err {
-            HarnessError::Internal(_) => SeraErrorCode::Internal,
-            HarnessError::NotSupported(_) => SeraErrorCode::NotImplemented,
         };
         SeraError::with_source(code, err.to_string(), err)
     }

--- a/rust/crates/sera-types/src/harness.rs
+++ b/rust/crates/sera-types/src/harness.rs
@@ -42,6 +42,24 @@ pub enum HarnessError {
     Failed(String),
     #[error("harness shutting down")]
     ShuttingDown,
+    #[error("harness error: {0}")]
+    Internal(String),
+    #[error("not supported: {0}")]
+    NotSupported(String),
+}
+
+impl From<HarnessError> for sera_errors::SeraError {
+    fn from(err: HarnessError) -> Self {
+        use sera_errors::SeraErrorCode;
+        let code = match &err {
+            HarnessError::AgentNotFound(_) => SeraErrorCode::NotFound,
+            HarnessError::Failed(_) => SeraErrorCode::Internal,
+            HarnessError::ShuttingDown => SeraErrorCode::Unavailable,
+            HarnessError::Internal(_) => SeraErrorCode::Internal,
+            HarnessError::NotSupported(_) => SeraErrorCode::NotImplemented,
+        };
+        sera_errors::SeraError::with_source(code, err.to_string(), err)
+    }
 }
 
 /// Registry of active agent harnesses.


### PR DESCRIPTION
Extends `sera-types::harness::HarnessError` with missing variants from `sera-runtime::harness::HarnessError`, deletes the duplicate, re-exports from sera-types.