### PR TITLE
fix(sera-gateway): wire constitutional_config into startup (sera-b8uk)

### DIFF
--- a/rust/crates/sera-gateway/src/bin/sera.rs
+++ b/rust/crates/sera-gateway/src/bin/sera.rs
@@ -60,6 +60,8 @@ use sera_types::config_manifest::{AgentSpec, ConnectorSpec, ProviderSpec};
 use sera_types::event::IncomingEvent as DomainEvent;
 use sera_types::hook::{HookChain, HookContext, HookPoint, HookResult};
 use sera_types::principal::{PrincipalId, PrincipalKind, PrincipalRef};
+use sera_meta::constitutional::ConstitutionalRegistry;
+use sera_gateway::constitutional_config;
 
 // ── Phase-3 SPEC-interop crates ──────────────────────────────────────────────
 use sera_a2a::{A2aClient, A2aRequest, A2aRouter, InProcRouter, LoopbackTransport};
@@ -604,6 +606,11 @@ struct AppState {
     /// Production boot uses SqliteGitSessionStore (sera-4i4i); tests keep
     /// InMemorySessionStore to avoid writing shadow-git dirs to disk.
     session_store: Arc<dyn SessionStore>,
+    /// Constitutional rule registry. Seeded at startup from
+    /// `SERA_CONSTITUTIONAL_RULES_PATH` (default `/etc/sera/constitutional_rules.yaml`).
+    /// Empty when the file is absent — constitutional_gate hooks still run but
+    /// find no rules to evaluate (fail-open vs fail-closed is the hook's choice).
+    constitutional_registry: Arc<ConstitutionalRegistry>,
 }
 
 // ── Phase-3 trait impls ──────────────────────────────────────────────────────
@@ -2919,6 +2926,19 @@ async fn run_start(config: PathBuf, port: u16) -> anyhow::Result<()> {
         Some(mail_lookup.clone()),
     ));
 
+    // Seed constitutional rules from SERA_CONSTITUTIONAL_RULES_PATH (or the
+    // default /etc/sera/constitutional_rules.yaml). Missing file → no-op (Ok(0)).
+    // Parse error → fail-fast (propagate Err so the process exits with context).
+    let constitutional_registry = Arc::new(ConstitutionalRegistry::new());
+    match constitutional_config::seed_registry_from_env(&constitutional_registry).await {
+        Ok(count) => {
+            tracing::info!(count, "Constitutional rules seeded from env path");
+        }
+        Err(e) => {
+            return Err(anyhow::anyhow!("Failed to load constitutional rules: {e}"));
+        }
+    }
+
     let state = Arc::new(AppState {
         db: Mutex::new(db),
         manifests,
@@ -2955,6 +2975,7 @@ async fn run_start(config: PathBuf, port: u16) -> anyhow::Result<()> {
                     .expect("failed to initialize SqliteGitSessionStore"),
             )
         },
+        constitutional_registry,
     });
 
     // 4. Start event processing loop.
@@ -3396,6 +3417,7 @@ mod tests {
             // sera-4i4i: intentional test-fixture — InMemorySessionStore avoids
             // writing shadow-git dirs to the filesystem during tests.
             session_store: Arc::new(InMemorySessionStore::new()),
+            constitutional_registry: Arc::new(ConstitutionalRegistry::new()),
         })
     }
 
@@ -3432,6 +3454,7 @@ mod tests {
             // sera-4i4i: intentional test-fixture — InMemorySessionStore avoids
             // writing shadow-git dirs to the filesystem during tests.
             session_store: Arc::new(InMemorySessionStore::new()),
+            constitutional_registry: Arc::new(ConstitutionalRegistry::new()),
         })
     }
 
@@ -3468,6 +3491,7 @@ mod tests {
             // sera-4i4i: intentional test-fixture — InMemorySessionStore avoids
             // writing shadow-git dirs to the filesystem during tests.
             session_store: Arc::new(InMemorySessionStore::new()),
+            constitutional_registry: Arc::new(ConstitutionalRegistry::new()),
         })
     }
 
@@ -3504,6 +3528,7 @@ mod tests {
             // sera-4i4i: intentional test-fixture — InMemorySessionStore avoids
             // writing shadow-git dirs to the filesystem during tests.
             session_store: Arc::new(InMemorySessionStore::new()),
+            constitutional_registry: Arc::new(ConstitutionalRegistry::new()),
         })
     }
 
