### PR TITLE
feat(sera-tui): add composer pane with tui-textarea (sera-p5rn)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5599,6 +5599,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "tracing-subscriber",
+ "tui-textarea",
  "wiremock",
 ]
 
@@ -6875,6 +6876,17 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tui-textarea"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a5318dd619ed73c52a9417ad19046724effc1287fb75cdcc4eca1d6ac1acbae"
+dependencies = [
+ "crossterm 0.28.1",
+ "ratatui",
+ "unicode-width 0.2.0",
+]
 
 [[package]]
 name = "tungstenite"

--- a/rust/crates/sera-tui/Cargo.toml
+++ b/rust/crates/sera-tui/Cargo.toml
@@ -30,6 +30,7 @@ clap.workspace = true
 futures-util.workspace = true
 once_cell.workspace = true
 bytes = "1"
+tui-textarea = "0.7"
 
 # Optional integration-test support.  Cargo does not permit dev-dependencies
 # to be optional, so the harness/mock stack lives up here with a feature flag.

--- a/rust/crates/sera-tui/src/app/actions.rs
+++ b/rust/crates/sera-tui/src/app/actions.rs
@@ -68,6 +68,13 @@ pub enum Action {
     /// End-of-buffer; only the Session view listens for it, where it
     /// re-enables auto-scroll after the user paused it by scrolling up.
     EndOfBuffer,
+    /// Toggle focus between the composer and transcript inside SessionView.
+    ToggleComposerFocus,
+    /// Submit the composer buffer (Session view only).  Drains the textarea
+    /// into `pending_sends`; G.0.2 will wire the send to the gateway.
+    SubmitComposer,
+    /// Forward a raw key event to the focused composer textarea.
+    ComposerInput(crossterm::event::KeyEvent),
     /// No-op — used when a key doesn't match any binding.  Reducing to
     /// this instead of returning `Option<Action>` lets the dispatch table
     /// stay a plain `match`.

--- a/rust/crates/sera-tui/src/app/mod.rs
+++ b/rust/crates/sera-tui/src/app/mod.rs
@@ -189,6 +189,21 @@ impl App {
                     self.session.jump_to_end();
                 }
             }
+            Action::ToggleComposerFocus => {
+                if let ViewKind::Session = self.focus {
+                    self.session.toggle_focus();
+                }
+            }
+            Action::SubmitComposer => {
+                if let ViewKind::Session = self.focus {
+                    self.session.submit_composer();
+                }
+            }
+            Action::ComposerInput(key) => {
+                if let ViewKind::Session = self.focus {
+                    self.session.input_to_composer(key);
+                }
+            }
             Action::NoOp => {}
         }
     }

--- a/rust/crates/sera-tui/src/input.rs
+++ b/rust/crates/sera-tui/src/input.rs
@@ -60,6 +60,39 @@ pub fn translate(event: &KeyEvent, kb: &TuiKeybindings) -> Action {
     Action::NoOp
 }
 
+/// Session-view translator.  When `composer_focused` is true the composer
+/// textarea intercepts most keys; only global exits (quit) and the two
+/// session-specific bindings are checked first.
+///
+/// When `composer_focused` is false the transcript pane is active and we
+/// fall back to the standard `translate` so scroll keys work normally.
+pub fn translate_session(
+    event: &KeyEvent,
+    kb: &TuiKeybindings,
+    composer_focused: bool,
+) -> Action {
+    // Global exits always win regardless of composer state.
+    if matches_key(event, &kb.quit) {
+        return Action::Quit;
+    }
+
+    // Session-specific bindings checked before the global table.
+    if matches_key(event, &kb.submit_message) {
+        return Action::SubmitComposer;
+    }
+    if matches_key(event, &kb.toggle_composer_focus) {
+        return Action::ToggleComposerFocus;
+    }
+
+    if composer_focused {
+        // All other keys go straight to the textarea widget.
+        Action::ComposerInput(*event)
+    } else {
+        // Transcript is focused — standard navigation.
+        translate(event, kb)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -106,5 +139,60 @@ mod tests {
         let kb = TuiKeybindings::defaults();
         let ev = KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL);
         assert_eq!(translate(&ev, &kb), Action::Quit);
+    }
+
+    #[test]
+    fn session_tab_toggles_composer_focus() {
+        let kb = TuiKeybindings::defaults();
+        assert_eq!(
+            translate_session(&ev(KeyCode::Tab), &kb, true),
+            Action::ToggleComposerFocus,
+        );
+        assert_eq!(
+            translate_session(&ev(KeyCode::Tab), &kb, false),
+            Action::ToggleComposerFocus,
+        );
+    }
+
+    #[test]
+    fn session_ctrl_enter_submits() {
+        let kb = TuiKeybindings::defaults();
+        let ctrl_enter = KeyEvent::new(KeyCode::Enter, KeyModifiers::CONTROL);
+        assert_eq!(
+            translate_session(&ctrl_enter, &kb, true),
+            Action::SubmitComposer,
+        );
+        assert_eq!(
+            translate_session(&ctrl_enter, &kb, false),
+            Action::SubmitComposer,
+        );
+    }
+
+    #[test]
+    fn session_plain_key_goes_to_composer_when_focused() {
+        let kb = TuiKeybindings::defaults();
+        let key_h = ev(KeyCode::Char('h'));
+        assert_eq!(
+            translate_session(&key_h, &kb, true),
+            Action::ComposerInput(key_h),
+        );
+    }
+
+    #[test]
+    fn session_plain_key_scrolls_when_transcript_focused() {
+        let kb = TuiKeybindings::defaults();
+        assert_eq!(
+            translate_session(&ev(KeyCode::Up), &kb, false),
+            Action::Up,
+        );
+    }
+
+    #[test]
+    fn session_quit_always_wins() {
+        let kb = TuiKeybindings::defaults();
+        assert_eq!(
+            translate_session(&ev(KeyCode::Char('q')), &kb, true),
+            Action::Quit,
+        );
     }
 }

