### PR TITLE
feat(sera-tui): inline HITL approval modal (sera-1x16)

### DIFF
--- a/rust/crates/sera-tui/src/app/actions.rs
+++ b/rust/crates/sera-tui/src/app/actions.rs
@@ -92,6 +92,21 @@ pub enum Action {
     PickerDown,
     /// Confirm the currently highlighted session.
     PickerSelect,
+    /// Approve the HITL request currently shown in the inline modal.
+    /// Constructed by external callers; the modal intercept in `App::dispatch`
+    /// maps `Action::Approve` directly to `AppCommand::ApproveModal`.
+    #[allow(dead_code)]
+    ApproveHitl(String),
+    /// Reject the HITL request currently shown in the inline modal.
+    #[allow(dead_code)]
+    RejectHitl(String),
+    /// Escalate the HITL request currently shown in the inline modal.
+    #[allow(dead_code)]
+    EscalateHitl(String),
+    /// Dismiss the inline HITL modal without taking action (leaves request
+    /// in the HITL queue pane).
+    #[allow(dead_code)]
+    DismissHitlModal,
     /// No-op — used when a key doesn't match any binding.  Reducing to
     /// this instead of returning `Option<Action>` lets the dispatch table
     /// stay a plain `match`.

--- a/rust/crates/sera-tui/src/app/mod.rs
+++ b/rust/crates/sera-tui/src/app/mod.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 use tokio::sync::mpsc::{self, UnboundedSender};
 use tokio_stream::StreamExt as _;
 
-use crate::client::{ConnectionState, GatewayClient, SseUpdate};
+use crate::client::{ConnectionState, GatewayClient, HitlRequest, SseUpdate};
 use crate::keybindings::TuiKeybindings;
 use crate::views::agent_list::AgentListView;
 use crate::views::evolve_status::EvolveStatusView;
@@ -78,6 +78,12 @@ pub enum AppCommand {
     LoadSessionsForPicker(String),
     /// Load a specific session by id (from picker selection).
     OpenSession(String),
+    /// Approve the HITL request shown in the inline modal.
+    ApproveModal(String),
+    /// Reject the HITL request shown in the inline modal.
+    RejectModal(String),
+    /// Escalate the HITL request shown in the inline modal.
+    EscalateModal(String),
 }
 
 /// Root application state.
@@ -104,6 +110,10 @@ pub struct App {
     pub session_picker: SessionPickerView,
     /// Whether the session picker modal is currently visible.
     pub show_session_picker: bool,
+    /// When a HITL request fires on the active session, this is populated
+    /// and a centered modal overlay is rendered over the current pane.
+    /// `None` means no modal is open.
+    pub show_hitl_modal: Option<HitlRequest>,
 
     /// Commands emitted by `dispatch` that the runtime must execute.
     /// The field is `pub` so the runtime (in `run`) can drain it each
@@ -130,6 +140,7 @@ impl App {
             active_agent_id: None,
             session_picker: SessionPickerView::new(),
             show_session_picker: false,
+            show_hitl_modal: None,
             pending: Vec::new(),
             show_help: false,
         }
@@ -140,6 +151,37 @@ impl App {
     /// `GatewayClient::new("http://127.0.0.1:1", …)` that never fires
     /// and still exercise the full reducer.
     pub fn dispatch(&mut self, action: Action) {
+        // When the inline HITL modal is open, remap approve/reject/escalate/back
+        // to modal-scoped actions and swallow everything else so the background
+        // pane doesn't receive input while the modal is shown.
+        if self.show_hitl_modal.is_some() {
+            match action {
+                Action::Approve => {
+                    let id = self.show_hitl_modal.as_ref().map(|r| r.id.clone()).unwrap_or_default();
+                    self.show_hitl_modal = None;
+                    self.pending.push(AppCommand::ApproveModal(id));
+                }
+                Action::Reject => {
+                    let id = self.show_hitl_modal.as_ref().map(|r| r.id.clone()).unwrap_or_default();
+                    self.show_hitl_modal = None;
+                    self.pending.push(AppCommand::RejectModal(id));
+                }
+                Action::Escalate => {
+                    let id = self.show_hitl_modal.as_ref().map(|r| r.id.clone()).unwrap_or_default();
+                    self.show_hitl_modal = None;
+                    self.pending.push(AppCommand::EscalateModal(id));
+                }
+                Action::Back | Action::DismissHitlModal => {
+                    self.show_hitl_modal = None;
+                }
+                // Quit still works even with modal open.
+                Action::Quit => self.should_quit = true,
+                // All other keys are swallowed while the modal is open.
+                _ => {}
+            }
+            return;
+        }
+
         match action {
             Action::Quit => self.should_quit = true,
             Action::NextView => {
@@ -308,6 +350,12 @@ impl App {
                     self.pending.push(AppCommand::OpenSession(id));
                 }
             }
+            // These are only dispatched via the modal intercept path above, so
+            // reaching here means the modal was already closed.  Treat as no-op.
+            Action::ApproveHitl(_)
+            | Action::RejectHitl(_)
+            | Action::EscalateHitl(_)
+            | Action::DismissHitlModal => {}
             Action::NoOp => {}
         }
     }
@@ -360,6 +408,15 @@ impl App {
             ViewKind::Evolve => format!("  {}:↑  {}:↓", display_first(&kb.up), display_first(&kb.down)),
         };
         base + &extra
+    }
+}
+
+/// Show the modal for `req` if the active session belongs to its agent and no
+/// modal is already open.  Called after every HITL refresh so the operator
+/// gets an immediate pop-up when a request arrives for their current session.
+pub fn maybe_show_hitl_modal(app: &mut App, req: HitlRequest) {
+    if app.show_hitl_modal.is_none() {
+        app.show_hitl_modal = Some(req);
     }
 }
 
@@ -447,6 +504,36 @@ impl Runtime {
                 AppCommand::OpenSession(session_id) => {
                     self.load_session_by_id(app, session_id).await;
                 }
+                AppCommand::ApproveModal(id) => match app.client.approve_hitl(&id).await {
+                    Ok(()) => {
+                        app.status = Status::info(format!("approved {id}"));
+                        Self::refresh_hitl(app).await;
+                    }
+                    Err(e) => {
+                        app.hitl.set_error(e.to_string());
+                        app.status = Status::error(format!("approve failed: {e}"));
+                    }
+                },
+                AppCommand::RejectModal(id) => match app.client.reject_hitl(&id).await {
+                    Ok(()) => {
+                        app.status = Status::info(format!("rejected {id}"));
+                        Self::refresh_hitl(app).await;
+                    }
+                    Err(e) => {
+                        app.hitl.set_error(e.to_string());
+                        app.status = Status::error(format!("reject failed: {e}"));
+                    }
+                },
+                AppCommand::EscalateModal(id) => match app.client.escalate_hitl(&id).await {
+                    Ok(()) => {
+                        app.status = Status::info(format!("escalated {id}"));
+                        Self::refresh_hitl(app).await;
+                    }
+                    Err(e) => {
+                        app.hitl.set_error(e.to_string());
+                        app.status = Status::error(format!("escalate failed: {e}"));
+                    }
+                },
             }
         }
     }
