### PR TITLE
feat(sera-tui): J.0.1 chat-dominant layout pivot

### DIFF
--- a/rust/crates/sera-tui/src/app/actions.rs
+++ b/rust/crates/sera-tui/src/app/actions.rs
@@ -8,12 +8,33 @@
 //! state.
 
 /// Which top-level pane is currently focused.
+///
+/// **J.0.1 layout pivot**: view rotation (NextView/PrevView) is no longer the
+/// primary navigator — the TUI is chat-dominant and the main canvas is always
+/// the Session view.  `ViewKind` is kept because `Focus` (see below) does not
+/// yet subsume the modal-dispatch branches in tests; it is effectively unused
+/// by the new rendering path.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ViewKind {
     Agents,
     Session,
     Hitl,
     Evolve,
+}
+
+/// Which region of the chat-dominant layout currently has keyboard focus.
+///
+/// `Composer` is the default — the user types into the multi-line textarea.
+/// `Transcript` is entered for scroll navigation.  Modals (agents, HITL,
+/// evolve, session picker) are tracked separately on the `App` struct.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Focus {
+    Composer,
+    /// Entered for scroll navigation — constructed by J.0.2 (Tab toggle)
+    /// once the block-based transcript lands; reserved here in J.0.1 so
+    /// the rest of the app code can pattern-match exhaustively.
+    #[allow(dead_code)]
+    Transcript,
 }
 
 impl ViewKind {
@@ -37,15 +58,6 @@ impl ViewKind {
         }
     }
 
-    /// Short label for header/footer chrome.
-    pub fn label(self) -> &'static str {
-        match self {
-            Self::Agents => "Agents",
-            Self::Session => "Session",
-            Self::Hitl => "HITL",
-            Self::Evolve => "Evolve",
-        }
-    }
 }
 
 /// Every input the reducer understands.  Kept flat on purpose — nested
