### PR TITLE
test(sera-e2e-harness): Phase 2 — S2.1 config, S4.3 KillSwitch, S4.4 Constitutional gate

### DIFF
--- a/rust/crates/sera-e2e-harness/src/lib.rs
+++ b/rust/crates/sera-e2e-harness/src/lib.rs
@@ -166,6 +166,22 @@ impl InProcessGateway {
         runtime_bin: &Path,
         llm_base_url: &str,
     ) -> Result<Self> {
+        Self::start_local_with_env(gateway_bin, runtime_bin, llm_base_url, &[]).await
+    }
+
+    /// Boot a gateway with the same defaults as [`Self::start_local`] but
+    /// with extra environment variables applied after the harness defaults.
+    ///
+    /// Use this for scenarios that need to override a default (e.g. set
+    /// `SERA_ADMIN_SOCK` to a tempdir-scoped path for the kill-switch
+    /// scenario, or unset `SERA_ALLOW_MISSING_CONSTITUTIONAL_GATE` by
+    /// passing `("SERA_ALLOW_MISSING_CONSTITUTIONAL_GATE", "0")`).
+    pub async fn start_local_with_env(
+        gateway_bin: &Path,
+        runtime_bin: &Path,
+        llm_base_url: &str,
+        extra_env: &[(&str, &str)],
+    ) -> Result<Self> {
         let model = resolve_model_env();
         let root = GatewayRoot::new_local(llm_base_url, &model)?;
         let (child, base_url) = spawn_gateway(
@@ -174,6 +190,7 @@ impl InProcessGateway {
             gateway_bin,
             runtime_bin,
             llm_base_url,
+            extra_env,
         )
         .await?;
         let gateway = Self {
@@ -205,6 +222,7 @@ impl InProcessGateway {
             gateway_bin,
             runtime_bin,
             llm_base_url,
+            &[],
         )
         .await?;
         let gateway = Self {
@@ -288,12 +306,18 @@ impl InProcessGateway {
 /// Spawn `sera-gateway start --config X --port P` rooted in `root_dir`, drain
 /// stdio into tracing, and return the child handle + picked port's base URL.
 /// Does not poll for health — caller is expected to call `wait_for_health`.
+///
+/// `extra_env` entries are applied after the harness defaults, so a scenario
+/// can override any default (e.g. set `SERA_ALLOW_MISSING_CONSTITUTIONAL_GATE`
+/// to `"0"` for the constitutional-gate scenario, or set `SERA_ADMIN_SOCK` to
+/// a tempdir path for the kill-switch scenario).
 async fn spawn_gateway(
     root_dir: &Path,
     config_path: &Path,
     gateway_bin: &Path,
     runtime_bin: &Path,
     llm_base_url: &str,
+    extra_env: &[(&str, &str)],
 ) -> Result<(Child, String)> {
     let port = pick_free_port()?;
     let addr = format!("127.0.0.1:{port}");
@@ -329,6 +353,10 @@ async fn spawn_gateway(
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
         .kill_on_drop(true);
+
+    for (k, v) in extra_env {
+        cmd.env(k, v);
+    }
 
     let mut child = cmd
         .spawn()

--- a/rust/crates/sera-e2e-harness/src/lib.rs
+++ b/rust/crates/sera-e2e-harness/src/lib.rs
@@ -113,12 +113,22 @@ impl GatewayRoot {
     /// `model` field.  Use [`resolve_model_env`] to pick `model` when the
     /// caller doesn't have a specific value in mind.
     pub fn new_local(llm_base_url: &str, model: &str) -> Result<Self> {
+        Self::new_with_manifest(&minimal_sera_yaml(llm_base_url, model))
+    }
+
+    /// Create a fresh tempdir containing a caller-supplied `sera.yaml` body.
+    ///
+    /// Use this when a scenario needs a specific manifest shape — e.g. two
+    /// agents for the multi-agent load test, or an agent with a `policyRef`
+    /// for the capability-policy scenarios.  [`minimal_sera_yaml`] and
+    /// [`multi_agent_sera_yaml`] are the convenience renderers.
+    pub fn new_with_manifest(manifest: &str) -> Result<Self> {
         let tempdir = tempfile::Builder::new()
             .prefix("sera-e2e-")
             .tempdir()
             .context("creating tempdir for GatewayRoot")?;
         let config_path = tempdir.path().join("sera.yaml");
-        std::fs::write(&config_path, minimal_sera_yaml(llm_base_url, model))
+        std::fs::write(&config_path, manifest)
             .context("writing sera.yaml into tempdir")?;
         let db_path = tempdir.path().join("sera.db");
         Ok(Self { dir: tempdir, config_path, db_path })
@@ -424,6 +434,49 @@ spec:
       You are a SERA e2e test persona. Reply briefly.
 "#
     )
+}
+
+/// Multi-agent manifest — one Instance, one Provider, N Agents named by the
+/// caller.  Each agent shares the same provider + model; persona anchors
+/// differ so the manifest-loader's agent-ordering and list endpoint can be
+/// asserted on distinct payloads.
+///
+/// Use this for S2.x manifest scenarios that need more than one agent.
+pub fn multi_agent_sera_yaml(llm_base_url: &str, model: &str, agent_names: &[&str]) -> String {
+    let mut out = format!(
+        r#"apiVersion: sera.dev/v1
+kind: Instance
+metadata:
+  name: sera-e2e
+spec: {{}}
+---
+apiVersion: sera.dev/v1
+kind: Provider
+metadata:
+  name: mock-openai
+spec:
+  kind: openai-compatible
+  base_url: "{llm_base_url}"
+  default_model: {model}
+"#
+    );
+    for name in agent_names {
+        out.push_str(&format!(
+            r#"---
+apiVersion: sera.dev/v1
+kind: Agent
+metadata:
+  name: {name}
+spec:
+  provider: mock-openai
+  model: {model}
+  persona:
+    immutable_anchor: |
+      You are {name}, a SERA e2e test persona. Reply briefly.
+"#
+        ));
+    }
+    out
 }
 
 #[cfg(test)]

--- a/rust/crates/sera-e2e-harness/tests/scenarios_s2_config.rs
+++ b/rust/crates/sera-e2e-harness/tests/scenarios_s2_config.rs
@@ -1,0 +1,97 @@
+//! S2 — Config & manifest scenarios (Phase 2 of the TEST-SCENARIOS plan).
+//!
+//! Covers the gateway's manifest-loading surface — operators author a
+//! `sera.yaml` on disk; the gateway reads, validates, and exposes its view
+//! via `/api/agents`.  If this surface regresses every downstream feature
+//! depends on undefined behaviour, so a minimal load+list scenario is the
+//! cheapest regression guard.
+//!
+//! Covered:
+//! * S2.1 — a manifest declaring two agents produces a `/api/agents`
+//!   response listing both by name.  Follow-ups (hot-reload, secret
+//!   resolution, policy_ref binding) are filed separately so this file
+//!   stays focused on the happy path.
+
+#![cfg(feature = "integration")]
+
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+
+use sera_e2e_harness::binaries::{gateway_bin, runtime_bin};
+use sera_e2e_harness::mock_llm::start_mock_llm;
+use sera_e2e_harness::{multi_agent_sera_yaml, resolve_model_env, GatewayRoot, InProcessGateway};
+
+fn init_tracing() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_env("SERA_E2E_LOG")
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn")),
+        )
+        .with_test_writer()
+        .try_init();
+}
+
+fn bins_or_skip() -> Option<(std::path::PathBuf, std::path::PathBuf)> {
+    Some((gateway_bin()?, runtime_bin()?))
+}
+
+/// S2.1 — A two-agent manifest loads and `GET /api/agents` lists both by
+/// name.  Guards against regressions in the manifest loader's multi-document
+/// YAML parsing and the gateway's `agents_handler` response shape.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn s2_1_multi_agent_manifest_loads_and_lists() -> Result<()> {
+    init_tracing();
+
+    let (gw_bin, rt_bin) = match bins_or_skip() {
+        Some(b) => b,
+        None => {
+            eprintln!("[S2.1] SKIP: gateway/runtime bins not built");
+            return Ok(());
+        }
+    };
+    let (llm, _mock) = match start_mock_llm().await {
+        Ok(u) => u,
+        Err(e) => {
+            eprintln!("[S2.1] SKIP: wiremock unavailable ({e})");
+            return Ok(());
+        }
+    };
+
+    let model = resolve_model_env();
+    let manifest = multi_agent_sera_yaml(&llm, &model, &["sera", "helper"]);
+    let root = GatewayRoot::new_with_manifest(&manifest).context("building multi-agent root")?;
+
+    let gw = InProcessGateway::start_with_root(&root, &gw_bin, &rt_bin, &llm)
+        .await
+        .context("booting gateway for S2.1")?;
+
+    let http = reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()?;
+
+    let agents: serde_json::Value = http
+        .get(format!("{}/api/agents", gw.base_url))
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    let arr = agents.as_array().context("agents must be a JSON array")?;
+    assert_eq!(arr.len(), 2, "expected exactly two agents, got {arr:?}");
+
+    // Collect names into a set — the gateway is free to order the list.
+    let names: std::collections::HashSet<&str> = arr
+        .iter()
+        .filter_map(|a| a.get("name").and_then(|v| v.as_str()))
+        .collect();
+    assert!(
+        names.contains("sera") && names.contains("helper"),
+        "expected agents `sera` and `helper`, got {names:?}"
+    );
+
+    if let Err(e) = gw.shutdown().await {
+        eprintln!("gateway shutdown returned: {e}");
+    }
+    Ok(())
+}

--- a/rust/crates/sera-e2e-harness/tests/scenarios_s4_policy.rs
+++ b/rust/crates/sera-e2e-harness/tests/scenarios_s4_policy.rs
@@ -1,0 +1,171 @@
+//! S4 — Security / policy scenarios (Phase 2 of the TEST-SCENARIOS plan).
+//!
+//! These tests prove the gateway's enforcement surfaces do what the spec
+//! says.  Phase 2 opens with S4.3 KillSwitch: the rest of S4 (CapabilityPolicy
+//! deny, SSRF at integration level, Constitutional gate) is tracked separately
+//! because it requires more fixture setup (policy files, tool-call-emitting
+//! mock LLM).
+//!
+//! Covered in this file:
+//! * S4.3 — arming the KillSwitch via `ROLLBACK` on the admin socket makes
+//!   all non-health HTTP requests return 503, while `/api/health` continues
+//!   to respond.  This is the first-line operator panic button — if it
+//!   regresses, no amount of in-flight cancellation machinery matters.
+
+#![cfg(all(unix, feature = "integration"))]
+
+use std::io::{Read, Write};
+use std::os::unix::net::UnixStream;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+
+use sera_e2e_harness::binaries::{gateway_bin, runtime_bin};
+use sera_e2e_harness::mock_llm::start_mock_llm;
+use sera_e2e_harness::InProcessGateway;
+
+fn init_tracing() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_env("SERA_E2E_LOG")
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn")),
+        )
+        .with_test_writer()
+        .try_init();
+}
+
+fn bins_or_skip() -> Option<(std::path::PathBuf, std::path::PathBuf)> {
+    Some((gateway_bin()?, runtime_bin()?))
+}
+
+/// S4.3 — The KillSwitch admin-socket gate blocks subsequent non-health
+/// requests after a `ROLLBACK` command.  Baseline request succeeds, rollback
+/// is sent, next request returns 503, but `/api/health` still answers.
+///
+/// This exercises `kill_switch_gate` middleware + `spawn_admin_socket` +
+/// `handle_command("ROLLBACK")` end-to-end through the real gateway binary.
+/// The existing `killswitch_abort.rs` test covers the in-flight cancellation
+/// path at unit scope; this scenario is the HTTP-surface counterpart.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn s4_3_killswitch_rollback_blocks_new_requests() -> Result<()> {
+    init_tracing();
+
+    let (gw_bin, rt_bin) = match bins_or_skip() {
+        Some(b) => b,
+        None => {
+            eprintln!("[S4.3] SKIP: gateway/runtime bins not built");
+            return Ok(());
+        }
+    };
+    let (llm, _mock) = match start_mock_llm().await {
+        Ok(u) => u,
+        Err(e) => {
+            eprintln!("[S4.3] SKIP: wiremock unavailable ({e})");
+            return Ok(());
+        }
+    };
+
+    // Per-test admin socket path — must be unique so concurrent test runs
+    // don't collide on `/tmp/sera-admin.sock`.  `tempfile::tempdir()` is
+    // enough: the dir's drop removes the socket file after the test.
+    let sock_dir = tempfile::tempdir().context("creating sock tempdir")?;
+    let sock_path = sock_dir.path().join("admin.sock");
+    let sock_str = sock_path
+        .to_str()
+        .context("tempdir path is not UTF-8")?
+        .to_owned();
+
+    let gw = InProcessGateway::start_local_with_env(
+        &gw_bin,
+        &rt_bin,
+        &llm,
+        &[("SERA_ADMIN_SOCK", sock_str.as_str())],
+    )
+    .await
+    .context("booting gateway for S4.3")?;
+
+    let http = reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()?;
+
+    // ── Baseline: /api/agents must work before the rollback ──
+    let before = http
+        .get(format!("{}/api/agents", gw.base_url))
+        .send()
+        .await?;
+    assert!(
+        before.status().is_success(),
+        "baseline /api/agents must be 2xx; got {}",
+        before.status()
+    );
+
+    // ── Fire ROLLBACK over the admin socket ──
+    //
+    // The socket binds in a background task inside the gateway child process.
+    // It is created during boot but may race with the first health probe; we
+    // retry the connect a few times so a slow CI runner doesn't flake.
+    let mut connected = None;
+    for _ in 0..30 {
+        match UnixStream::connect(&sock_path) {
+            Ok(s) => {
+                connected = Some(s);
+                break;
+            }
+            Err(_) => tokio::time::sleep(Duration::from_millis(100)).await,
+        }
+    }
+    let mut sock =
+        connected.context("admin socket did not come up within 3s of gateway boot")?;
+    sock.write_all(b"ROLLBACK\n").context("writing ROLLBACK")?;
+    sock.set_read_timeout(Some(Duration::from_secs(2))).ok();
+    let mut resp = String::new();
+    sock.read_to_string(&mut resp).context("reading admin socket response")?;
+    assert!(
+        resp.contains("ARMED") || resp.contains("OK"),
+        "admin socket should acknowledge ROLLBACK; got {resp:?}"
+    );
+
+    // ── After rollback: /api/agents must be 503 ──
+    //
+    // The gateway's rollback handler cancels in-flight turns asynchronously;
+    // the gate flag itself flips synchronously via `KillSwitch::arm()` in
+    // `handle_command("ROLLBACK")`, so the next request should see 503
+    // immediately.  Retry once against eventual consistency.
+    let mut blocked_status: Option<reqwest::StatusCode> = None;
+    for _ in 0..10 {
+        let resp = http
+            .get(format!("{}/api/agents", gw.base_url))
+            .send()
+            .await?;
+        blocked_status = Some(resp.status());
+        if resp.status() == reqwest::StatusCode::SERVICE_UNAVAILABLE {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    assert_eq!(
+        blocked_status,
+        Some(reqwest::StatusCode::SERVICE_UNAVAILABLE),
+        "after ROLLBACK /api/agents must be 503; got {blocked_status:?}"
+    );
+
+    // ── /api/health must still answer ──
+    //
+    // `kill_switch_gate` in the gateway binary excludes health endpoints so
+    // readiness probes / orchestrators can observe the halted state without
+    // getting 503s from every surface.
+    let h = http
+        .get(format!("{}/api/health", gw.base_url))
+        .send()
+        .await?;
+    assert!(
+        h.status().is_success(),
+        "/api/health must remain 2xx after rollback; got {}",
+        h.status()
+    );
+
+    if let Err(e) = gw.shutdown().await {
+        eprintln!("gateway shutdown returned: {e}");
+    }
+    Ok(())
+}

--- a/rust/crates/sera-e2e-harness/tests/scenarios_s4_policy.rs
+++ b/rust/crates/sera-e2e-harness/tests/scenarios_s4_policy.rs
@@ -11,6 +11,9 @@
 //!   all non-health HTTP requests return 503, while `/api/health` continues
 //!   to respond.  This is the first-line operator panic button — if it
 //!   regresses, no amount of in-flight cancellation machinery matters.
+//! * S4.4 — the ConstitutionalGate hook rejects turns when no policy is
+//!   installed AND the permissive `SERA_ALLOW_MISSING_CONSTITUTIONAL_GATE`
+//!   flag is disabled.  Mirrors the fail-closed production posture.
 
 #![cfg(all(unix, feature = "integration"))]
 
@@ -162,6 +165,86 @@ async fn s4_3_killswitch_rollback_blocks_new_requests() -> Result<()> {
         h.status().is_success(),
         "/api/health must remain 2xx after rollback; got {}",
         h.status()
+    );
+
+    if let Err(e) = gw.shutdown().await {
+        eprintln!("gateway shutdown returned: {e}");
+    }
+    Ok(())
+}
+
+/// S4.4 — The ConstitutionalGate rejects turns when no policy is installed
+/// and the permissive `SERA_ALLOW_MISSING_CONSTITUTIONAL_GATE` flag is off.
+///
+/// The production fail-closed posture: an operator who has not provisioned
+/// a constitution cannot run turns.  The harness's other scenarios pass
+/// `SERA_ALLOW_MISSING_CONSTITUTIONAL_GATE=1` to match `sera start --local`'s
+/// permissive dev mode; this scenario disables that flag to prove the gate
+/// still bites.  The runtime returns an interrupted-turn reply whose text
+/// embeds the gate reason — a 200 status with a specific body, not a 5xx.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn s4_4_constitutional_gate_rejects_turn_when_no_policy_installed() -> Result<()> {
+    init_tracing();
+
+    let (gw_bin, rt_bin) = match bins_or_skip() {
+        Some(b) => b,
+        None => {
+            eprintln!("[S4.4] SKIP: gateway/runtime bins not built");
+            return Ok(());
+        }
+    };
+    let (llm, _mock) = match start_mock_llm().await {
+        Ok(u) => u,
+        Err(e) => {
+            eprintln!("[S4.4] SKIP: wiremock unavailable ({e})");
+            return Ok(());
+        }
+    };
+
+    // Override the harness default of "1" with "0".  `spawn_gateway` applies
+    // `extra_env` *after* the default, and `Command::env` is last-writer-wins
+    // per key, so this flips the flag off for just this scenario.
+    let gw = InProcessGateway::start_local_with_env(
+        &gw_bin,
+        &rt_bin,
+        &llm,
+        &[("SERA_ALLOW_MISSING_CONSTITUTIONAL_GATE", "0")],
+    )
+    .await
+    .context("booting gateway for S4.4")?;
+
+    let http = reqwest::Client::builder()
+        .timeout(Duration::from_secs(15))
+        .build()?;
+
+    // POST a chat turn — the LLM mock will return a normal reply, but the
+    // gate should intercept before the runtime ever forwards content back.
+    let resp: serde_json::Value = http
+        .post(format!("{}/api/chat", gw.base_url))
+        .json(&serde_json::json!({
+            "agent": "sera",
+            "message": "S4.4 should be rejected",
+            "stream": false,
+        }))
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+
+    let response_text = resp
+        .get("response")
+        .and_then(|v| v.as_str())
+        .context("response missing `response` field")?;
+
+    // The runtime wraps the gate reason as `[interrupted: <reason>]`.  We
+    // assert on the reason substring rather than the literal bracketed
+    // form so a future reply-formatting change doesn't silently break the
+    // test — the reason string itself is the stable contract (published
+    // as `sera_runtime::turn::MISSING_GATE_REASON`).
+    assert!(
+        response_text.contains("no ConstitutionalGate policy installed"),
+        "turn must be interrupted by the gate; got: {response_text:?}"
     );
 
     if let Err(e) = gw.shutdown().await {

--- a/scripts/verify-scenarios.sh
+++ b/scripts/verify-scenarios.sh
@@ -37,12 +37,13 @@ CARGO_ARGS=(
 case "$FILTER" in
     "")          ;;
     s1)          CARGO_ARGS+=(--test scenarios_s1_bootstrap) ;;
+    s2)          CARGO_ARGS+=(--test scenarios_s2_config) ;;
     s3)          CARGO_ARGS+=(--test scenarios_s3_single_agent) ;;
     s4)          CARGO_ARGS+=(--test scenarios_s4_policy) ;;
     original)    CARGO_ARGS+=(--test local_profile_turn) ;;
     *)
         echo "unknown filter: $FILTER" >&2
