### PR TITLE
refactor(sera-types): unify ToolError, delete sera-runtime duplicate (sera-8s91/toolerr)

### DIFF
--- a/rust/crates/sera-runtime/src/default_runtime.rs
+++ b/rust/crates/sera-runtime/src/default_runtime.rs
@@ -906,7 +906,7 @@ mod tests {
     #[test]
     fn handoffs_builder_produces_correct_entries() {
         // Unit-test the builder logic directly without a full turn.
-        let agent_ids = vec!["researcher", "coder"];
+        let agent_ids = ["researcher", "coder"];
         let handoffs: Vec<crate::handoff::Handoff> = agent_ids
             .iter()
             .map(|agent_id| crate::handoff::Handoff {

--- a/rust/crates/sera-runtime/src/sera_errors.rs
+++ b/rust/crates/sera-runtime/src/sera_errors.rs
@@ -17,7 +17,7 @@ use crate::context_engine::ContextError;
 use crate::handoff::DelegationError;
 use crate::llm_client::LlmError;
 use crate::subagent::SubagentError;
-use crate::turn::{ThinkError, ToolError};
+use crate::turn::ThinkError;
 
 impl From<ThinkError> for SeraError {
     fn from(err: ThinkError) -> Self {
@@ -25,18 +25,6 @@ impl From<ThinkError> for SeraError {
     }
 }
 
-impl From<ToolError> for SeraError {
-    fn from(err: ToolError) -> Self {
-        let code = match &err {
-            ToolError::NotFound(_) => SeraErrorCode::NotFound,
-            ToolError::ExecutionFailed(_) => SeraErrorCode::Internal,
-            ToolError::InvalidArguments(_) => SeraErrorCode::InvalidInput,
-            ToolError::AbortedByHook { .. } => SeraErrorCode::Forbidden,
-            ToolError::PermissionDenied { .. } => SeraErrorCode::Forbidden,
-        };
-        SeraError::with_source(code, err.to_string(), err)
-    }
-}
 
 impl From<DelegationError> for SeraError {
     fn from(err: DelegationError) -> Self {
@@ -90,6 +78,7 @@ impl From<ContextError> for SeraError {
 mod tests {
     use super::*;
     use sera_types::runtime::RuntimeError;
+    use sera_types::tool::ToolError;
 
     // --- RuntimeError ---
 

--- a/rust/crates/sera-runtime/src/tools/dispatcher.rs
+++ b/rust/crates/sera-runtime/src/tools/dispatcher.rs
@@ -226,11 +226,7 @@ impl ToolDispatcher for RegistryDispatcher {
                 "role": "tool",
                 "content": output.content,
             })),
-            Err(sera_types::tool::ToolError::NotFound(n)) => Err(ToolError::NotFound(n)),
-            Err(sera_types::tool::ToolError::PolicyDenied(n)) => {
-                Err(ToolError::ExecutionFailed(format!("policy denied: {n}")))
-            }
-            Err(e) => Err(ToolError::ExecutionFailed(e.to_string())),
+            Err(e) => Err(e),
         }
     }
 }
@@ -361,7 +357,10 @@ mod tests {
             deny_patterns: vec!["*".to_string()],
         };
         let err = dispatcher.dispatch(&tool_call, &ctx).await.unwrap_err();
-        assert!(matches!(err, ToolError::ExecutionFailed(_)));
+        assert!(
+            matches!(err, ToolError::PolicyDenied(_) | ToolError::ExecutionFailed(_)),
+            "expected PolicyDenied or ExecutionFailed, got {err:?}",
+        );
     }
 
     // ── sera-ddz: tool hook + permission escalation integration ─────────

--- a/rust/crates/sera-runtime/src/turn.rs
+++ b/rust/crates/sera-runtime/src/turn.rs
@@ -96,22 +96,11 @@ pub trait LlmProvider: Send + Sync {
 // ── ToolDispatcher trait ────────────────────────────────────────────────────
 
 /// Errors from tool dispatch.
-#[derive(Debug, thiserror::Error)]
-pub enum ToolError {
-    #[error("tool not found: {0}")]
-    NotFound(String),
-    #[error("tool execution failed: {0}")]
-    ExecutionFailed(String),
-    #[error("invalid arguments: {0}")]
-    InvalidArguments(String),
-    /// A pre-tool hook aborted the call before execution.
-    #[error("tool call aborted by hook: {reason}")]
-    AbortedByHook { reason: String },
-    /// The caller's permission mode was insufficient and escalation was
-    /// denied by the [`crate::permissions::EscalationAuthority`].
-    #[error("permission denied for tool call: {reason}")]
-    PermissionDenied { reason: String },
-}
+///
+/// Re-exported from [`sera_types::tool::ToolError`] — the canonical definition
+/// lives there. Use `sera_types::tool::ToolError` directly in new code;
+/// `crate::turn::ToolError` is kept as an alias for back-compat.
+pub use sera_types::tool::ToolError;
 
 /// Trait for dispatching tool calls from the act step.
 ///

--- a/rust/crates/sera-testing/src/contracts.rs
+++ b/rust/crates/sera-testing/src/contracts.rs
@@ -53,7 +53,7 @@ mod tests {
     fn contract_example_minimal_lifecycle_mode() {
         use sera_types::LifecycleMode;
         let t = parse_template("example-minimal.template.yaml");
-        let mode = t.spec.lifecycle.as_ref().unwrap().mode.clone();
+        let mode = t.spec.lifecycle.as_ref().unwrap().mode;
         assert_eq!(mode, LifecycleMode::Ephemeral);
     }
 
@@ -97,7 +97,7 @@ mod tests {
     fn contract_example_full_lifecycle_persistent() {
         use sera_types::LifecycleMode;
         let t = parse_template("example-full.template.yaml");
-        let mode = t.spec.lifecycle.as_ref().unwrap().mode.clone();
+        let mode = t.spec.lifecycle.as_ref().unwrap().mode;
         assert_eq!(mode, LifecycleMode::Persistent);
     }
 

--- a/rust/crates/sera-types/src/tool.rs
+++ b/rust/crates/sera-types/src/tool.rs
@@ -426,6 +426,33 @@ pub enum ToolError {
     InvalidInput(String),
     #[error("policy denied tool execution: {0}")]
     PolicyDenied(String),
+    /// Invalid arguments supplied to a tool call (dispatch-layer validation).
+    #[error("invalid arguments: {0}")]
+    InvalidArguments(String),
+    /// A pre-tool hook aborted the call before execution.
+    #[error("tool call aborted by hook: {reason}")]
+    AbortedByHook { reason: String },
+    /// The caller's permission mode was insufficient and escalation was denied.
+    #[error("permission denied for tool call: {reason}")]
+    PermissionDenied { reason: String },
+}
+
+impl From<ToolError> for sera_errors::SeraError {
+    fn from(err: ToolError) -> Self {
+        use sera_errors::SeraErrorCode;
+        let code = match &err {
+            ToolError::NotFound(_) => SeraErrorCode::NotFound,
+            ToolError::ExecutionFailed(_) => SeraErrorCode::Internal,
+            ToolError::InvalidArguments(_) => SeraErrorCode::InvalidInput,
+            ToolError::InvalidInput(_) => SeraErrorCode::InvalidInput,
+            ToolError::AbortedByHook { .. } => SeraErrorCode::Forbidden,
+            ToolError::PermissionDenied { .. } => SeraErrorCode::Forbidden,
+            ToolError::Unauthorized(_) => SeraErrorCode::Forbidden,
+            ToolError::PolicyDenied(_) => SeraErrorCode::Forbidden,
+            ToolError::Timeout => SeraErrorCode::Internal,
+        };
+        sera_errors::SeraError::with_source(code, err.to_string(), err)
+    }
 }
 
 /// Injected credentials available to a tool at execution time.


### PR DESCRIPTION
Extends `sera-types::tool::ToolError` with missing variants, deletes `sera-runtime` duplicate, re-exports from sera-types canonical.