@@ -483,6 +570,16 @@ impl Runtime {
         match app.client.list_hitl().await {
             Ok(list) => {
                 let n = list.len();
+                // If the active session's agent has a pending request and no
+                // modal is already open, surface it immediately.
+                if let Some(active_agent) = &app.active_agent_id.clone()
+                    && let Some(req) = list
+                        .iter()
+                        .find(|r| r.agent_id == *active_agent && r.status == "pending")
+                        .cloned()
+                {
+                    maybe_show_hitl_modal(app, req);
+                }
                 app.hitl.set_requests(list);
                 app.status = Status::info(format!("{n} HITL request(s)"));
             }

--- a/rust/crates/sera-tui/src/keybindings.rs
+++ b/rust/crates/sera-tui/src/keybindings.rs
@@ -157,6 +157,15 @@ pub fn matches_key(event: &KeyEvent, bindings: &[KeyBinding]) -> bool {
         .any(|b| b.code == event.code && b.modifiers == event.modifiers)
 }
 
+/// Return the display string for the first binding in `bindings`, or `"?"`
+/// when the slice is empty.  Shared by view modules that render hint lines.
+pub fn display_first(bindings: &[KeyBinding]) -> String {
+    bindings
+        .first()
+        .map(|b| b.display())
+        .unwrap_or_else(|| "?".into())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rust/crates/sera-tui/src/ui.rs
+++ b/rust/crates/sera-tui/src/ui.rs
@@ -11,6 +11,7 @@ use ratatui::Frame;
 
 use crate::app::{actions::ViewKind, App, StatusLevel};
 use crate::client::ConnectionState;
+use crate::views::hitl_modal::render_hitl_modal;
 use crate::views::status_bar::StatusBar;
 
 /// Render the whole screen.
@@ -55,6 +56,11 @@ pub fn render(frame: &mut Frame, app: &mut App) {
     // Session picker modal — rendered last so it overlays everything.
     if app.show_session_picker {
         app.session_picker.render(frame, frame.area());
+    }
+
+    // Inline HITL modal — rendered on top of all panes (including picker).
+    if let Some(req) = &app.show_hitl_modal {
+        render_hitl_modal(frame, req, &app.keybindings);
     }
 }
 

--- a/rust/crates/sera-tui/src/views/hitl_modal.rs
+++ b/rust/crates/sera-tui/src/views/hitl_modal.rs
@@ -1,0 +1,165 @@
+//! Inline HITL approval modal — centered overlay rendered over the active pane.
+//!
+//! When a permission request fires on the operator's active session, the app
+//! sets `App::show_hitl_modal = Some(req)` and `ui::render` calls
+//! [`render_hitl_modal`] after the normal pane render so the overlay appears
+//! on top.
+//!
+//! Key bindings (shown in the modal footer, driven by [`TuiKeybindings`]):
+//! * approve key (`a`) — approve and dismiss
+//! * reject key (`x`) — reject and dismiss
+//! * escalate key (`e`) — escalate and dismiss
+//! * back key (`Esc`) — dismiss without action (request stays in HITL queue)
+
+use ratatui::layout::{Alignment, Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
+use ratatui::Frame;
+
+use crate::client::HitlRequest;
+use crate::keybindings::{display_first, TuiKeybindings};
+
+/// Render a centered modal overlay for `req`.
+///
+/// The modal is 60 columns wide and 12 rows tall, centred in `frame.area()`.
+/// It renders on top of whatever pane is currently active — the caller is
+/// responsible for rendering the background pane first.
+pub fn render_hitl_modal(frame: &mut Frame, req: &HitlRequest, kb: &TuiKeybindings) {
+    let area = centered_rect(60, 12, frame.area());
+
+    // Clear the region so the modal has a clean background.
+    frame.render_widget(Clear, area);
+
+    let block = Block::default()
+        .title(Span::styled(
+            " Permission Request ",
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        ))
+        .title_alignment(Alignment::Center)
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Yellow));
+
+    // Inner area (inside the border).
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    // Split inner into body (top) + hint (bottom 1 line).
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(0), Constraint::Length(1)])
+        .split(inner);
+
+    // Body: agent, tool/summary, requested scope (age field carries timestamp).
+    let body_lines = vec![
+        Line::from(vec![
+            Span::styled("Agent:   ", Style::default().fg(Color::DarkGray)),
+            Span::raw(req.agent_id.as_str()),
+        ]),
+        Line::from(vec![
+            Span::styled("Request: ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                req.summary.as_str(),
+                Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+            ),
+        ]),
+        Line::from(vec![
+            Span::styled("Time:    ", Style::default().fg(Color::DarkGray)),
+            Span::raw(req.age.as_str()),
+        ]),
+        Line::from(vec![
+            Span::styled("Status:  ", Style::default().fg(Color::DarkGray)),
+            Span::raw(req.status.as_str()),
+        ]),
+    ];
+
+    let body = Paragraph::new(body_lines).wrap(Wrap { trim: false });
+    frame.render_widget(body, rows[0]);
+
+    // Hint line at the bottom of the modal.
+    let hint = Line::from(vec![
+        Span::styled(
+            format!("{}:approve", display_first(&kb.approve)),
+            Style::default().fg(Color::Green),
+        ),
+        Span::raw("  "),
+        Span::styled(
+            format!("{}:reject", display_first(&kb.reject)),
+            Style::default().fg(Color::Red),
+        ),
+        Span::raw("  "),
+        Span::styled(
+            format!("{}:escalate", display_first(&kb.escalate)),
+            Style::default().fg(Color::Yellow),
+        ),
+        Span::raw("  "),
+        Span::styled(
+            format!("{}:dismiss", display_first(&kb.back)),
+            Style::default().fg(Color::DarkGray),
+        ),
+    ]);
+    let hint_p = Paragraph::new(hint).alignment(Alignment::Center);
+    frame.render_widget(hint_p, rows[1]);
+}
+
+/// Compute a [`Rect`] centred inside `area` with the given width and height.
+/// Clamps to `area` so the modal never overflows on tiny terminals.
+fn centered_rect(width: u16, height: u16, area: Rect) -> Rect {
+    let w = width.min(area.width);
+    let h = height.min(area.height);
+    let x = area.x + (area.width.saturating_sub(w)) / 2;
+    let y = area.y + (area.height.saturating_sub(h)) / 2;
+    Rect::new(x, y, w, h)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::keybindings::TuiKeybindings;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    fn req() -> HitlRequest {
+        HitlRequest {
+            id: "h1".into(),
+            agent_id: "agent-alpha".into(),
+            summary: "write /tmp/secret".into(),
+            age: "2026-04-24T10:00:00Z".into(),
+            status: "pending".into(),
+        }
+    }
+
+    #[test]
+    fn centered_rect_fits_inside_area() {
+        let area = Rect::new(0, 0, 80, 24);
+        let r = centered_rect(60, 12, area);
+        assert!(r.x + r.width <= area.x + area.width);
+        assert!(r.y + r.height <= area.y + area.height);
+        assert_eq!(r.width, 60);
+        assert_eq!(r.height, 12);
+    }
+
+    #[test]
+    fn centered_rect_clamps_to_area() {
+        let area = Rect::new(0, 0, 20, 5);
+        let r = centered_rect(60, 12, area);
+        assert_eq!(r.width, 20);
+        assert_eq!(r.height, 5);
+    }
+
+    #[test]
+    fn render_modal_produces_output_with_title_and_keys() {
+        let kb = TuiKeybindings::defaults();
+        let r = req();
+        let backend = TestBackend::new(80, 24);
+        let mut term = Terminal::new(backend).unwrap();
+        term.draw(|f| render_hitl_modal(f, &r, &kb)).unwrap();
+        let buf = term.backend().buffer().clone();
+        let rendered: String = buf.content().iter().map(|c| c.symbol()).collect::<Vec<_>>().join("");
+        assert!(rendered.contains("Permission Request"), "title missing");
+        assert!(rendered.contains("agent-alpha"), "agent_id missing");
+        assert!(rendered.contains("write /tmp/secret"), "summary missing");
+    }
+}

--- a/rust/crates/sera-tui/src/views/mod.rs
+++ b/rust/crates/sera-tui/src/views/mod.rs
@@ -6,6 +6,7 @@
 
 pub mod agent_list;
 pub mod evolve_status;
+pub mod hitl_modal;
 pub mod hitl_queue;
 pub mod session;
 pub mod session_picker;


### PR DESCRIPTION
Closes sera-1x16.

## Summary
- New `views/hitl_modal.rs` centered overlay with Approve/Reject/Escalate actions (a/r/e keys, Esc dismisses)
- Surfaces when a pending HITL request exists for the active agent
- Calls POST /api/hitl/requests/{id}/{approve|reject|escalate} on the client
- Gateway routes land in Wave D (sera-z6ql) — TUI logs not-implemented until then

## Test plan
- [x] cargo test -p sera-tui passes (91)
- [x] cargo clippy -p sera-tui --all-targets -- -D warnings clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)