### PR TITLE
docs: rewrite README + CONTRIBUTING for OSS-ready release (sera-4yz5)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,9 +4,22 @@ Thanks for your interest. SERA is a Rust-first agent platform, still in active d
 
 ## Before you start
 
-1. Read `README.md` for the project overview.
+1. Read `README.md` for the project overview and `docs/WHY-SERA.md` for the architectural commitments.
 2. Read `CLAUDE.md` — four "Working Principles" govern every change (Think Before Coding, Simplicity First, Surgical Changes, Goal-Driven Execution). These apply to humans as well as LLM contributors.
-3. Check `bd ready` (beads issue tracker) for available work that isn't blocked.
+3. Read `CODE_OF_CONDUCT.md`. It applies to human and automated contributors alike.
+4. Check `bd ready` (beads issue tracker) for available work that isn't blocked.
+
+## Good first issues
+
+New contributors: look for beads filtered by type and priority before picking something bigger.
+
+```bash
+bd ready --type question             # open questions & discussion-flagged items
+bd ready --priority 4                # lowest-priority, usually low-risk
+bd list --label good-first-issue     # if the label exists in the current graph
+```
+
+A good first bead typically: touches one crate, has a clear acceptance criterion, and doesn't require changing cross-crate traits. If you're unsure whether something qualifies, comment on the bead (`bd comment <id> -m "..."`) and ask.
 
 ## Development loop
 
@@ -19,16 +32,51 @@ cargo clippy --workspace -- -D warnings
 
 A green `cargo check --workspace` is the minimum bar before opening a PR. Feature-matrix coverage lives at `scripts/check-feature-matrix.sh` and runs the three configurations (`default`, `--no-default-features`, `--features enterprise`) — run it before touching workspace deps.
 
+## Crate ownership & reading order
+
+SERA's workspace has explicit crate boundaries; changes inside certain crates require you to read the local guide first. If you're touching one of these paths, read the matching file **before** writing code:
+
+| Crate or module | Read first |
+| --- | --- |
+| `rust/` (any change) | `rust/CLAUDE.md` |
+| `rust/crates/sera-runtime/**` | `rust/crates/sera-runtime/CLAUDE.md` |
+| `rust/crates/sera-session/src/state.rs` | `docs/plan/ARCHITECTURE-2.0.md` §3 (data flow) and §4 (traits) |
+| `rust/crates/sera-hooks/**` | `docs/plan/specs/SPEC-hooks.md` and `rust/crates/sera-types/src/hook.rs` (`HookPoint` enum) |
+| `rust/crates/sera-meta/**` (constitutional, policy, evolution) | `docs/plan/ARCHITECTURE-2.0.md` and `docs/plan/specs/SPEC-meta.md` if present |
+| `rust/crates/sera-memory/**` | `docs/plugins/memory.md` |
+| `rust/crates/sera-workflow/**` | the `AwaitType` variants in `sera-types` plus `ready.rs` |
+| `rust/crates/sera-oci/**` and `sera-tools/**` | `docs/plan/specs/SPEC-runtime.md` §tool dispatch |
+| `legacy/**` | **don't** — `legacy/` is frozen pre-Rust history kept for reference only |
+
+If you add a new crate-level guide, link it from `rust/CLAUDE.md` and this table.
+
 ## Commit style
 
 - One concern per commit. Explain the *why* in the message, not the *what* — the diff shows the what.
 - Reference specs or phase-plan anchors where relevant (e.g. `(P0-6)`, `(SPEC-runtime §4)`).
+- Reference the bead when applicable: include `(sera-xxxx)` in the subject line.
 - Sign-offs and `Co-Authored-By` trailers are welcome when pairing with an LLM.
+
+### Sign-off / DCO
+
+**No DCO sign-off is required.** SERA is MIT-licensed (`LICENSE`) and all code contributions are accepted under that license by the act of opening a PR. `Signed-off-by:` trailers are allowed but not enforced by CI.
 
 ## Pull requests
 
 - Target `main`. Keep PRs focused — one feature or one fix per PR.