@@ -5061,6 +5086,7 @@ mod tests {
             // sera-4i4i: intentional test-fixture — InMemorySessionStore avoids
             // writing shadow-git dirs to the filesystem during tests.
             session_store: Arc::new(InMemorySessionStore::new()),
+            constitutional_registry: Arc::new(ConstitutionalRegistry::new()),
         });
 
         let app = build_router(Arc::clone(&state));

--- a/rust/crates/sera-gateway/src/bin/sera.rs
+++ b/rust/crates/sera-gateway/src/bin/sera.rs
@@ -610,6 +610,9 @@ struct AppState {
     /// `SERA_CONSTITUTIONAL_RULES_PATH` (default `/etc/sera/constitutional_rules.yaml`).
     /// Empty when the file is absent — constitutional_gate hooks still run but
     /// find no rules to evaluate (fail-open vs fail-closed is the hook's choice).
+    /// Field is populated but not yet read by any hook handler; the
+    /// ConstitutionalGateHook that consults it is filed as sera-0yh3.
+    #[allow(dead_code)]
     constitutional_registry: Arc<ConstitutionalRegistry>,
 }
 
@@ -4362,6 +4365,7 @@ mod tests {
             // sera-4i4i: intentional test-fixture — InMemorySessionStore avoids
             // writing shadow-git dirs to the filesystem during tests.
             session_store: Arc::new(InMemorySessionStore::new()),
+            constitutional_registry: Arc::new(ConstitutionalRegistry::new()),
         };
         let headers = HeaderMap::new();
         assert!(validate_api_key(&state, &headers).is_ok());
@@ -4401,6 +4405,7 @@ mod tests {
             // sera-4i4i: intentional test-fixture — InMemorySessionStore avoids
             // writing shadow-git dirs to the filesystem during tests.
             session_store: Arc::new(InMemorySessionStore::new()),
+            constitutional_registry: Arc::new(ConstitutionalRegistry::new()),
         };
         let mut headers = HeaderMap::new();
         headers.insert("authorization", "Bearer my-key".parse().unwrap());
@@ -4441,6 +4446,7 @@ mod tests {
             // sera-4i4i: intentional test-fixture — InMemorySessionStore avoids
             // writing shadow-git dirs to the filesystem during tests.
             session_store: Arc::new(InMemorySessionStore::new()),
+            constitutional_registry: Arc::new(ConstitutionalRegistry::new()),
         };
         let mut headers = HeaderMap::new();
         headers.insert("authorization", "Bearer wrong".parse().unwrap());
@@ -4484,6 +4490,7 @@ mod tests {
             // sera-4i4i: intentional test-fixture — InMemorySessionStore avoids
             // writing shadow-git dirs to the filesystem during tests.
             session_store: Arc::new(InMemorySessionStore::new()),
+            constitutional_registry: Arc::new(ConstitutionalRegistry::new()),
         };
         let headers = HeaderMap::new();
         assert_eq!(
@@ -5165,6 +5172,7 @@ mod tests {
                 // sera-4i4i: intentional test-fixture — InMemorySessionStore avoids
                 // writing shadow-git dirs to the filesystem during tests.
                 session_store: Arc::new(InMemorySessionStore::new()),
+                constitutional_registry: Arc::new(ConstitutionalRegistry::new()),
             })
         };
         let app = build_router(state);

--- a/rust/crates/sera-gateway/src/constitutional_config.rs
+++ b/rust/crates/sera-gateway/src/constitutional_config.rs
@@ -519,6 +519,50 @@ lol3: &lol3 [*lol2, *lol2, *lol2, *lol2, *lol2, *lol2, *lol2, *lol2, *lol2]
         // either way — the important invariant is the process is still alive here.
     }
 