-        echo "known: s1 | s3 | s4 | original | <empty for all>" >&2
+        echo "known: s1 | s2 | s3 | s4 | original | <empty for all>" >&2
         exit 2
         ;;
 esac

--- a/scripts/verify-scenarios.sh
+++ b/scripts/verify-scenarios.sh
@@ -38,10 +38,11 @@ case "$FILTER" in
     "")          ;;
     s1)          CARGO_ARGS+=(--test scenarios_s1_bootstrap) ;;
     s3)          CARGO_ARGS+=(--test scenarios_s3_single_agent) ;;
+    s4)          CARGO_ARGS+=(--test scenarios_s4_policy) ;;
     original)    CARGO_ARGS+=(--test local_profile_turn) ;;
     *)
         echo "unknown filter: $FILTER" >&2
-        echo "known: s1 | s3 | original | <empty for all>" >&2
+        echo "known: s1 | s3 | s4 | original | <empty for all>" >&2
         exit 2
         ;;
 esac


### PR DESCRIPTION
## Summary

Phase 2 test scenarios — three new integration tests plus harness extensions.

### Scenarios added

- **S2.1** — A two-agent manifest loads and `GET /api/agents` returns both
- **S4.3** — `ROLLBACK` over the admin socket makes non-health requests 503 while `/api/health` keeps answering
- **S4.4** — With `SERA_ALLOW_MISSING_CONSTITUTIONAL_GATE=0`, the gate intercepts turns (fail-closed posture)

### Harness changes

- `InProcessGateway::start_local_with_env(gw, rt, llm, extra_env)` — thread extra env through the spawn; `start_local` becomes a zero-extra-env delegate
- `GatewayRoot::new_with_manifest(yaml)` — caller-supplied manifest body for scenarios that need more than the default single agent
- `multi_agent_sera_yaml(llm, model, &["a", "b"])` — renderer for N-agent manifests

### Test runner

- `./scripts/verify-scenarios.sh s2` / `s4` — narrow to one group

### Scope-honest exclusions

- **S4.1 CapabilityPolicy deny** — needs a stateful mock (tool_call then content) + YAML policy fixture. Filed separately (see bd).
- **S4.2 SSRF integration** — needs a tool that makes outbound HTTP. Pending.
- **S5.x HITL** — needs ticket-triggering infrastructure. Pending.

## Test plan

- [x] `./scripts/verify-scenarios.sh` — **9/9 green locally** (1 local_profile_turn + 2 S1 + 1 S2 + 3 S3 + 2 S4)
- [x] `cargo clippy -p sera-e2e-harness --features integration --tests -- -D warnings` clean
- [x] All existing scenarios untouched except via additive harness changes

Tracks sera-9tim Phase 2.