--- a/rust/crates/sera-tui/src/keybindings.rs
+++ b/rust/crates/sera-tui/src/keybindings.rs
@@ -80,6 +80,10 @@ pub struct TuiKeybindings {
     pub end_of_buffer: Vec<KeyBinding>,
     pub page_up: Vec<KeyBinding>,
     pub page_down: Vec<KeyBinding>,
+    /// Toggle focus between the composer and transcript inside the Session view.
+    pub toggle_composer_focus: Vec<KeyBinding>,
+    /// Submit the composer buffer as a pending message (Session view only).
+    pub submit_message: Vec<KeyBinding>,
 }
 
 impl TuiKeybindings {
@@ -112,6 +116,11 @@ impl TuiKeybindings {
             end_of_buffer: vec![KeyBinding::plain(KeyCode::End)],
             page_up: vec![KeyBinding::plain(KeyCode::PageUp)],
             page_down: vec![KeyBinding::plain(KeyCode::PageDown)],
+            toggle_composer_focus: vec![KeyBinding::plain(KeyCode::Tab)],
+            submit_message: vec![
+                KeyBinding::with_mods(KeyCode::Enter, KeyModifiers::CONTROL),
+                KeyBinding::with_mods(KeyCode::Enter, KeyModifiers::ALT),
+            ],
         }
     }
 }
@@ -163,6 +172,8 @@ mod tests {
         assert!(!kb.down.is_empty());
         assert!(!kb.select.is_empty());
         assert!(!kb.back.is_empty());
+        assert!(!kb.toggle_composer_focus.is_empty());
+        assert!(!kb.submit_message.is_empty());
     }
 
     #[test]

--- a/rust/crates/sera-tui/src/main.rs
+++ b/rust/crates/sera-tui/src/main.rs
@@ -34,7 +34,8 @@ mod views;
 use app::{App, Runtime};
 use client::GatewayClient;
 use config::Config;
-use input::translate;
+use app::actions::ViewKind;
+use input::{translate, translate_session};
 use keybindings::TuiKeybindings;
 
 #[tokio::main]
@@ -118,7 +119,11 @@ async fn run<B: ratatui::backend::Backend + io::Write>(
             && let Event::Key(key) = event::read()?
             && key.kind == KeyEventKind::Press
         {
-            let action = translate(&key, &app.keybindings);
+            let action = if app.focus == ViewKind::Session {
+                translate_session(&key, &app.keybindings, app.session.composer_focused())
+            } else {
+                translate(&key, &app.keybindings)
+            };
             app.dispatch(action);
         }
 

--- a/rust/crates/sera-tui/src/views/session.rs
+++ b/rust/crates/sera-tui/src/views/session.rs
@@ -1,19 +1,29 @@
-//! Session view — metadata header, streaming transcript, tool log.
+//! Session view — metadata header, streaming transcript, tool log, composer.
 
+use crossterm::event::KeyEvent;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{List, ListItem, Paragraph};
+use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph};
 use ratatui::Frame;
+use tui_textarea::TextArea;
 
 use super::agent_list::make_block;
 use crate::client::{ConnectionState, SessionSummary, StreamEvent, TranscriptEntry};
