### PR TITLE
feat(sera-gateway): wire ApprovalRouter + HTTP HITL routes (sera-z6ql, Wave D Phase 1)

### DIFF
--- a/rust/crates/sera-gateway/src/bin/sera.rs
+++ b/rust/crates/sera-gateway/src/bin/sera.rs
@@ -49,6 +49,9 @@ use sera_runtime::skill_dispatch::SkillDispatchEngine;
 // sera-uwk0: Mail gate ingress correlator (Design B — RFC 5322 headers +
 // SERA-issued nonce fallback). Wired into AppState + `/api/mail/inbound`.
 use sera_gateway::capability_enforcement::{CapabilityRegistry, PolicyDenial};
+use sera_gateway::hitl_gateway::{
+    HitlAppState, InMemoryTicketStore, TicketStore, resolve_approval_routing, resolve_hitl_mode,
+};
 use sera_gateway::kill_switch::{KillSwitch, admin_sock_path, spawn_admin_socket};
 #[cfg(test)]
 use sera_gateway::session_store::InMemorySessionStore;
@@ -78,6 +81,8 @@ mod route_a2a;
 mod route_agui;
 #[path = "../routes/plugins.rs"]
 mod route_plugins;
+#[path = "../routes/hitl.rs"]
+mod route_hitl;
 
 use route_a2a::{A2aAppState, A2aPeerRegistry};
 use route_agui::{AguiAppState, AguiHub};
@@ -510,33 +515,6 @@ struct TurnEvents {
     usage: UsageInfo,
 }
 
-// ── HITL flagged-operation pattern gate ─────────────────────────────────────
-//
-// FIXME: MVS HITL gate — pattern-match only. Full ApprovalRouter wiring
-// (sera-hitl crate) requires deeper audit of the approval-token round-trip
-// and DomainEvent surface; tracked as a follow-up in CHAT_HARNESS.md.
-//
-// These substrings are scanned case-insensitively against inbound chat
-// messages before dispatch. Hits short-circuit with 403
-// `hitl_approval_required`.
-const FLAGGED_OPERATIONS: &[&str] = &[
-    "rm -rf",
-    "sudo ",
-    "drop table",
-    "git push --force",
-    "docker system prune",
-];
-
-/// Scan `msg` for any flagged operation substring (case-insensitive) and
-/// return the matching pattern if found.
-fn detect_flagged_operation(msg: &str) -> Option<&'static str> {
-    let lower = msg.to_ascii_lowercase();
-    FLAGGED_OPERATIONS
-        .iter()
-        .find(|pat| lower.contains(**pat))
-        .copied()
-}
-
 // ── Shared state ────────────────────────────────────────────────────────────
 
 struct AppState {
@@ -635,6 +613,13 @@ struct AppState {
     /// (`StdioHarness::send_turn`) and on any future gateway-side tool
     /// dispatch. Agents with no `policyRef` bypass the check (permissive).
     capability_registry: Arc<CapabilityRegistry>,
+    /// HITL ticket store (sera-z6ql, Wave D Phase 1). Populated by
+    /// `chat_handler` whenever the ApprovalRouter says a turn needs
+    /// approval; read by the `/api/hitl/requests[/…]` routes so humans can
+    /// approve / reject / escalate. Phase 1 uses an in-memory store —
+    /// process restart loses in-flight tickets (no suspended turns to
+    /// resume anyway). SQLite-backed store is a follow-up.
+    ticket_store: Arc<dyn TicketStore>,
 }
 
 impl AppState {
@@ -721,6 +706,15 @@ impl PluginsAppState for AppState {
     }
     fn plugin_registry(&self) -> Arc<InMemoryPluginRegistry> {
         Arc::clone(&self.plugin_registry)
+    }
+}
+
+impl HitlAppState for AppState {
+    fn api_key(&self) -> &Option<String> {
+        &self.api_key
+    }
+    fn ticket_store(&self) -> Arc<dyn TicketStore> {
+        Arc::clone(&self.ticket_store)
     }
 }
 
@@ -1158,16 +1152,65 @@ async fn chat_handler(
         }
     }
 
