### PR TITLE
feat(sera-tui): add bottom status bar (sera-gntz)

### DIFF
--- a/rust/crates/sera-tui/src/app/mod.rs
+++ b/rust/crates/sera-tui/src/app/mod.rs
@@ -88,7 +88,7 @@ pub struct App {
     pub connection: ConnectionState,
     pub client: Arc<GatewayClient>,
 
-    /// The agent currently being viewed in the Session pane.
+    /// The agent currently being viewed / targeted by composer sends.
     /// Set by `Action::Select` and `Action::SelectAgent`.
     pub active_agent_id: Option<String>,
 
@@ -96,10 +96,6 @@ pub struct App {
     /// The field is `pub` so the runtime (in `run`) can drain it each
     /// tick without needing a getter.
     pub pending: Vec<AppCommand>,
-
-    /// Agent targeted by composer sends.  Set by G.0.3 (sera-0fp7) when the
-    /// operator selects an agent.  None = drop with warn (no agent chosen yet).
-    pub active_agent_id: Option<String>,
 }
 
 impl App {
@@ -117,7 +113,6 @@ impl App {
             client: Arc::new(client),
             active_agent_id: None,
             pending: Vec::new(),
-            active_agent_id: None,
         }
     }
 

--- a/rust/crates/sera-tui/src/ui.rs
+++ b/rust/crates/sera-tui/src/ui.rs
@@ -11,6 +11,7 @@ use ratatui::Frame;
 
 use crate::app::{actions::ViewKind, App, StatusLevel};
 use crate::client::ConnectionState;
+use crate::views::status_bar::StatusBar;
 
 /// Render the whole screen.
 pub fn render(frame: &mut Frame, app: &mut App) {
@@ -20,6 +21,7 @@ pub fn render(frame: &mut Frame, app: &mut App) {
             Constraint::Length(3),
             Constraint::Min(0),
             Constraint::Length(2),
+            Constraint::Length(1),
         ])
         .split(frame.area());
 
@@ -34,6 +36,16 @@ pub fn render(frame: &mut Frame, app: &mut App) {
     }
 
     render_footer(frame, chunks[2], app);
+
+    // Status bar: agent name + session short-id + connection state.
+    let agent = app.active_agent_id.as_deref();
+    let session_id = app.session.session.as_ref().map(|s| s.id.as_str());
+    StatusBar {
+        agent,
+        session_id,
+        conn: app.connection,
+    }
+    .render(frame, chunks[3]);
 }
 
 fn render_title(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {

--- a/rust/crates/sera-tui/src/views/mod.rs
+++ b/rust/crates/sera-tui/src/views/mod.rs
@@ -8,3 +8,4 @@ pub mod agent_list;
 pub mod evolve_status;
 pub mod hitl_queue;
 pub mod session;
+pub mod status_bar;

--- a/rust/crates/sera-tui/src/views/status_bar.rs
+++ b/rust/crates/sera-tui/src/views/status_bar.rs
@@ -1,0 +1,134 @@
+//! Bottom status bar — one line showing connection state, active agent, and
+//! session short-id.
+//!
+//! Lane state is intentionally stubbed as "idle" until a future bead adds a
+//! real lane-state source.
+
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::Paragraph;
+use ratatui::Frame;
+
+use crate::client::ConnectionState;
+
+/// Stateless status bar widget.  Caller constructs one per render tick from
+/// fields already held by `App` and `SessionView`.
+pub struct StatusBar<'a> {
+    /// Active agent name derived from the current session, or `None`.
+    pub agent: Option<&'a str>,
+    /// Full session id — first 8 chars are shown; `None` renders as `-`.
+    pub session_id: Option<&'a str>,
+    /// Current connection state.
+    pub conn: ConnectionState,
+}
+
+impl StatusBar<'_> {
+    pub fn render(&self, frame: &mut Frame, area: Rect) {
+        let agent_label = self.agent.unwrap_or("no agent");
+        let session_label: String = match self.session_id {
+            None | Some("") => "-".to_owned(),
+            Some(id) => id.chars().take(8).collect(),
+        };
+
+        let (conn_label, conn_color) = conn_style(self.conn);
+
+        let spans = vec![
+            Span::raw(" agent="),
+            Span::styled(
+                agent_label.to_owned(),
+                Style::default().fg(Color::White),
+            ),
+            Span::raw(" · session="),
+            Span::styled(session_label, Style::default().fg(Color::White)),
+            Span::raw(" · "),
+            Span::styled(conn_label, Style::default().fg(conn_color)),
+            Span::raw(" · lane=idle "),
+        ];
+
+        let bar = Paragraph::new(Line::from(spans))
+            .style(Style::default().fg(Color::DarkGray));
+        frame.render_widget(bar, area);
+    }
+}
+
+fn conn_style(state: ConnectionState) -> (&'static str, Color) {
+    match state {
+        ConnectionState::Connected => ("connected", Color::Cyan),
+        ConnectionState::Reconnecting => ("reconnecting", Color::Yellow),
+        ConnectionState::Disconnected => ("disconnected", Color::DarkGray),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    fn render_to_string(bar: StatusBar<'_>, width: u16) -> String {
+        let backend = TestBackend::new(width, 1);
+        let mut term = Terminal::new(backend).unwrap();
+        term.draw(|f| bar.render(f, f.area())).unwrap();
+        term.backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|c| c.symbol())
+            .collect::<Vec<_>>()
+            .join("")
+    }
+
+    #[test]
+    fn renders_no_agent_label_when_active_none() {
+        let bar = StatusBar {
+            agent: None,
+            session_id: None,
+            conn: ConnectionState::Disconnected,
+        };
+        let out = render_to_string(bar, 80);
+        assert!(out.contains("no agent"), "expected 'no agent' in: {out}");
+    }
+
+    #[test]
+    fn renders_agent_name_when_set() {
+        let bar = StatusBar {
+            agent: Some("sera"),
+            session_id: Some("abc123def456"),
+            conn: ConnectionState::Connected,
+        };
+        let out = render_to_string(bar, 80);
+        assert!(out.contains("sera"), "expected 'sera' in: {out}");
+        assert!(out.contains("abc123de"), "expected truncated session id in: {out}");
+    }
+
+    #[test]
+    fn connection_state_color_maps_correctly() {
+        assert_eq!(conn_style(ConnectionState::Connected).1, Color::Cyan);
+        assert_eq!(conn_style(ConnectionState::Reconnecting).1, Color::Yellow);
+        assert_eq!(conn_style(ConnectionState::Disconnected).1, Color::DarkGray);
+    }
+
+    #[test]
+    fn session_id_truncated_to_8_chars() {
+        let bar = StatusBar {
+            agent: Some("test"),
+            session_id: Some("0123456789abcdef"),
+            conn: ConnectionState::Connected,
+        };
+        let out = render_to_string(bar, 80);
+        assert!(out.contains("01234567"), "expected first 8 chars in: {out}");
+        assert!(!out.contains("01234567890"), "should not contain full id in: {out}");
+    }
+
+    #[test]
+    fn missing_session_id_renders_dash() {
+        let bar = StatusBar {
+            agent: Some("test"),
+            session_id: None,
+            conn: ConnectionState::Connected,
+        };
+        let out = render_to_string(bar, 80);
+        assert!(out.contains("session=-"), "expected 'session=-' in: {out}");
+    }
+}


### PR DESCRIPTION
## Summary

- New `views/status_bar.rs` module: stateless `StatusBar<'a>` widget that renders a 1-line bottom bar showing agent name, session short-id (first 8 chars), connection state (color-coded), and lane placeholder ("idle")
- Wired into `ui.rs` top-level layout as a 4th `Constraint::Length(1)` row at the bottom
- Fixed a pre-existing duplicate `active_agent_id` field in `app/mod.rs` that was already on the branch (would have blocked any further compilation)

Part of Wave G umbrella sera-dux5.

## Color coding

| State | Color |
|---|---|
| Connected | Cyan |
| Reconnecting | Yellow |
| Disconnected | DarkGray |

## Test plan

- [x] `renders_no_agent_label_when_active_none` — "no agent" shown when `agent=None`
- [x] `renders_agent_name_when_set` — agent name and truncated session id render correctly
- [x] `connection_state_color_maps_correctly` — all three states map to correct colors
- [x] `session_id_truncated_to_8_chars` — long ids are truncated to first 8 chars
- [x] `missing_session_id_renders_dash` — `None` session renders as `-`
- [x] All 88 existing `sera-tui` tests pass
- [x] `cargo clippy -p sera-tui --all-targets -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)