### PR TITLE
fix(sera-runtime): serialize gate-resolution tests via shared mutex (sera-3gri)

### DIFF
--- a/rust/crates/sera-runtime/src/main.rs
+++ b/rust/crates/sera-runtime/src/main.rs
@@ -473,21 +473,27 @@ async fn run_heartbeat(config: &RuntimeConfig) {
 #[cfg(test)]
 mod tests {
     use super::resolve_allow_missing_gate;
+    use std::sync::Mutex;
+
+    // cargo test runs tests in parallel by default, so all four tests below
+    // would otherwise race on SERA_ALLOW_MISSING_CONSTITUTIONAL_GATE — one
+    // setting "1", another setting "false", with assertions interleaving.
+    // Holding this mutex for the whole test (env mutation + assertion)
+    // serialises them.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     /// `SERA_ALLOW_MISSING_CONSTITUTIONAL_GATE` unset → permissive = false.
     #[test]
     fn gate_defaults_to_false_when_env_unset() {
-        // Guard: only run when the env var is not already set by the caller.
-        if std::env::var("SERA_ALLOW_MISSING_CONSTITUTIONAL_GATE").is_ok() {
-            return;
-        }
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = EnvGuard::unset("SERA_ALLOW_MISSING_CONSTITUTIONAL_GATE");
         assert!(!resolve_allow_missing_gate());
     }
 
     /// Value `"1"` → permissive = true (env path).
     #[test]
     fn gate_true_for_value_one() {
-        // Use a scoped env helper to avoid leaking between parallel tests.
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let _guard = EnvGuard::set("SERA_ALLOW_MISSING_CONSTITUTIONAL_GATE", "1");
         assert!(resolve_allow_missing_gate());
     }
@@ -495,6 +501,7 @@ mod tests {
     /// Value `"true"` (case-insensitive) → permissive = true.
     #[test]
     fn gate_true_for_value_true_case_insensitive() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let _guard = EnvGuard::set("SERA_ALLOW_MISSING_CONSTITUTIONAL_GATE", "TRUE");
         assert!(resolve_allow_missing_gate());
     }
@@ -502,6 +509,7 @@ mod tests {
     /// Value `"false"` → permissive = false (not opted in).
     #[test]
     fn gate_false_for_value_false() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let _guard = EnvGuard::set("SERA_ALLOW_MISSING_CONSTITUTIONAL_GATE", "false");
         assert!(!resolve_allow_missing_gate());
     }
@@ -516,15 +524,23 @@ mod tests {
     impl EnvGuard {
         fn set(key: &'static str, value: &str) -> Self {
             let prev = std::env::var(key).ok();
-            // SAFETY: tests run single-threaded (no other threads read this var).
+            // SAFETY: ENV_LOCK serialises every test that reads or writes the
+            // gate env var, so no concurrent reader can observe a torn value.
             unsafe { std::env::set_var(key, value) };
+            Self { key, prev }
+        }
+
+        fn unset(key: &'static str) -> Self {
+            let prev = std::env::var(key).ok();
+            // SAFETY: see EnvGuard::set.
+            unsafe { std::env::remove_var(key) };
             Self { key, prev }
         }
     }
 
     impl Drop for EnvGuard {
         fn drop(&mut self) {
-            // SAFETY: tests run single-threaded (no other threads read this var).
+            // SAFETY: see EnvGuard::set.
             unsafe {
                 match &self.prev {
                     Some(v) => std::env::set_var(self.key, v),


### PR DESCRIPTION
## Summary

Closes sera-3gri. The four `resolve_allow_missing_gate()` unit tests in `sera-runtime/src/main.rs` all read and mutate the same process env var (`SERA_ALLOW_MISSING_CONSTITUTIONAL_GATE`). Under cargo test's default parallel scheduler, they raced — one test setting `"1"` while another was asserting on `"false"` produced intermittent failures (~10% reproduction rate, observed during the L.0 PR's full workspace test run).

The pre-existing `EnvGuard` RAII helper restored the var on drop, but did nothing about *reads* interleaving with another test's *write*. The fix:

- Added a static `Mutex<()>` (`ENV_LOCK`) that every gate test acquires for its entire body — env mutation AND assertion are now in the same critical section.
- Added `EnvGuard::unset()` so `gate_defaults_to_false_when_env_unset` can pin the env into a known unset state instead of bailing when the host shell already has the var set (the previous early-return made that test silently no-op'd in some CI environments).
- Updated the `SAFETY:` comments to reflect the actual invariant (mutex serialisation, not single-threaded execution).

## Test plan

- [x] Ran `cargo test -p sera-runtime --bin sera-runtime -- gate` five times sequentially: 4 passed each time, no flake
- [x] Same gate tests still pass under `cargo test --workspace`
- [ ] CI green on `validate-rust` and `ci-e2e-smoke`

🤖 Generated with [Claude Code](https://claude.com/claude-code)