### PR TITLE
refactor(sera-types): rename harness PluginRegistration → PluginHookEntry (sera-8s91/plugreg)

### DIFF
--- a/rust/crates/sera-gateway/src/plugin/mod.rs
+++ b/rust/crates/sera-gateway/src/plugin/mod.rs
@@ -1,6 +1,6 @@
 //! Plugin registry — hooks for plugin events.
 
 pub use crate::harness_dispatch::{
-    PluginEvent, PluginRegistration, PluginRegistry, new_plugin_registry,
+    PluginEvent, PluginHookEntry, PluginRegistry, new_plugin_registry,
     validate_plugin_event_namespace,
 };

--- a/rust/crates/sera-types/src/harness.rs
+++ b/rust/crates/sera-types/src/harness.rs
@@ -86,11 +86,11 @@ pub struct PluginEvent {
 }
 
 /// Plugin registry for plugin hooks.
-pub type PluginRegistry = Arc<RwLock<Vec<PluginRegistration>>>;
+pub type PluginRegistry = Arc<RwLock<Vec<PluginHookEntry>>>;
 
 /// A registered plugin.
 #[derive(Debug, Clone)]
-pub struct PluginRegistration {
+pub struct PluginHookEntry {
     pub name: String,
     pub namespace: String,
 }
@@ -101,7 +101,7 @@ pub fn new_plugin_registry() -> PluginRegistry {
 }
 
 /// Validate that a plugin event namespace matches the registered plugin.
-pub fn validate_plugin_event_namespace(plugin: &PluginRegistration, event: &PluginEvent) -> bool {
+pub fn validate_plugin_event_namespace(plugin: &PluginHookEntry, event: &PluginEvent) -> bool {
     event.event_type.starts_with(&plugin.namespace)
 }
 
@@ -160,7 +160,7 @@ mod tests {
 
     #[test]
     fn validate_plugin_event_namespace_matching_prefix() {
-        let plugin = PluginRegistration {
+        let plugin = PluginHookEntry {
             name: "my-plugin".to_string(),
             namespace: "my_plugin.".to_string(),
         };
@@ -170,7 +170,7 @@ mod tests {
 
     #[test]
     fn validate_plugin_event_namespace_exact_match() {
-        let plugin = PluginRegistration {
+        let plugin = PluginHookEntry {
             name: "my-plugin".to_string(),
             namespace: "my_plugin".to_string(),
         };
@@ -180,7 +180,7 @@ mod tests {
 
     #[test]
     fn validate_plugin_event_namespace_no_match() {
-        let plugin = PluginRegistration {
+        let plugin = PluginHookEntry {
             name: "my-plugin".to_string(),
             namespace: "my_plugin.".to_string(),
         };
@@ -190,7 +190,7 @@ mod tests {
 
     #[test]
     fn validate_plugin_event_namespace_empty_namespace_matches_all() {
-        let plugin = PluginRegistration {
+        let plugin = PluginHookEntry {
             name: "catch-all".to_string(),
             namespace: String::new(),
         };


### PR DESCRIPTION
Pure rename of the stub `PluginRegistration` in `sera-types::harness` → `PluginHookEntry`. `sera-plugins::types::PluginRegistration` (the full plugin registration type) is unchanged.