### PR TITLE
feat(sera-tui): session picker modal + resume (sera-3onl)

### DIFF
--- a/rust/crates/sera-tui/src/app/actions.rs
+++ b/rust/crates/sera-tui/src/app/actions.rs
@@ -80,6 +80,16 @@ pub enum Action {
     /// Sets `App.active_agent_id` and triggers session load via
     /// `AppCommand::LoadSessionFor`.
     SelectAgent(String),
+    /// Open the session picker modal for the current agent.
+    OpenSessionPicker,
+    /// Close the session picker without selecting.
+    ClosePicker,
+    /// Move picker selection up.
+    PickerUp,
+    /// Move picker selection down.
+    PickerDown,
+    /// Confirm the currently highlighted session.
+    PickerSelect,
     /// No-op — used when a key doesn't match any binding.  Reducing to
     /// this instead of returning `Option<Action>` lets the dispatch table
     /// stay a plain `match`.

--- a/rust/crates/sera-tui/src/app/mod.rs
+++ b/rust/crates/sera-tui/src/app/mod.rs
@@ -20,6 +20,7 @@ use crate::views::agent_list::AgentListView;
 use crate::views::evolve_status::EvolveStatusView;
 use crate::views::hitl_queue::HitlQueueView;
 use crate::views::session::SessionView;
+use crate::views::session_picker::SessionPickerView;
 
 pub use actions::{Action, ViewKind};
 
@@ -71,6 +72,10 @@ pub enum AppCommand {
     Escalate(String),
     /// POST a message to /api/chat and pipe the SSE stream into SessionView.
     SendChat { agent: String, message: String },
+    /// Fetch sessions for the picker modal (agent_id filter).
+    LoadSessionsForPicker(String),
+    /// Load a specific session by id (from picker selection).
+    OpenSession(String),
 }
 
 /// Root application state.
@@ -92,6 +97,12 @@ pub struct App {
     /// Set by `Action::Select` and `Action::SelectAgent`.
     pub active_agent_id: Option<String>,
 
+    /// Session picker modal state.  Rendered on top of the current view
+    /// when `show_session_picker` is true.
+    pub session_picker: SessionPickerView,
+    /// Whether the session picker modal is currently visible.
+    pub show_session_picker: bool,
+
     /// Commands emitted by `dispatch` that the runtime must execute.
     /// The field is `pub` so the runtime (in `run`) can drain it each
     /// tick without needing a getter.
@@ -112,6 +123,8 @@ impl App {
             connection: ConnectionState::Disconnected,
             client: Arc::new(client),
             active_agent_id: None,
+            session_picker: SessionPickerView::new(),
+            show_session_picker: false,
             pending: Vec::new(),
         }
     }
@@ -237,6 +250,34 @@ impl App {
                     self.session.input_to_composer(key);
                 }
             }
+            Action::OpenSessionPicker => {
+                if let Some(agent_id) = self.active_agent_id.clone() {
+                    self.pending
+                        .push(AppCommand::LoadSessionsForPicker(agent_id));
+                }
+            }
+            Action::ClosePicker => {
+                self.show_session_picker = false;
+            }
+            Action::PickerUp => {
+                if self.show_session_picker {
+                    self.session_picker.move_up();
+                }
+            }
+            Action::PickerDown => {
+                if self.show_session_picker {
+                    self.session_picker.move_down();
+                }
+            }
+            Action::PickerSelect => {
+                if self.show_session_picker
+                    && let Some(session) = self.session_picker.selected()
+                {
+                    let id = session.id.clone();
+                    self.show_session_picker = false;
+                    self.pending.push(AppCommand::OpenSession(id));
+                }
+            }
             Action::NoOp => {}
         }
     }
@@ -360,6 +401,22 @@ impl Runtime {
                 AppCommand::SendChat { agent, message } => {
                     self.send_chat(app, agent, message).await;
                 }
+                AppCommand::LoadSessionsForPicker(agent_id) => {
+                    match app.client.list_sessions(Some(&agent_id)).await {
+                        Ok(sessions) => {
+                            let n = sessions.len();
+                            app.session_picker.set_sessions(sessions);
+                            app.show_session_picker = true;
+                            app.status = Status::info(format!("{n} session(s) — use ↑/↓ Enter to resume, Esc to close"));
+                        }
+                        Err(e) => {
+                            app.status = Status::error(format!("session list failed: {e}"));
+                        }
+                    }
+                }
+                AppCommand::OpenSession(session_id) => {
+                    self.load_session_by_id(app, session_id).await;
+                }
             }
         }
     }
@@ -459,6 +516,42 @@ impl Runtime {
                 }
             }
         });