-    // ── HITL pattern gate ────────────────────────────────────────────────
-    // FIXME: MVS HITL gate — pattern-match only. Full ApprovalRouter
-    // wiring (sera-hitl crate) requires deeper audit; tracked as follow-up
-    // in CHAT_HARNESS.md.
-    if let Some(flag) = detect_flagged_operation(&req.message) {
+    // ── HITL gate (sera-z6ql, Wave D Phase 1) ────────────────────────────
+    // Consult the real ApprovalRouter using the agent's manifest-declared
+    // enforcement_mode + approval_policy. Phase 1 blocks-and-tickets on
+    // needs_approval == true — no suspension/resume. The HTTP routes under
+    // /api/hitl/requests expose the resulting ticket for review.
+    let hitl_mode = resolve_hitl_mode(&agent_spec);
+    let hitl_routing = resolve_approval_routing(&agent_spec);
+    // Phase 1 risk proxy: we don't yet know which tool the LLM will call,
+    // so we use Execute as a conservative default. The router treats this
+    // as 0.7 for threshold matching — Standard mode with non-empty static
+    // routing still gates, Strict always gates, Autonomous never gates.
+    let risk_for_gate = sera_types::tool::RiskLevel::Execute;
+    if sera_hitl::ApprovalRouter::needs_approval(hitl_mode, risk_for_gate, &hitl_routing) {
         release_lane(&state, &session_key).await;
+
+        // Mint a Ticket via the resolved chain (Phase 1: single ticket per
+        // blocked turn). Keep the spec deliberately thin — we only know the
+        // message and agent at this gate point.
+        let spec = sera_hitl::ApprovalSpec {
+            scope: sera_hitl::ApprovalScope::ToolCall {
+                tool_name: "*".to_string(),
+                risk_level: risk_for_gate,
+            },
+            description: format!(
+                "Chat turn pending approval for agent '{}'",
+                agent_name
+            ),
+            urgency: sera_hitl::ApprovalUrgency::Medium,
+            routing: hitl_routing,
+            timeout: std::time::Duration::from_secs(300),
+            required_approvals: 1,
+            evidence: sera_hitl::ApprovalEvidence {
+                tool_args: Some(serde_json::json!({ "message": req.message })),
+                risk_score: Some(sera_hitl::ApprovalRouter::risk_level_to_score_public(
+                    risk_for_gate,
+                )),
+                principal: PrincipalRef {
+                    id: PrincipalId::new("http-chat"),
+                    kind: PrincipalKind::Human,
+                },
+                session_context: Some(session_key.clone()),
+                additional: Default::default(),
+            },
+        };
+        let ticket = sera_hitl::ApprovalTicket::new(spec, session_key.clone());
+        let ticket_id = ticket.id.clone();
+        if let Err(e) = state.ticket_store.insert(ticket).await {
+            tracing::error!(error = %e, "ticket_store.insert failed; rejecting turn");
+            return Err(StatusCode::INTERNAL_SERVER_ERROR);
+        }
+
+        // OCSF Policy Activity audit entry (class_uid=6003) — best-effort.
+        emit_hitl_required_audit(&agent_name, &session_key, &ticket_id, hitl_mode).await;
+
         let body = serde_json::json!({
             "error": "hitl_approval_required",
-            "reason": format!("flagged operation detected: {flag}"),
-            "message": "This request touches a flagged operation and requires human approval. Re-submit with approval or a safer phrasing.",
+            "reason": format!("agent '{}' requires approval ({:?} mode)", agent_name, hitl_mode),
+            "ticket_id": ticket_id,
+            "message": "This request requires approval. Use the /api/hitl/requests routes to review and approve.",
         });
         return Ok((StatusCode::FORBIDDEN, Json(body)).into_response());
     }
@@ -1915,6 +1958,47 @@ async fn emit_policy_denial_audit(denial: &PolicyDenial) {
         // return transient errors. Log and move on — the denial is still
         // enforced in-memory.
         tracing::debug!(error = %e, "audit backend unavailable for policy denial");
+    }
+}
+
+/// Emit an OCSF v1.7.0 Policy Activity (class_uid=6003) audit entry marking
+/// a chat turn as blocked pending HITL approval (sera-z6ql, Wave D Phase 1).
+/// Best-effort — uninitialised backends log a warning and continue.
+async fn emit_hitl_required_audit(
+    agent_name: &str,
+    session_key: &str,
+    ticket_id: &str,
+    mode: sera_hitl::HitlMode,
+) {
+    use sera_telemetry::audit::{AuditEntry, audit_append};
+
+    let payload = serde_json::json!({
+        "activity_id": 1, // "Deny" — the turn was not dispatched
+        "action_id": "blocked",
+        "category_uid": 6, // Application Activity
+        "class_uid": 6003, // Policy Activity
+        "severity_id": 3, // Medium
+        "actor": { "user": { "name": "http-chat" } },
+        "policy": { "name": format!("hitl:{:?}", mode) },
+        "resource": {
+            "name": agent_name,
+            "type": "agent",
+            "uid": session_key,
+        },
+        "status": "Failure",
+        "status_detail": "approval required",
+        "unmapped": { "ticket_id": ticket_id },
+    });
+    let this_hash = AuditEntry::compute_hash(6003, &payload, &[0u8; 32]);
+    let entry = AuditEntry {
+        ocsf_class_uid: 6003,
+        payload,
+        prev_hash: [0u8; 32],
+        this_hash,
+        signature: None,
+    };
+    if let Err(e) = audit_append(entry).await {
+        tracing::debug!(error = %e, "audit backend unavailable for HITL gate");
     }
 }
 
@@ -3272,6 +3356,7 @@ async fn run_start(config: PathBuf, port: u16) -> anyhow::Result<()> {
         },
         constitutional_registry,
         capability_registry: Arc::clone(&capability_registry),
+        ticket_store: Arc::new(InMemoryTicketStore::new()),
     });
 
     // 4. Start event processing loop.
@@ -3618,6 +3703,27 @@ fn build_router(state: Arc<AppState>) -> Router {
             "/api/plugins/hot-reload",
             post(route_plugins::hot_reload::<AppState>),
         )
+        // ── HITL approval requests (sera-z6ql, Wave D Phase 1) ───────────────
+        .route(
+            "/api/hitl/requests",
+            get(route_hitl::list_tickets::<AppState>),
+        )
+        .route(
+            "/api/hitl/requests/{id}",
+            get(route_hitl::get_ticket::<AppState>),
+        )
+        .route(
+            "/api/hitl/requests/{id}/approve",
+            post(route_hitl::approve_ticket::<AppState>),
+        )
+        .route(
+            "/api/hitl/requests/{id}/reject",
+            post(route_hitl::reject_ticket::<AppState>),
+        )
+        .route(
+            "/api/hitl/requests/{id}/escalate",
+            post(route_hitl::escalate_ticket::<AppState>),
+        )
         // ── sera-8d1.2-follow: party mode (circles/{id}/party) ───────────────
         .route(
             "/api/circles/{id}/party",
@@ -3723,6 +3829,7 @@ mod tests {
             session_store: Arc::new(InMemorySessionStore::new()),
             constitutional_registry: Arc::new(ConstitutionalRegistry::new()),
             capability_registry: Arc::new(CapabilityRegistry::empty()),
+            ticket_store: Arc::new(InMemoryTicketStore::new()),
         })
     }
 
@@ -3764,6 +3871,7 @@ mod tests {
             session_store: Arc::new(InMemorySessionStore::new()),
             constitutional_registry: Arc::new(ConstitutionalRegistry::new()),
             capability_registry: Arc::new(CapabilityRegistry::empty()),
+            ticket_store: Arc::new(InMemoryTicketStore::new()),
         })
     }
 
@@ -3805,6 +3913,7 @@ mod tests {
             session_store: Arc::new(InMemorySessionStore::new()),
             constitutional_registry: Arc::new(ConstitutionalRegistry::new()),
             capability_registry: Arc::new(CapabilityRegistry::empty()),
+            ticket_store: Arc::new(InMemoryTicketStore::new()),
         })
     }
 
@@ -3846,6 +3955,7 @@ mod tests {
             session_store: Arc::new(InMemorySessionStore::new()),
             constitutional_registry: Arc::new(ConstitutionalRegistry::new()),
             capability_registry: Arc::new(CapabilityRegistry::empty()),
+            ticket_store: Arc::new(InMemoryTicketStore::new()),
         })
     }
 
@@ -4231,31 +4341,86 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
     }
 
-    // -- HITL pattern gate --
+    // -- HITL ApprovalRouter gate (sera-z6ql, Wave D Phase 1) --
 
