### PR TITLE
fix(sera-tools): close hostname-based SSRF via DNS-time validation + IP pinning

### DIFF
--- a/rust/crates/sera-runtime/src/tools/http_request.rs
+++ b/rust/crates/sera-runtime/src/tools/http_request.rs
@@ -95,46 +95,49 @@ impl Tool for HttpRequest {
             .ok_or_else(|| ToolError::InvalidInput("Missing 'url'".to_string()))?;
         let method = args["method"].as_str().unwrap_or("GET").to_uppercase();
 
-        // SSRF guard (sera-udjf) — parse the URL, extract the host, and
-        // validate IP literals against the blocklist.  `SsrfValidator`
-        // returns `NotAllowed` for hostnames; we swallow that variant and
-        // let the request proceed (full DNS-resolved SSRF protection is a
-        // follow-up).  Every other variant (Loopback, LinkLocal, PrivateRange,
-        // CloudMetadata, ParseError) is fatal.
+        // SSRF guard (sera-udjf) — parse the URL, resolve the host via
+        // `tokio::net::lookup_host` (returns IP literals verbatim, system
+        // resolver for hostnames), validate every resolved IP, and pin the
+        // DNS answer in reqwest to mitigate DNS rebinding.
         let parsed = reqwest::Url::parse(url)
             .map_err(|e| ToolError::InvalidInput(format!("invalid URL: {e}")))?;
-        if let Some(host) = parsed.host_str() {
-            match SsrfValidator::validate(host) {
-                Ok(()) => {}
-                Err(sera_tools::ssrf::SsrfError::NotAllowed { .. }) => {
-                    // Hostname — allowed for now; DNS-time re-validation is pending.
-                }
-                Err(e) => {
-                    return Err(ToolError::ExecutionFailed(format!(
-                        "ssrf: refusing to fetch {host}: {e}"
-                    )));
-                }
-            }
-        }
+        let host = parsed
+            .host_str()
+            .ok_or_else(|| ToolError::InvalidInput(format!("URL has no host: {url}")))?
+            .to_owned();
+        let port = parsed.port_or_known_default().unwrap_or(80);
+        let pinned_addrs = SsrfValidator::resolve_and_validate(&host, port)
+            .await
+            .map_err(|e| {
+                ToolError::ExecutionFailed(format!("ssrf: refusing to fetch {host}: {e}"))
+            })?;
 
-        // Re-validate every redirect hop — the default reqwest policy
-        // follows up to 10 hops, and a public-hostname URL that 302s to
-        // `http://169.254.169.254/…` would otherwise slip the initial
-        // SSRF check entirely.
+        // Same-host redirects are safe (DNS pinned via resolve_to_addrs).
+        // Cross-host redirects are stricter: IP literals get validated; a
+        // different hostname is blocked outright because we cannot do an
+        // async resolve inside the sync redirect policy closure (and a
+        // fresh DNS lookup would skip the pin).
+        let redirect_host = host.clone();
         let client = reqwest::Client::builder()
-            .redirect(reqwest::redirect::Policy::custom(|attempt| {
-                // Copy the host into an owned String so the borrow of
-                // `attempt` ends before we move it into follow()/error().
-                let host = attempt.url().host_str().map(str::to_owned);
-                match host {
-                    Some(h) => match SsrfValidator::validate(&h) {
-                        Ok(()) | Err(sera_tools::ssrf::SsrfError::NotAllowed { .. }) => {
-                            attempt.follow()
+            .resolve_to_addrs(&host, &pinned_addrs)
+            .redirect(reqwest::redirect::Policy::custom(move |attempt| {
+                let target = attempt.url().host_str().map(str::to_owned);
+                match target.as_deref() {
+                    Some(t) if t == redirect_host => attempt.follow(),
+                    Some(t) => {
+                        if t.parse::<std::net::IpAddr>().is_ok() {
+                            match SsrfValidator::validate(t) {
+                                Ok(()) => attempt.follow(),
+                                Err(e) => attempt.error(std::io::Error::other(format!(
+                                    "ssrf: redirect blocked to {t}: {e}"
+                                ))),
+                            }
+                        } else {
+                            attempt.error(std::io::Error::other(format!(
+                                "ssrf: cross-host hostname redirect blocked: {t}"
+                            )))
                         }
-                        Err(e) => attempt.error(std::io::Error::other(format!(
-                            "ssrf: redirect blocked to {h}: {e}"
-                        ))),
-                    },
+                    }
                     None => attempt.follow(),
                 }
             }))
@@ -210,6 +213,31 @@ mod tests {
                 "{url} should be SSRF-rejected, got {result:?}"
             );
         }
+    }
+
+    /// sera-udjf hostname-bypass closure — `http://localhost/` resolves
+    /// (on every Linux distro the test runs on) to 127.0.0.1 / ::1, both
+    /// loopback.  Pre-fix the validator only saw the hostname `localhost`
+    /// and returned `NotAllowed`, which the integration swallowed and let
+    /// through.  Post-fix the DNS resolution runs first, the loopback IP
+    /// is rejected, and the request never leaves the process.
+    ///
+    /// The test does not require any specific resolver configuration —
+    /// `localhost` is reserved by RFC 6761 and every system resolver maps
+    /// it to loopback.
+    #[tokio::test]
+    async fn execute_rejects_hostname_resolving_to_loopback() {
+        let tool = HttpRequest;
+        let input = ToolInput {
+            name: "http-request".to_string(),
+            call_id: "test".to_string(),
+            arguments: json!({ "url": "http://localhost/" }),
+        };
+        let result = tool.execute(input, ToolContext::default()).await;
+        assert!(
+            matches!(result, Err(ToolError::ExecutionFailed(ref msg)) if msg.contains("ssrf:")),
+            "localhost must be rejected via DNS-resolved SSRF guard, got {result:?}"
+        );
     }
 
     /// Malformed URLs surface as `InvalidInput` rather than a network error

--- a/rust/crates/sera-runtime/src/tools/web_fetch.rs
+++ b/rust/crates/sera-runtime/src/tools/web_fetch.rs
@@ -75,37 +75,43 @@ impl Tool for WebFetch {
             .ok_or_else(|| ToolError::InvalidInput("Missing 'url'".to_string()))?;
         let max_length = args["max_length"].as_u64().unwrap_or(50_000) as usize;
 
-        // SSRF guard (sera-udjf) — same policy as http-request: reject IP
-        // literals in blocked ranges; hostname hosts flow through for now.
+        // SSRF guard (sera-udjf) — same policy as http-request: resolve
+        // the host (DNS for hostnames, identity for IP literals), validate
+        // every resolved IP, pin the answer in reqwest.
         let parsed = reqwest::Url::parse(url)
             .map_err(|e| ToolError::InvalidInput(format!("invalid URL: {e}")))?;
-        if let Some(host) = parsed.host_str() {
-            match SsrfValidator::validate(host) {
-                Ok(()) => {}
-                Err(sera_tools::ssrf::SsrfError::NotAllowed { .. }) => {}
-                Err(e) => {
-                    return Err(ToolError::ExecutionFailed(format!(
-                        "ssrf: refusing to fetch {host}: {e}"
-                    )));
-                }
-            }
-        }
+        let host = parsed
+            .host_str()
+            .ok_or_else(|| ToolError::InvalidInput(format!("URL has no host: {url}")))?
+            .to_owned();
+        let port = parsed.port_or_known_default().unwrap_or(80);
+        let pinned_addrs = SsrfValidator::resolve_and_validate(&host, port)
+            .await
+            .map_err(|e| {
+                ToolError::ExecutionFailed(format!("ssrf: refusing to fetch {host}: {e}"))
+            })?;
 
-        // Re-validate every redirect hop — same policy as the sibling
-        // http-request tool.  Public-hostname URLs that 302 to a private
-        // IP must be blocked at the hop, not just at the initial URL.
+        let redirect_host = host.clone();
         let client = reqwest::Client::builder()
-            .redirect(reqwest::redirect::Policy::custom(|attempt| {
-                let host = attempt.url().host_str().map(str::to_owned);
-                match host {
-                    Some(h) => match SsrfValidator::validate(&h) {
-                        Ok(()) | Err(sera_tools::ssrf::SsrfError::NotAllowed { .. }) => {
-                            attempt.follow()
+            .resolve_to_addrs(&host, &pinned_addrs)
+            .redirect(reqwest::redirect::Policy::custom(move |attempt| {
+                let target = attempt.url().host_str().map(str::to_owned);
+                match target.as_deref() {
+                    Some(t) if t == redirect_host => attempt.follow(),
+                    Some(t) => {
+                        if t.parse::<std::net::IpAddr>().is_ok() {
+                            match SsrfValidator::validate(t) {
+                                Ok(()) => attempt.follow(),
+                                Err(e) => attempt.error(std::io::Error::other(format!(
+                                    "ssrf: redirect blocked to {t}: {e}"
+                                ))),
+                            }
+                        } else {
+                            attempt.error(std::io::Error::other(format!(
+                                "ssrf: cross-host hostname redirect blocked: {t}"
+                            )))
                         }
-                        Err(e) => attempt.error(std::io::Error::other(format!(
-                            "ssrf: redirect blocked to {h}: {e}"
-                        ))),
-                    },
+                    }
                     None => attempt.follow(),
                 }
             }))

--- a/rust/crates/sera-tools/src/ssrf.rs
+++ b/rust/crates/sera-tools/src/ssrf.rs
@@ -1,6 +1,6 @@
 //! SSRF protection — blocks requests to loopback, link-local, private, and cloud metadata endpoints.
 
-use std::net::IpAddr;
+use std::net::{IpAddr, SocketAddr};
 
 /// Errors from SSRF validation.
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
@@ -113,6 +113,44 @@ impl SsrfValidator {
                 Ok(())
             }
         }
+    }
+
+    /// Resolve a hostname (or accept an IP literal) and validate every
+    /// resolved address against the SSRF blocklist.  Returns the list of
+    /// safe `SocketAddr`s the caller should pin via
+    /// `reqwest::ClientBuilder::resolve_to_addrs` to mitigate DNS rebinding.
+    ///
+    /// `host` can be a hostname (`example.com`) or an IP literal
+    /// (`10.0.0.1`); both go through `tokio::net::lookup_host`, which
+    /// returns the IP literal verbatim and resolves the hostname via the
+    /// system resolver.  Every returned address is checked — a hostname
+    /// that resolves to a mix of public and private IPs is rejected
+    /// outright, because using the public IP would leave the connect
+    /// path open to reroute on the next resolution.
+    pub async fn resolve_and_validate(
+        host: &str,
+        port: u16,
+    ) -> Result<Vec<SocketAddr>, SsrfError> {
+        let target = format!("{host}:{port}");
+        let addrs: Vec<SocketAddr> = match tokio::net::lookup_host(&target).await {
+            Ok(iter) => iter.collect(),
+            Err(e) => {
+                return Err(SsrfError::ParseError {
+                    reason: format!("DNS lookup for {host} failed: {e}"),
+                });
+            }
+        };
+        if addrs.is_empty() {
+            return Err(SsrfError::ParseError {
+                reason: format!("DNS lookup for {host} returned no addresses"),
+            });
+        }
+        // Validate every resolved IP — a single blocked answer rejects the
+        // whole hostname (don't allow partial-trust resolution).
+        for addr in &addrs {
+            Self::validate(&addr.ip().to_string())?;
+        }
+        Ok(addrs)
     }
 
     /// IPv4-specific rules.  Split out so [`Ipv6Addr::to_ipv4_mapped`] can


### PR DESCRIPTION
## Summary

Closes the deferred MEDIUM finding from PR #1091's security review — hostname inputs to `http-request` / `web-fetch` no longer bypass SSRF validation.

### The gap (concrete attack paths)

Pre-fix, a hostname URL flowed through unchecked. Three live exploitations:

1. **Attacker-controlled DNS** — `internal.evil.com` → A `10.0.0.1`. LLM tool fetches → connects to RFC-1918 inside the operator's network.
2. **Cloud metadata aliases** — `metadata.google.internal` CNAMEs to `169.254.169.254`. LLM-instructed fetch → IMDS credential exfil.
3. **DNS rebinding** — validator sees public IP, kernel resolves freshly on connect → private IP.

### The fix

Three layers:

1. **`SsrfValidator::resolve_and_validate(host, port)`** — async wrapper around `tokio::net::lookup_host`. Validates EVERY resolved IP against the existing blocklist. A hostname with even one blocked IP is rejected outright (no partial-trust resolution).

2. **`http-request` + `web-fetch`** now:
   - Resolve the URL's host before constructing the `reqwest::Client`
   - Reject if any resolved IP is blocked
   - **Pin the validated IPs** via `ClientBuilder::resolve_to_addrs(host, &addrs)` so the kernel can't re-resolve to a different IP between check and connect (DNS rebinding mitigation)

3. **Redirect policy hardened**:
   - Same-host hops → allowed (DNS still pinned)
   - Cross-host IP-literal hops → validated as before
   - Cross-host hostname hops → **blocked** (sync closure can't async-resolve, so we refuse rather than gamble)

### Tests

- New unit: `http://localhost/` rejected via DNS-resolved loopback (was allowed pre-fix)
- Existing 61 SSRF + 4 http_request + 2 web_fetch + 15 integration scenarios all green

## Test plan

- [x] `cargo test -p sera-runtime --lib tools::http_request` — 4/4 (including new hostname case)
- [x] `cargo test -p sera-tools --lib ssrf` — 61/61
- [x] `./scripts/verify-scenarios.sh` — 15/15 integration green
- [x] `cargo check -p sera-runtime` clean

## Follow-ups still open

- **HITL auth-bypass scenarios** (LOW) — separate test surface, file separately
- **Runtime-side CapabilityRegistry** — in-process tool dispatch still bypasses gateway-side check
- DNS resolver hardening: an upstream resolver returning poisoned answers within reqwest's retry window could still re-rebind. Mitigation requires either passing an explicit `tokio::net::TcpSocket::connect` to a pre-resolved IP (bypassing reqwest's resolver entirely) or using a custom `Resolve` impl. Diminishing returns for the MVP threat model.

Tracks sera-9tim / sera-udjf hardening.