+    }
+
+    /// Load a specific session by id (called from picker selection).
+    async fn load_session_by_id(&mut self, app: &mut App, session_id: String) {
+        // Fetch transcript and re-subscribe SSE for the chosen session.
+        let transcript = app
+            .client
+            .session_transcript(&session_id)
+            .await
+            .unwrap_or_default();
+
+        // Build a minimal SessionSummary for the view header.
+        let summary = crate::client::SessionSummary {
+            id: session_id.clone(),
+            agent_id: app.active_agent_id.clone().unwrap_or_default(),
+            created_at: String::new(),
+            state: "active".to_owned(),
+        };
+        app.session.set_session(summary);
+        app.session.set_transcript(transcript);
+        app.focus = ViewKind::Session;
+
+        if let Some(handle) = self.sse_task.take() {
+            handle.abort();
+        }
+        let (bridge_tx, mut bridge_rx) = mpsc::channel::<SseUpdate>(64);
+        let forward_to = self.sse_tx.clone();
+        tokio::spawn(async move {
+            while let Some(u) = bridge_rx.recv().await {
+                if forward_to.send(u).is_err() {
+                    break;
+                }
+            }
+        });
+        self.sse_task = Some(app.client.spawn_sse(session_id.clone(), bridge_tx));
+        app.status = Status::info(format!("resumed session {session_id}"));
     }
 
     async fn load_session_for(&mut self, app: &mut App, agent_id: String) {

--- a/rust/crates/sera-tui/src/input.rs
+++ b/rust/crates/sera-tui/src/input.rs
@@ -57,6 +57,9 @@ pub fn translate(event: &KeyEvent, kb: &TuiKeybindings) -> Action {
     if matches_key(event, &kb.end_of_buffer) {
         return Action::EndOfBuffer;
     }
+    if matches_key(event, &kb.open_session_picker) {
+        return Action::OpenSessionPicker;
+    }
     Action::NoOp
 }
 

--- a/rust/crates/sera-tui/src/keybindings.rs
+++ b/rust/crates/sera-tui/src/keybindings.rs
@@ -84,6 +84,8 @@ pub struct TuiKeybindings {
     pub toggle_composer_focus: Vec<KeyBinding>,
     /// Submit the composer buffer as a pending message (Session view only).
     pub submit_message: Vec<KeyBinding>,
+    /// Open the session picker modal (default: Ctrl+P).
+    pub open_session_picker: Vec<KeyBinding>,
 }
 
 impl TuiKeybindings {
@@ -121,6 +123,11 @@ impl TuiKeybindings {
                 KeyBinding::with_mods(KeyCode::Enter, KeyModifiers::CONTROL),
                 KeyBinding::with_mods(KeyCode::Enter, KeyModifiers::ALT),
             ],
+            // Ctrl+P — no conflict with existing bindings.
+            open_session_picker: vec![KeyBinding::with_mods(
+                KeyCode::Char('p'),
+                KeyModifiers::CONTROL,
+            )],
         }
     }
 }
@@ -174,6 +181,7 @@ mod tests {
         assert!(!kb.back.is_empty());
         assert!(!kb.toggle_composer_focus.is_empty());
         assert!(!kb.submit_message.is_empty());
+        assert!(!kb.open_session_picker.is_empty());
     }
 
     #[test]

