### PR TITLE
fix(clippy): resolve 3 trivial lints (sera-r1e4, sera-bax6)

### DIFF
--- a/rust/crates/sera-cache/src/lib.rs
+++ b/rust/crates/sera-cache/src/lib.rs
@@ -203,7 +203,7 @@ mod tests {
     #[tokio::test]
     async fn store_and_retrieve_number_value() {
         let cache = MokaBackend::new(100);
-        let val = serde_json::json!(3.14159);
+        let val = serde_json::json!(std::f64::consts::PI);
         cache.set("num_key", val.clone(), None).await.unwrap();
         let got = cache.get("num_key").await.unwrap();
         assert_eq!(got, Some(val));
@@ -284,7 +284,7 @@ mod tests {
                     _ => {
                         // Delete
                         let key = format!("mixed_{}", i.saturating_sub(2));
-                        let _ = cache_clone.delete(&key).await.unwrap();
+                        cache_clone.delete(&key).await.unwrap();
                     }
                 }
             });

--- a/rust/crates/sera-mail/tests/correlator_tests.rs
+++ b/rust/crates/sera-mail/tests/correlator_tests.rs
@@ -569,16 +569,14 @@ async fn spoofed_sender_with_valid_message_id_still_resolves_by_headers() {
 
     // Reply claims to be from a different sender but references the correct
     // Message-ID.
-    let raw = format!(
-        "From: attacker@evil.com\r\n\
+    let raw = "From: attacker@evil.com\r\n\
          To: sera@example.com\r\n\
          Subject: Re: Approval needed\r\n\
          Message-ID: <r-123@attacker>\r\n\
          In-Reply-To: <sera-spoof@sera.local>\r\n\
          Content-Type: text/plain\r\n\
          \r\n\
-         \"Approved\"\r\n"
-    );
+         \"Approved\"\r\n".to_string();
     let msg = parse_raw_message(raw.as_bytes()).unwrap();
     let outcome = correlator.correlate(&msg).await.unwrap();
     assert!(matches!(


### PR DESCRIPTION
- sera-mail/tests/correlator_tests.rs:572: Replace format!() with no interpolation with .to_string() literal
- sera-cache/src/lib.rs:206: Use std::f64::consts::PI instead of hardcoded 3.14159
- sera-cache/src/lib.rs:287: Drop unused let _ = binding