+
+/// Which pane inside the Session view holds keyboard focus.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ComposerFocus {
+    Composer,
+    Transcript,
+}
 
 /// Viewer state for a single session.  Owns:
 /// * metadata (agent id, session id, state)
 /// * transcript lines (seeded by GET, appended by SSE)
 /// * tool events (SSE only, non-message events)
 /// * scroll bookkeeping — auto-scrolls to tail unless the user has paused
+/// * a multi-line composer for drafting outgoing messages
 pub struct SessionView {
     pub session: Option<SessionSummary>,
     pub transcript: Vec<TranscriptEntry>,
@@ -21,10 +31,17 @@ pub struct SessionView {
     pub scroll_offset: u16,
     pub auto_scroll: bool,
     pub conn: ConnectionState,
+    pub composer: TextArea<'static>,
+    pub focus: ComposerFocus,
+    /// Messages drained from the composer via `submit_composer`.
+    /// G.0.2 (sera-5d4k) will wire these to POST /api/chat.
+    pub pending_sends: Vec<String>,
 }
 
 impl SessionView {
     pub fn new() -> Self {
+        let mut composer = TextArea::default();
+        composer.set_placeholder_text("Type a message…");
         Self {
             session: None,
             transcript: Vec::new(),
@@ -32,6 +49,9 @@ impl SessionView {
             scroll_offset: 0,
             auto_scroll: true,
             conn: ConnectionState::Disconnected,
+            composer,
+            focus: ComposerFocus::Composer,
+            pending_sends: Vec::new(),
         }
     }
 
@@ -111,19 +131,60 @@ impl SessionView {
         self.scroll_offset = 0;
     }
 
+    /// Toggle keyboard focus between the composer and the transcript.
+    pub fn toggle_focus(&mut self) {
+        self.focus = match self.focus {
+            ComposerFocus::Composer => ComposerFocus::Transcript,
+            ComposerFocus::Transcript => ComposerFocus::Composer,
+        };
+    }
+
+    /// Returns true when the composer currently holds focus.
+    pub fn composer_focused(&self) -> bool {
+        self.focus == ComposerFocus::Composer
+    }
+
+    /// Forward a raw key event to the composer textarea.
+    pub fn input_to_composer(&mut self, event: KeyEvent) {
+        self.composer.input(event);
+    }
+
+    /// Drain the composer buffer and return the accumulated text.
+    /// Resets the textarea to empty.
+    pub fn take_composer_text(&mut self) -> String {
+        let text = self.composer.lines().join("\n");
+        let mut fresh = TextArea::default();
+        fresh.set_placeholder_text("Type a message…");
+        self.composer = fresh;
+        text
+    }
+
+    /// Submit the current composer buffer: drain text → push to
+    /// `pending_sends` → log.  No-op when the buffer is blank.
+    pub fn submit_composer(&mut self) {
+        let text = self.take_composer_text();
+        if text.trim().is_empty() {
+            return;
+        }
+        tracing::info!(message = %text, "composer submit queued (pending G.0.2 wiring)");
+        self.pending_sends.push(text);
+    }
+
     pub fn render(&self, frame: &mut Frame, area: Rect, focused: bool) {
         let chunks = Layout::default()
             .direction(Direction::Vertical)
             .constraints([
-                Constraint::Length(3),
-                Constraint::Min(0),
-                Constraint::Length(7),
+                Constraint::Length(3), // metadata header
+                Constraint::Min(3),    // transcript
+                Constraint::Length(7), // tool log
+                Constraint::Length(5), // composer
             ])
             .split(area);
 
         self.render_metadata(frame, chunks[0], focused);
         self.render_transcript(frame, chunks[1], focused);
         self.render_tool_log(frame, chunks[2], focused);
+        self.render_composer(frame, chunks[3]);
     }
 
     fn render_metadata(&self, frame: &mut Frame, area: Rect, focused: bool) {
@@ -144,6 +205,7 @@ impl SessionView {
     }
 
     fn render_transcript(&self, frame: &mut Frame, area: Rect, focused: bool) {
+        let transcript_focused = focused && self.focus == ComposerFocus::Transcript;
         let items: Vec<ListItem<'_>> = if self.transcript.is_empty() {
             vec![ListItem::new(Line::from(Span::styled(
                 "(no transcript yet — waiting for first event)",
@@ -160,19 +222,15 @@ impl SessionView {
                         "tool" => Color::Yellow,
                         _ => Color::White,
                     };
-                    let header = Line::from(vec![
-                        Span::styled(
-                            format!("[{}]", entry.role),
-                            Style::default()
-                                .fg(role_color)
-                                .add_modifier(Modifier::BOLD),
-                        ),
-                    ]);
+                    let header = Line::from(vec![Span::styled(
+                        format!("[{}]", entry.role),
+                        Style::default()
+                            .fg(role_color)
+                            .add_modifier(Modifier::BOLD),
+                    )]);
                     let mut lines = vec![ListItem::new(header)];
                     for body_line in entry.text.lines() {
-                        lines.push(ListItem::new(Line::from(Span::raw(
-                            body_line.to_owned(),
-                        ))));
+                        lines.push(ListItem::new(Line::from(Span::raw(body_line.to_owned()))));
                     }
                     lines.push(ListItem::new(Line::from("")));
                     lines
@@ -193,7 +251,7 @@ impl SessionView {
             items
         };
 
-        let list = List::new(shown).block(make_block("Transcript", focused));
+        let list = List::new(shown).block(make_block("Transcript", transcript_focused));
         frame.render_widget(list, area);
     }
 
@@ -212,11 +270,30 @@ impl SessionView {
                 .rev()
                 .take(5)
                 .rev()
-                .map(|l| ListItem::new(Span::styled(l.clone(), Style::default().fg(Color::Yellow))))
+                .map(|l| {
+                    ListItem::new(Span::styled(l.clone(), Style::default().fg(Color::Yellow)))
+                })
                 .collect()
         };
         let list = List::new(items).block(make_block("Tool events", focused));
         frame.render_widget(list, area);
+    }
+
+    fn render_composer(&self, frame: &mut Frame, area: Rect) {
+        let composer_focused = self.focus == ComposerFocus::Composer;
+        let border_style = if composer_focused {
+            Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(Color::DarkGray)
+        };
+        // Render the textarea widget into the inner area (inside the border).
+        let block = Block::default()
+            .title("Composer — Ctrl+Enter to send")
+            .borders(Borders::ALL)
+            .border_style(border_style);
+        let inner = block.inner(area);
+        frame.render_widget(block, area);
+        frame.render_widget(&self.composer, inner);
     }
 }
 
@@ -346,5 +423,51 @@ mod tests {
         assert_eq!(truncate_or_dash("", 5), "—");
         assert_eq!(truncate_or_dash("abc", 5), "abc");
         assert_eq!(truncate_or_dash("abcdefgh", 5), "abcd…");
+    }
+
+    // --- Composer-specific tests (G.0.1) ---
+
+    #[test]
+    fn composer_starts_focused_and_empty() {
+        let v = SessionView::new();
+        assert_eq!(v.focus, ComposerFocus::Composer);
+        assert!(v.composer.lines().iter().all(|l| l.is_empty()));
+        assert!(v.pending_sends.is_empty());
+    }
+
+    #[test]
+    fn composer_toggle_focus_switches_active_pane() {
+        let mut v = SessionView::new();
+        assert_eq!(v.focus, ComposerFocus::Composer);
+        v.toggle_focus();
+        assert_eq!(v.focus, ComposerFocus::Transcript);
+        v.toggle_focus();
+        assert_eq!(v.focus, ComposerFocus::Composer);
+    }
+
+    #[test]
+    fn submit_drains_composer_into_pending_sends() {
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+        let mut v = SessionView::new();
+        // Type "hello" into the composer.
+        for ch in "hello".chars() {
+            v.input_to_composer(KeyEvent::new(KeyCode::Char(ch), KeyModifiers::NONE));
+        }
+        assert!(!v.composer.lines().join("").is_empty());
+
+        v.submit_composer();
+
+        assert_eq!(v.pending_sends.len(), 1);
+        assert_eq!(v.pending_sends[0], "hello");
+        // Composer should be empty after drain.
+        assert!(v.composer.lines().iter().all(|l| l.is_empty()));
+    }
+
+    #[test]
+    fn submit_with_empty_buffer_is_noop() {
+        let mut v = SessionView::new();
+        v.submit_composer();
+        assert!(v.pending_sends.is_empty());
     }
 }


### PR DESCRIPTION
First step toward an interactive chat surface (Wave G umbrella: sera-dux5).

Closes sera-p5rn.

## Summary

- `tui-textarea = 0.7` added as dep
- `SessionView.composer: TextArea<'static>` + `composer_focus: ComposerFocus`
- `SessionView::render` splits bottom 5 lines for composer (titled border, dim placeholder)
- `Tab` toggles composer/transcript focus (keybinding; no hardcoded key codes)
- `Ctrl+Enter` drains composer via `take_composer_text()` into `pending_sends`
- Nothing posted to the gateway yet — G.0.2 (sera-5d4k) wires that up

## Test plan
- [x] cargo test -p sera-tui passes (77 passed — 9 new)
- [x] cargo clippy -p sera-tui --all-targets -- -D warnings clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)