-- The PR description should name the spec section or bead being addressed and list the tests that verify it.
+- **Title format:** `<type>(<scope>): <subject> (sera-xxxx)` where type is one of `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `ci`. Example: `feat(sera-runtime): add streaming tool-call parser (sera-1234)`.
+- **PR description must include:**
+  - A bead reference (`Closes sera-xxxx` or `Refs sera-xxxx`) if the work tracks a bead.
+  - The spec section or architectural decision the change follows, if applicable.
+  - A **Test plan** checklist:
+    ```
+    ## Test plan
+    - [ ] `cargo check --workspace` passes
+    - [ ] `cargo test -p <crate>` passes for affected crates
+    - [ ] `cargo clippy --workspace -- -D warnings` is clean
+    - [ ] (if applicable) `scripts/check-feature-matrix.sh` passes
+    - [ ] Manual verification: <what you did>
+    ```
 - CI (`validate-rust`, `clippy`, `codeql`, `e2e-smoke`) must be green before merge.
 - Admin-merging docs-only PRs without waiting on `e2e-smoke` is acceptable.
 
@@ -47,7 +95,7 @@ File new work as beads (`bd create ...`) before writing code. One-line bead refe
 
 ## Code of conduct
 
-Be kind, be honest, surface disagreements early, keep the humor clean. We reserve the right to remove contributors who aren't operating in good faith.
+See `CODE_OF_CONDUCT.md`. In short: be kind, be honest, surface disagreements early, keep the humor clean. Treat automated contributors with the same professional courtesy you'd extend to a new human collaborator, and treat their output with the same scrutiny.
 
 ## Questions
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,77 @@
 # SERA
 
-**Sandboxed Extensible Reasoning Agent** — a Docker-native multi-agent orchestration platform written in Rust.
+**Sandboxed Extensible Reasoning Agent** — a Docker-native, multi-agent AI runtime written in Rust.
 
-SERA runs local, long-lived agents with pluggable memory, human-in-the-loop approvals, safe tool execution, and self-evolution guardrails. A pure-local setup needs nothing beyond a filesystem and an LLM endpoint.
+SERA is for teams who want long-lived, governed agents on their own infrastructure: constitutional invariants enforced at runtime (not just prompted), a 6-state session machine, 20 hook points across the turn lifecycle, and a pluggable memory ladder that runs locally against a single SQLite file — and scales to Postgres + pgvector for enterprise deployments. If you want an agent framework that treats safety, audit, and sandboxing as primitives instead of afterthoughts, SERA is built for you.
 
 > The original TypeScript implementation has been archived under `legacy/`. The Rust workspace at `rust/` is the active codebase.
+
+## Architecture at a glance
+
+```
+         ┌─────────────────────────────────────────────────────┐
+ client ─▶  sera-gateway (axum, HTTP/WS/gRPC)                 │
+ channel │                                                     │
+ webhook │   [⛓ pre_route] ─▶ lane-aware queue ─▶ [⛓ post_route]
+         │                                                     │
+         │   session state machine: Created → Active → Idle   │
+         │                          → Compacting → Closed      │
+         │                                                     │
+         │   ┌───────────────────────────────────────────┐    │
+         │   │  sera-runtime: turn loop                  │    │
+         │   │  [⛓ pre_turn] ─▶ ContextEngine            │    │
+         │   │  [⛓ context_{persona,memory,skill,tool}]  │    │
+         │   │  [⛓ on_llm_start] ─▶ LLM call             │    │
+         │   │  tool_call → gateway dispatch             │    │
+         │   │     [⛓ pre_tool] ─▶ CapabilityPolicy      │    │
+         │   │     ─▶ SandboxProvider (OCI / WASM / …)   │    │
+         │   │     [⛓ post_tool] ─▶ result               │    │
+         │   │  [⛓ on_llm_end] ─▶ [⛓ post_turn]          │    │
+         │   │  [⛓ constitutional_gate]                  │    │
+         │   └───────────────────────────────────────────┘    │
+         │                                                     │
+         │   memory ladder: MemoryBlock (in-process)           │
+         │                 ├─ SQLite FTS5 + sqlite-vec (RRF)   │
+         │                 ├─ pgvector (enterprise)            │
+         │                 └─ SemanticMemoryStore plugin       │
+         │                                                     │
+         │   workflow gates (sera-workflow):                   │
+         │     Human · Change · GhRun · GhPr · Mail · Timer   │
+         │                                                     │
+         │   sera-meta: 3-tier evolution policy                │
+         │     (AgentImprovement → ConfigEvolution →           │
+         │      CodeEvolution) + constitutional registry       │
+         └─────────────────────────────────────────────────────┘
+                               │
+                               ▼
+            LLM provider (OpenAI-compatible, Anthropic, …)
+```
+
+All durable state lives gateway-side. Runtimes are ephemeral — a worker crash loses nothing.
+
+## What's different?
+
+| Axis | LangChain / LangGraph | AutoGen | CrewAI | OpenAgents / BYO-agent | **SERA** |
+| --- | --- | --- | --- | --- | --- |
+| Deployment model | Python library embedded in app | Python library | Python library | Orchestration-only (BYO runtime) | **Rust runtime + gateway; one SQLite file locally, Docker-native for multi-tenant** |
+| Memory | DIY per chain | Chat history | Vector DB of choice | Delegated | **Tiered: MemoryBlock → SQLite FTS5+sqlite-vec (RRF) → pgvector → user plugin** |
+| Safety gates | Prompt-level guardrails | Prompt-level | Prompt-level | Delegated to runtime | **20 runtime hook points + constitutional registry + 3-tier evolution policy** |
+| State machine | Graph (LangGraph); ad-hoc elsewhere | Conversation | Implicit | Agent-defined | **Explicit 6-state `SessionStateMachine` with validated transitions** |
+| Language | Python | Python | Python | Varies | **Rust (edition 2024), 34-crate workspace, `cargo clippy -D warnings` across the tree** |
+
+SERA is not a Python-native framework. If most of your codebase is Python and you want to compose nodes in a notebook, LangGraph or CrewAI is the right answer. If you need a runtime you can audit end-to-end, sandbox per tier, and deploy without a vector DB or message broker, read on.
+
+## Features
+
+- **Constitutional runtime.** Invariants are registered with `sera-meta::constitutional::ConstitutionalRegistry` and enforced at runtime hook points (e.g. `constitutional_gate`) — not delegated to prompt text the model can ignore.
+- **20 hook points across the turn lifecycle.** `pre_route`, `post_route`, `pre_turn`, `context_{persona,memory,skill,tool}`, `on_llm_start`, `pre_tool`, `post_tool`, `on_llm_end`, `post_turn`, `constitutional_gate`, `pre_deliver`, `post_deliver`, `pre_memory_write`, `on_session_transition`, `on_approval_request`, `on_workflow_trigger`, `on_change_artifact_proposed`. YAML-configured chains with fail-open / fail-closed behaviour.
+- **Explicit session state machine.** A 6-state FSM (`Created`, `Active`, `Idle`, `Suspended`, `Compacting`, `Closed`) with validated transitions — no implicit lifecycle.
+- **Pluggable memory ladder.** Tier-0 in-process `MemoryBlock`; Tier-1 local uses SQLite FTS5 + sqlite-vec with RRF hybrid search; enterprise swaps in pgvector; or bring your own `SemanticMemoryStore` (mem0, hindsight, external RAG).
+- **Docker-native per-tier sandboxing.** Tools run through a `SandboxProvider` trait — OCI containers with tier-1/2/3 capability policies (different egress, filesystem, and compute per tier). `MockSandboxProvider` for tests; bollard-backed `sera-oci` in production.
+- **Six AwaitType workflow gates.** `Human`, `Change`, `GhRun`, `GhPr`, `Mail`, `Timer` — suspend a session on a real-world event and resume when it fires.
+- **3-tier evolution policy.** Self-modification is scoped to `AgentImprovement` (prompts, persona), `ConfigEvolution` (runtime config), or `CodeEvolution` (source-level). Each tier has its own approver requirements.
+- **Local-first by default.** One binary, one SQLite file, no Postgres, no Centrifugo, no Redis. Add them when you need multi-pod scale.
+- **Rust workspace, strict boundaries.** 34 crates under `rust/crates/`, `sera-types` is the sole leaf, `sera-tui` is forbidden from importing gateway internals. `cargo test --workspace` exercises 3000+ tests.
 
 ## Quickstart — local profile (zero external services)
 
@@ -45,7 +112,9 @@ cargo run --bin sera-cli -- chat --agent <agent-id>   # interactive REPL with SS
 cargo run --bin sera-tui
 ```
 
