### PR TITLE
feat(sera-tui): slash commands /new /clear /agent /help /quit (sera-bulp)

### DIFF
--- a/rust/crates/sera-tui/src/app/actions.rs
+++ b/rust/crates/sera-tui/src/app/actions.rs
@@ -53,6 +53,8 @@ impl ViewKind {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Action {
     Quit,
+    /// Execute a parsed slash command from the composer.
+    ExecuteSlash(super::slash::SlashCommand),
     Refresh,
     NextView,
     PrevView,

--- a/rust/crates/sera-tui/src/app/mod.rs
+++ b/rust/crates/sera-tui/src/app/mod.rs
@@ -8,6 +8,7 @@
 //! * async refresh helpers that load data from the gateway
 
 pub mod actions;
+pub mod slash;
 
 use std::sync::Arc;
 
@@ -22,6 +23,7 @@ use crate::views::hitl_queue::HitlQueueView;
 use crate::views::session::SessionView;
 
 pub use actions::{Action, ViewKind};
+pub use slash::SlashCommand;
 
 /// Footer-bar messages the app surfaces to the operator.
 #[derive(Debug, Clone)]
@@ -96,6 +98,9 @@ pub struct App {
     /// The field is `pub` so the runtime (in `run`) can drain it each
     /// tick without needing a getter.
     pub pending: Vec<AppCommand>,
+
+    /// When true, the help modal is rendered over the session pane.
+    pub show_help: bool,
 }
 
 impl App {
@@ -113,6 +118,7 @@ impl App {
             client: Arc::new(client),
             active_agent_id: None,
             pending: Vec::new(),
+            show_help: false,
         }
     }
 
@@ -211,6 +217,14 @@ impl App {
             Action::SubmitComposer => {
                 if let ViewKind::Session = self.focus {
                     self.session.submit_composer();
+                    // Drain slash commands first — parse and dispatch each.
+                    let slashes: Vec<String> = self.session.pending_slash.drain(..).collect();
+                    for raw in slashes {
+                        match slash::parse(&raw) {
+                            Ok(cmd) => self.dispatch(Action::ExecuteSlash(cmd)),
+                            Err(msg) => self.status = Status::warn(msg),
+                        }
+                    }
                     // Drain pending_sends into SendChat commands.
                     let messages: Vec<String> = self.session.pending_sends.drain(..).collect();
                     for message in messages {
@@ -232,6 +246,22 @@ impl App {
                     }
                 }
             }
+            Action::ExecuteSlash(cmd) => match cmd {
+                SlashCommand::New => {
+                    self.session.transcript.clear();
+                    self.session.tool_log.clear();
+                    self.status = Status::info("new turn");
+                }
+                SlashCommand::Agent(name) => {
+                    self.dispatch(Action::SelectAgent(name));
+                }
+                SlashCommand::Help => {
+                    self.show_help = !self.show_help;
+                }
+                SlashCommand::Quit => {
+                    self.should_quit = true;
+                }
+            },
             Action::ComposerInput(key) => {
                 if let ViewKind::Session = self.focus {
                     self.session.input_to_composer(key);
@@ -695,6 +725,51 @@ mod tests {
             app.pending.last(),
             Some(AppCommand::LoadSessionFor(id)) if id == "agent-42"
         ));
+    }
+
+    // --- ExecuteSlash dispatch tests (G.1.1) ---
+
+    #[test]
+    fn execute_slash_new_clears_transcript_and_tool_log() {
+        let mut app = App::new(client(), TuiKeybindings::defaults());
+        app.session.transcript.push(crate::client::TranscriptEntry {
+            role: "user".into(),
+            text: "old".into(),
+        });
+        app.session.tool_log.push("old tool event".into());
+        app.dispatch(Action::ExecuteSlash(SlashCommand::New));
+        assert!(app.session.transcript.is_empty());
+        assert!(app.session.tool_log.is_empty());
+        assert_eq!(app.status.text, "new turn");
+    }
+
+    #[test]
+    fn execute_slash_quit_sets_should_quit() {
+        let mut app = App::new(client(), TuiKeybindings::defaults());
+        app.dispatch(Action::ExecuteSlash(SlashCommand::Quit));
+        assert!(app.should_quit);
+    }
+
+    #[test]
+    fn execute_slash_agent_delegates_to_select_agent() {
+        let mut app = App::new(client(), TuiKeybindings::defaults());
+        app.dispatch(Action::ExecuteSlash(SlashCommand::Agent("bot-7".to_owned())));
+        assert_eq!(app.active_agent_id.as_deref(), Some("bot-7"));
+        assert_eq!(app.focus, ViewKind::Session);
+        assert!(matches!(
+            app.pending.last(),
+            Some(AppCommand::LoadSessionFor(id)) if id == "bot-7"
+        ));
+    }
+
+    #[test]
+    fn execute_slash_help_toggles_show_help() {
+        let mut app = App::new(client(), TuiKeybindings::defaults());
+        assert!(!app.show_help);
+        app.dispatch(Action::ExecuteSlash(SlashCommand::Help));
+        assert!(app.show_help);
+        app.dispatch(Action::ExecuteSlash(SlashCommand::Help));
+        assert!(!app.show_help);
     }
 
     #[test]

--- a/rust/crates/sera-tui/src/app/slash.rs
+++ b/rust/crates/sera-tui/src/app/slash.rs
@@ -1,0 +1,93 @@
+//! Slash-command parser for the TUI composer.
+//!
+//! When the composer text starts with `/`, [`parse`] converts it to a
+//! [`SlashCommand`] variant instead of sending it to the chat API.
+
+/// Commands that can be typed in the TUI composer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SlashCommand {
+    /// Clear transcript + tool log and start a fresh turn.
+    New,
+    /// Switch the active agent by name.
+    Agent(String),
+    /// Show the help modal with all available commands.
+    Help,
+    /// Exit the TUI cleanly.
+    Quit,
+}
+
+/// Parse a `/`-prefixed string into a [`SlashCommand`].
+///
+/// Returns `Err` with a human-readable message when the command is unknown
+/// or has invalid arguments.
+pub fn parse(input: &str) -> Result<SlashCommand, String> {
+    let trimmed = input.trim();
+    let without_slash = trimmed.strip_prefix('/').unwrap_or(trimmed);
+
+    let (cmd, rest) = match without_slash.split_once(char::is_whitespace) {
+        Some((c, r)) => (c, r.trim()),
+        None => (without_slash, ""),
+    };
+
+    match cmd {
+        "new" | "clear" => Ok(SlashCommand::New),
+        "agent" => {
+            if rest.is_empty() {
+                Err("/agent requires a name: /agent <name>".to_owned())
+            } else {
+                Ok(SlashCommand::Agent(rest.to_owned()))
+            }
+        }
+        "help" => Ok(SlashCommand::Help),
+        "quit" => Ok(SlashCommand::Quit),
+        other => Err(format!("unknown command: /{other}  (type /help for list)")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_new() {
+        assert_eq!(parse("/new"), Ok(SlashCommand::New));
+    }
+
+    #[test]
+    fn parse_clear_is_alias_for_new() {
+        assert_eq!(parse("/clear"), Ok(SlashCommand::New));
+    }
+
+    #[test]
+    fn parse_agent_with_name() {
+        assert_eq!(parse("/agent my-bot"), Ok(SlashCommand::Agent("my-bot".to_owned())));
+    }
+
+    #[test]
+    fn parse_agent_without_name_is_error() {
+        assert!(parse("/agent").is_err());
+        assert!(parse("/agent ").is_err());
+    }
+
+    #[test]
+    fn parse_help() {
+        assert_eq!(parse("/help"), Ok(SlashCommand::Help));
+    }
+
+    #[test]
+    fn parse_quit() {
+        assert_eq!(parse("/quit"), Ok(SlashCommand::Quit));
+    }
+
+    #[test]
+    fn parse_unknown_is_error() {
+        let err = parse("/frobnicate");
+        assert!(err.is_err());
+        assert!(err.unwrap_err().contains("frobnicate"));
+    }
+
+    #[test]
+    fn parse_trims_whitespace() {
+        assert_eq!(parse("  /new  "), Ok(SlashCommand::New));
+    }
+}

--- a/rust/crates/sera-tui/src/ui.rs
+++ b/rust/crates/sera-tui/src/ui.rs
@@ -3,10 +3,10 @@
 //! Owns only the top-level layout (title bar, body, footer) — each pane
 //! delegates to its view module.
 
-use ratatui::layout::{Constraint, Direction, Layout};
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, Paragraph};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph};
 use ratatui::Frame;
 
 use crate::app::{actions::ViewKind, App, StatusLevel};
@@ -36,6 +36,11 @@ pub fn render(frame: &mut Frame, app: &mut App) {
     }
 
     render_footer(frame, chunks[2], app);
+
+    // Help modal — rendered on top of everything when /help is active.
+    if app.show_help {
+        render_help_modal(frame, chunks[1]);
+    }
 
     // Status bar: agent name + session short-id + connection state.
     let agent = app.active_agent_id.as_deref();
@@ -96,6 +101,48 @@ fn conn_badge(state: ConnectionState) -> Span<'static> {
         label,
         Style::default().fg(color).add_modifier(Modifier::BOLD),
     )
+}
+
+fn render_help_modal(frame: &mut Frame, area: Rect) {
+    let modal_area = centered_rect(50, 10, area);
+    frame.render_widget(Clear, modal_area);
+    let text = vec![
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("  /new, /clear  ", Style::default().fg(Color::Cyan)),
+            Span::raw("clear transcript and tool log"),
+        ]),
+        Line::from(vec![
+            Span::styled("  /agent <name> ", Style::default().fg(Color::Cyan)),
+            Span::raw("switch active agent"),
+        ]),
+        Line::from(vec![
+            Span::styled("  /help         ", Style::default().fg(Color::Cyan)),
+            Span::raw("toggle this help modal"),
+        ]),
+        Line::from(vec![
+            Span::styled("  /quit         ", Style::default().fg(Color::Cyan)),
+            Span::raw("exit the TUI"),
+        ]),
+        Line::from(""),
+    ];
+    let modal = Paragraph::new(text).block(
+        Block::default()
+            .title(" Commands ")
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::Cyan)),
+    );
+    frame.render_widget(modal, modal_area);
+}
+
+/// Return a [`Rect`] centered in `area` with the given width (columns) and
+/// height (rows).  Both are clamped to the parent dimensions.
+fn centered_rect(width: u16, height: u16, area: Rect) -> Rect {
+    let w = width.min(area.width);
+    let h = height.min(area.height);
+    let x = area.x + (area.width.saturating_sub(w)) / 2;
+    let y = area.y + (area.height.saturating_sub(h)) / 2;
+    Rect::new(x, y, w, h)
 }
 
 fn render_footer(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {

--- a/rust/crates/sera-tui/src/views/session.rs
+++ b/rust/crates/sera-tui/src/views/session.rs
@@ -36,6 +36,9 @@ pub struct SessionView {
     /// Messages drained from the composer via `submit_composer`.
     /// G.0.2 (sera-5d4k) will wire these to POST /api/chat.
     pub pending_sends: Vec<String>,
+    /// Slash-command strings drained from the composer via `submit_composer`.
+    /// The app dispatcher parses and executes these each tick.
+    pub pending_slash: Vec<String>,
 }
 
 impl SessionView {
@@ -52,6 +55,7 @@ impl SessionView {
             composer,
             focus: ComposerFocus::Composer,
             pending_sends: Vec::new(),
+            pending_slash: Vec::new(),
         }
     }
 
@@ -159,15 +163,20 @@ impl SessionView {
         text
     }
 
-    /// Submit the current composer buffer: drain text → push to
-    /// `pending_sends` → log.  No-op when the buffer is blank.
+    /// Submit the current composer buffer: drain text → route to either
+    /// `pending_slash` (if the text starts with `/`) or `pending_sends`.
+    /// No-op when the buffer is blank.
     pub fn submit_composer(&mut self) {
         let text = self.take_composer_text();
         if text.trim().is_empty() {
             return;
         }
-        tracing::info!(message = %text, "composer submit queued (pending G.0.2 wiring)");
-        self.pending_sends.push(text);
+        if text.trim_start().starts_with('/') {
+            self.pending_slash.push(text);
+        } else {
+            tracing::info!(message = %text, "composer submit queued (pending G.0.2 wiring)");
+            self.pending_sends.push(text);
+        }
     }
 
     pub fn render(&self, frame: &mut Frame, area: Rect, focused: bool) {
@@ -469,5 +478,36 @@ mod tests {
         let mut v = SessionView::new();
         v.submit_composer();
         assert!(v.pending_sends.is_empty());
+    }
+
+    // --- Slash command routing tests (G.1.1) ---
+
+    #[test]
+    fn slash_text_routes_to_pending_slash_not_sends() {
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+        let mut v = SessionView::new();
+        for ch in "/new".chars() {
+            v.input_to_composer(KeyEvent::new(KeyCode::Char(ch), KeyModifiers::NONE));
+        }
+        v.submit_composer();
+
+        assert_eq!(v.pending_slash.len(), 1);
+        assert_eq!(v.pending_slash[0], "/new");
+        assert!(v.pending_sends.is_empty());
+    }
+
+    #[test]
+    fn plain_text_routes_to_pending_sends_not_slash() {
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+        let mut v = SessionView::new();
+        for ch in "hello".chars() {
+            v.input_to_composer(KeyEvent::new(KeyCode::Char(ch), KeyModifiers::NONE));
+        }
+        v.submit_composer();
+
+        assert_eq!(v.pending_sends.len(), 1);
+        assert!(v.pending_slash.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

- New `app/slash.rs` module with `SlashCommand` enum (`New`, `Agent(String)`, `Help`, `Quit`) and `parse()` function
- `SessionView` gains `pending_slash: Vec<String>`; `submit_composer` routes `/`-prefixed text there instead of `pending_sends`
- `App::dispatch` handles `Action::ExecuteSlash(cmd)`: `/new`/`/clear` clears transcript+tool_log, `/agent <name>` delegates to `SelectAgent`, `/help` toggles a `show_help` modal, `/quit` sets `should_quit`
- Help modal rendered via `ui::render_help_modal` using ratatui `Clear` widget, centered over the session body pane

## Test plan

- [ ] `cargo test -p sera-tui` — 102 tests pass (up from ~89 before this bead)
- [ ] `cargo clippy -p sera-tui --all-targets -- -D warnings` — no issues
- [ ] `slash::parse` unit tests cover all 5 commands + error cases
- [ ] `SessionView` routing tests: `/foo` → `pending_slash`, `foo` → `pending_sends`
- [ ] `App::dispatch` tests for all four `ExecuteSlash` variants

Closes sera-bulp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)