--- a/rust/crates/sera-tui/src/main.rs
+++ b/rust/crates/sera-tui/src/main.rs
@@ -119,21 +119,41 @@ async fn run<B: ratatui::backend::Backend + io::Write>(
             && let Event::Key(key) = event::read()?
             && key.kind == KeyEventKind::Press
         {
-            let action = if app.focus == ViewKind::Session {
-                translate_session(&key, &app.keybindings, app.session.composer_focused())
+            // When the session picker modal is open it intercepts all keys;
+            // only Up/Down/Enter/Esc are forwarded — everything else is dropped.
+            let action = if app.show_session_picker {
+                use crossterm::event::KeyCode;
+                use keybindings::matches_key;
+                if matches_key(&key, &app.keybindings.up) {
+                    crate::app::Action::PickerUp
+                } else if matches_key(&key, &app.keybindings.down) {
+                    crate::app::Action::PickerDown
+                } else if matches_key(&key, &app.keybindings.select) {
+                    crate::app::Action::PickerSelect
+                } else if matches_key(&key, &app.keybindings.back)
+                    || key.code == KeyCode::Esc
+                {
+                    crate::app::Action::ClosePicker
+                } else {
+                    crate::app::Action::NoOp
+                }
             } else {
-                translate(&key, &app.keybindings)
-            };
-            // When Enter is pressed in the Agents pane, resolve the selected
-            // agent ID here and dispatch SelectAgent so the action carries an
-            // explicit ID (spec G.0.3).
-            let action = if action == crate::app::Action::Select
-                && app.focus == ViewKind::Agents
-                && let Some(id) = app.agents.selected_id()
-            {
-                crate::app::Action::SelectAgent(id)
-            } else {
-                action
+                let a = if app.focus == ViewKind::Session {
+                    translate_session(&key, &app.keybindings, app.session.composer_focused())
+                } else {
+                    translate(&key, &app.keybindings)
+                };
+                // When Enter is pressed in the Agents pane, resolve the selected
+                // agent ID here and dispatch SelectAgent so the action carries an
+                // explicit ID (spec G.0.3).
+                if a == crate::app::Action::Select
+                    && app.focus == ViewKind::Agents
+                    && let Some(id) = app.agents.selected_id()
+                {
+                    crate::app::Action::SelectAgent(id)
+                } else {
+                    a
+                }
             };
             app.dispatch(action);
         }

--- a/rust/crates/sera-tui/src/ui.rs
+++ b/rust/crates/sera-tui/src/ui.rs
@@ -46,6 +46,11 @@ pub fn render(frame: &mut Frame, app: &mut App) {
         conn: app.connection,
     }
     .render(frame, chunks[3]);
+
+    // Session picker modal — rendered last so it overlays everything.
+    if app.show_session_picker {
+        app.session_picker.render(frame, frame.area());
+    }
 }
 
 fn render_title(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {

--- a/rust/crates/sera-tui/src/views/mod.rs
+++ b/rust/crates/sera-tui/src/views/mod.rs
@@ -8,4 +8,5 @@ pub mod agent_list;
 pub mod evolve_status;
 pub mod hitl_queue;
 pub mod session;
+pub mod session_picker;
 pub mod status_bar;

--- a/rust/crates/sera-tui/src/views/session_picker.rs
+++ b/rust/crates/sera-tui/src/views/session_picker.rs
@@ -1,0 +1,207 @@
+//! Session picker modal — centered overlay listing sessions for the active agent.
+//!
+//! Triggered by `open_session_picker` (default: Ctrl+P).  Arrow keys navigate,
+//! Enter resumes the chosen session, Esc closes.
+
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, List, ListItem, ListState};
+use ratatui::Frame;
+
+use crate::client::SessionSummary;
+
+/// Modal overlay listing all sessions for the active agent.
+pub struct SessionPickerView {
+    pub sessions: Vec<SessionSummary>,
+    pub cursor: usize,
+}
+
+impl SessionPickerView {
+    pub fn new() -> Self {
+        Self {
+            sessions: Vec::new(),
+            cursor: 0,
+        }
+    }
+
+    pub fn set_sessions(&mut self, s: Vec<SessionSummary>) {
+        self.sessions = s;
+        self.cursor = 0;
+    }
+
+    pub fn move_up(&mut self) {
+        if self.cursor > 0 {
+            self.cursor -= 1;
+        }
+    }
+
+    pub fn move_down(&mut self) {
+        if !self.sessions.is_empty() && self.cursor + 1 < self.sessions.len() {
+            self.cursor += 1;
+        }
+    }
+
+    pub fn selected(&self) -> Option<&SessionSummary> {
+        self.sessions.get(self.cursor)
+    }
+
+    pub fn render(&self, frame: &mut Frame, area: Rect) {
+        let modal = centered_rect(60, 50, area);
+
+        // Clear the background so the modal overlays cleanly.
+        frame.render_widget(Clear, modal);
+
+        if self.sessions.is_empty() {
+            let p = ratatui::widgets::Paragraph::new("No sessions found for this agent.")
+                .style(Style::default().fg(Color::DarkGray))
+                .block(
+                    Block::default()
+                        .title(" Sessions (Ctrl+P) ")
+                        .borders(Borders::ALL)
+                        .border_style(Style::default().fg(Color::Cyan)),
+                );
+            frame.render_widget(p, modal);
+            return;
+        }
+
+        let items: Vec<ListItem<'_>> = self
+            .sessions
+            .iter()
+            .enumerate()
+            .map(|(i, s)| {
+                let short_id = if s.id.len() > 12 {
+                    format!("{}…", &s.id[..11])
+                } else {
+                    s.id.clone()
+                };
+                let created = if s.created_at.len() >= 10 {
+                    s.created_at[..10].to_owned()
+                } else if s.created_at.is_empty() {
+                    "—".to_owned()
+                } else {
+                    s.created_at.clone()
+                };
+                let focused = i == self.cursor;
+                let style = if focused {
+                    Style::default()
+                        .fg(Color::Black)
+                        .bg(Color::Cyan)
+                        .add_modifier(Modifier::BOLD)
+                } else {
+                    Style::default().fg(Color::White)
+                };
+                ListItem::new(Line::from(vec![Span::styled(
+                    format!(" {:<14} {}  [{}]", short_id, created, s.state),
+                    style,
+                )]))
+            })
+            .collect();
+
+        let mut list_state = ListState::default();
+        list_state.select(Some(self.cursor));
+
+        let list = List::new(items)
+            .block(
+                Block::default()
+                    .title(" Sessions — ↑/↓ navigate  Enter:resume  Esc:close ")
+                    .borders(Borders::ALL)
+                    .border_style(Style::default().fg(Color::Cyan)),
+            )
+            .highlight_style(
+                Style::default()
+                    .fg(Color::Black)
+                    .bg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            );
+
+        frame.render_stateful_widget(list, modal, &mut list_state);
+    }
+}
+
+impl Default for SessionPickerView {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Calculate a centered [`Rect`] that takes `percent_x`% of width and
+/// `percent_y`% of height from `r`.
+fn centered_rect(percent_x: u16, percent_y: u16, r: Rect) -> Rect {
+    let w = r.width * percent_x / 100;
+    let h = r.height * percent_y / 100;
+    let x = r.x + (r.width.saturating_sub(w)) / 2;
+    let y = r.y + (r.height.saturating_sub(h)) / 2;
+    Rect::new(x, y, w.max(1), h.max(1))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sess(id: &str) -> SessionSummary {
+        SessionSummary {
+            id: id.to_owned(),
+            agent_id: "agent-1".to_owned(),
+            created_at: "2026-04-18T00:00:00Z".to_owned(),
+            state: "active".to_owned(),
+        }
+    }
+
+    #[test]
+    fn new_has_empty_sessions_and_zero_cursor() {
+        let p = SessionPickerView::new();
+        assert!(p.sessions.is_empty());
+        assert_eq!(p.cursor, 0);
+        assert!(p.selected().is_none());
+    }
+
+    #[test]
+    fn set_sessions_resets_cursor() {
+        let mut p = SessionPickerView::new();
+        p.set_sessions(vec![sess("s1"), sess("s2"), sess("s3")]);
+        p.move_down();
+        p.move_down();
+        assert_eq!(p.cursor, 2);
+        p.set_sessions(vec![sess("s4")]);
+        assert_eq!(p.cursor, 0);
+    }
+
+    #[test]
+    fn move_up_at_top_is_noop() {
+        let mut p = SessionPickerView::new();
+        p.set_sessions(vec![sess("s1"), sess("s2")]);
+        p.move_up(); // already at 0
+        assert_eq!(p.cursor, 0);
+    }
+
+    #[test]
+    fn move_down_at_bottom_is_noop() {
+        let mut p = SessionPickerView::new();
+        p.set_sessions(vec![sess("s1"), sess("s2")]);
+        p.move_down(); // -> 1
+        p.move_down(); // at bottom
+        assert_eq!(p.cursor, 1);
+    }
+
+    #[test]
+    fn selected_returns_cursor_position() {
+        let mut p = SessionPickerView::new();
+        p.set_sessions(vec![sess("s1"), sess("s2"), sess("s3")]);
+        assert_eq!(p.selected().map(|s| s.id.as_str()), Some("s1"));
+        p.move_down();
+        assert_eq!(p.selected().map(|s| s.id.as_str()), Some("s2"));
+        p.move_down();
+        assert_eq!(p.selected().map(|s| s.id.as_str()), Some("s3"));
+    }
+
+    #[test]
+    fn centered_rect_fits_inside_parent() {
+        let parent = Rect::new(0, 0, 100, 40);
+        let modal = centered_rect(60, 50, parent);
+        assert!(modal.x >= parent.x);
+        assert!(modal.y >= parent.y);
+        assert!(modal.right() <= parent.right());
+        assert!(modal.bottom() <= parent.bottom());
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `Ctrl+P` keybinding (`open_session_picker`) to open a centered modal overlay listing all sessions for the active agent (via `GET /api/sessions?agent_id=<id>`)
- New `views/session_picker.rs` module: `SessionPickerView { sessions, cursor }` with `move_up`/`move_down`/`selected`/`render` — modal uses `ratatui::widgets::Clear` for clean overlay
- Arrow keys navigate the list, Enter resumes the chosen session (`OpenSession` command → `load_session_by_id`), Esc closes — all other keys are intercepted while picker is open
- Extends Wave G (sera-dux5)

## Test plan

- [ ] `cargo test -p sera-tui` — 94 tests pass (includes 5 new `session_picker` unit tests: `new`, `move_up_at_top_is_noop`, `move_down_at_bottom_is_noop`, `set_sessions_resets_cursor`, `selected_returns_cursor_position`)
- [ ] `cargo clippy -p sera-tui -- -D warnings` — clean
- [ ] Keybinding conflict check: `Ctrl+P` was unbound; no conflicts with existing bindings
- [ ] Manual: launch TUI, select agent, press `Ctrl+P` → modal appears; navigate with arrows; Enter resumes selected session; Esc closes without changing session

🤖 Generated with [Claude Code](https://claude.com/claude-code)