### PR TITLE
feat(sera-tui): agent selector → active session binding (sera-0fp7)

### DIFF
--- a/rust/crates/sera-tui/src/app/actions.rs
+++ b/rust/crates/sera-tui/src/app/actions.rs
@@ -75,6 +75,11 @@ pub enum Action {
     SubmitComposer,
     /// Forward a raw key event to the focused composer textarea.
     ComposerInput(crossterm::event::KeyEvent),
+    /// Select a specific agent by ID and switch to the Session pane.
+    /// Dispatched when the AgentList confirms a selection (Enter on a row).
+    /// Sets `App.active_agent_id` and triggers session load via
+    /// `AppCommand::LoadSessionFor`.
+    SelectAgent(String),
     /// No-op — used when a key doesn't match any binding.  Reducing to
     /// this instead of returning `Option<Action>` lets the dispatch table
     /// stay a plain `match`.

--- a/rust/crates/sera-tui/src/app/mod.rs
+++ b/rust/crates/sera-tui/src/app/mod.rs
@@ -85,6 +85,10 @@ pub struct App {
     pub connection: ConnectionState,
     pub client: Arc<GatewayClient>,
 
+    /// The agent currently being viewed in the Session pane.
+    /// Set by `Action::Select` and `Action::SelectAgent`.
+    pub active_agent_id: Option<String>,
+
     /// Commands emitted by `dispatch` that the runtime must execute.
     /// The field is `pub` so the runtime (in `run`) can drain it each
     /// tick without needing a getter.
@@ -104,6 +108,7 @@ impl App {
             evolve: EvolveStatusView::new(),
             connection: ConnectionState::Disconnected,
             client: Arc::new(client),
+            active_agent_id: None,
             pending: Vec::new(),
         }
     }
@@ -150,9 +155,15 @@ impl App {
                 if self.focus == ViewKind::Agents
                     && let Some(id) = self.agents.selected_id()
                 {
+                    self.active_agent_id = Some(id.clone());
                     self.focus = ViewKind::Session;
                     self.pending.push(AppCommand::LoadSessionFor(id));
                 }
+            }
+            Action::SelectAgent(id) => {
+                self.active_agent_id = Some(id.clone());
+                self.focus = ViewKind::Session;
+                self.pending.push(AppCommand::LoadSessionFor(id));
             }
             Action::Back => {
                 if self.focus != ViewKind::Agents {
@@ -412,7 +423,11 @@ impl Runtime {
                     self.sse_task = Some(app.client.spawn_sse(session.id.clone(), bridge_tx));
                     app.status = Status::info(format!("session {} loaded", session.id));
                 } else {
-                    app.status = Status::warn(format!("no sessions for agent {agent_id}"));
+                    // No sessions yet — clear any stale transcript so the
+                    // composer pane starts fresh; the first Ctrl+Enter will
+                    // create the session server-side.
+                    app.session.set_transcript(Vec::new());
+                    app.status = Status::info(format!("no sessions for agent {agent_id} — ready to chat"));
                 }
             }
             Err(e) => {
@@ -592,5 +607,45 @@ mod tests {
         let mut app = App::new(client(), TuiKeybindings::defaults());
         app.dispatch(Action::Refresh);
         assert!(matches!(app.pending.last(), Some(AppCommand::RefreshAll)));
+    }
+
+    #[test]
+    fn select_agent_sets_active_agent_id() {
+        let mut app = App::new(client(), TuiKeybindings::defaults());
+        assert_eq!(app.active_agent_id, None);
+        app.dispatch(Action::SelectAgent("agent-42".to_owned()));
+        assert_eq!(app.active_agent_id.as_deref(), Some("agent-42"));
+    }
+
+    #[test]
+    fn select_agent_switches_to_session_pane() {
+        let mut app = App::new(client(), TuiKeybindings::defaults());
+        assert_eq!(app.focus, ViewKind::Agents);
+        app.dispatch(Action::SelectAgent("agent-42".to_owned()));
+        assert_eq!(app.focus, ViewKind::Session);
+        assert!(matches!(
+            app.pending.last(),
+            Some(AppCommand::LoadSessionFor(id)) if id == "agent-42"
+        ));
+    }
+
+    #[test]
+    fn select_agent_without_existing_session_clears_transcript() {
+        // The transcript-clearing happens inside load_session_for (runtime),
+        // but we verify the dispatch sets the right command so the runtime
+        // will reach the clear path on empty session list.
+        let mut app = App::new(client(), TuiKeybindings::defaults());
+        // Pre-populate transcript with stale data.
+        app.session.set_transcript(vec![
+            crate::client::TranscriptEntry { role: "user".into(), text: "old message".into() },
+        ]);
+        app.dispatch(Action::SelectAgent("fresh-agent".to_owned()));
+        // Dispatch is pure — transcript not cleared yet (that's runtime's job).
+        // But active_agent_id is set and LoadSessionFor is queued.
+        assert_eq!(app.active_agent_id.as_deref(), Some("fresh-agent"));
+        assert!(matches!(
+            app.pending.last(),
+            Some(AppCommand::LoadSessionFor(id)) if id == "fresh-agent"
+        ));
     }
 }

--- a/rust/crates/sera-tui/src/main.rs
+++ b/rust/crates/sera-tui/src/main.rs
@@ -124,6 +124,17 @@ async fn run<B: ratatui::backend::Backend + io::Write>(
             } else {
                 translate(&key, &app.keybindings)
             };
+            // When Enter is pressed in the Agents pane, resolve the selected
+            // agent ID here and dispatch SelectAgent so the action carries an
+            // explicit ID (spec G.0.3).
+            let action = if action == crate::app::Action::Select
+                && app.focus == ViewKind::Agents
+                && let Some(id) = app.agents.selected_id()
+            {
+                crate::app::Action::SelectAgent(id)
+            } else {
+                action
+            };
             app.dispatch(action);
         }
 


### PR DESCRIPTION
## Summary

- Adds `App.active_agent_id: Option<String>` — set whenever an agent is selected
- Adds `Action::SelectAgent(String)` variant dispatched by the event loop when Enter is pressed in the Agents pane, carrying the explicit agent ID
- `App::dispatch(Action::SelectAgent)` sets `active_agent_id`, switches `focus` to `ViewKind::Session`, and queues `AppCommand::LoadSessionFor(id)`
- `Runtime::load_session_for` (existing) handles the rest: lists sessions for the agent, loads transcript if one exists, subscribes SSE; clears transcript when no session exists so the composer starts fresh
- Event loop in `main.rs` converts `Action::Select` → `Action::SelectAgent(id)` when focus is Agents, wiring the Enter keybinding to the new action

## Coordination with G.0.2

G.0.2 (sera-5d4k) adds `active_agent_id` independently. This bead owns the field add — rebase last-to-merge if there's a conflict (trivial, single field).

## Sessions endpoint

`GET /api/sessions?agent_id=<id>` — already existed in `client.rs` via `list_sessions(Some(&agent_id))`. No new client method needed.

## Test plan

- [x] `select_agent_sets_active_agent_id` — dispatching `SelectAgent("agent-42")` sets `active_agent_id = Some("agent-42")`
- [x] `select_agent_switches_to_session_pane` — focus becomes `ViewKind::Session` and `LoadSessionFor` is queued
- [x] `select_agent_without_existing_session_clears_transcript` — `active_agent_id` is set and command is queued (runtime clears transcript on empty session list)
- [x] All 80 existing tests pass
- [x] `cargo clippy -p sera-tui --all-targets -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)