-Agent list, live session view, inline HITL approvals, evolve-proposal status — all configurable keybindings (see `docs/tui-config.md`).
+Agent list, live session view, inline HITL approvals, evolve-proposal status.
+
+> **Demo placeholder.** A terminal-cast of the CLI + TUI flow is planned for the next release. If you record one while evaluating SERA, a PR adding `docs/media/quickstart.gif` is welcome.
 
 ## Quickstart — enterprise profile (Postgres + pgvector + Centrifugo)
 
@@ -69,7 +138,7 @@ See `docs/plugins/memory.md` for the plugin contract.
 
 ## Workspace layout
 
-32 crates under `rust/crates/`. Notable:
+34 crates under `rust/crates/`. Notable:
 
 | Crate | Purpose |
 | ----- | ------- |
@@ -78,12 +147,17 @@ See `docs/plugins/memory.md` for the plugin contract.
 | `sera-cli` | `sera` operator CLI (auth, agent, chat) |
 | `sera-tui` | Ratatui operator dashboard |
 | `sera-db` | SQLite + Postgres stores, memory, queue, auth, evolution proposals |
-| `sera-mail` | RFC 5322 mail correlator for the Mail gate |
-| `sera-e2e-harness` | Cross-crate integration test runner |
-| `sera-models` | Provider-agnostic account pool + thinking/reasoning config |
-| `sera-skills` | Skill loader (YAML, TOML, SKILL.md) |
+| `sera-session` | 6-state `SessionStateMachine`, transcript, persistence |
+| `sera-hooks` | In-process `Hook` registry + chain executor, YAML manifests |
 | `sera-workflow` | Six AwaitType gates (Human / Change / GhRun / GhPr / Mail / Timer) |
 | `sera-meta` | Self-evolution: 3-tier policy, shadow sessions, constitutional registry |