-    #[test]
-    fn detect_flagged_operation_hits_rm_rf() {
-        assert_eq!(detect_flagged_operation("please rm -rf /"), Some("rm -rf"));
+    /// YAML manifest for a strict-mode agent — every turn must be approved.
+    /// Used by the HITL integration tests.
+    const STRICT_AGENT_YAML: &str = r#"---
+apiVersion: sera.dev/v1
+kind: Instance
+metadata:
+  name: my-sera
+spec:
+---
+apiVersion: sera.dev/v1
+kind: Provider
+metadata:
+  name: lm-studio
+spec:
+  kind: openai-compatible
+  base_url: "http://localhost:1234/v1"
+  default_model: qwen/qwen3.5-35b-a3b
+---
+apiVersion: sera.dev/v1
+kind: Agent
+metadata:
+  name: sera
+spec:
+  provider: lm-studio
+  model: qwen/qwen3.5-35b-a3b
+  enforcement_mode: strict
+  persona:
+    immutable_anchor: |
+      You are Sera, an autonomous assistant.
+"#;
+
+    async fn strict_state() -> Arc<AppState> {
+        let hook_registry = Arc::new(HookRegistry::new());
+        let chain_executor = Arc::new(ChainExecutor::new(Arc::clone(&hook_registry)));
+        Arc::new(AppState {
+            db: Mutex::new(SqliteDb::open_in_memory().unwrap()),
+            manifests: parse_manifests(STRICT_AGENT_YAML).unwrap(),
+            discord: None,
+            api_key: None,
+            lane_queue: Mutex::new(LaneQueue::new(10, QueueMode::Collect)),
+            hook_registry,
+            chain_executor,
+            harnesses: test_harnesses().await,
+            runtime_ready: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            shutting_down: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            mail_correlator: Arc::new(HeaderMailCorrelator::new(
+                Arc::new(InMemoryEnvelopeIndex::default()),
+                None,
+            )),
+            mail_lookup: Arc::new(InMemoryMailLookup::new()),
+            a2a_peers: Arc::new(RwLock::new(A2aPeerRegistry::new())),
+            a2a_router: Arc::new(InProcRouter::new(|_req: A2aRequest| async move {
+                Ok(serde_json::json!({"status": "test"}))
+            })),
+            agui_hub: Arc::new(RwLock::new(AguiHub::new())),
+            plugin_registry: Arc::new(InMemoryPluginRegistry::new()),
+            skill_engine: Arc::new(SkillDispatchEngine::new()),
+            semantic_store: Arc::new(
+                SqliteMemoryStore::open_in_memory(None).expect("open in-memory semantic store"),
+            ),
+            kill_switch: Arc::new(KillSwitch::new()),
+            active_cancellation_tokens: Arc::new(std::sync::Mutex::new(
+                std::collections::HashMap::new(),
+            )),
+            session_store: Arc::new(InMemorySessionStore::new()),
+            constitutional_registry: Arc::new(ConstitutionalRegistry::new()),
+            capability_registry: Arc::new(CapabilityRegistry::empty()),
+            ticket_store: Arc::new(InMemoryTicketStore::new()),
+        })
     }
 
-    #[test]
-    fn detect_flagged_operation_is_case_insensitive() {
-        assert_eq!(
-            detect_flagged_operation("Please DROP TABLE users;"),
-            Some("drop table")
-        );
-    }
-
-    #[test]
-    fn detect_flagged_operation_misses_benign_text() {
-        assert!(detect_flagged_operation("remove this line").is_none());
-        assert!(detect_flagged_operation("hello world").is_none());
-    }
-
+    /// Strict-mode agent blocks every turn with 403 `hitl_approval_required`
+    /// and the response body carries a `ticket_id` the caller can look up
+    /// via the `/api/hitl/requests` routes.
     #[tokio::test]
-    async fn hitl_gate_blocks_rm_rf() {
-        let state = test_state_async().await;
-        let app = build_router(state);
+    async fn hitl_strict_mode_blocks_chat_turn_and_mints_ticket() {
+        let state = strict_state().await;
+        let app = build_router(Arc::clone(&state));
 
         let response = app
             .oneshot(
@@ -4264,7 +4429,7 @@ mod tests {
                     .uri("/api/chat")
                     .header("Content-Type", "application/json")
                     .body(Body::from(
-                        serde_json::json!({ "message": "please rm -rf /" }).to_string(),
+                        serde_json::json!({ "message": "hello" }).to_string(),
                     ))
                     .unwrap(),
             )
@@ -4277,12 +4442,77 @@ mod tests {
             .unwrap();
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(json["error"], "hitl_approval_required");
-        assert!(
-            json["reason"]
-                .as_str()
-                .unwrap_or_default()
-                .contains("rm -rf"),
-            "reason should mention the matched pattern"
+        let ticket_id = json["ticket_id"].as_str().unwrap().to_owned();
+        assert!(!ticket_id.is_empty());
+
+        // Ticket is visible via GET /api/hitl/requests.
+        let list_resp = build_router(Arc::clone(&state))
+            .oneshot(
+                Request::builder()
+                    .uri("/api/hitl/requests")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(list_resp.status(), StatusCode::OK);
+        let list_body = axum::body::to_bytes(list_resp.into_body(), 16384)
+            .await
+            .unwrap();
+        let list_json: serde_json::Value = serde_json::from_slice(&list_body).unwrap();
+        assert_eq!(list_json["count"], 1);
+        assert_eq!(list_json["tickets"][0]["id"], ticket_id);
+
+        // Approve the ticket.
+        let approve_resp = build_router(Arc::clone(&state))
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/api/hitl/requests/{ticket_id}/approve"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(approve_resp.status(), StatusCode::OK);
+
+        // The ticket now reads back as Approved.
+        let got = state
+            .ticket_store
+            .get(&ticket_id)
+            .await
+            .expect("ticket should still exist after approve");
+        assert_eq!(got.status, sera_hitl::TicketStatus::Approved);
+    }
+
+    /// The default (autonomous) agent in TEMPLATE_YAML must not be gated —
+    /// regression test covering the old pattern-match removal.
+    #[tokio::test]
+    async fn hitl_autonomous_mode_does_not_gate_benign_message() {
+        let state = test_state_async().await;
+        let app = build_router(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/chat")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({ "message": "hello" }).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        // The autonomous path must not return 403. It may succeed (200/OK)
+        // or fail downstream with 500/502 (the mock harness is not a real
+        // provider), but it must NOT be blocked by the HITL gate.
+        assert_ne!(
+            response.status(),
+            StatusCode::FORBIDDEN,
+            "autonomous agent must not be blocked by HITL gate"
         );
     }
 
@@ -4684,6 +4914,7 @@ mod tests {
             session_store: Arc::new(InMemorySessionStore::new()),
             constitutional_registry: Arc::new(ConstitutionalRegistry::new()),
             capability_registry: Arc::new(CapabilityRegistry::empty()),
+            ticket_store: Arc::new(InMemoryTicketStore::new()),
         };
         let headers = HeaderMap::new();
         assert!(validate_api_key(&state, &headers).is_ok());
@@ -4728,6 +4959,7 @@ mod tests {
             session_store: Arc::new(InMemorySessionStore::new()),
             constitutional_registry: Arc::new(ConstitutionalRegistry::new()),
             capability_registry: Arc::new(CapabilityRegistry::empty()),
+            ticket_store: Arc::new(InMemoryTicketStore::new()),
         };
         let mut headers = HeaderMap::new();
         headers.insert("authorization", "Bearer my-key".parse().unwrap());
@@ -4773,6 +5005,7 @@ mod tests {
             session_store: Arc::new(InMemorySessionStore::new()),
             constitutional_registry: Arc::new(ConstitutionalRegistry::new()),
             capability_registry: Arc::new(CapabilityRegistry::empty()),
+            ticket_store: Arc::new(InMemoryTicketStore::new()),
         };
         let mut headers = HeaderMap::new();
         headers.insert("authorization", "Bearer wrong".parse().unwrap());
@@ -4821,6 +5054,7 @@ mod tests {
             session_store: Arc::new(InMemorySessionStore::new()),
             constitutional_registry: Arc::new(ConstitutionalRegistry::new()),
             capability_registry: Arc::new(CapabilityRegistry::empty()),
+            ticket_store: Arc::new(InMemoryTicketStore::new()),
         };
         let headers = HeaderMap::new();
         assert_eq!(
@@ -5292,6 +5526,8 @@ mod tests {
             tools: None,
             workspace: None,
             policy_ref: None,
+            enforcement_mode: None,
+            approval_policy: None,
         };
         let skill_engine = SkillDispatchEngine::new();
         let semantic_store: Arc<dyn SemanticMemoryStore> = Arc::new(
@@ -5512,6 +5748,7 @@ mod tests {
             session_store: Arc::new(InMemorySessionStore::new()),
             constitutional_registry: Arc::new(ConstitutionalRegistry::new()),
             capability_registry: Arc::new(CapabilityRegistry::empty()),
+            ticket_store: Arc::new(InMemoryTicketStore::new()),
         });
 
         let app = build_router(Arc::clone(&state));
@@ -5595,6 +5832,7 @@ mod tests {
                 session_store: Arc::new(InMemorySessionStore::new()),
                 constitutional_registry: Arc::new(ConstitutionalRegistry::new()),
                 capability_registry: Arc::new(CapabilityRegistry::empty()),
+                ticket_store: Arc::new(InMemoryTicketStore::new()),
             })
         };
         let app = build_router(state);

--- a/rust/crates/sera-gateway/src/hitl_gateway.rs
+++ b/rust/crates/sera-gateway/src/hitl_gateway.rs
@@ -1,0 +1,310 @@
+//! HITL gateway plumbing — Wave D Phase 1 (sera-z6ql).
+//!
+//! This module owns the pieces that connect the sera-hitl crate (router,
+//! ticket state machine, escalation chains) to the HTTP gateway:
+//!
+//! - [`TicketStore`] trait + [`InMemoryTicketStore`] default implementation.
+//! - Helpers for resolving an [`AgentSpec`]'s HITL configuration into
+//!   concrete `sera_hitl` types.
+//! - Phase 1 decision: the consultation in `chat_handler` only *blocks and
+//!   tickets* when approval is required. No suspension or resume — that is
+//!   Phase 2 (follow-up bead).
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+use sera_hitl::{ApprovalRouting, ApprovalTicket, HitlMode};
+use sera_types::config_manifest::AgentSpec;
+
+// ── TicketStore ──────────────────────────────────────────────────────────────
+
+/// Errors surfaced from [`TicketStore`] operations. Kept intentionally small
+/// for Phase 1 — the only failure modes are "not found" and "backend error".
+#[derive(Debug, thiserror::Error)]
+pub enum TicketStoreError {
+    #[error("ticket not found: {id}")]
+    NotFound { id: String },
+    #[error("ticket store backend error: {reason}")]
+    Backend { reason: String },
+}
+
+/// Persistence boundary for approval tickets.
+///
+/// Phase 1 uses [`InMemoryTicketStore`] exclusively. A SQLite-backed store
+/// (mirroring `SqliteGitSessionStore`) is a follow-up.
+#[async_trait::async_trait]
+pub trait TicketStore: Send + Sync {
+    /// Persist a freshly minted ticket. Replaces any existing entry with the
+    /// same ID — tickets are immutable after creation except through
+    /// `update_*` calls on this trait.
+    async fn insert(&self, ticket: ApprovalTicket) -> Result<(), TicketStoreError>;
+
+    /// Fetch a ticket by ID. Returns [`TicketStoreError::NotFound`] when the
+    /// ticket does not exist.
+    async fn get(&self, id: &str) -> Result<ApprovalTicket, TicketStoreError>;
+
+    /// List every ticket currently in the store. Callers filter client-side;
+    /// pagination lives in Phase 2.
+    async fn list(&self) -> Result<Vec<ApprovalTicket>, TicketStoreError>;
+
+    /// Overwrite an existing ticket with a mutated copy (after approve,
+    /// reject, or escalate). Returns [`TicketStoreError::NotFound`] if the
+    /// ticket is unknown — callers must `get` first to obtain the current
+    /// state.
+    async fn update(&self, ticket: ApprovalTicket) -> Result<(), TicketStoreError>;
+}
+
+/// Process-local [`TicketStore`] backed by a `HashMap`. Sufficient for Phase 1
+/// — tickets are ephemeral anyway (Phase 1 does not resume suspended turns).
+#[derive(Default)]
+pub struct InMemoryTicketStore {
+    inner: RwLock<HashMap<String, ApprovalTicket>>,
+}
+
+impl InMemoryTicketStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[async_trait::async_trait]
+impl TicketStore for InMemoryTicketStore {
+    async fn insert(&self, ticket: ApprovalTicket) -> Result<(), TicketStoreError> {
+        let mut map = self.inner.write().await;
+        map.insert(ticket.id.clone(), ticket);
+        Ok(())
+    }
+
+    async fn get(&self, id: &str) -> Result<ApprovalTicket, TicketStoreError> {
+        let map = self.inner.read().await;
+        map.get(id)
+            .cloned()
+            .ok_or_else(|| TicketStoreError::NotFound { id: id.to_owned() })
+    }
+
+    async fn list(&self) -> Result<Vec<ApprovalTicket>, TicketStoreError> {
+        let map = self.inner.read().await;
+        Ok(map.values().cloned().collect())
+    }
+
+    async fn update(&self, ticket: ApprovalTicket) -> Result<(), TicketStoreError> {
+        let mut map = self.inner.write().await;
+        if !map.contains_key(&ticket.id) {
+            return Err(TicketStoreError::NotFound {
+                id: ticket.id.clone(),
+            });
+        }
+        map.insert(ticket.id.clone(), ticket);
+        Ok(())
+    }
+}
+
+// ── AgentSpec → HITL config resolution ───────────────────────────────────────
+
+/// Resolve an [`AgentSpec`]'s opaque `enforcement_mode` string into a concrete
+/// [`HitlMode`]. Defaults to [`HitlMode::Autonomous`] when absent or when
+/// parsing fails — fail-open preserves the pre-wiring behaviour for agents
+/// with no explicit HITL configuration.
+pub fn resolve_hitl_mode(spec: &AgentSpec) -> HitlMode {
+    match spec.enforcement_mode.as_deref() {
+        Some(raw) => {
+            let json = format!("\"{}\"", raw);
+            serde_json::from_str::<HitlMode>(&json).unwrap_or(HitlMode::Autonomous)
+        }
+        None => HitlMode::Autonomous,
+    }
+}
+
+/// Resolve an [`AgentSpec`]'s opaque `approval_policy` JSON blob into a
+/// concrete [`ApprovalRouting`]. Defaults to [`ApprovalRouting::Autonomous`]
+/// when absent or when deserialisation fails.
+pub fn resolve_approval_routing(spec: &AgentSpec) -> ApprovalRouting {
+    match spec.approval_policy.as_ref() {
+        Some(value) => serde_json::from_value::<ApprovalRouting>(value.clone())
+            .unwrap_or(ApprovalRouting::Autonomous),
+        None => ApprovalRouting::Autonomous,
+    }
+}
+
+// ── AppState trait abstraction for the HITL routes ───────────────────────────
+
+/// Abstraction over the binary's `AppState` so the HITL HTTP handlers can
+/// live in the library half of the crate (following the existing pattern in
+/// `routes/plugins.rs`, `routes/a2a.rs`, etc.).
+pub trait HitlAppState: Send + Sync + 'static {
+    fn api_key(&self) -> &Option<String>;
+    fn ticket_store(&self) -> Arc<dyn TicketStore>;
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sera_hitl::{
+        ApprovalEvidence, ApprovalScope, ApprovalSpec, ApprovalUrgency,
+    };
+    use sera_types::principal::Principal;
+    use sera_types::tool::RiskLevel;
+    use std::time::Duration;
+
+    fn sample_ticket() -> ApprovalTicket {
+        let spec = ApprovalSpec {
+            scope: ApprovalScope::ToolCall {
+                tool_name: "shell".to_string(),
+                risk_level: RiskLevel::Execute,
+            },
+            description: "test ticket".to_string(),
+            urgency: ApprovalUrgency::Medium,
+            routing: ApprovalRouting::Autonomous,
+            timeout: Duration::from_secs(300),
+            required_approvals: 1,
+            evidence: ApprovalEvidence {
+                tool_args: None,
+                risk_score: None,
+                principal: Principal::default_admin().as_ref(),
+                session_context: None,
+                additional: Default::default(),
+            },
+        };
+        ApprovalTicket::new(spec, "session-1")
+    }
+
+    #[tokio::test]
+    async fn in_memory_insert_and_get() {
+        let store = InMemoryTicketStore::new();
+        let ticket = sample_ticket();
+        let id = ticket.id.clone();
+        store.insert(ticket).await.unwrap();
+        let got = store.get(&id).await.unwrap();
+        assert_eq!(got.id, id);
+    }
+
+    #[tokio::test]
+    async fn in_memory_get_missing_is_not_found() {
+        let store = InMemoryTicketStore::new();
+        let err = store.get("nope").await.unwrap_err();
+        assert!(matches!(err, TicketStoreError::NotFound { .. }));
+    }
+
+    #[tokio::test]
+    async fn in_memory_list_returns_all() {
+        let store = InMemoryTicketStore::new();
+        store.insert(sample_ticket()).await.unwrap();
+        store.insert(sample_ticket()).await.unwrap();
+        let all = store.list().await.unwrap();
+        assert_eq!(all.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn in_memory_update_missing_is_not_found() {
+        let store = InMemoryTicketStore::new();
+        let ticket = sample_ticket();
+        let err = store.update(ticket).await.unwrap_err();
+        assert!(matches!(err, TicketStoreError::NotFound { .. }));
+    }
+
+    #[tokio::test]
+    async fn in_memory_update_persists_new_state() {
+        let store = InMemoryTicketStore::new();
+        let ticket = sample_ticket();
+        let id = ticket.id.clone();
+        store.insert(ticket.clone()).await.unwrap();
+
+        let mut mutated = ticket;
+        mutated
+            .approve(Principal::default_admin().as_ref(), Some("ok".into()))
+            .unwrap();
+        store.update(mutated).await.unwrap();
+
+        let got = store.get(&id).await.unwrap();
+        assert_eq!(got.status, sera_hitl::TicketStatus::Approved);
+    }
+
+    #[test]
+    fn resolve_mode_defaults_to_autonomous() {
+        let spec = AgentSpec {
+            provider: "x".into(),
+            model: None,
+            persona: None,
+            tools: None,
+            workspace: None,
+            policy_ref: None,
+            enforcement_mode: None,
+            approval_policy: None,
+        };
+        assert_eq!(resolve_hitl_mode(&spec), HitlMode::Autonomous);
+    }
+
+    #[test]
+    fn resolve_mode_parses_strict() {
+        let spec = AgentSpec {
+            provider: "x".into(),
+            model: None,
+            persona: None,
+            tools: None,
+            workspace: None,
+            policy_ref: None,
+            enforcement_mode: Some("strict".into()),
+            approval_policy: None,
+        };
+        assert_eq!(resolve_hitl_mode(&spec), HitlMode::Strict);
+    }
+
+    #[test]
+    fn resolve_mode_unknown_value_falls_back_to_autonomous() {
+        let spec = AgentSpec {
+            provider: "x".into(),
+            model: None,
+            persona: None,
+            tools: None,
+            workspace: None,
+            policy_ref: None,
+            enforcement_mode: Some("bogus".into()),
+            approval_policy: None,
+        };
+        assert_eq!(resolve_hitl_mode(&spec), HitlMode::Autonomous);
+    }
+
+    #[test]
+    fn resolve_routing_defaults_to_autonomous() {
+        let spec = AgentSpec {
+            provider: "x".into(),
+            model: None,
+            persona: None,
+            tools: None,
+            workspace: None,
+            policy_ref: None,
+            enforcement_mode: None,
+            approval_policy: None,
+        };
+        assert!(matches!(
+            resolve_approval_routing(&spec),
+            ApprovalRouting::Autonomous
+        ));
+    }
+
+    #[test]
+    fn resolve_routing_parses_static() {
+        let json = serde_json::json!({
+            "mode": "static",
+            "targets": [{ "kind": "role", "name": "ops" }],
+        });
+        let spec = AgentSpec {
+            provider: "x".into(),
+            model: None,
+            persona: None,
+            tools: None,
+            workspace: None,
+            policy_ref: None,
+            enforcement_mode: None,
+            approval_policy: Some(json),
+        };
+        let routing = resolve_approval_routing(&spec);
+        match routing {
+            ApprovalRouting::Static { targets } => assert_eq!(targets.len(), 1),
+            other => panic!("expected Static, got {other:?}"),
+        }
+    }
+}

--- a/rust/crates/sera-gateway/src/lib.rs
+++ b/rust/crates/sera-gateway/src/lib.rs
@@ -7,6 +7,7 @@ pub mod db_backend;
 pub mod envelope;
 pub mod generation;
 pub mod harness_dispatch;
+pub mod hitl_gateway;
 pub mod kill_switch;
 pub mod party;
 pub mod plugin;

--- a/rust/crates/sera-gateway/src/routes/hitl.rs
+++ b/rust/crates/sera-gateway/src/routes/hitl.rs
@@ -1,0 +1,516 @@
+//! HITL approval request routes — Wave D Phase 1 (sera-z6ql).
+//!
+//! Routes:
+//!   GET  /api/hitl/requests              — list all tickets
+//!   GET  /api/hitl/requests/{id}         — fetch a single ticket
+//!   POST /api/hitl/requests/{id}/approve — approve (marks ticket but does
+//!                                          NOT resume the suspended turn)
+//!   POST /api/hitl/requests/{id}/reject  — reject
+//!   POST /api/hitl/requests/{id}/escalate — advance to the next target
+//!
+//! Phase 1 scope: approve/reject/escalate mutate the ticket state machine
+//! only. The chat_handler turn that created the ticket already returned 403
+//! to the caller — resume semantics are Phase 2.
+#![allow(dead_code)]
+
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::{HeaderMap, StatusCode},
+};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+use sera_hitl::{ApprovalTicket, HitlError};
+use sera_types::principal::Principal;
+
+use sera_gateway::hitl_gateway::{HitlAppState, TicketStoreError};
+
+// ── Request/response shapes ──────────────────────────────────────────────────
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ListTicketsResponse {
+    pub tickets: Vec<ApprovalTicket>,
+    pub count: usize,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct DecisionBody {
+    /// Optional free-text reason recorded against the decision.
+    #[serde(default)]
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DecisionResponse {
+    pub id: String,
+    pub status: sera_hitl::TicketStatus,
+}
+
+// ── Auth ─────────────────────────────────────────────────────────────────────
+
+fn check_auth(api_key: &Option<String>, headers: &HeaderMap) -> Result<(), StatusCode> {
+    let expected = match api_key {
+        None => return Ok(()),
+        Some(k) => k,
+    };
+    let provided = headers
+        .get("authorization")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "));
+    match provided {
+        Some(k) if k == expected => Ok(()),
+        _ => Err(StatusCode::UNAUTHORIZED),
+    }
+}
+
+// ── Error mapping ────────────────────────────────────────────────────────────
+
+fn map_store_err(err: TicketStoreError) -> StatusCode {
+    match err {
+        TicketStoreError::NotFound { .. } => StatusCode::NOT_FOUND,
+        TicketStoreError::Backend { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+    }
+}
+
+fn map_hitl_err(err: &HitlError) -> StatusCode {
+    match err {
+        HitlError::TicketNotFound { .. } => StatusCode::NOT_FOUND,
+        HitlError::TicketExpired { .. } => StatusCode::GONE,
+        HitlError::InvalidTransition { .. } => StatusCode::CONFLICT,
+        HitlError::EscalationExhausted { .. } => StatusCode::CONFLICT,
+        HitlError::InsufficientApprovals { .. } => StatusCode::CONFLICT,
+    }
+}
+
+// ── Handlers ─────────────────────────────────────────────────────────────────
+
+/// GET /api/hitl/requests — list every known ticket.
+pub async fn list_tickets<S>(
+    State(state): State<Arc<S>>,
+    headers: HeaderMap,
+) -> Result<Json<ListTicketsResponse>, StatusCode>
+where
+    S: HitlAppState,
+{
+    check_auth(state.api_key(), &headers)?;
+    let tickets = state
+        .ticket_store()
+        .list()
+        .await
+        .map_err(map_store_err)?;
+    let count = tickets.len();
+    Ok(Json(ListTicketsResponse { tickets, count }))
+}
+
+/// GET /api/hitl/requests/{id}
+pub async fn get_ticket<S>(
+    State(state): State<Arc<S>>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+) -> Result<Json<ApprovalTicket>, StatusCode>
+where
+    S: HitlAppState,
+{
+    check_auth(state.api_key(), &headers)?;
+    let ticket = state.ticket_store().get(&id).await.map_err(map_store_err)?;
+    Ok(Json(ticket))
+}
+
+/// POST /api/hitl/requests/{id}/approve
+///
+/// Phase 1: records the approval on the ticket; no suspended turn is
+/// resumed. The approver principal is the default admin until the auth
+/// layer threads a real identity here (tracked for Phase 2).
+pub async fn approve_ticket<S>(
+    State(state): State<Arc<S>>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+    body: Option<Json<DecisionBody>>,
+) -> Result<Json<DecisionResponse>, StatusCode>
+where
+    S: HitlAppState,
+{
+    check_auth(state.api_key(), &headers)?;
+
+    let store = state.ticket_store();
+    let mut ticket = store.get(&id).await.map_err(map_store_err)?;
+    let reason = body.and_then(|Json(b)| b.reason);
+
+    let status = ticket
+        .approve(Principal::default_admin().as_ref(), reason)
+        .map_err(|e| map_hitl_err(&e))?;
+    store.update(ticket).await.map_err(map_store_err)?;
+
+    Ok(Json(DecisionResponse { id, status }))
+}
+
+/// POST /api/hitl/requests/{id}/reject
+pub async fn reject_ticket<S>(
+    State(state): State<Arc<S>>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+    body: Option<Json<DecisionBody>>,
+) -> Result<Json<DecisionResponse>, StatusCode>
+where
+    S: HitlAppState,
+{
+    check_auth(state.api_key(), &headers)?;
+
+    let store = state.ticket_store();
+    let mut ticket = store.get(&id).await.map_err(map_store_err)?;
+    let reason = body.and_then(|Json(b)| b.reason);
+
+    let status = ticket
+        .reject(Principal::default_admin().as_ref(), reason)
+        .map_err(|e| map_hitl_err(&e))?;
+    store.update(ticket).await.map_err(map_store_err)?;
+
+    Ok(Json(DecisionResponse { id, status }))
+}
+
+/// POST /api/hitl/requests/{id}/escalate
+pub async fn escalate_ticket<S>(
+    State(state): State<Arc<S>>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+) -> Result<Json<DecisionResponse>, StatusCode>
+where
+    S: HitlAppState,
+{
+    check_auth(state.api_key(), &headers)?;
+
+    let store = state.ticket_store();
+    let mut ticket = store.get(&id).await.map_err(map_store_err)?;
+    ticket.escalate().map_err(|e| map_hitl_err(&e))?;
+    let status = ticket.status;
+    store.update(ticket).await.map_err(map_store_err)?;
+
+    Ok(Json(DecisionResponse { id, status }))
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sera_gateway::hitl_gateway::{InMemoryTicketStore, TicketStore};
+    use axum::{
+        Router,
+        body::Body,
+        http::Request,
+        routing::{get, post},
+    };
+    use sera_hitl::{
+        ApprovalEvidence, ApprovalRouting, ApprovalScope, ApprovalSpec, ApprovalUrgency,
+        TicketStatus,
+    };
+    use sera_types::tool::RiskLevel;
+    use std::time::Duration;
+    use tower::ServiceExt;
+
+    struct TestState {
+        api_key: Option<String>,
+        tickets: Arc<InMemoryTicketStore>,
+    }
+
+    impl HitlAppState for TestState {
+        fn api_key(&self) -> &Option<String> {
+            &self.api_key
+        }
+        fn ticket_store(&self) -> Arc<dyn TicketStore> {
+            Arc::clone(&self.tickets) as Arc<dyn TicketStore>
+        }
+    }
+
+    fn sample_ticket() -> ApprovalTicket {
+        let spec = ApprovalSpec {
+            scope: ApprovalScope::ToolCall {
+                tool_name: "shell".to_string(),
+                risk_level: RiskLevel::Execute,
+            },
+            description: "test".to_string(),
+            urgency: ApprovalUrgency::Medium,
+            routing: ApprovalRouting::Autonomous,
+            timeout: Duration::from_secs(300),
+            required_approvals: 1,
+            evidence: ApprovalEvidence {
+                tool_args: None,
+                risk_score: None,
+                principal: Principal::default_admin().as_ref(),
+                session_context: None,
+                additional: Default::default(),
+            },
+        };
+        ApprovalTicket::new(spec, "session-1")
+    }
+
+    fn router(state: Arc<TestState>) -> Router {
+        Router::new()
+            .route("/api/hitl/requests", get(list_tickets::<TestState>))
+            .route(
+                "/api/hitl/requests/{id}",
+                get(get_ticket::<TestState>),
+            )
+            .route(
+                "/api/hitl/requests/{id}/approve",
+                post(approve_ticket::<TestState>),
+            )
+            .route(
+                "/api/hitl/requests/{id}/reject",
+                post(reject_ticket::<TestState>),
+            )
+            .route(
+                "/api/hitl/requests/{id}/escalate",
+                post(escalate_ticket::<TestState>),
+            )
+            .with_state(state)
+    }
+
+    async fn fresh_state_with_ticket() -> (Arc<TestState>, String) {
+        let tickets = Arc::new(InMemoryTicketStore::new());
+        let t = sample_ticket();
+        let id = t.id.clone();
+        tickets.insert(t).await.unwrap();
+        let state = Arc::new(TestState {
+            api_key: None,
+            tickets,
+        });
+        (state, id)
+    }
+
+    #[tokio::test]
+    async fn list_tickets_empty() {
+        let state = Arc::new(TestState {
+            api_key: None,
+            tickets: Arc::new(InMemoryTicketStore::new()),
+        });
+        let app = router(state);
+        let resp = app
+            .oneshot(Request::get("/api/hitl/requests").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let parsed: ListTicketsResponse = serde_json::from_slice(&body).unwrap();
+        assert_eq!(parsed.count, 0);
+    }
+
+    #[tokio::test]
+    async fn list_tickets_with_entry() {
+        let (state, _id) = fresh_state_with_ticket().await;
+        let app = router(state);
+        let resp = app
+            .oneshot(Request::get("/api/hitl/requests").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let parsed: ListTicketsResponse = serde_json::from_slice(&body).unwrap();
+        assert_eq!(parsed.count, 1);
+    }
+
+    #[tokio::test]
+    async fn get_ticket_not_found() {
+        let state = Arc::new(TestState {
+            api_key: None,
+            tickets: Arc::new(InMemoryTicketStore::new()),
+        });
+        let app = router(state);
+        let resp = app
+            .oneshot(
+                Request::get("/api/hitl/requests/nope")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn get_ticket_happy_path() {
+        let (state, id) = fresh_state_with_ticket().await;
+        let app = router(state);
+        let resp = app
+            .oneshot(
+                Request::get(format!("/api/hitl/requests/{id}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn approve_ticket_marks_approved() {
+        let (state, id) = fresh_state_with_ticket().await;
+        let app = router(Arc::clone(&state));
+        let resp = app
+            .oneshot(
+                Request::post(format!("/api/hitl/requests/{id}/approve"))
+                    .header("content-type", "application/json")
+                    .body(Body::from("{}"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let got = state.ticket_store().get(&id).await.unwrap();
+        assert_eq!(got.status, TicketStatus::Approved);
+    }
+
+    #[tokio::test]
+    async fn approve_ticket_without_body_is_ok() {
+        // Callers can approve with no body — the DecisionBody is optional.
+        let (state, id) = fresh_state_with_ticket().await;
+        let app = router(Arc::clone(&state));
+        let resp = app
+            .oneshot(
+                Request::post(format!("/api/hitl/requests/{id}/approve"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn reject_ticket_marks_rejected() {
+        let (state, id) = fresh_state_with_ticket().await;
+        let app = router(Arc::clone(&state));
+        let resp = app
+            .oneshot(
+                Request::post(format!("/api/hitl/requests/{id}/reject"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"reason":"nope"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let got = state.ticket_store().get(&id).await.unwrap();
+        assert_eq!(got.status, TicketStatus::Rejected);
+    }
+
+    #[tokio::test]
+    async fn escalate_ticket_advances_target_index() {
+        // Build a ticket whose routing has two targets so escalation succeeds.
+        let routing = ApprovalRouting::Static {
+            targets: vec![
+                sera_hitl::ApprovalTarget::Agent {
+                    id: "a1".to_string(),
+                },
+                sera_hitl::ApprovalTarget::Role {
+                    name: "ops".to_string(),
+                },
+            ],
+        };
+        let spec = ApprovalSpec {
+            scope: ApprovalScope::ToolCall {
+                tool_name: "shell".to_string(),
+                risk_level: RiskLevel::Execute,
+            },
+            description: "x".to_string(),
+            urgency: ApprovalUrgency::Medium,
+            routing,
+            timeout: Duration::from_secs(300),
+            required_approvals: 1,
+            evidence: ApprovalEvidence {
+                tool_args: None,
+                risk_score: None,
+                principal: Principal::default_admin().as_ref(),
+                session_context: None,
+                additional: Default::default(),
+            },
+        };
+        let t = ApprovalTicket::new(spec, "session-esc");
+        let id = t.id.clone();
+
+        let tickets = Arc::new(InMemoryTicketStore::new());
+        tickets.insert(t).await.unwrap();
+        let state = Arc::new(TestState {
+            api_key: None,
+            tickets,
+        });
+
+        let app = router(Arc::clone(&state));
+        let resp = app
+            .oneshot(
+                Request::post(format!("/api/hitl/requests/{id}/escalate"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let got = state.ticket_store().get(&id).await.unwrap();
+        assert_eq!(got.status, TicketStatus::Escalated);
+        assert_eq!(got.current_target_index, 1);
+    }
+
+    #[tokio::test]
+    async fn escalate_without_room_returns_conflict() {
+        let (state, id) = fresh_state_with_ticket().await;
+        // Autonomous routing has zero targets — escalate must report conflict.
+        let app = router(state);
+        let resp = app
+            .oneshot(
+                Request::post(format!("/api/hitl/requests/{id}/escalate"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+    }
+
+    #[tokio::test]
+    async fn approve_on_already_approved_returns_conflict() {
+        let (state, id) = fresh_state_with_ticket().await;
+        let app = router(Arc::clone(&state));
+        // First approval succeeds.
+        let r1 = app
+            .clone()
+            .oneshot(
+                Request::post(format!("/api/hitl/requests/{id}/approve"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(r1.status(), StatusCode::OK);
+        // Second approval hits the terminal-state guard → 409.
+        let r2 = app
+            .oneshot(
+                Request::post(format!("/api/hitl/requests/{id}/approve"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(r2.status(), StatusCode::CONFLICT);
+    }
+
+    #[tokio::test]
+    async fn auth_required_when_api_key_set() {
+        let tickets = Arc::new(InMemoryTicketStore::new());
+        let state = Arc::new(TestState {
+            api_key: Some("secret".into()),
+            tickets,
+        });
+        let app = router(state);
+        let resp = app
+            .oneshot(
+                Request::get("/api/hitl/requests")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/rust/crates/sera-types/src/config_manifest.rs
+++ b/rust/crates/sera-types/src/config_manifest.rs
@@ -214,6 +214,21 @@ pub struct AgentSpec {
     /// policy is enforced — the agent is permissive by default.
     #[serde(default, alias = "policyRef", skip_serializing_if = "Option::is_none")]
     pub policy_ref: Option<String>,
+    /// HITL enforcement mode — `autonomous` (no approvals), `standard`
+    /// (policy-driven), or `strict` (every tool call needs approval).
+    /// Stored as an opaque lowercase string so this crate stays free of a
+    /// cyclic dep on `sera-hitl`. The gateway parses it into
+    /// `sera_hitl::HitlMode` via serde when consulted. Defaults to
+    /// `autonomous` when absent. Wave D (sera-z6ql).
+    #[serde(default, alias = "enforcementMode", skip_serializing_if = "Option::is_none")]
+    pub enforcement_mode: Option<String>,
+    /// HITL approval routing — serialised `sera_hitl::ApprovalRouting`. Kept
+    /// as a generic JSON value for the same crate-layering reason as
+    /// `enforcement_mode`. The gateway deserialises it into the concrete
+    /// type before calling `ApprovalRouter::needs_approval`. Absent =
+    /// `{ "mode": "autonomous" }`. Wave D (sera-z6ql).
+    #[serde(default, alias = "approvalPolicy", skip_serializing_if = "Option::is_none")]
+    pub approval_policy: Option<serde_json::Value>,
 }
 
 /// Persona configuration within an agent spec.


### PR DESCRIPTION
Closes sera-z6ql (Phase 1).

## Summary
- Replace FIXME detect_flagged_operation with real ApprovalRouter consultation
- New InMemoryTicketStore + new AppState field
- On needs_approval: mint Ticket, emit OCSF audit, return 403 approval-required
- 5 new HTTP routes for ticket list/get/approve/reject/escalate
- Phase 1 scope — approve/reject mark the ticket but don't yet resume suspended turns; Phase 2 will add suspension/resume

## Test plan
- [x] cargo test -p sera-gateway passes (316 passed)
- [x] cargo clippy -p sera-gateway --all-targets -- -D warnings clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)