+    // ---- seed_registry_from_env -------------------------------------------
+
+    #[tokio::test]
+    async fn seed_registry_from_env_seeds_two_rules() {
+        let yaml = b"- id: env-rule-1\n  description: \"First env rule\"\n  enforcement_point: pre_approval\n- id: env-rule-2\n  description: \"Second env rule\"\n  enforcement_point: pre_proposal\n";
+        let mut tmp = NamedTempFile::new().unwrap();
+        tmp.write_all(yaml).unwrap();
+
+        let path_str = tmp.path().to_str().unwrap().to_owned();
+        std::env::set_var("SERA_CONSTITUTIONAL_RULES_PATH", &path_str);
+
+        let registry = ConstitutionalRegistry::new();
+        let count = seed_registry_from_env(&registry)
+            .await
+            .expect("seed_registry_from_env should succeed when env var points to a valid file");
+
+        std::env::remove_var("SERA_CONSTITUTIONAL_RULES_PATH");
+
+        assert_eq!(count, 2, "should seed exactly 2 rules");
+        assert_eq!(registry.all_rules().await.len(), 2);
+        assert!(registry.get("env-rule-1").await.is_some());
+        assert!(registry.get("env-rule-2").await.is_some());
+    }
+
+    #[tokio::test]
+    async fn seed_registry_from_env_no_op_when_default_path_absent() {
+        // When SERA_CONSTITUTIONAL_RULES_PATH is unset the loader falls back to
+        // DEFAULT_RULES_PATH (/etc/sera/constitutional_rules.yaml). That file
+        // almost certainly doesn't exist in CI, so the call must return Ok(0).
+        std::env::remove_var("SERA_CONSTITUTIONAL_RULES_PATH");
+
+        // Skip if the default path exists on this machine (e.g. a developer
+        // environment that has real rules installed) to avoid a false failure.
+        if std::path::Path::new(DEFAULT_RULES_PATH).exists() {
+            return;
+        }
+
+        let registry = ConstitutionalRegistry::new();
+        let result = seed_registry_from_env(&registry).await;
+        assert!(result.is_ok(), "missing default file must be a no-op, not an error");
+        assert_eq!(result.unwrap(), 0);
+        assert!(registry.all_rules().await.is_empty());
+    }
+
     // ---- relative path env var --------------------------------------------
 
     #[tokio::test]

--- a/rust/crates/sera-gateway/src/constitutional_config.rs
+++ b/rust/crates/sera-gateway/src/constitutional_config.rs
@@ -528,14 +528,14 @@ lol3: &lol3 [*lol2, *lol2, *lol2, *lol2, *lol2, *lol2, *lol2, *lol2, *lol2]
         tmp.write_all(yaml).unwrap();
 
         let path_str = tmp.path().to_str().unwrap().to_owned();
-        std::env::set_var("SERA_CONSTITUTIONAL_RULES_PATH", &path_str);
+        unsafe { std::env::set_var("SERA_CONSTITUTIONAL_RULES_PATH", &path_str); }
 
         let registry = ConstitutionalRegistry::new();
         let count = seed_registry_from_env(&registry)
             .await
             .expect("seed_registry_from_env should succeed when env var points to a valid file");
 
-        std::env::remove_var("SERA_CONSTITUTIONAL_RULES_PATH");
+        unsafe { std::env::remove_var("SERA_CONSTITUTIONAL_RULES_PATH"); }
 
         assert_eq!(count, 2, "should seed exactly 2 rules");
         assert_eq!(registry.all_rules().await.len(), 2);
@@ -548,7 +548,7 @@ lol3: &lol3 [*lol2, *lol2, *lol2, *lol2, *lol2, *lol2, *lol2, *lol2, *lol2]
         // When SERA_CONSTITUTIONAL_RULES_PATH is unset the loader falls back to
         // DEFAULT_RULES_PATH (/etc/sera/constitutional_rules.yaml). That file
         // almost certainly doesn't exist in CI, so the call must return Ok(0).
-        std::env::remove_var("SERA_CONSTITUTIONAL_RULES_PATH");
+        unsafe { std::env::remove_var("SERA_CONSTITUTIONAL_RULES_PATH"); }
 
         // Skip if the default path exists on this machine (e.g. a developer
         // environment that has real rules installed) to avoid a false failure.

--- a/rust/crates/sera-gateway/src/lib.rs
+++ b/rust/crates/sera-gateway/src/lib.rs
@@ -1,6 +1,7 @@
 //! SERA Gateway — reusable library for gateway types, transport, and harness dispatch.
 
 pub mod connector;
+pub mod constitutional_config;
 pub mod db_backend;
 pub mod envelope;
 pub mod generation;


### PR DESCRIPTION
Closes sera-b8uk.

## Summary
Wires the previously-dead `constitutional_config.rs` into gateway startup so ConstitutionalRegistry is populated from `SERA_CONSTITUTIONAL_RULES_PATH`.

## Test plan
- [x] cargo test -p sera-gateway constitutional passes
- [x] cargo check --workspace passes
- [x] No-op when env var unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)