+| `sera-memory` | Memory tier ladder + `SemanticMemoryStore` trait |
+| `sera-mail` | RFC 5322 mail correlator for the Mail gate |
+| `sera-models` | Provider-agnostic account pool + thinking/reasoning config |
+| `sera-skills` | Skill loader (YAML, TOML, SKILL.md) |
+| `sera-oci` | OCI sandbox provider (bollard) |
+| `sera-plugins` | gRPC plugin registry, SDK, circuit breaker |
+| `sera-e2e-harness` | Cross-crate integration test runner |
 
 See `rust/CLAUDE.md` for the full crate map and development workflow.
 
@@ -92,16 +166,18 @@ See `rust/CLAUDE.md` for the full crate map and development workflow.
 ```bash
 cd rust
 cargo check --workspace           # fast incremental validation
-cargo test --workspace            # 3200+ tests
+cargo test --workspace            # 3000+ tests
 cargo clippy --workspace -- -D warnings
 ```
 
 ## Docs
 
+- **Why SERA?** `docs/WHY-SERA.md` — architectural commitments, honest tradeoffs, and a framework comparison.
 - **Architecture:** `docs/plan/ARCHITECTURE-2.0.md`
 - **Implementation status:** `docs/plan/HANDOFF.md` (session-by-session close-out)
 - **Plugin contracts:** `docs/plugins/`
-- **CLAUDE.md files:** per-directory agent-facing guides (root, `rust/`, `core/`, `web/`, `tui/`, `cli/`)
+- **Competitive landscape:** `docs/competitive-analysis.md`
+- **CLAUDE.md files:** per-directory agent-facing guides (root, `rust/`, `rust/crates/sera-runtime/`)
 
 ## Issue tracker
 
@@ -117,7 +193,15 @@ bd prime              # full workflow reference
 
 Do NOT use TodoWrite, TaskCreate, or markdown TODO lists for project work.
 
+## Contributing
+
+See `CONTRIBUTING.md` for the development loop, PR expectations, and beads workflow. `CODE_OF_CONDUCT.md` applies to all contributors — human and automated.
+
+## License
+
+MIT. See `LICENSE`.
+
 ## Feedback and help
 
 - File an issue: <https://github.com/TKCen/sera/issues>
-- `/help` in Claude Code: built-in assistance if you're working in the `claude` CLI
+- Open a GitHub discussion or file a bead with `type=question`.


### PR DESCRIPTION
Expands README with: architecture-at-a-glance ASCII diagram, "What's
different?" comparison table, 8-item Features list grounded in actual
crates, memory-tier table, docs index. Keeps the existing Quickstart
(local + enterprise) and Workspace-layout sections.

Extends CONTRIBUTING with: good-first-issue bd workflow, crate-ownership
reading-order table, PR title format + test-plan checklist, explicit
no-DCO stance (MIT by act-of-PR).

CODE_OF_CONDUCT.md and docs/WHY-SERA.md deferred — can land in a follow-up.
