### PR TITLE
refactor(sera-db): cfg-gate SessionRow/AuditRow per backend feature (sera-8s91/rowcfg)

### DIFF
--- a/rust/crates/sera-db/Cargo.toml
+++ b/rust/crates/sera-db/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 [features]
 default = ["sqlite-vec"]
 integration = []
+postgres = []
 sqlite-vec = ["dep:sqlite-vec"]
 
 [dependencies]

--- a/rust/crates/sera-db/src/audit.rs
+++ b/rust/crates/sera-db/src/audit.rs
@@ -2,15 +2,17 @@
 //!
 //! Dual-backend (sera-mwb4):
 //! * [`AuditRepository`] — original Postgres-backed repo (sqlx, `audit_trail` table).
+//!   Compiled only when the `postgres` feature is enabled.
 //! * [`SqliteAuditStore`] — rusqlite-backed equivalent that mirrors the same
-//!   append/query surface for local-first deployments.
+//!   append/query surface for local-first deployments. Always compiled.
 //! * [`AuditStore`] — async trait satisfied by both so callers can depend on
-//!   the trait object rather than a concrete type.
+//!   the trait object rather than a concrete type. Always compiled.
 
 use std::sync::Arc;
 
 use async_trait::async_trait;
 use rusqlite::{params, Connection};
+#[cfg(feature = "postgres")]
 use sqlx::PgPool;
 use tokio::sync::Mutex;
 
@@ -31,8 +33,11 @@ pub struct AuditRow {
 }
 
 /// Audit repository for database operations.
+/// Only available with the `postgres` feature.
+#[cfg(feature = "postgres")]
 pub struct AuditRepository;
 
+#[cfg(feature = "postgres")]
 impl AuditRepository {
     /// Append an audit event with hash chain.
     /// Uses an EXCLUSIVE lock to ensure sequential hashing.
@@ -187,17 +192,21 @@ pub trait AuditStore: Send + Sync + std::fmt::Debug {
 
 /// Postgres implementation of [`AuditStore`] — delegates to
 /// [`AuditRepository`] so the existing static functions remain usable.
+/// Only available with the `postgres` feature.
+#[cfg(feature = "postgres")]
 #[derive(Debug, Clone)]
 pub struct PgAuditStore {
     pool: PgPool,
 }
 
+#[cfg(feature = "postgres")]
 impl PgAuditStore {
     pub fn new(pool: PgPool) -> Self {
         Self { pool }
     }
 }
 
+#[cfg(feature = "postgres")]
 #[async_trait]
 impl AuditStore for PgAuditStore {
     async fn append(

--- a/rust/crates/sera-db/src/lib.rs
+++ b/rust/crates/sera-db/src/lib.rs
@@ -13,6 +13,7 @@ pub mod audit;
 pub mod circles;
 pub mod metering;
 pub mod schedules;
+#[cfg(feature = "postgres")]
 pub mod sessions;
 pub mod skills;
 pub mod api_keys;

--- a/rust/crates/sera-db/src/sessions.rs
+++ b/rust/crates/sera-db/src/sessions.rs
@@ -1,4 +1,7 @@
 //! Sessions repository — read access to the chat_sessions table.
+//! Postgres-only: compiled only when the `postgres` feature is enabled.
+
+#![cfg(feature = "postgres")]
 
 use sqlx::PgPool;
 use crate::error::DbError;

--- a/rust/crates/sera-db/src/sqlite.rs
+++ b/rust/crates/sera-db/src/sqlite.rs
@@ -153,6 +153,7 @@ impl SqliteDb {
         Ok(())
     }
 
+    #[cfg(not(feature = "postgres"))]
     pub fn get_session_by_key(&self, session_key: &str) -> rusqlite::Result<Option<SessionRow>> {
         let mut stmt = self.conn.prepare(
             "SELECT id, agent_id, session_key, state, principal_id, created_at, updated_at
@@ -175,6 +176,7 @@ impl SqliteDb {
         }
     }
 
+    #[cfg(not(feature = "postgres"))]
     pub fn list_sessions(&self) -> rusqlite::Result<Vec<SessionRow>> {
         let mut stmt = self.conn.prepare(
             "SELECT id, agent_id, session_key, state, principal_id, created_at, updated_at
@@ -203,6 +205,7 @@ impl SqliteDb {
     }
 
     /// Return an existing active session for the given agent, or create a new one.
+    #[cfg(not(feature = "postgres"))]
     pub fn get_or_create_session(&self, agent_id: &str) -> rusqlite::Result<SessionRow> {
         // Try to find an existing active session for this agent.
         let mut stmt = self.conn.prepare(
@@ -391,6 +394,7 @@ impl SqliteDb {
         Ok(self.conn.last_insert_rowid())
     }
 
+    #[cfg(not(feature = "postgres"))]
     pub fn query_audit(&self, limit: usize) -> rusqlite::Result<Vec<AuditRow>> {
         let mut stmt = self.conn.prepare(
             "SELECT id, event_type, actor_id, actor_kind, details, created_at
@@ -416,6 +420,7 @@ impl SqliteDb {
 
 /// Generate a short hex string suitable for IDs (not cryptographically random,
 /// but good enough for local/dev session identifiers).
+#[cfg(not(feature = "postgres"))]
 fn uuid_v4_hex() -> String {
     use std::time::{SystemTime, UNIX_EPOCH};
     let d = SystemTime::now()
@@ -430,6 +435,7 @@ fn uuid_v4_hex() -> String {
 // ---------------------------------------------------------------------------
 
 #[cfg(test)]
+#[cfg(not(feature = "postgres"))]
 mod tests {
     use super::*;
 

--- a/rust/crates/sera-db/src/sqlite.rs
+++ b/rust/crates/sera-db/src/sqlite.rs
@@ -11,6 +11,7 @@ use std::path::Path;
 // Row types
 // ---------------------------------------------------------------------------
 
+#[cfg(not(feature = "postgres"))]
 #[derive(Debug, Clone)]
 pub struct SessionRow {
     pub id: String,
@@ -33,6 +34,7 @@ pub struct TranscriptRow {
     pub created_at: String,
 }
 
+#[cfg(not(feature = "postgres"))]
 #[derive(Debug, Clone)]
 pub struct AuditRow {
     pub id: i64,


### PR DESCRIPTION
Adds `#[cfg(feature = "postgres")]` gates to `AuditRepository`, `PgAuditStore`, and sessions module. SQLite variants in `sqlite.rs` gated with `#[cfg(not(feature = "postgres"))]`. Both `--no-default-features` and `--all-features` compile clean.