@@ -88,6 +100,14 @@ pub enum Action {
     OpenSessionPicker,
     /// Close the session picker without selecting.
     ClosePicker,
+    /// Open the agents picker modal (chat-dominant layout, default Ctrl+A).
+    OpenAgentsModal,
+    /// Open the HITL queue modal (chat-dominant layout, default Ctrl+H).
+    OpenHitlModal,
+    /// Open the evolve status modal (chat-dominant layout, default Ctrl+E).
+    OpenEvolveModal,
+    /// Close whichever J.0.1 modal (agents, hitl, evolve) is currently open.
+    CloseModal,
     /// Move picker selection up.
     PickerUp,
     /// Move picker selection down.
@@ -133,13 +153,6 @@ mod tests {
         assert_eq!(ViewKind::Session.prev(), ViewKind::Agents);
         assert_eq!(ViewKind::Hitl.prev(), ViewKind::Session);
         assert_eq!(ViewKind::Evolve.prev(), ViewKind::Hitl);
-    }
-
-    #[test]
-    fn view_label_is_non_empty() {
-        for v in [ViewKind::Agents, ViewKind::Session, ViewKind::Hitl, ViewKind::Evolve] {
-            assert!(!v.label().is_empty(), "label empty for {v:?}");
-        }
     }
 
     #[test]

--- a/rust/crates/sera-tui/src/app/mod.rs
+++ b/rust/crates/sera-tui/src/app/mod.rs
@@ -23,7 +23,7 @@ use crate::views::hitl_queue::HitlQueueView;
 use crate::views::session::SessionView;
 use crate::views::session_picker::SessionPickerView;
 
-pub use actions::{Action, ViewKind};
+pub use actions::{Action, Focus, ViewKind};
 pub use slash::SlashCommand;
 
 /// Footer-bar messages the app surfaces to the operator.
@@ -88,7 +88,17 @@ pub enum AppCommand {
 
 /// Root application state.
 pub struct App {
+    /// **J.0.1**: legacy view pointer — kept so the existing
+    /// NextView/PrevView actions and tests still compile.  In the
+    /// chat-dominant layout the main canvas is always Session, so this
+    /// field is no longer used by `ui::render`.
     pub focus: ViewKind,
+    /// **J.0.1**: keyboard focus inside the chat-dominant layout.
+    /// Composer (typing) vs Transcript (scrolling).  Default is Composer.
+    /// Read by J.0.2 (block-based transcript) onwards; currently set but
+    /// not yet consulted by any renderer.
+    #[allow(dead_code)]
+    pub chat_focus: Focus,
     pub should_quit: bool,
     pub keybindings: TuiKeybindings,
     pub status: Status,
@@ -115,6 +125,14 @@ pub struct App {
     /// `None` means no modal is open.
     pub show_hitl_modal: Option<HitlRequest>,
 
+    /// **J.0.1**: whether the agents picker modal (Ctrl+A) is visible.
+    pub show_agents_modal: bool,
+    /// **J.0.1**: whether the HITL queue modal (Ctrl+H) is visible.
+    /// Distinct from `show_hitl_modal` (the inline approval overlay).
+    pub show_hitl_queue_modal: bool,
+    /// **J.0.1**: whether the evolve status modal (Ctrl+E) is visible.
+    pub show_evolve_modal: bool,
+
     /// Commands emitted by `dispatch` that the runtime must execute.
     /// The field is `pub` so the runtime (in `run`) can drain it each
     /// tick without needing a getter.
@@ -128,6 +146,7 @@ impl App {
     pub fn new(client: GatewayClient, keybindings: TuiKeybindings) -> Self {
         Self {
             focus: ViewKind::Agents,
+            chat_focus: Focus::Composer,
             should_quit: false,
             keybindings,
             status: Status::info("ready"),
@@ -141,9 +160,19 @@ impl App {
             session_picker: SessionPickerView::new(),
             show_session_picker: false,
             show_hitl_modal: None,
+            show_agents_modal: false,
+            show_hitl_queue_modal: false,
+            show_evolve_modal: false,
             pending: Vec::new(),
             show_help: false,
         }
+    }
+
+    /// Returns true when any J.0.1 overlay modal (agents / HITL queue /
+    /// evolve status) is currently shown.  Used by `dispatch` to reroute
+    /// input to modal-scoped actions.
+    pub fn any_j01_modal_open(&self) -> bool {
+        self.show_agents_modal || self.show_hitl_queue_modal || self.show_evolve_modal
     }
 
     /// Apply `action` to the state.  Pure apart from pushing commands
@@ -151,6 +180,81 @@ impl App {
     /// `GatewayClient::new("http://127.0.0.1:1", …)` that never fires
     /// and still exercise the full reducer.
     pub fn dispatch(&mut self, action: Action) {
+        // J.0.1 modal precedence — when any chat-dominant modal is open
+        // (agents / HITL queue / evolve), swallow background input and only
+        // honour close/quit + modal-scoped navigation.
+        if self.any_j01_modal_open() {
+            match action {
+                Action::CloseModal | Action::Back => {
+                    // ESC closes the topmost modal — evolve > hitl > agents.
+                    if self.show_evolve_modal {
+                        self.show_evolve_modal = false;
+                    } else if self.show_hitl_queue_modal {
+                        self.show_hitl_queue_modal = false;
+                    } else if self.show_agents_modal {
+                        self.show_agents_modal = false;
+                    }
+                }
+                Action::Quit => self.should_quit = true,
+                Action::Up => {
+                    if self.show_agents_modal {
+                        self.agents.up();
+                    } else if self.show_hitl_queue_modal {
+                        self.hitl.up();
+                    } else if self.show_evolve_modal {
+                        self.evolve.up();
+                    }
+                }
+                Action::Down => {
+                    if self.show_agents_modal {
+                        self.agents.down();
+                    } else if self.show_hitl_queue_modal {
+                        self.hitl.down();
+                    } else if self.show_evolve_modal {
+                        self.evolve.down();
+                    }
+                }
+                Action::Select | Action::SelectAgent(_) => {
+                    if self.show_agents_modal
+                        && let Some(id) = self.agents.selected_id()
+                    {
+                        self.active_agent_id = Some(id.clone());
+                        self.show_agents_modal = false;
+                        self.pending.push(AppCommand::LoadSessionFor(id));
+                    }
+                }
+                Action::Approve => {
+                    if self.show_hitl_queue_modal
+                        && let Some(id) = self.hitl.selected_id()
+                    {
+                        self.hitl.clear_error();
+                        self.pending.push(AppCommand::Approve(id));
+                    }
+                }
+                Action::Reject => {
+                    if self.show_hitl_queue_modal
+                        && let Some(id) = self.hitl.selected_id()
+                    {
+                        self.hitl.clear_error();
+                        self.pending.push(AppCommand::Reject(id));
+                    }
+                }
+                Action::Escalate => {
+                    if self.show_hitl_queue_modal
+                        && let Some(id) = self.hitl.selected_id()
+                    {
+                        self.hitl.clear_error();
+                        self.pending.push(AppCommand::Escalate(id));
+                    }
+                }
+                Action::Refresh => self.pending.push(AppCommand::RefreshAll),
+                // Swallow everything else — composer typing must not leak
+                // behind the modal.
+                _ => {}
+            }
+            return;
+        }
+
         // When the inline HITL modal is open, remap approve/reject/escalate/back
         // to modal-scoped actions and swallow everything else so the background
         // pane doesn't receive input while the modal is shown.
@@ -336,6 +440,25 @@ impl App {
             Action::ClosePicker => {
                 self.show_session_picker = false;
             }
+            Action::OpenAgentsModal => {
+                self.show_agents_modal = true;
+                // Fetch fresh agent list when opening so the operator sees
+                // current state rather than whatever was cached.
+                self.pending.push(AppCommand::RefreshAll);
+            }
+            Action::OpenHitlModal => {
+                self.show_hitl_queue_modal = true;
+                self.pending.push(AppCommand::RefreshAll);
+            }
+            Action::OpenEvolveModal => {
+                self.show_evolve_modal = true;
+                self.pending.push(AppCommand::RefreshAll);
+            }
+            Action::CloseModal => {
+                // No J.0.1 modal is open in this branch (would have been
+                // handled above).  Fall through to a no-op so the dispatch
+                // match stays exhaustive.
+            }
             Action::PickerUp => {
                 if self.show_session_picker {
                     self.session_picker.move_up();
@@ -379,40 +502,70 @@ impl App {
         }
     }
 
-    /// Footer hint row for the currently focused view.  Changes by pane so
-    /// the operator sees the relevant keybindings.
+    /// Footer hint row — context-sensitive for the chat-dominant layout.
+    /// Modal-open states show modal-relevant bindings; otherwise the hint
+    /// reflects the composer/transcript focus.
     pub fn footer_hint(&self) -> String {
         let kb = &self.keybindings;
-        let base = format!(
-            "{}:quit  {}:refresh  {}:tab  {}:S-tab",
-            display_first(&kb.quit),
-            display_first(&kb.refresh),
-            display_first(&kb.next_view),
-            display_first(&kb.prev_view)
-        );
-        let extra = match self.focus {
-            ViewKind::Agents => format!(
-                "  {}:select  {}:↑  {}:↓",
-                display_first(&kb.select),
-                display_first(&kb.up),
-                display_first(&kb.down)
-            ),
-            ViewKind::Session => format!(
-                "  {}:back  {}:↑  {}:↓  {}:end",
-                display_first(&kb.back),
-                display_first(&kb.up),
-                display_first(&kb.down),
-                display_first(&kb.end_of_buffer)
-            ),
-            ViewKind::Hitl => format!(
-                "  {}:approve  {}:reject  {}:escalate",
+
+        // HITL inline approval modal takes priority — its bindings are
+        // already in its own footer but we still swap the global hint so
+        // the operator doesn't see stale composer hints.
+        if self.show_hitl_modal.is_some() {
+            return format!(
+                "{}:approve  {}:reject  {}:escalate  {}:dismiss",
                 display_first(&kb.approve),
                 display_first(&kb.reject),
-                display_first(&kb.escalate)
-            ),
-            ViewKind::Evolve => format!("  {}:↑  {}:↓", display_first(&kb.up), display_first(&kb.down)),
-        };
-        base + &extra
+                display_first(&kb.escalate),
+                display_first(&kb.back),
+            );
+        }
+
+        if self.show_agents_modal {
+            return format!(
+                "{}:select  {}:↑  {}:↓  esc:close",
+                display_first(&kb.select),
+                display_first(&kb.up),
+                display_first(&kb.down),
+            );
+        }
+        if self.show_hitl_queue_modal {
+            return format!(
+                "{}:approve  {}:reject  {}:escalate  {}:↑  {}:↓  esc:close",
+                display_first(&kb.approve),
+                display_first(&kb.reject),
+                display_first(&kb.escalate),
+                display_first(&kb.up),
+                display_first(&kb.down),
+            );
+        }
+        if self.show_evolve_modal {
+            return format!(
+                "{}:↑  {}:↓  esc:close",
+                display_first(&kb.up),
+                display_first(&kb.down),
+            );
+        }
+        if self.show_session_picker {
+            return format!(
+                "{}:select  {}:↑  {}:↓  esc:close",
+                display_first(&kb.select),
+                display_first(&kb.up),
+                display_first(&kb.down),
+            );
+        }
+
+        // No modal — chat-dominant base hints.
+        format!(
+            "{}:send  {}:focus  {}:agents  {}:hitl  {}:evolve  {}:sessions  {}:quit",
+            display_first(&kb.submit_message),
+            display_first(&kb.toggle_composer_focus),
+            display_first(&kb.open_agents_modal),
+            display_first(&kb.open_hitl_modal),
+            display_first(&kb.open_evolve_modal),
+            display_first(&kb.open_session_picker),
+            display_first(&kb.quit),
+        )
     }
 }
 
@@ -886,12 +1039,16 @@ mod tests {
     }
 
     #[test]
-    fn footer_hint_changes_with_focus() {
+    fn footer_hint_changes_with_modal_state() {
+        // J.0.1: footer_hint reflects modal-open state, not the legacy
+        // ViewKind focus.  The base (no-modal) hint mentions "send" for
+        // the composer; opening the HITL queue modal swaps in approve.
         let mut app = App::new(client(), TuiKeybindings::defaults());
-        let agents_hint = app.footer_hint();
-        app.focus = ViewKind::Hitl;
+        let base_hint = app.footer_hint();
+        assert!(base_hint.contains("send"));
+        app.show_hitl_queue_modal = true;
         let hitl_hint = app.footer_hint();
-        assert_ne!(agents_hint, hitl_hint);
+        assert_ne!(base_hint, hitl_hint);
         assert!(hitl_hint.contains("approve"));
     }
 

--- a/rust/crates/sera-tui/src/input.rs
+++ b/rust/crates/sera-tui/src/input.rs
@@ -60,6 +60,15 @@ pub fn translate(event: &KeyEvent, kb: &TuiKeybindings) -> Action {
     if matches_key(event, &kb.open_session_picker) {
         return Action::OpenSessionPicker;
     }
+    if matches_key(event, &kb.open_agents_modal) {
+        return Action::OpenAgentsModal;
+    }
+    if matches_key(event, &kb.open_hitl_modal) {
+        return Action::OpenHitlModal;
+    }
+    if matches_key(event, &kb.open_evolve_modal) {
+        return Action::OpenEvolveModal;
+    }
     Action::NoOp
 }
 
@@ -85,6 +94,21 @@ pub fn translate_session(
     }
     if matches_key(event, &kb.toggle_composer_focus) {
         return Action::ToggleComposerFocus;
+    }
+
+    // J.0.1 modal-open shortcuts — handled even when composer has focus so
+    // Ctrl+A/H/E open their modal instead of reaching the textarea.
+    if matches_key(event, &kb.open_agents_modal) {
+        return Action::OpenAgentsModal;
+    }
+    if matches_key(event, &kb.open_hitl_modal) {
+        return Action::OpenHitlModal;
+    }
+    if matches_key(event, &kb.open_evolve_modal) {
+        return Action::OpenEvolveModal;
+    }
+    if matches_key(event, &kb.open_session_picker) {
+        return Action::OpenSessionPicker;
     }
 
     if composer_focused {

--- a/rust/crates/sera-tui/src/keybindings.rs
+++ b/rust/crates/sera-tui/src/keybindings.rs
@@ -86,6 +86,14 @@ pub struct TuiKeybindings {
     pub submit_message: Vec<KeyBinding>,
     /// Open the session picker modal (default: Ctrl+P).
     pub open_session_picker: Vec<KeyBinding>,
+    /// Open the agents picker modal (default: Ctrl+A) — chat-dominant layout.
+    pub open_agents_modal: Vec<KeyBinding>,
+    /// Open the HITL queue modal (default: Ctrl+H) — chat-dominant layout.
+    /// Distinct from the inline HITL approval modal triggered by a pending
+    /// request on the active session.
+    pub open_hitl_modal: Vec<KeyBinding>,
+    /// Open the evolve status modal (default: Ctrl+E) — chat-dominant layout.
+    pub open_evolve_modal: Vec<KeyBinding>,
 }
 
 impl TuiKeybindings {
@@ -126,6 +134,18 @@ impl TuiKeybindings {
             // Ctrl+P — no conflict with existing bindings.
             open_session_picker: vec![KeyBinding::with_mods(
                 KeyCode::Char('p'),
+                KeyModifiers::CONTROL,
+            )],
+            open_agents_modal: vec![KeyBinding::with_mods(
+                KeyCode::Char('a'),
+                KeyModifiers::CONTROL,
+            )],
+            open_hitl_modal: vec![KeyBinding::with_mods(
+                KeyCode::Char('h'),
+                KeyModifiers::CONTROL,
+            )],
+            open_evolve_modal: vec![KeyBinding::with_mods(
+                KeyCode::Char('e'),
                 KeyModifiers::CONTROL,
             )],
         }
@@ -191,6 +211,9 @@ mod tests {
         assert!(!kb.toggle_composer_focus.is_empty());
         assert!(!kb.submit_message.is_empty());
         assert!(!kb.open_session_picker.is_empty());
+        assert!(!kb.open_agents_modal.is_empty());
+        assert!(!kb.open_hitl_modal.is_empty());
+        assert!(!kb.open_evolve_modal.is_empty());
     }
 
     #[test]

--- a/rust/crates/sera-tui/src/main.rs
+++ b/rust/crates/sera-tui/src/main.rs
@@ -1,10 +1,13 @@
 //! SERA TUI — operator terminal UI built with ratatui + crossterm.
 //!
-//! Four panes rotate under Tab / Shift-Tab:
-//! * **Agents** — list of agent instances (GET /api/agents)
-//! * **Session** — metadata + streaming transcript (SSE where available)
-//! * **HITL** — pending permission requests, approve/reject/escalate
-//! * **Evolve** — read-only view over evolve proposals
+//! **J.0.1 chat-dominant layout**: the main canvas is a full-screen Session
+//! view (metadata + transcript + tool log), with a composer pinned at the
+//! bottom and a one-line status/hint footer.  Agents, HITL queue, and
+//! evolve status are accessed as modal overlays:
+//! * **Ctrl+A** — agents modal (select / switch agent)
+//! * **Ctrl+H** — HITL queue modal (approve/reject/escalate)
+//! * **Ctrl+E** — evolve status modal (read-only)
+//! * **Ctrl+P** — session picker modal (resume existing session)
 //!
 //! All keybindings are configurable via [`keybindings::TuiKeybindings`].
 //! No hardcoded key-code checks in dispatch code (project CLAUDE.md rule).
@@ -37,9 +40,8 @@ mod views;
 use app::{App, Runtime};
 use client::GatewayClient;
 use config::Config;
-use app::actions::ViewKind;
-use input::{translate, translate_session};
-use keybindings::TuiKeybindings;
+use input::translate_session;
+use keybindings::{matches_key, TuiKeybindings};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -126,15 +128,20 @@ async fn run<B: ratatui::backend::Backend + io::Write>(
         // have a chance to run each tick.
         if event::poll(tick)? {
             match event::read()? {
-                Event::Paste(content) if app.focus == ViewKind::Session => {
+                // Pastes go to the composer — the composer is always the
+                // input sink in the chat-dominant layout, as long as no
+                // modal is on top.
+                Event::Paste(content)
+                    if !app.show_session_picker
+                        && !app.any_j01_modal_open()
+                        && app.show_hitl_modal.is_none() =>
+                {
                     app.dispatch(crate::app::Action::PasteToComposer(content));
                 }
                 Event::Key(key) if key.kind == KeyEventKind::Press => {
-                    // When the session picker modal is open it intercepts all keys;
-                    // only Up/Down/Enter/Esc are forwarded — everything else is dropped.
+                    use crossterm::event::KeyCode;
                     let action = if app.show_session_picker {
-                        use crossterm::event::KeyCode;
-                        use keybindings::matches_key;
+                        // Session picker intercept: only navigation/select/esc.
                         if matches_key(&key, &app.keybindings.up) {
                             crate::app::Action::PickerUp
                         } else if matches_key(&key, &app.keybindings.down) {
@@ -148,23 +155,42 @@ async fn run<B: ratatui::backend::Backend + io::Write>(
                         } else {
                             crate::app::Action::NoOp
                         }
-                    } else {
-                        let a = if app.focus == ViewKind::Session {
-                            translate_session(&key, &app.keybindings, app.session.composer_focused())
-                        } else {
-                            translate(&key, &app.keybindings)
-                        };
-                        // When Enter is pressed in the Agents pane, resolve the selected
-                        // agent ID here and dispatch SelectAgent so the action carries an
-                        // explicit ID (spec G.0.3).
-                        if a == crate::app::Action::Select
-                            && app.focus == ViewKind::Agents
-                            && let Some(id) = app.agents.selected_id()
+                    } else if app.any_j01_modal_open() {
+                        // J.0.1 modal intercept: translate plain key bindings
+                        // (up/down/select/approve/reject/escalate/quit/esc).
+                        // The composer does NOT receive keystrokes while a
+                        // modal is open.
+                        if matches_key(&key, &app.keybindings.quit) {
+                            crate::app::Action::Quit
+                        } else if matches_key(&key, &app.keybindings.back)
+                            || key.code == KeyCode::Esc
                         {
-                            crate::app::Action::SelectAgent(id)
+                            crate::app::Action::CloseModal
+                        } else if matches_key(&key, &app.keybindings.up) {
+                            crate::app::Action::Up
+                        } else if matches_key(&key, &app.keybindings.down) {
+                            crate::app::Action::Down
+                        } else if matches_key(&key, &app.keybindings.select) {
+                            crate::app::Action::Select
+                        } else if matches_key(&key, &app.keybindings.approve) {
+                            crate::app::Action::Approve
+                        } else if matches_key(&key, &app.keybindings.reject) {
+                            crate::app::Action::Reject
+                        } else if matches_key(&key, &app.keybindings.escalate) {
+                            crate::app::Action::Escalate
+                        } else if matches_key(&key, &app.keybindings.refresh) {
+                            crate::app::Action::Refresh
                         } else {
-                            a
+                            crate::app::Action::NoOp
                         }
+                    } else {
+                        // Chat-dominant default — Session canvas is always
+                        // the background, composer may or may not have focus.
+                        translate_session(
+                            &key,
+                            &app.keybindings,
+                            app.session.composer_focused(),
+                        )
                     };
                     app.dispatch(action);
                 }

--- a/rust/crates/sera-tui/src/ui.rs
+++ b/rust/crates/sera-tui/src/ui.rs
@@ -1,7 +1,20 @@
-//! Central render entry point.
+//! Central render entry point — **chat-dominant** layout (J.0.1).
 //!
-//! Owns only the top-level layout (title bar, body, footer) — each pane
-//! delegates to its view module.
+//! The screen is one big transcript canvas with a composer pinned at the
+//! bottom and a single-line status/hint footer.  Agents, HITL queue, and
+//! evolve status are accessed as modal overlays via Ctrl+A/H/E.
+//!
+//! Layout:
+//! ```text
+//! ┌──────────────────────────────────────────────┐
+//! │ main (Min(3))         — Session chat canvas  │
+//! ├──────────────────────────────────────────────┤
+//! │ composer (Length(5))  — multi-line input     │
+//! ├──────────────────────────────────────────────┤
+//! │ status (Length(1))    — agent/session/conn   │
+//! │ hint   (Length(1))    — contextual keys      │
+//! └──────────────────────────────────────────────┘
+//! ```
 
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
@@ -9,8 +22,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, Paragraph};
 use ratatui::Frame;
 
-use crate::app::{actions::ViewKind, App, StatusLevel};
-use crate::client::ConnectionState;
+use crate::app::{App, StatusLevel};
 use crate::views::hitl_modal::render_hitl_modal;
 use crate::views::status_bar::StatusBar;
 
@@ -19,29 +31,18 @@ pub fn render(frame: &mut Frame, app: &mut App) {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(3),
-            Constraint::Min(0),
-            Constraint::Length(2),
-            Constraint::Length(1),
+            Constraint::Min(3),    // main chat canvas
+            Constraint::Length(5), // composer
+            Constraint::Length(1), // status bar
+            Constraint::Length(1), // key hint
         ])
         .split(frame.area());
 
-    render_title(frame, chunks[0], app);
+    // Main canvas: Session chat (metadata + transcript + tool log).
+    app.session.render_chat(frame, chunks[0], true);
 
-    // Body is the focused view rendered full-area.
-    match app.focus {
-        ViewKind::Agents => app.agents.render(frame, chunks[1], true),
-        ViewKind::Session => app.session.render(frame, chunks[1], true),
-        ViewKind::Hitl => app.hitl.render(frame, chunks[1], true),
-        ViewKind::Evolve => app.evolve.render(frame, chunks[1], true),
-    }
-
-    render_footer(frame, chunks[2], app);
-
-    // Help modal — rendered on top of everything when /help is active.
-    if app.show_help {
-        render_help_modal(frame, chunks[1]);
-    }
+    // Composer — always visible, regardless of modal state.
+    app.session.render_composer_only(frame, chunks[1]);
 
     // Status bar: agent name + session short-id + connection state.
     let agent = app.active_agent_id.as_deref();
@@ -51,71 +52,94 @@ pub fn render(frame: &mut Frame, app: &mut App) {
         session_id,
         conn: app.connection,
     }
-    .render(frame, chunks[3]);
+    .render(frame, chunks[2]);
 
-    // Session picker modal — rendered last so it overlays everything.
+    // Key hint footer — context-sensitive.
+    render_hint(frame, chunks[3], app);
+
+    // Modal overlays — rendered on top of everything, topmost last.
+    if app.show_agents_modal {
+        render_agents_modal(frame, app);
+    }
+    if app.show_hitl_queue_modal {
+        render_hitl_queue_modal(frame, app);
+    }
+    if app.show_evolve_modal {
+        render_evolve_modal(frame, app);
+    }
+
+    // Session picker modal (Ctrl+P) — pre-existing modal.
     if app.show_session_picker {
         app.session_picker.render(frame, frame.area());
     }
 
-    // Inline HITL modal — rendered on top of all panes (including picker).
+    // Help modal — rendered when /help is active.
+    if app.show_help {
+        render_help_modal(frame, frame.area());
+    }
+
+    // Inline HITL approval modal — highest priority overlay.
     if let Some(req) = &app.show_hitl_modal {
         render_hitl_modal(frame, req, &app.keybindings);
     }
 }
 
-fn render_title(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
-    let tabs = [
-        ViewKind::Agents,
-        ViewKind::Session,
-        ViewKind::Hitl,
-        ViewKind::Evolve,
-    ];
-    let mut spans: Vec<Span<'_>> = Vec::with_capacity(tabs.len() * 2 + 4);
-    spans.push(Span::styled(
-        " SERA ",
-        Style::default()
-            .fg(Color::Cyan)
-            .add_modifier(Modifier::BOLD),
-    ));
-    spans.push(Span::raw("│ "));
-    for (i, v) in tabs.iter().enumerate() {
-        let focused = *v == app.focus;
-        let style = if focused {
-            Style::default()
-                .fg(Color::Black)
-                .bg(Color::Cyan)
-                .add_modifier(Modifier::BOLD)
-        } else {
-            Style::default().fg(Color::DarkGray)
-        };
-        spans.push(Span::styled(format!(" {} ", v.label()), style));
-        if i + 1 < tabs.len() {
-            spans.push(Span::raw(" "));
-        }
-    }
-    spans.push(Span::raw("  "));
-    spans.push(conn_badge(app.connection));
-
-    let title = Paragraph::new(Line::from(spans))
-        .block(Block::default().borders(Borders::BOTTOM));
-    frame.render_widget(title, area);
+fn render_hint(frame: &mut Frame, area: Rect, app: &App) {
+    let hint = app.footer_hint();
+    let status_style = match app.status.level {
+        StatusLevel::Info => Style::default().fg(Color::DarkGray),
+        StatusLevel::Warn => Style::default().fg(Color::Yellow),
+        StatusLevel::Error => Style::default().fg(Color::Red),
+    };
+    // When there's an active status message, prefer it; otherwise show the hint.
+    let text = if app.status.text.is_empty() || app.status.text == "ready" {
+        hint
+    } else {
+        format!("{}  ·  {}", hint, app.status.text)
+    };
+    let p = Paragraph::new(text).style(status_style);
+    frame.render_widget(p, area);
 }
 
-fn conn_badge(state: ConnectionState) -> Span<'static> {
-    let (label, color) = match state {
-        ConnectionState::Connected => ("● connected", Color::Green),
-        ConnectionState::Reconnecting => ("● reconnecting", Color::Yellow),
-        ConnectionState::Disconnected => ("● disconnected", Color::Red),
-    };
-    Span::styled(
-        label,
-        Style::default().fg(color).add_modifier(Modifier::BOLD),
-    )
+fn render_agents_modal(frame: &mut Frame, app: &mut App) {
+    let area = centered_modal(70, 60, frame.area());
+    frame.render_widget(Clear, area);
+    // Draw a titled border, then hand the inner area to the existing view.
+    let block = Block::default()
+        .title(" Agents — Enter:select  ↑/↓  esc:close ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    app.agents.render(frame, inner, true);
+}
+
+fn render_hitl_queue_modal(frame: &mut Frame, app: &mut App) {
+    let area = centered_modal(75, 60, frame.area());
+    frame.render_widget(Clear, area);
+    let block = Block::default()
+        .title(" HITL Queue — a:approve  x:reject  e:escalate  esc:close ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Yellow));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    app.hitl.render(frame, inner, true);
+}
+
+fn render_evolve_modal(frame: &mut Frame, app: &mut App) {
+    let area = centered_modal(75, 60, frame.area());
+    frame.render_widget(Clear, area);
+    let block = Block::default()
+        .title(" Evolve — ↑/↓  esc:close ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Magenta));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    app.evolve.render(frame, inner, true);
 }
 
 fn render_help_modal(frame: &mut Frame, area: Rect) {
-    let modal_area = centered_rect(50, 10, area);
+    let modal_area = centered_rect(60, 14, area);
     frame.render_widget(Clear, modal_area);
     let text = vec![
         Line::from(""),
@@ -136,18 +160,45 @@ fn render_help_modal(frame: &mut Frame, area: Rect) {
             Span::raw("exit the TUI"),
         ]),
         Line::from(""),
+        Line::from(vec![
+            Span::styled("  Ctrl+A        ", Style::default().fg(Color::Cyan)),
+            Span::raw("agents modal"),
+        ]),
+        Line::from(vec![
+            Span::styled("  Ctrl+H        ", Style::default().fg(Color::Cyan)),
+            Span::raw("HITL queue modal"),
+        ]),
+        Line::from(vec![
+            Span::styled("  Ctrl+E        ", Style::default().fg(Color::Cyan)),
+            Span::raw("evolve modal"),
+        ]),
+        Line::from(vec![
+            Span::styled("  Ctrl+P        ", Style::default().fg(Color::Cyan)),
+            Span::raw("session picker"),
+        ]),
+        Line::from(""),
     ];
-    let modal = Paragraph::new(text).block(
+    let modal = Paragraph::new(text).style(Style::default()).block(
         Block::default()
             .title(" Commands ")
             .borders(Borders::ALL)
-            .border_style(Style::default().fg(Color::Cyan)),
+            .border_style(Style::default().fg(Color::Cyan))
+            .title_style(Style::default().add_modifier(Modifier::BOLD)),
     );
     frame.render_widget(modal, modal_area);
 }
 
-/// Return a [`Rect`] centered in `area` with the given width (columns) and
-/// height (rows).  Both are clamped to the parent dimensions.
+/// Centered rectangle by percentage of the parent area.
+fn centered_modal(percent_x: u16, percent_y: u16, r: Rect) -> Rect {
+    let w = r.width * percent_x / 100;
+    let h = r.height * percent_y / 100;
+    let x = r.x + (r.width.saturating_sub(w)) / 2;
+    let y = r.y + (r.height.saturating_sub(h)) / 2;
+    Rect::new(x, y, w.max(1), h.max(1))
+}
+
+/// Return a [`Rect`] centered in `area` with the given width and height.
+/// Both are clamped to the parent dimensions.
 fn centered_rect(width: u16, height: u16, area: Rect) -> Rect {
     let w = width.min(area.width);
     let h = height.min(area.height);
@@ -156,31 +207,11 @@ fn centered_rect(width: u16, height: u16, area: Rect) -> Rect {
     Rect::new(x, y, w, h)
 }
 
-fn render_footer(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
-    let hint = app.footer_hint();
-    let status_style = match app.status.level {
-        StatusLevel::Info => Style::default().fg(Color::Green),
-        StatusLevel::Warn => Style::default().fg(Color::Yellow),
-        StatusLevel::Error => Style::default().fg(Color::Red),
-    };
-
-    // Split footer into hint (top line) and status (bottom line).
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([Constraint::Length(1), Constraint::Length(1)])
-        .split(area);
-
-    let hint_p = Paragraph::new(hint).style(Style::default().fg(Color::DarkGray));
-    frame.render_widget(hint_p, chunks[0]);
-    let status_p = Paragraph::new(app.status.text.clone()).style(status_style);
-    frame.render_widget(status_p, chunks[1]);
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::app::App;
-    use crate::client::{ConnectionState, GatewayClient};
+    use crate::client::GatewayClient;
     use crate::keybindings::TuiKeybindings;
     use ratatui::backend::TestBackend;
     use ratatui::Terminal;
@@ -195,7 +226,7 @@ mod tests {
     }
 
     #[test]
-    fn render_agents_view_produces_output() {
+    fn render_chat_canvas_produces_output() {
         let mut app = App::new(client(), TuiKeybindings::defaults());
         let backend = TestBackend::new(80, 20);
         let mut term = Terminal::new(backend).unwrap();
@@ -207,22 +238,24 @@ mod tests {
             .map(|c| c.symbol())
             .collect::<Vec<_>>()
             .join("");
-        assert!(rendered.contains("SERA"));
-        assert!(rendered.contains("Agents"));
+        // Chat-dominant canvas shows the Session header text.
+        assert!(rendered.contains("No session selected"));
     }
 
     #[test]
-    fn connection_badge_labels_all_states() {
-        for (state, expect) in [
-            (ConnectionState::Connected, "connected"),
-            (ConnectionState::Reconnecting, "reconnecting"),
-            (ConnectionState::Disconnected, "disconnected"),
-        ] {
-            let span = conn_badge(state);
-            assert!(
-                span.content.contains(expect),
-                "badge for {state:?} did not mention {expect}"
-            );
-        }
+    fn render_with_agents_modal_shows_agents_title() {
+        let mut app = App::new(client(), TuiKeybindings::defaults());
+        app.show_agents_modal = true;
+        let backend = TestBackend::new(80, 20);
+        let mut term = Terminal::new(backend).unwrap();
+        term.draw(|f| render(f, &mut app)).unwrap();
+        let buf = term.backend().buffer().clone();
+        let rendered: String = buf
+            .content()
+            .iter()
+            .map(|c| c.symbol())
+            .collect::<Vec<_>>()
+            .join("");
+        assert!(rendered.contains("Agents"), "agents modal title not rendered");
     }
 }

--- a/rust/crates/sera-tui/src/views/session.rs
+++ b/rust/crates/sera-tui/src/views/session.rs
@@ -217,21 +217,30 @@ impl SessionView {
         }
     }
 
-    pub fn render(&self, frame: &mut Frame, area: Rect, focused: bool) {
+    /// **J.0.1**: render the chat canvas (metadata + transcript + tool log)
+    /// without the composer.  The chat-dominant layout draws the composer
+    /// in a dedicated strip of the root layout, so the Session view must
+    /// skip it to avoid double rendering.
+    pub fn render_chat(&self, frame: &mut Frame, area: Rect, focused: bool) {
         let chunks = Layout::default()
             .direction(Direction::Vertical)
             .constraints([
                 Constraint::Length(3), // metadata header
                 Constraint::Min(3),    // transcript
                 Constraint::Length(7), // tool log
-                Constraint::Length(5), // composer
             ])
             .split(area);
 
         self.render_metadata(frame, chunks[0], focused);
         self.render_transcript(frame, chunks[1], focused);
         self.render_tool_log(frame, chunks[2], focused);
-        self.render_composer(frame, chunks[3]);
+    }
+
+    /// **J.0.1**: render only the composer into `area`.  Paired with
+    /// [`render_chat`] for the chat-dominant layout where composer has
+    /// its own slot in the root layout.
+    pub fn render_composer_only(&self, frame: &mut Frame, area: Rect) {
+        self.render_composer(frame, area);
     }
 
     fn render_metadata(&self, frame: &mut Frame, area: Rect, focused: bool) {


### PR DESCRIPTION
Closes J.0.1 under Wave J umbrella (sera-dux5).

## Summary
Retires 4-pane rotation. Session becomes the full-screen canvas; AgentList, HitlQueue, EvolveStatus become modal overlays (Ctrl+A/H/E). Composer is part of the root layout, not nested in Session.

## Test plan
- [x] cargo test -p sera-tui passes (113)
- [x] cargo clippy -p sera-tui --all-targets -- -D warnings clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)