### PR TITLE
qa(sera-config): assert parse error surfaces line number (sera-vvyl)

### DIFF
--- a/rust/crates/sera-config/src/manifest_loader.rs
+++ b/rust/crates/sera-config/src/manifest_loader.rs
@@ -539,6 +539,28 @@ spec: {}
     }
 
     #[test]
+    fn invalid_yaml_error_includes_line_number() {
+        let yaml = r#"
+apiVersion: sera.dev/v1
+kind: Instance
+metadata:
+  name: test
+spec:
+  bad: [unclosed
+"#;
+        let err = parse_manifests(yaml).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            matches!(err, ManifestLoadError::ParseError { .. }),
+            "expected ParseError, got: {err:?}",
+        );
+        assert!(
+            msg.to_lowercase().contains("line"),
+            "parse error should surface line info to make debugging tractable; got: {msg}",
+        );
+    }
+
+    #[test]
     fn parse_bad_api_version() {
         let yaml = r#"
 apiVersion: noslash


### PR DESCRIPTION
## Summary

Closes sera-vvyl. The existing `parse_invalid_yaml` test in `manifest_loader::tests` only matched on the `ParseError` enum variant — it did not verify that the line/column information from `serde_yaml::Error` actually reaches the rendered error string.

This adds `invalid_yaml_error_includes_line_number` which uses a multi-line manifest with a known-bad construct (unclosed flow sequence) and asserts that:

1. The error variant is still `ParseError`
2. The rendered error string contains the substring `line` (case-insensitive)

Together these prevent a future loader refactor from silently stripping location info — that would make debugging YAML errors significantly harder for users hand-editing manifests.

## Test plan

- [x] `cargo test -p sera-config invalid_yaml_error_includes` passes locally
- [x] `cargo test -p sera-config` overall green
- [ ] CI green on `validate-rust` and `ci-e2e-smoke`

🤖 Generated with [Claude Code](https://claude.com/claude-code)