### PR TITLE
fix(sera-cli): detect keyring mock backend, fall back to file store (sera-nw0u)

### DIFF
--- a/rust/crates/sera-cli/src/token_store.rs
+++ b/rust/crates/sera-cli/src/token_store.rs
@@ -187,27 +187,39 @@ impl TokenStore for MockTokenStore {
 
 /// Build the best available `TokenStore` for the current platform.
 ///
-/// Tries `KeyringTokenStore` first; falls back to `FileTokenStore` when the
-/// keychain is unavailable (e.g. headless CI, WSL without a secret-service
-/// daemon).
+/// Tries `KeyringTokenStore` first.  On Linux/WSL2 the `keyring` crate falls
+/// back to an in-memory `MockCredential` when no secret-service features are
+/// compiled in.  `MockCredential` advertises `CredentialPersistence::EntryOnly`
+/// — data lives only in the `Entry` object and is lost when the process exits.
+///
+/// We detect this by querying the default credential builder's persistence
+/// level.  Any value other than `UntilDelete` (or `UntilReboot`) is treated as
+/// ephemeral and triggers a fallback to [`FileTokenStore`]
+/// (`~/.sera/token`, mode `0600`).
 pub fn best_available_store() -> Box<dyn TokenStore> {
-    match KeyringTokenStore::new() {
-        Ok(ks) => {
-            // Probe with a harmless load — if the keyring daemon isn't running
-            // on Linux this will fail with `PlatformFailure`.
-            match ks.load() {
-                Ok(_) => {
-                    tracing::debug!("using OS keyring for token storage");
-                    return Box::new(ks);
-                }
-                Err(e) => {
-                    tracing::debug!("keyring probe failed ({e}), falling back to file store");
-                }
-            }
+    if let Ok(ks) = KeyringTokenStore::new() {
+        if keyring_is_persistent() {
+            tracing::debug!("using OS keyring for token storage");
+            return Box::new(ks);
         }
-        Err(e) => {
-            tracing::debug!("keyring unavailable ({e}), falling back to file store");
-        }
+        tracing::debug!("keyring backend is ephemeral (MockCredential), falling back to file store");
+    } else {
+        tracing::debug!("keyring unavailable, falling back to file store");
     }
     Box::new(FileTokenStore::new(FileTokenStore::default_path()))
+}
+
+/// Returns `true` when the active keyring backend will persist credentials
+/// beyond the lifetime of this process.
+///
+/// The `keyring` crate's `default::default_credential_builder().persistence()`
+/// returns `CredentialPersistence::EntryOnly` when the platform has no
+/// suitable secret-service daemon and falls back to `MockCredential`.  We
+/// treat only `UntilDelete` and `UntilReboot` as acceptable for token storage.
+fn keyring_is_persistent() -> bool {
+    use keyring::credential::CredentialPersistence;
+    matches!(
+        keyring::default::default_credential_builder().persistence(),
+        CredentialPersistence::UntilDelete | CredentialPersistence::UntilReboot
+    )
 }


### PR DESCRIPTION
## Summary

- **Root cause**: On Linux/WSL2, `keyring` v3 compiles in `MockCredential` when only `apple-native`/`windows-native` features are enabled. `MockCredential` is purely in-memory (`CredentialPersistence::EntryOnly`) — all data is stored in the `Entry` object and lost when the process exits.
- **Old probe flaw**: `best_available_store()` called `ks.load()`, which returns `Ok(None)` from `MockCredential` (no entry yet). This was indistinguishable from an empty-but-real keyring, so the mock was always selected and tokens never persisted across process exits.
- **Fix**: Add `keyring_is_persistent()` which queries `keyring::default::default_credential_builder().persistence()`. The `keyring` crate's `default` module resolves to `mock` on Linux when no secret-service features are compiled in, and `MockCredentialBuilder::persistence()` returns `CredentialPersistence::EntryOnly`. We only accept `UntilDelete` or `UntilReboot` as durable; anything else falls through to `FileTokenStore` (`~/.sera/token`, mode `0600`).

## Approach taken

Option (2) from the task brief — detect the ephemeral backend at runtime. The detection uses the `keyring` crate's own `CredentialPersistence` API — zero side effects, no writes, no daemon probing. More robust than adding D-Bus/secret-service features that require `libdbus-1-dev` (unavailable in WSL build environments).

## Test plan

- [x] `cargo check -p sera-cli` — clean compile
- [x] `cargo clippy -p sera-cli -- -D warnings` — no issues  
- [x] `cargo test -p sera-cli` — 58 tests passed across 7 suites (all auth tests pass)
- [ ] Manual: `./target/release/sera auth login --token <key> --endpoint http://localhost:3001` → exit → new shell → `sera auth whoami` should show the principal (reads from `~/.sera/token`)

Closes sera-nw0u

🤖 Generated with [Claude Code](https://claude.com/claude-code)