### PR TITLE
feat(sera-gateway): L.3 admin HTTP port + control-plane endpoints (sera-nrn9)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5177,6 +5177,7 @@ dependencies = [
  "serde_yaml",
  "sha2",
  "sqlx",
+ "subtle",
  "tempfile",
  "thiserror 2.0.18",
  "time",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -88,6 +88,7 @@ proptest = "1"
 
 # Crypto
 sha2 = "0.10"
+subtle = "2"
 
 # Semver constraints (sera-skills SkillRef versioning)
 semver = "1"

--- a/rust/crates/sera-gateway/Cargo.toml
+++ b/rust/crates/sera-gateway/Cargo.toml
@@ -47,6 +47,7 @@ uuid.workspace = true
 time.workspace = true
 jsonwebtoken.workspace = true
 sha2.workspace = true
+subtle.workspace = true
 hex.workspace = true
 base64.workspace = true
 urlencoding.workspace = true

--- a/rust/crates/sera-gateway/src/admin/audit.rs
+++ b/rust/crates/sera-gateway/src/admin/audit.rs
@@ -1,0 +1,213 @@
+//! JSONL audit log for the admin HTTP server (sera-nrn9).
+//!
+//! Every admin request — success or failure — appends one JSON object per line
+//! to `<data_root>/admin-audit.jsonl`. The token is never written verbatim:
+//! callers pass an opaque [`TokenFingerprint`] that exposes only the first
+//! eight hex chars of `sha256(token)`.
+//!
+//! The writer is intentionally small and synchronous on the file IO side —
+//! `tokio::fs::OpenOptions::append` is used inside an `async fn` so the
+//! middleware does not need to spawn a blocking task. Failures are logged via
+//! `tracing` but never propagated to the request path; an audit-write failure
+//! must not turn a 200 response into a 500.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use chrono::Utc;
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use tokio::io::AsyncWriteExt;
+use tokio::sync::Mutex;
+
+/// Opaque first-8-hex-chars-of-sha256(token) wrapper. Logged in place of the
+/// raw admin token.
+#[derive(Debug, Clone)]
+pub struct TokenFingerprint(String);
+
+impl TokenFingerprint {
+    pub fn of(token: &str) -> Self {
+        let digest = Sha256::digest(token.as_bytes());
+        let hex = hex::encode(digest);
+        Self(hex[..8].to_string())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// One audit row.
+#[derive(Debug, Serialize)]
+pub struct AdminAuditEntry<'a> {
+    pub ts: String,
+    pub caller: &'a str,
+    pub method: &'a str,
+    pub path: &'a str,
+    pub status: u16,
+    #[serde(skip_serializing_if = "serde_json::Value::is_null")]
+    pub args: serde_json::Value,
+    pub ms: u64,
+}
+
+/// Append-only JSONL writer guarded by a tokio Mutex so concurrent admin
+/// requests do not interleave their bytes.
+pub struct AdminAuditLogger {
+    path: PathBuf,
+    lock: Mutex<()>,
+}
+
+impl AdminAuditLogger {
+    pub fn new(path: PathBuf) -> Self {
+        Self {
+            path,
+            lock: Mutex::new(()),
+        }
+    }
+
+    pub fn shared(path: PathBuf) -> Arc<Self> {
+        Arc::new(Self::new(path))
+    }
+
+    /// Resolve the audit log path: `<data_root>/admin-audit.jsonl`.
+    pub fn default_path<P: AsRef<Path>>(data_root: P) -> PathBuf {
+        data_root.as_ref().join("admin-audit.jsonl")
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Append one row. Errors are logged via `tracing::warn!` and swallowed —
+    /// the audit log must never break a request.
+    pub async fn append(&self, entry: AdminAuditEntry<'_>) {
+        let line = match serde_json::to_string(&entry) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!(error = %e, "admin audit serialize failed");
+                return;
+            }
+        };
+
+        if let Some(parent) = self.path.parent()
+            && !parent.as_os_str().is_empty()
+            && let Err(e) = tokio::fs::create_dir_all(parent).await
+        {
+            tracing::warn!(error = %e, path = %parent.display(), "admin audit mkdir failed");
+            return;
+        }
+
+        let _guard = self.lock.lock().await;
+        let mut file = match tokio::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.path)
+            .await
+        {
+            Ok(f) => f,
+            Err(e) => {
+                tracing::warn!(error = %e, path = %self.path.display(), "admin audit open failed");
+                return;
+            }
+        };
+        if let Err(e) = file.write_all(line.as_bytes()).await {
+            tracing::warn!(error = %e, "admin audit write failed");
+            return;
+        }
+        if let Err(e) = file.write_all(b"\n").await {
+            tracing::warn!(error = %e, "admin audit newline write failed");
+            return;
+        }
+        if let Err(e) = file.flush().await {
+            tracing::warn!(error = %e, "admin audit flush failed");
+        }
+    }
+}
+
+/// Build the canonical timestamp string used in audit rows.
+pub fn now_iso() -> String {
+    Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn fingerprint_is_first_eight_hex_of_sha256() {
+        let fp = TokenFingerprint::of("hello");
+        // sha256("hello") = 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
+        assert_eq!(fp.as_str(), "2cf24dba");
+    }
+
+    #[test]
+    fn fingerprint_does_not_leak_token() {
+        let fp = TokenFingerprint::of("super-secret-admin-token");
+        assert_eq!(fp.as_str().len(), 8);
+        assert!(!fp.as_str().contains("super"));
+        assert!(!fp.as_str().contains("admin"));
+    }
+
+    #[tokio::test]
+    async fn append_creates_file_and_writes_line() {
+        let dir = TempDir::new().unwrap();
+        let path = AdminAuditLogger::default_path(dir.path());
+        let logger = AdminAuditLogger::new(path.clone());
+
+        logger
+            .append(AdminAuditEntry {
+                ts: "2026-04-27T07:30:00.000Z".to_string(),
+                caller: "abcd1234",
+                method: "POST",
+                path: "/admin/policies/reload",
+                status: 200,
+                args: serde_json::Value::Null,
+                ms: 12,
+            })
+            .await;
+
+        let contents = std::fs::read_to_string(&path).unwrap();
+        assert!(contents.ends_with('\n'));
+        let parsed: serde_json::Value = serde_json::from_str(contents.trim()).unwrap();
+        assert_eq!(parsed["caller"], "abcd1234");
+        assert_eq!(parsed["status"], 200);
+        assert_eq!(parsed["path"], "/admin/policies/reload");
+    }
+
+    #[tokio::test]
+    async fn append_handles_concurrent_writes_without_truncation() {
+        let dir = TempDir::new().unwrap();
+        let path = AdminAuditLogger::default_path(dir.path());
+        let logger = Arc::new(AdminAuditLogger::new(path.clone()));
+
+        let mut handles = Vec::new();
+        for i in 0..16 {
+            let logger = Arc::clone(&logger);
+            handles.push(tokio::spawn(async move {
+                logger
+                    .append(AdminAuditEntry {
+                        ts: now_iso(),
+                        caller: "fffffff",
+                        method: "GET",
+                        path: "/admin/sessions",
+                        status: 200,
+                        args: serde_json::json!({"i": i}),
+                        ms: 1,
+                    })
+                    .await;
+            }));
+        }
+        for h in handles {
+            h.await.unwrap();
+        }
+
+        let contents = std::fs::read_to_string(&path).unwrap();
+        let lines: Vec<&str> = contents.lines().collect();
+        assert_eq!(lines.len(), 16);
+        for line in lines {
+            // Every line must parse as JSON — no torn writes.
+            serde_json::from_str::<serde_json::Value>(line).unwrap();
+        }
+    }
+}

--- a/rust/crates/sera-gateway/src/admin/auth.rs
+++ b/rust/crates/sera-gateway/src/admin/auth.rs
@@ -1,0 +1,165 @@
+//! Admin token auth for the admin HTTP server (sera-nrn9).
+//!
+//! Reads `Authorization: Bearer <token>` and compares it against the configured
+//! admin token in constant time. The bootstrap API key MUST NOT pass admin
+//! auth — the admin token is a separate secret. Missing/invalid → 401.
+
+use std::sync::Arc;
+
+use axum::extract::{Request, State};
+use axum::http::StatusCode;
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
+use rand::RngCore;
+use subtle::ConstantTimeEq;
+
+use crate::admin::audit::TokenFingerprint;
+
+/// Per-request token fingerprint stashed in request extensions so audit log
+/// writers can reach it without re-reading the header.
+#[derive(Debug, Clone)]
+pub struct AdminCaller(pub TokenFingerprint);
+
+/// Per-process admin token configuration.
+#[derive(Debug, Clone)]
+pub struct AdminAuth {
+    expected: Arc<String>,
+}
+
+impl AdminAuth {
+    pub fn new(token: impl Into<String>) -> Self {
+        Self {
+            expected: Arc::new(token.into()),
+        }
+    }
+
+    /// Resolve the admin token from `SERA_ADMIN_TOKEN`. When unset and
+    /// `local` is true, generate a random 32-byte hex token and print it once
+    /// to stderr. When unset and `local` is false, returns an error so the
+    /// caller can fail to start.
+    pub fn resolve(local: bool) -> Result<Self, AdminAuthError> {
+        if let Ok(t) = std::env::var("SERA_ADMIN_TOKEN")
+            && !t.trim().is_empty()
+        {
+            return Ok(Self::new(t));
+        }
+        if !local {
+            return Err(AdminAuthError::TokenMissing);
+        }
+        let mut buf = [0u8; 32];
+        rand::thread_rng().fill_bytes(&mut buf);
+        let token = hex::encode(buf);
+        eprintln!(
+            "sera admin token (local mode, regenerated each boot):\n  SERA_ADMIN_TOKEN={token}"
+        );
+        Ok(Self::new(token))
+    }
+
+    /// Compare `provided` to the configured token in constant time. Equal
+    /// length is enforced — the comparator early-returns on length mismatch
+    /// because subtle's `ct_eq` requires equal-length slices.
+    pub fn matches(&self, provided: &str) -> bool {
+        let expected = self.expected.as_bytes();
+        let provided = provided.as_bytes();
+        if expected.len() != provided.len() {
+            return false;
+        }
+        bool::from(expected.ct_eq(provided))
+    }
+
+    /// Token, useful for tests that need to construct request headers.
+    pub fn token(&self) -> &str {
+        &self.expected
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum AdminAuthError {
+    #[error(
+        "SERA_ADMIN_TOKEN is not set; admin server cannot start in non-local mode without it"
+    )]
+    TokenMissing,
+}
+
+/// Axum middleware: require a valid `Authorization: Bearer <admin-token>` on
+/// every admin route. On success injects an [`AdminCaller`] into request
+/// extensions so downstream audit logging can extract the fingerprint.
+pub async fn require_admin_token(
+    State(auth): State<Arc<AdminAuth>>,
+    mut request: Request,
+    next: Next,
+) -> Response {
+    let token: Option<String> = request
+        .headers()
+        .get("authorization")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|h| h.strip_prefix("Bearer "))
+        .map(|s| s.to_string());
+
+    let token = match token {
+        Some(t) => t,
+        None => return StatusCode::UNAUTHORIZED.into_response(),
+    };
+
+    if !auth.matches(&token) {
+        return StatusCode::UNAUTHORIZED.into_response();
+    }
+
+    request
+        .extensions_mut()
+        .insert(AdminCaller(TokenFingerprint::of(&token)));
+    next.run(request).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn matches_is_true_for_equal_tokens() {
+        let auth = AdminAuth::new("token-abc");
+        assert!(auth.matches("token-abc"));
+    }
+
+    #[test]
+    fn matches_is_false_for_different_tokens() {
+        let auth = AdminAuth::new("token-abc");
+        assert!(!auth.matches("token-xyz"));
+    }
+
+    #[test]
+    fn matches_is_false_for_different_lengths() {
+        let auth = AdminAuth::new("short");
+        assert!(!auth.matches("a-much-longer-token"));
+    }
+
+    #[test]
+    fn bootstrap_dev_key_does_not_match_admin_token() {
+        let auth = AdminAuth::new("admin-only-token");
+        assert!(!auth.matches("sera_bootstrap_dev_123"));
+    }
+
+    #[test]
+    fn resolve_errors_when_unset_and_not_local() {
+        let saved = std::env::var("SERA_ADMIN_TOKEN").ok();
+        // SAFETY: single-threaded test scope.
+        unsafe { std::env::remove_var("SERA_ADMIN_TOKEN") };
+        let result = AdminAuth::resolve(false);
+        if let Some(v) = saved {
+            unsafe { std::env::set_var("SERA_ADMIN_TOKEN", v) };
+        }
+        assert!(matches!(result, Err(AdminAuthError::TokenMissing)));
+    }
+
+    #[test]
+    fn resolve_uses_env_var_when_set() {
+        let saved = std::env::var("SERA_ADMIN_TOKEN").ok();
+        unsafe { std::env::set_var("SERA_ADMIN_TOKEN", "explicit-token") };
+        let auth = AdminAuth::resolve(false).unwrap();
+        match saved {
+            Some(v) => unsafe { std::env::set_var("SERA_ADMIN_TOKEN", v) },
+            None => unsafe { std::env::remove_var("SERA_ADMIN_TOKEN") },
+        }
+        assert!(auth.matches("explicit-token"));
+    }
+}

--- a/rust/crates/sera-gateway/src/admin/mod.rs
+++ b/rust/crates/sera-gateway/src/admin/mod.rs
@@ -1,0 +1,27 @@
+//! Admin HTTP control-plane (sera-nrn9, L.3).
+//!
+//! Separate HTTP server that runs alongside the public API. Binds to
+//! `127.0.0.1:3002` by default and requires a separate `SERA_ADMIN_TOKEN`.
+//! Every request is appended to a JSONL audit log with a token fingerprint
+//! (never the raw token) so operators can trace who did what.
+//!
+//! Endpoint inventory:
+//! * `/admin/workflows[/{id}]` — workflow CRUD (create/delete return 501 in L.3)
+//! * `/admin/policies[/{name}]`, `/reload`, `/validate` — capability policies
+//! * `/admin/sessions[/{id}]` — list/show/kill (cancellation token fired)
+//! * `/admin/agents/{id}`, `/agents/spawn` — show; spawn/kill return 501
+//! * `/admin/killswitch/{arm,disarm,status}` — HTTP twin of the unix admin sock
+
+pub mod audit;
+pub mod auth;
+pub mod routes;
+pub mod server;
+pub mod state;
+
+pub use audit::{AdminAuditEntry, AdminAuditLogger, TokenFingerprint};
+pub use auth::{AdminAuth, AdminAuthError, AdminCaller, require_admin_token};
+pub use server::{
+    DEFAULT_ADMIN_BIND, DEFAULT_ADMIN_PORT, build_admin_router, resolve_admin_bind,
+    resolve_admin_port, serve_admin,
+};
+pub use state::{AdminAppState, AdminSessionInfo, CancellationRegistry};

--- a/rust/crates/sera-gateway/src/admin/routes/agents.rs
+++ b/rust/crates/sera-gateway/src/admin/routes/agents.rs
@@ -1,0 +1,69 @@
+//! Admin agent control (sera-nrn9).
+//!
+//! `show` reads from the existing manifest set surfaced by the AppState.
+//! `spawn` and `kill` are 501 in L.3 — process-level lifecycle hooks ship in a
+//! follow-up bead. The route shells exist so CLI verbs (L.4) and the main
+//! agent (L.5) can wire against a stable URL today.
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+
+use crate::admin::state::AdminAppState;
+
+/// GET /admin/agents/{id}
+pub async fn show<S>(
+    State(state): State<Arc<S>>,
+    Path(id): Path<String>,
+) -> Result<Json<serde_json::Value>, StatusCode>
+where
+    S: AdminAppState,
+{
+    state
+        .agent_metadata(&id)
+        .map(Json)
+        .ok_or(StatusCode::NOT_FOUND)
+}
+
+/// POST /admin/agents/spawn
+pub async fn spawn<S>(
+    State(state): State<Arc<S>>,
+    Json(body): Json<serde_json::Value>,
+) -> Result<(StatusCode, Json<serde_json::Value>), (StatusCode, Json<serde_json::Value>)>
+where
+    S: AdminAppState,
+{
+    match state.spawn_agent(body).await {
+        Some(meta) => Ok((StatusCode::CREATED, Json(meta))),
+        None => Err((
+            StatusCode::NOT_IMPLEMENTED,
+            Json(serde_json::json!({
+                "error": "agent_spawn_not_implemented",
+                "detail": "process_manager not wired into gateway boot — L.3 ships the route shell only"
+            })),
+        )),
+    }
+}
+
+/// DELETE /admin/agents/{id}
+pub async fn kill<S>(
+    State(state): State<Arc<S>>,
+    Path(id): Path<String>,
+) -> Result<StatusCode, (StatusCode, Json<serde_json::Value>)>
+where
+    S: AdminAppState,
+{
+    if state.kill_agent(&id).await {
+        Ok(StatusCode::NO_CONTENT)
+    } else {
+        Err((
+            StatusCode::NOT_IMPLEMENTED,
+            Json(serde_json::json!({
+                "error": "agent_kill_not_implemented",
+                "detail": "process_manager not wired into gateway boot — L.3 ships the route shell only"
+            })),
+        ))
+    }
+}

--- a/rust/crates/sera-gateway/src/admin/routes/killswitch.rs
+++ b/rust/crates/sera-gateway/src/admin/routes/killswitch.rs
@@ -1,0 +1,44 @@
+//! Killswitch HTTP control-plane (sera-nrn9). Backed by the same
+//! [`KillSwitch`](crate::kill_switch::KillSwitch) as the unix admin socket;
+//! both surfaces stay live so existing tooling continues to work.
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::State;
+use axum::http::StatusCode;
+
+use crate::admin::state::AdminAppState;
+
+/// POST /admin/killswitch/arm
+pub async fn arm<S>(State(state): State<Arc<S>>) -> StatusCode
+where
+    S: AdminAppState,
+{
+    state.kill_switch().arm();
+    tracing::warn!(
+        event = "KILL_SWITCH_ACTIVATED",
+        "Admin kill switch armed via HTTP /admin/killswitch/arm"
+    );
+    StatusCode::NO_CONTENT
+}
+
+/// POST /admin/killswitch/disarm
+pub async fn disarm<S>(State(state): State<Arc<S>>) -> StatusCode
+where
+    S: AdminAppState,
+{
+    state.kill_switch().disarm();
+    tracing::info!("Admin kill switch disarmed via HTTP /admin/killswitch/disarm");
+    StatusCode::NO_CONTENT
+}
+
+/// GET /admin/killswitch/status
+pub async fn status<S>(State(state): State<Arc<S>>) -> Json<serde_json::Value>
+where
+    S: AdminAppState,
+{
+    Json(serde_json::json!({
+        "armed": state.kill_switch().is_armed(),
+    }))
+}

--- a/rust/crates/sera-gateway/src/admin/routes/mod.rs
+++ b/rust/crates/sera-gateway/src/admin/routes/mod.rs
@@ -1,0 +1,7 @@
+//! Route handler modules for the admin HTTP server (sera-nrn9).
+
+pub mod agents;
+pub mod killswitch;
+pub mod policies;
+pub mod sessions;
+pub mod workflows;

--- a/rust/crates/sera-gateway/src/admin/routes/policies.rs
+++ b/rust/crates/sera-gateway/src/admin/routes/policies.rs
@@ -1,0 +1,195 @@
+//! Capability policy admin routes (sera-nrn9).
+//!
+//! `list` and `show` read directly from the configured policies directory;
+//! `reload` re-runs `CapabilityRegistry::load_and_bind` and replaces the
+//! gateway's `Arc<CapabilityRegistry>` atomically. `validate` is parse-only —
+//! it never replaces the registry.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::{Path as AxumPath, State};
+use axum::http::StatusCode;
+
+use crate::admin::state::AdminAppState;
+use crate::capability_enforcement::CapabilityRegistry;
+
+/// GET /admin/policies — directory listing of `kind: CapabilityPolicy` files.
+pub async fn list<S>(State(state): State<Arc<S>>) -> Json<serde_json::Value>
+where
+    S: AdminAppState,
+{
+    let dir = state.policies_dir();
+    let names = read_policy_names(&dir);
+    Json(serde_json::json!({
+        "dir": dir.display().to_string(),
+        "policies": names,
+    }))
+}
+
+/// GET /admin/policies/{name} — raw YAML content of one policy file.
+pub async fn show<S>(
+    State(state): State<Arc<S>>,
+    AxumPath(name): AxumPath<String>,
+) -> Result<Json<serde_json::Value>, StatusCode>
+where
+    S: AdminAppState,
+{
+    if !is_safe_name(&name) {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+    let dir = state.policies_dir();
+    let yaml = match find_and_read(&dir, &name) {
+        Some(s) => s,
+        None => return Err(StatusCode::NOT_FOUND),
+    };
+
+    let parsed: serde_yaml::Value = serde_yaml::from_str(&yaml)
+        .map_err(|_| StatusCode::UNPROCESSABLE_ENTITY)?;
+    let json: serde_json::Value =
+        serde_json::to_value(parsed).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    Ok(Json(serde_json::json!({
+        "name": name,
+        "manifest": json,
+    })))
+}
+
+/// POST /admin/policies/reload — re-load policies from disk and swap the
+/// shared registry handle. Returns the names of the loaded policies.
+pub async fn reload<S>(
+    State(state): State<Arc<S>>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)>
+where
+    S: AdminAppState,
+{
+    let dir = state.policies_dir();
+    // We re-load with no agent bindings: the binding map is rebuilt from the
+    // manifests at boot. Reload-without-restart of agents is a follow-up; for
+    // L.3 the goal is just to re-read the policy bodies so capability changes
+    // take effect on the next dispatch.
+    let reg = CapabilityRegistry::load_and_bind::<_, String, String>(
+        &dir,
+        Vec::<(String, Option<String>)>::new(),
+    )
+    .map_err(|e| {
+        (
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(serde_json::json!({
+                "error": "policy_load_failed",
+                "detail": e.to_string(),
+            })),
+        )
+    })?;
+
+    let mut names: Vec<String> = Vec::new();
+    let _ = read_policy_names_into(&dir, &mut names);
+
+    let new = Arc::new(reg);
+    {
+        let cell = state.capability_registry();
+        let mut guard = cell.write().await;
+        *guard = new;
+    }
+
+    tracing::info!(loaded = names.len(), "admin policy reload complete");
+    Ok(Json(serde_json::json!({
+        "loaded": names.len(),
+        "policies": names,
+    })))
+}
+
+/// POST /admin/policies/validate — try to parse each policy file and report
+/// per-file errors. Never replaces the registry.
+pub async fn validate<S>(
+    State(state): State<Arc<S>>,
+) -> Result<Json<serde_json::Value>, StatusCode>
+where
+    S: AdminAppState,
+{
+    let dir = state.policies_dir();
+    if !dir.exists() {
+        return Ok(Json(serde_json::json!({
+            "dir": dir.display().to_string(),
+            "ok": true,
+            "results": [],
+        })));
+    }
+
+    let mut results = Vec::new();
+    let entries = std::fs::read_dir(&dir).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let name = match path.file_stem().and_then(|s| s.to_str()) {
+            Some(n) => n.to_string(),
+            None => continue,
+        };
+        let ext = path.extension().and_then(|s| s.to_str()).unwrap_or("");
+        if ext != "yaml" && ext != "yml" {
+            continue;
+        }
+        match std::fs::read_to_string(&path).and_then(|s| {
+            serde_yaml::from_str::<serde_yaml::Value>(&s)
+                .map_err(|e| std::io::Error::other(e.to_string()))
+        }) {
+            Ok(_) => results.push(serde_json::json!({"file": name, "ok": true})),
+            Err(e) => results.push(serde_json::json!({
+                "file": name,
+                "ok": false,
+                "error": e.to_string(),
+            })),
+        }
+    }
+    let all_ok = results
+        .iter()
+        .all(|r| r.get("ok").and_then(|v| v.as_bool()).unwrap_or(false));
+    Ok(Json(serde_json::json!({
+        "dir": dir.display().to_string(),
+        "ok": all_ok,
+        "results": results,
+    })))
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+fn is_safe_name(name: &str) -> bool {
+    !name.is_empty()
+        && !name.contains('/')
+        && !name.contains('\\')
+        && !name.contains("..")
+}
+
+fn read_policy_names(dir: &Path) -> Vec<String> {
+    let mut out = Vec::new();
+    let _ = read_policy_names_into(dir, &mut out);
+    out
+}
+
+fn read_policy_names_into(dir: &Path, out: &mut Vec<String>) -> std::io::Result<()> {
+    out.clear();
+    if !dir.exists() {
+        return Ok(());
+    }
+    for entry in std::fs::read_dir(dir)?.flatten() {
+        let path = entry.path();
+        let ext = path.extension().and_then(|s| s.to_str()).unwrap_or("");
+        if ext != "yaml" && ext != "yml" {
+            continue;
+        }
+        if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
+            out.push(stem.to_string());
+        }
+    }
+    out.sort();
+    Ok(())
+}
+
+fn find_and_read(dir: &Path, name: &str) -> Option<String> {
+    for ext in ["yaml", "yml"] {
+        let path = dir.join(format!("{name}.{ext}"));
+        if let Ok(s) = std::fs::read_to_string(&path) {
+            return Some(s);
+        }
+    }
+    None
+}

--- a/rust/crates/sera-gateway/src/admin/routes/sessions.rs
+++ b/rust/crates/sera-gateway/src/admin/routes/sessions.rs
@@ -1,0 +1,50 @@
+//! Admin session inspect/kill (sera-nrn9).
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+
+use crate::admin::state::{AdminAppState, AdminSessionInfo};
+
+/// GET /admin/sessions
+pub async fn list<S>(State(state): State<Arc<S>>) -> Json<Vec<AdminSessionInfo>>
+where
+    S: AdminAppState,
+{
+    Json(state.list_sessions().await)
+}
+
+/// GET /admin/sessions/{id}
+pub async fn show<S>(
+    State(state): State<Arc<S>>,
+    Path(id): Path<String>,
+) -> Result<Json<AdminSessionInfo>, StatusCode>
+where
+    S: AdminAppState,
+{
+    state
+        .get_session(&id)
+        .await
+        .map(Json)
+        .ok_or(StatusCode::NOT_FOUND)
+}
+
+/// DELETE /admin/sessions/{id} — fires the registered cancellation token, if
+/// any. Returns 204 even when no token was registered (idempotent).
+pub async fn kill<S>(
+    State(state): State<Arc<S>>,
+    Path(id): Path<String>,
+) -> StatusCode
+where
+    S: AdminAppState,
+{
+    let cancelled = state.cancel_session(&id);
+    tracing::info!(
+        session_id = %id,
+        cancelled,
+        "admin DELETE /admin/sessions/{{id}}"
+    );
+    StatusCode::NO_CONTENT
+}

--- a/rust/crates/sera-gateway/src/admin/routes/workflows.rs
+++ b/rust/crates/sera-gateway/src/admin/routes/workflows.rs
@@ -1,0 +1,95 @@
+//! Admin workflow CRUD (sera-nrn9).
+//!
+//! Reads from the same workflow_store wired into the public API. Create and
+//! delete return 501 — the existing store has insert/get but no delete, and
+//! the admin "create from manifest" path needs scheduling integration that
+//! lands with L.5.
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+
+use crate::admin::state::AdminAppState;
+
+fn not_ready() -> (StatusCode, Json<serde_json::Value>) {
+    (
+        StatusCode::NOT_IMPLEMENTED,
+        Json(serde_json::json!({
+            "error": "workflow_store_not_ready",
+            "detail": "admin workflow CRUD is gated on L.5 wiring; route shell only in L.3"
+        })),
+    )
+}
+
+/// GET /admin/workflows
+pub async fn list<S>(State(state): State<Arc<S>>) -> Json<serde_json::Value>
+where
+    S: AdminAppState,
+{
+    let Some(store) = state.workflow_store() else {
+        return Json(serde_json::json!({"workflows": []}));
+    };
+    let records = store.list().await;
+    let summaries: Vec<_> = records
+        .into_iter()
+        .map(|r| {
+            serde_json::json!({
+                "id": r.task.id.to_string(),
+                "agent_id": r.agent_id,
+                "status": r.status,
+                "title": r.task.title,
+            })
+        })
+        .collect();
+    Json(serde_json::json!({"workflows": summaries}))
+}
+
+/// POST /admin/workflows
+pub async fn create<S>(
+    State(_state): State<Arc<S>>,
+    Json(_body): Json<serde_json::Value>,
+) -> Result<(StatusCode, Json<serde_json::Value>), (StatusCode, Json<serde_json::Value>)>
+where
+    S: AdminAppState,
+{
+    Err(not_ready())
+}
+
+/// GET /admin/workflows/{id}
+pub async fn show<S>(
+    State(state): State<Arc<S>>,
+    Path(id): Path<String>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)>
+where
+    S: AdminAppState,
+{
+    let Some(store) = state.workflow_store() else {
+        return Err(not_ready());
+    };
+    let rec = store.get(&id).await.ok_or((
+        StatusCode::NOT_FOUND,
+        Json(serde_json::json!({"error": "workflow_not_found"})),
+    ))?;
+    Ok(Json(serde_json::json!({
+        "id": rec.task.id.to_string(),
+        "agent_id": rec.agent_id,
+        "resume_token": rec.resume_token,
+        "status": rec.status,
+        "resolved_at": rec.resolved_at,
+        "title": rec.task.title,
+        "await_type": rec.task.await_type,
+    })))
+}
+
+/// DELETE /admin/workflows/{id}
+pub async fn delete<S>(
+    State(_state): State<Arc<S>>,
+    Path(_id): Path<String>,
+) -> Result<StatusCode, (StatusCode, Json<serde_json::Value>)>
+where
+    S: AdminAppState,
+{
+    Err(not_ready())
+}

--- a/rust/crates/sera-gateway/src/admin/server.rs
+++ b/rust/crates/sera-gateway/src/admin/server.rs
@@ -1,0 +1,160 @@
+//! Admin HTTP server bring-up (sera-nrn9).
+//!
+//! Builds a router that:
+//! 1. Logs every request to the JSONL audit file (success or failure).
+//! 2. Requires a valid admin token via `Authorization: Bearer …`.
+//! 3. Dispatches to one of the typed handler modules under `routes/`.
+//!
+//! The server binds separately from the public API (default `127.0.0.1:3002`)
+//! so localhost-only deployments and bind-mounted reverse proxies can keep
+//! the surfaces apart.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Instant;
+
+use axum::Router;
+use axum::extract::{Request, State};
+use axum::middleware::{self, Next};
+use axum::response::Response;
+use axum::routing::{get, post};
+
+use crate::admin::audit::{AdminAuditEntry, AdminAuditLogger, TokenFingerprint, now_iso};
+use crate::admin::auth::{AdminCaller, require_admin_token};
+use crate::admin::routes::{agents, killswitch, policies, sessions, workflows};
+use crate::admin::state::AdminAppState;
+
+/// Default admin HTTP port. Picked above the public API (3001) and below the
+/// `--local` user-facing port (42540).
+pub const DEFAULT_ADMIN_PORT: u16 = 3002;
+
+/// Default bind address — localhost only.
+pub const DEFAULT_ADMIN_BIND: &str = "127.0.0.1";
+
+/// Build the admin router, layered with auth + audit middleware.
+pub fn build_admin_router<S>(state: Arc<S>) -> Router
+where
+    S: AdminAppState,
+{
+    let auth = state.auth();
+    let audit = state.audit();
+
+    Router::new()
+        // ── workflows ──────────────────────────────────────────────────────
+        .route(
+            "/admin/workflows",
+            get(workflows::list::<S>).post(workflows::create::<S>),
+        )
+        .route(
+            "/admin/workflows/{id}",
+            get(workflows::show::<S>).delete(workflows::delete::<S>),
+        )
+        // ── policies ───────────────────────────────────────────────────────
+        .route("/admin/policies", get(policies::list::<S>))
+        .route("/admin/policies/reload", post(policies::reload::<S>))
+        .route("/admin/policies/validate", post(policies::validate::<S>))
+        .route("/admin/policies/{name}", get(policies::show::<S>))
+        // ── sessions ───────────────────────────────────────────────────────
+        .route("/admin/sessions", get(sessions::list::<S>))
+        .route(
+            "/admin/sessions/{id}",
+            get(sessions::show::<S>).delete(sessions::kill::<S>),
+        )
+        // ── agents ─────────────────────────────────────────────────────────
+        .route("/admin/agents/spawn", post(agents::spawn::<S>))
+        .route(
+            "/admin/agents/{id}",
+            get(agents::show::<S>).delete(agents::kill::<S>),
+        )
+        // ── killswitch ─────────────────────────────────────────────────────
+        .route("/admin/killswitch/arm", post(killswitch::arm::<S>))
+        .route("/admin/killswitch/disarm", post(killswitch::disarm::<S>))
+        .route("/admin/killswitch/status", get(killswitch::status::<S>))
+        // Layers wrap inside-out: the LAST `.layer(...)` runs FIRST on a
+        // request. We want audit to observe every request — including 401s —
+        // so audit must be the outermost layer, applied last.
+        .layer(middleware::from_fn_with_state(
+            Arc::clone(&auth),
+            require_admin_token,
+        ))
+        .layer(middleware::from_fn_with_state(audit, audit_layer))
+        .with_state(state)
+}
+
+/// Bind the admin listener and serve until `shutdown` resolves.
+///
+/// Returns the bound [`SocketAddr`] via the `bound` channel so callers can
+/// observe the actual port (useful for `:0` in tests).
+pub async fn serve_admin<S>(
+    state: Arc<S>,
+    addr: SocketAddr,
+    bound: tokio::sync::oneshot::Sender<SocketAddr>,
+    shutdown: impl std::future::Future<Output = ()> + Send + 'static,
+) -> std::io::Result<()>
+where
+    S: AdminAppState,
+{
+    let app = build_admin_router(state);
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    let local = listener.local_addr()?;
+    tracing::info!(%local, "admin HTTP server listening");
+    let _ = bound.send(local);
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown)
+        .await
+}
+
+/// Middleware wrapper: capture method/path/status/duration and write one row
+/// to the audit log. Runs *after* auth so the [`AdminCaller`] extension is
+/// already populated; if the request was rejected by auth (401) it falls back
+/// to a fingerprint of the empty string. We intentionally do not log the
+/// request body — admin requests can carry secrets (e.g. a workflow manifest
+/// with embedded API keys), and surface area for accidental leaks must be
+/// small.
+async fn audit_layer(
+    State(audit): State<Arc<AdminAuditLogger>>,
+    request: Request,
+    next: Next,
+) -> Response {
+    let method = request.method().clone();
+    let path = request.uri().path().to_string();
+    let started = Instant::now();
+    let response = next.run(request).await;
+    let status = response.status().as_u16();
+    let caller = response
+        .extensions()
+        .get::<AdminCaller>()
+        .map(|c| c.0.clone())
+        .unwrap_or_else(|| TokenFingerprint::of(""));
+
+    audit
+        .append(AdminAuditEntry {
+            ts: now_iso(),
+            caller: caller.as_str(),
+            method: method.as_str(),
+            path: &path,
+            status,
+            args: serde_json::Value::Null,
+            ms: started.elapsed().as_millis() as u64,
+        })
+        .await;
+    response
+}
+
+/// Resolve the admin port from `SERA_ADMIN_PORT` (default [`DEFAULT_ADMIN_PORT`]).
+pub fn resolve_admin_port() -> u16 {
+    std::env::var("SERA_ADMIN_PORT")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_ADMIN_PORT)
+}
+
+/// Resolve the admin bind address from `SERA_ADMIN_BIND` (default
+/// [`DEFAULT_ADMIN_BIND`]).
+pub fn resolve_admin_bind() -> String {
+    std::env::var("SERA_ADMIN_BIND")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| DEFAULT_ADMIN_BIND.to_string())
+}
+

--- a/rust/crates/sera-gateway/src/admin/state.rs
+++ b/rust/crates/sera-gateway/src/admin/state.rs
@@ -1,0 +1,86 @@
+//! Admin app-state abstraction (sera-nrn9).
+//!
+//! Routes are generic over [`AdminAppState`] so the binary's `AppState` can
+//! plug in production stores while tests use lightweight fakes — same pattern
+//! `routes::workflow` already follows for the public API.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use crate::admin::audit::AdminAuditLogger;
+use crate::admin::auth::AdminAuth;
+use crate::capability_enforcement::CapabilityRegistry;
+use crate::kill_switch::KillSwitch;
+use crate::workflow_store::WorkflowTaskStore;
+use tokio::sync::RwLock;
+use tokio_util::sync::CancellationToken;
+
+/// Snapshot of a session for `/admin/sessions` listings. Kept narrow so impls
+/// don't have to expose their full transcript surface.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct AdminSessionInfo {
+    pub id: String,
+    pub agent_id: String,
+    pub session_key: String,
+    pub state: String,
+}
+
+/// Capabilities the admin handlers require from the surrounding app state.
+///
+/// Capability negotiation is intentionally narrow: each method returns either
+/// the live thing we can act on, or `None` to indicate the handler should
+/// answer 501. No silent fallbacks — the handler decides what to do with the
+/// `None`.
+#[async_trait::async_trait]
+pub trait AdminAppState: Send + Sync + 'static {
+    fn auth(&self) -> Arc<AdminAuth>;
+    fn audit(&self) -> Arc<AdminAuditLogger>;
+    fn kill_switch(&self) -> Arc<KillSwitch>;
+    fn capability_registry(&self) -> Arc<RwLock<Arc<CapabilityRegistry>>>;
+    fn policies_dir(&self) -> PathBuf;
+
+    /// Workflow store, when wired. None → routes return 501.
+    fn workflow_store(&self) -> Option<Arc<dyn WorkflowTaskStore>> {
+        None
+    }
+
+    /// List active sessions.
+    async fn list_sessions(&self) -> Vec<AdminSessionInfo> {
+        Vec::new()
+    }
+
+    /// Look up one session by id.
+    async fn get_session(&self, _id: &str) -> Option<AdminSessionInfo> {
+        None
+    }
+
+    /// Cancel an in-flight session by session_key, returning the cancelled
+    /// token (so the caller can also drop the lane slot). Returns `false`
+    /// when no token was registered for that session.
+    fn cancel_session(&self, _session_key: &str) -> bool {
+        false
+    }
+
+    /// Look up agent metadata for `id`. None → 404.
+    fn agent_metadata(&self, _id: &str) -> Option<serde_json::Value> {
+        None
+    }
+
+    /// Spawn an agent. Default impl returns None → routes return 501.
+    async fn spawn_agent(&self, _spec: serde_json::Value) -> Option<serde_json::Value> {
+        None
+    }
+
+    /// Kill an agent by id. Default impl returns false → routes return 501.
+    async fn kill_agent(&self, _id: &str) -> bool {
+        false
+    }
+}
+
+/// In-flight cancellation token registry helper. The binary's `AppState`
+/// already owns one of these on the `active_cancellation_tokens` field; the
+/// trait method [`AdminAppState::cancel_session`] is the canonical hook
+/// admin routes use, so we expose this helper here for tests that want to
+/// stand up an `AdminAppState` impl quickly.
+pub type CancellationRegistry =
+    Arc<std::sync::Mutex<std::collections::HashMap<String, CancellationToken>>>;

--- a/rust/crates/sera-gateway/src/bin/sera.rs
+++ b/rust/crates/sera-gateway/src/bin/sera.rs
@@ -49,6 +49,10 @@ use sera_memory::{DEFAULT_SQLITE_VEC_DIMENSIONS, SqliteMemoryStore};
 use sera_runtime::skill_dispatch::SkillDispatchEngine;
 // sera-uwk0: Mail gate ingress correlator (Design B — RFC 5322 headers +
 // SERA-issued nonce fallback). Wired into AppState + `/api/mail/inbound`.
+use sera_gateway::admin::{
+    AdminAppState, AdminAuditLogger, AdminAuth, AdminSessionInfo, resolve_admin_bind,
+    resolve_admin_port, serve_admin,
+};
 use sera_gateway::capability_enforcement::{CapabilityRegistry, PolicyDenial};
 use sera_gateway::hitl_gateway::{
     HitlAppState, InMemoryTicketStore, TicketStore, resolve_approval_routing, resolve_hitl_mode,
@@ -629,7 +633,12 @@ struct AppState {
     /// runtime NDJSON stream (`StdioHarness::send_turn`) and on any future
     /// gateway-side tool dispatch. Agents with no `policyRef` bypass the check
     /// (permissive).
-    capability_registry: Arc<CapabilityRegistry>,
+    ///
+    /// Wrapped in `RwLock<Arc<…>>` so the admin HTTP `POST /admin/policies/reload`
+    /// route (sera-nrn9) can swap the registry without restarting the gateway.
+    /// Readers acquire a shared lock + clone the inner `Arc`, so concurrent
+    /// turns never block the swap.
+    capability_registry: Arc<RwLock<Arc<CapabilityRegistry>>>,
     /// HITL ticket store (sera-z6ql, Wave D Phase 1). Populated by
     /// `chat_handler` whenever the ApprovalRouter says a turn needs
     /// approval; read by the `/api/hitl/requests[/…]` routes so humans can
@@ -642,6 +651,13 @@ struct AppState {
     /// the scheduler spawned in `run_start`. Phase 1 uses an in-memory
     /// store — SQLite-backed store is a follow-up bead.
     workflow_store: Arc<dyn WorkflowTaskStore>,
+    /// Admin HTTP auth (sera-nrn9, L.3). Separate token from the public
+    /// API's `api_key`. `None` when the admin server is not started (e.g. in
+    /// tests that don't exercise admin routes).
+    admin_auth: Option<Arc<AdminAuth>>,
+    /// JSONL audit log handle for admin requests (sera-nrn9). `None` when
+    /// the admin server is not started.
+    admin_audit: Option<Arc<AdminAuditLogger>>,
 }
 
 impl AppState {
@@ -693,6 +709,96 @@ impl AppState {
             token.cancel();
         }
         count
+    }
+}
+
+#[async_trait::async_trait]
+impl AdminAppState for AppState {
+    fn auth(&self) -> Arc<AdminAuth> {
+        Arc::clone(
+            self.admin_auth
+                .as_ref()
+                .expect("admin_auth must be initialised before serving admin HTTP"),
+        )
+    }
+
+    fn audit(&self) -> Arc<AdminAuditLogger> {
+        Arc::clone(
+            self.admin_audit
+                .as_ref()
+                .expect("admin_audit must be initialised before serving admin HTTP"),
+        )
+    }
+
+    fn kill_switch(&self) -> Arc<KillSwitch> {
+        Arc::clone(&self.kill_switch)
+    }
+
+    fn capability_registry(&self) -> Arc<RwLock<Arc<CapabilityRegistry>>> {
+        Arc::clone(&self.capability_registry)
+    }
+
+    fn policies_dir(&self) -> std::path::PathBuf {
+        CapabilityRegistry::resolve_policies_dir()
+    }
+
+    fn workflow_store(&self) -> Option<Arc<dyn WorkflowTaskStore>> {
+        Some(Arc::clone(&self.workflow_store))
+    }
+
+    async fn list_sessions(&self) -> Vec<AdminSessionInfo> {
+        let db = self.db.lock().await;
+        db.list_sessions()
+            .map(|rows| {
+                rows.into_iter()
+                    .map(|r| AdminSessionInfo {
+                        id: r.id,
+                        agent_id: r.agent_id,
+                        session_key: r.session_key,
+                        state: r.state,
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    async fn get_session(&self, id: &str) -> Option<AdminSessionInfo> {
+        let db = self.db.lock().await;
+        db.list_sessions()
+            .ok()?
+            .into_iter()
+            .find(|r| r.id == id || r.session_key == id)
+            .map(|r| AdminSessionInfo {
+                id: r.id,
+                agent_id: r.agent_id,
+                session_key: r.session_key,
+                state: r.state,
+            })
+    }
+
+    fn cancel_session(&self, session_key: &str) -> bool {
+        let mut map = self
+            .active_cancellation_tokens
+            .lock()
+            .expect("active_cancellation_tokens mutex poisoned");
+        if let Some(token) = map.remove(session_key) {
+            token.cancel();
+            true
+        } else {
+            false
+        }
+    }
+
+    fn agent_metadata(&self, id: &str) -> Option<serde_json::Value> {
+        let agent_names = self.manifests.agent_names();
+        let name = agent_names.iter().copied().find(|n| *n == id)?;
+        let spec = self.manifests.agent_spec(name).ok().flatten();
+        Some(serde_json::json!({
+            "name": name,
+            "provider": spec.as_ref().map(|s| s.provider.as_str()).unwrap_or(""),
+            "model": spec.as_ref().and_then(|s| s.model.as_deref()),
+            "has_tools": spec.as_ref().and_then(|s| s.tools.as_ref()).is_some(),
+        }))
     }
 }
 
@@ -1309,6 +1415,7 @@ async fn chat_handler(
                         agent_name,
                     } => {
                         let cancel = state.register_cancellation_token(&session_key);
+                        let cap_reg = state.capability_registry.read().await.clone();
                         let result = execute_turn(
                             &agent_spec,
                             &transcript,
@@ -1319,7 +1426,7 @@ async fn chat_handler(
                             &state.semantic_store,
                             &agent_name,
                             &cancel,
-                            &state.capability_registry,
+                            &cap_reg,
                         )
                         .await;
                         state.deregister_cancellation_token(&session_key);
@@ -1427,6 +1534,7 @@ async fn chat_handler(
     } else {
         // Synchronous JSON mode (existing behavior).
         let cancel = state.register_cancellation_token(&session_key);
+        let cap_reg = state.capability_registry.read().await.clone();
         let result = execute_turn(
             &agent_spec,
             &transcript,
@@ -1437,7 +1545,7 @@ async fn chat_handler(
             &state.semantic_store,
             &agent_name,
             &cancel,
-            &state.capability_registry,
+            &cap_reg,
         )
         .await;
         state.deregister_cancellation_token(&session_key);
@@ -2501,6 +2609,7 @@ async fn process_message(state: &AppState, msg: &DiscordMessage) -> anyhow::Resu
 
     // Execute the agent turn via the pre-connected harness.
     let cancel = state.register_cancellation_token(&session_key);
+    let cap_reg = state.capability_registry.read().await.clone();
     let result = execute_turn(
         &agent_spec,
         &transcript,
@@ -2511,7 +2620,7 @@ async fn process_message(state: &AppState, msg: &DiscordMessage) -> anyhow::Resu
         &state.semantic_store,
         &agent_name,
         &cancel,
-        &state.capability_registry,
+        &cap_reg,
     )
     .await;
     state.deregister_cancellation_token(&session_key);
@@ -2652,6 +2761,7 @@ async fn process_message(state: &AppState, msg: &DiscordMessage) -> anyhow::Resu
         };
 
         let cancel = state.register_cancellation_token(&session_key);
+        let cap_reg = state.capability_registry.read().await.clone();
         let follow_up = execute_turn(
             &agent_spec,
             &transcript,
@@ -2662,7 +2772,7 @@ async fn process_message(state: &AppState, msg: &DiscordMessage) -> anyhow::Resu
             &state.semantic_store,
             &agent_name,
             &cancel,
-            &state.capability_registry,
+            &cap_reg,
         )
         .await;
         state.deregister_cancellation_token(&session_key);
@@ -2961,7 +3071,7 @@ async fn main() -> anyhow::Result<()> {
             } else {
                 config
             };
-            run_start(config, port).await
+            run_start(config, port, local).await
         }
 
         Commands::Doctor { config, json } => {
@@ -3109,7 +3219,7 @@ async fn apply_local_defaults(config: PathBuf, port: u16) -> anyhow::Result<Path
     Ok(resolved_config)
 }
 
-async fn run_start(config: PathBuf, port: u16) -> anyhow::Result<()> {
+async fn run_start(config: PathBuf, port: u16, local: bool) -> anyhow::Result<()> {
     // 1. Load config.
     tracing::info!(config = %config.display(), "Loading SERA configuration");
     let manifests = load_manifest_file(&config)?;
@@ -3486,6 +3596,17 @@ async fn run_start(config: PathBuf, port: u16) -> anyhow::Result<()> {
         }
     }
 
+    // sera-nrn9: admin HTTP server auth + audit log. Token comes from
+    // SERA_ADMIN_TOKEN; in --local mode we mint a random token at boot and
+    // print it once to stderr so dev workflows still work.
+    let admin_auth = Arc::new(AdminAuth::resolve(local).map_err(|e| {
+        anyhow::anyhow!(
+            "{e} (set SERA_ADMIN_TOKEN to enable admin HTTP, or pass --local to auto-generate)"
+        )
+    })?);
+    let admin_audit_path = AdminAuditLogger::default_path(&data_root);
+    let admin_audit = AdminAuditLogger::shared(admin_audit_path);
+
     let state = Arc::new(AppState {
         db: Mutex::new(db),
         manifests,
@@ -3526,9 +3647,11 @@ async fn run_start(config: PathBuf, port: u16) -> anyhow::Result<()> {
             )
         },
         constitutional_registry,
-        capability_registry: Arc::clone(&capability_registry),
+        capability_registry: Arc::new(RwLock::new(Arc::clone(&capability_registry))),
         ticket_store: Arc::new(InMemoryTicketStore::new()),
         workflow_store: Arc::new(InMemoryWorkflowTaskStore::new()),
+        admin_auth: Some(Arc::clone(&admin_auth)),
+        admin_audit: Some(Arc::clone(&admin_audit)),
     });
 
     // 4. Start event processing loop.
@@ -3562,6 +3685,36 @@ async fn run_start(config: PathBuf, port: u16) -> anyhow::Result<()> {
                 "ROLLBACK received on admin socket — gateway halted"
             );
         });
+    }
+
+    // 4b. Start the admin HTTP server (sera-nrn9, L.3). Binds separately
+    // from the public API on `SERA_ADMIN_BIND:SERA_ADMIN_PORT` (default
+    // 127.0.0.1:3002). Runs in the background; the gateway considers itself
+    // ready once both listeners are bound.
+    let admin_shutdown = Arc::clone(&shutting_down);
+    let admin_state_clone = Arc::clone(&state);
+    let admin_bind = resolve_admin_bind();
+    let admin_port = resolve_admin_port();
+    let admin_addr: SocketAddr = format!("{admin_bind}:{admin_port}")
+        .parse()
+        .map_err(|e| anyhow::anyhow!("invalid admin bind address {admin_bind}:{admin_port}: {e}"))?;
+    let (admin_bound_tx, admin_bound_rx) = tokio::sync::oneshot::channel();
+    tokio::spawn(async move {
+        let shutdown = async move {
+            while !admin_shutdown.load(std::sync::atomic::Ordering::SeqCst) {
+                tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+            }
+        };
+        if let Err(e) =
+            serve_admin(admin_state_clone, admin_addr, admin_bound_tx, shutdown).await
+        {
+            tracing::error!(error = %e, "admin HTTP server exited with error");
+        }
+    });
+    match tokio::time::timeout(std::time::Duration::from_secs(2), admin_bound_rx).await {
+        Ok(Ok(addr)) => tracing::info!(%addr, "admin HTTP server bound"),
+        Ok(Err(_)) => tracing::warn!("admin HTTP server task ended before binding"),
+        Err(_) => tracing::warn!("admin HTTP server bind timed out — continuing anyway"),
     }
 
     // 5. Build and start HTTP server.
@@ -4020,9 +4173,11 @@ mod tests {
             // writing shadow-git dirs to the filesystem during tests.
             session_store: Arc::new(InMemorySessionStore::new()),
             constitutional_registry: Arc::new(ConstitutionalRegistry::new()),
-            capability_registry: Arc::new(CapabilityRegistry::empty()),
+            capability_registry: Arc::new(RwLock::new(Arc::new(CapabilityRegistry::empty()))),
             ticket_store: Arc::new(InMemoryTicketStore::new()),
             workflow_store: Arc::new(InMemoryWorkflowTaskStore::new()),
+            admin_auth: None,
+            admin_audit: None,
         })
     }
 
@@ -4063,9 +4218,11 @@ mod tests {
             // writing shadow-git dirs to the filesystem during tests.
             session_store: Arc::new(InMemorySessionStore::new()),
             constitutional_registry: Arc::new(ConstitutionalRegistry::new()),
-            capability_registry: Arc::new(CapabilityRegistry::empty()),
+            capability_registry: Arc::new(RwLock::new(Arc::new(CapabilityRegistry::empty()))),
             ticket_store: Arc::new(InMemoryTicketStore::new()),
             workflow_store: Arc::new(InMemoryWorkflowTaskStore::new()),
+            admin_auth: None,
+            admin_audit: None,
         })
     }
 
@@ -4106,9 +4263,11 @@ mod tests {
             // writing shadow-git dirs to the filesystem during tests.
             session_store: Arc::new(InMemorySessionStore::new()),
             constitutional_registry: Arc::new(ConstitutionalRegistry::new()),
-            capability_registry: Arc::new(CapabilityRegistry::empty()),
+            capability_registry: Arc::new(RwLock::new(Arc::new(CapabilityRegistry::empty()))),
             ticket_store: Arc::new(InMemoryTicketStore::new()),
             workflow_store: Arc::new(InMemoryWorkflowTaskStore::new()),
+            admin_auth: None,
+            admin_audit: None,
         })
     }
 
@@ -4149,9 +4308,11 @@ mod tests {
             // writing shadow-git dirs to the filesystem during tests.
             session_store: Arc::new(InMemorySessionStore::new()),
             constitutional_registry: Arc::new(ConstitutionalRegistry::new()),
-            capability_registry: Arc::new(CapabilityRegistry::empty()),
+            capability_registry: Arc::new(RwLock::new(Arc::new(CapabilityRegistry::empty()))),
             ticket_store: Arc::new(InMemoryTicketStore::new()),
             workflow_store: Arc::new(InMemoryWorkflowTaskStore::new()),
+            admin_auth: None,
+            admin_audit: None,
         })
     }
 
@@ -4641,9 +4802,11 @@ spec:
             )),
             session_store: Arc::new(InMemorySessionStore::new()),
             constitutional_registry: Arc::new(ConstitutionalRegistry::new()),
-            capability_registry: Arc::new(CapabilityRegistry::empty()),
+            capability_registry: Arc::new(RwLock::new(Arc::new(CapabilityRegistry::empty()))),
             ticket_store: Arc::new(InMemoryTicketStore::new()),
             workflow_store: Arc::new(InMemoryWorkflowTaskStore::new()),
+            admin_auth: None,
+            admin_audit: None,
         })
     }
 
@@ -5146,9 +5309,11 @@ spec:
             // writing shadow-git dirs to the filesystem during tests.
             session_store: Arc::new(InMemorySessionStore::new()),
             constitutional_registry: Arc::new(ConstitutionalRegistry::new()),
-            capability_registry: Arc::new(CapabilityRegistry::empty()),
+            capability_registry: Arc::new(RwLock::new(Arc::new(CapabilityRegistry::empty()))),
             ticket_store: Arc::new(InMemoryTicketStore::new()),
             workflow_store: Arc::new(InMemoryWorkflowTaskStore::new()),
+            admin_auth: None,
+            admin_audit: None,
         };
         let headers = HeaderMap::new();
         assert!(validate_api_key(&state, &headers).is_ok());
@@ -5192,9 +5357,11 @@ spec:
             // writing shadow-git dirs to the filesystem during tests.
             session_store: Arc::new(InMemorySessionStore::new()),
             constitutional_registry: Arc::new(ConstitutionalRegistry::new()),
-            capability_registry: Arc::new(CapabilityRegistry::empty()),
+            capability_registry: Arc::new(RwLock::new(Arc::new(CapabilityRegistry::empty()))),
             ticket_store: Arc::new(InMemoryTicketStore::new()),
             workflow_store: Arc::new(InMemoryWorkflowTaskStore::new()),
+            admin_auth: None,
+            admin_audit: None,
         };
         let mut headers = HeaderMap::new();
         headers.insert("authorization", "Bearer my-key".parse().unwrap());
@@ -5239,9 +5406,11 @@ spec:
             // writing shadow-git dirs to the filesystem during tests.
             session_store: Arc::new(InMemorySessionStore::new()),
             constitutional_registry: Arc::new(ConstitutionalRegistry::new()),
-            capability_registry: Arc::new(CapabilityRegistry::empty()),
+            capability_registry: Arc::new(RwLock::new(Arc::new(CapabilityRegistry::empty()))),
             ticket_store: Arc::new(InMemoryTicketStore::new()),
             workflow_store: Arc::new(InMemoryWorkflowTaskStore::new()),
+            admin_auth: None,
+            admin_audit: None,
         };
         let mut headers = HeaderMap::new();
         headers.insert("authorization", "Bearer wrong".parse().unwrap());
@@ -5289,9 +5458,11 @@ spec:
             // writing shadow-git dirs to the filesystem during tests.
             session_store: Arc::new(InMemorySessionStore::new()),
             constitutional_registry: Arc::new(ConstitutionalRegistry::new()),
-            capability_registry: Arc::new(CapabilityRegistry::empty()),
+            capability_registry: Arc::new(RwLock::new(Arc::new(CapabilityRegistry::empty()))),
             ticket_store: Arc::new(InMemoryTicketStore::new()),
             workflow_store: Arc::new(InMemoryWorkflowTaskStore::new()),
+            admin_auth: None,
+            admin_audit: None,
         };
         let headers = HeaderMap::new();
         assert_eq!(
@@ -5984,9 +6155,11 @@ spec:
             // writing shadow-git dirs to the filesystem during tests.
             session_store: Arc::new(InMemorySessionStore::new()),
             constitutional_registry: Arc::new(ConstitutionalRegistry::new()),
-            capability_registry: Arc::new(CapabilityRegistry::empty()),
+            capability_registry: Arc::new(RwLock::new(Arc::new(CapabilityRegistry::empty()))),
             ticket_store: Arc::new(InMemoryTicketStore::new()),
             workflow_store: Arc::new(InMemoryWorkflowTaskStore::new()),
+            admin_auth: None,
+            admin_audit: None,
         });
 
         let app = build_router(Arc::clone(&state));
@@ -6069,9 +6242,11 @@ spec:
                 // writing shadow-git dirs to the filesystem during tests.
                 session_store: Arc::new(InMemorySessionStore::new()),
                 constitutional_registry: Arc::new(ConstitutionalRegistry::new()),
-                capability_registry: Arc::new(CapabilityRegistry::empty()),
+                capability_registry: Arc::new(RwLock::new(Arc::new(CapabilityRegistry::empty()))),
                 ticket_store: Arc::new(InMemoryTicketStore::new()),
                 workflow_store: Arc::new(InMemoryWorkflowTaskStore::new()),
+                admin_auth: None,
+                admin_audit: None,
             })
         };
         let app = build_router(state);

--- a/rust/crates/sera-gateway/src/lib.rs
+++ b/rust/crates/sera-gateway/src/lib.rs
@@ -1,5 +1,6 @@
 //! SERA Gateway — reusable library for gateway types, transport, and harness dispatch.
 
+pub mod admin;
 pub mod capability_enforcement;
 pub mod connector;
 pub mod constitutional_config;

--- a/rust/crates/sera-gateway/tests/admin_server.rs
+++ b/rust/crates/sera-gateway/tests/admin_server.rs
@@ -1,0 +1,580 @@
+//! Admin HTTP server integration tests (sera-nrn9, L.3).
+//!
+//! Stands up the admin router via `build_admin_router` against a lightweight
+//! `AdminAppState` impl, then exercises every endpoint with valid + invalid
+//! tokens. The bootstrap dev key (used by the public API) must be rejected on
+//! every admin route — otherwise the separation of admin vs operator auth is
+//! meaningless.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use sera_gateway::admin::{
+    AdminAppState, AdminAuditLogger, AdminAuth, AdminSessionInfo, build_admin_router,
+};
+use sera_gateway::capability_enforcement::CapabilityRegistry;
+use sera_gateway::kill_switch::KillSwitch;
+use sera_gateway::workflow_store::{InMemoryWorkflowTaskStore, WorkflowTaskStore};
+use tempfile::TempDir;
+use tokio::sync::RwLock;
+use tokio_util::sync::CancellationToken;
+use tower::ServiceExt;
+
+const ADMIN_TOKEN: &str = "test-admin-token-1234567890abcdef";
+const BOOTSTRAP_KEY: &str = "sera_bootstrap_dev_123";
+
+struct TestState {
+    auth: Arc<AdminAuth>,
+    audit: Arc<AdminAuditLogger>,
+    kill_switch: Arc<KillSwitch>,
+    capability_registry: Arc<RwLock<Arc<CapabilityRegistry>>>,
+    policies_dir: PathBuf,
+    workflow_store: Arc<dyn WorkflowTaskStore>,
+    cancel_registry: std::sync::Mutex<std::collections::HashMap<String, CancellationToken>>,
+    sessions: std::sync::Mutex<Vec<AdminSessionInfo>>,
+}
+
+impl TestState {
+    fn new(tmp: &TempDir) -> Arc<Self> {
+        let auth = Arc::new(AdminAuth::new(ADMIN_TOKEN));
+        let audit_path = AdminAuditLogger::default_path(tmp.path());
+        let audit = AdminAuditLogger::shared(audit_path);
+        let policies_dir = tmp.path().join("policies");
+        std::fs::create_dir_all(&policies_dir).unwrap();
+        Arc::new(Self {
+            auth,
+            audit,
+            kill_switch: Arc::new(KillSwitch::new()),
+            capability_registry: Arc::new(RwLock::new(Arc::new(CapabilityRegistry::empty()))),
+            policies_dir,
+            workflow_store: Arc::new(InMemoryWorkflowTaskStore::new()),
+            cancel_registry: std::sync::Mutex::new(std::collections::HashMap::new()),
+            sessions: std::sync::Mutex::new(Vec::new()),
+        })
+    }
+
+    fn audit_path(&self) -> PathBuf {
+        self.audit.path().to_path_buf()
+    }
+}
+
+#[async_trait::async_trait]
+impl AdminAppState for TestState {
+    fn auth(&self) -> Arc<AdminAuth> {
+        Arc::clone(&self.auth)
+    }
+    fn audit(&self) -> Arc<AdminAuditLogger> {
+        Arc::clone(&self.audit)
+    }
+    fn kill_switch(&self) -> Arc<KillSwitch> {
+        Arc::clone(&self.kill_switch)
+    }
+    fn capability_registry(&self) -> Arc<RwLock<Arc<CapabilityRegistry>>> {
+        Arc::clone(&self.capability_registry)
+    }
+    fn policies_dir(&self) -> PathBuf {
+        self.policies_dir.clone()
+    }
+    fn workflow_store(&self) -> Option<Arc<dyn WorkflowTaskStore>> {
+        Some(Arc::clone(&self.workflow_store))
+    }
+    async fn list_sessions(&self) -> Vec<AdminSessionInfo> {
+        self.sessions.lock().unwrap().clone()
+    }
+    async fn get_session(&self, id: &str) -> Option<AdminSessionInfo> {
+        self.sessions
+            .lock()
+            .unwrap()
+            .iter()
+            .find(|s| s.id == id || s.session_key == id)
+            .cloned()
+    }
+    fn cancel_session(&self, session_key: &str) -> bool {
+        let mut map = self.cancel_registry.lock().unwrap();
+        if let Some(tok) = map.remove(session_key) {
+            tok.cancel();
+            true
+        } else {
+            false
+        }
+    }
+    fn agent_metadata(&self, id: &str) -> Option<serde_json::Value> {
+        if id == "agent-known" {
+            Some(serde_json::json!({"name": id, "provider": "test"}))
+        } else {
+            None
+        }
+    }
+}
+
+fn req(method: &str, path: &str, token: Option<&str>) -> Request<Body> {
+    let mut builder = Request::builder().method(method).uri(path);
+    if let Some(t) = token {
+        builder = builder.header("authorization", format!("Bearer {t}"));
+    }
+    builder.body(Body::empty()).unwrap()
+}
+
+fn req_json(method: &str, path: &str, token: Option<&str>, body: serde_json::Value) -> Request<Body> {
+    let mut builder = Request::builder()
+        .method(method)
+        .uri(path)
+        .header("content-type", "application/json");
+    if let Some(t) = token {
+        builder = builder.header("authorization", format!("Bearer {t}"));
+    }
+    builder
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap()
+}
+
+// ── Auth tests ─────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn missing_token_returns_401_on_every_route() {
+    let tmp = TempDir::new().unwrap();
+    let state = TestState::new(&tmp);
+    let app = build_admin_router(state);
+    for path in [
+        "/admin/workflows",
+        "/admin/policies",
+        "/admin/sessions",
+        "/admin/killswitch/status",
+    ] {
+        let resp = app.clone().oneshot(req("GET", path, None)).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED, "path={path}");
+    }
+}
+
+#[tokio::test]
+async fn bootstrap_key_does_not_grant_admin_access() {
+    let tmp = TempDir::new().unwrap();
+    let state = TestState::new(&tmp);
+    let app = build_admin_router(state);
+    for path in [
+        "/admin/workflows",
+        "/admin/policies",
+        "/admin/sessions",
+        "/admin/killswitch/status",
+    ] {
+        let resp = app
+            .clone()
+            .oneshot(req("GET", path, Some(BOOTSTRAP_KEY)))
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::UNAUTHORIZED,
+            "bootstrap key must not pass admin auth on {path}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn random_token_returns_401() {
+    let tmp = TempDir::new().unwrap();
+    let state = TestState::new(&tmp);
+    let app = build_admin_router(state);
+    let resp = app
+        .oneshot(req("GET", "/admin/policies", Some("random-token-xyz")))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn valid_token_passes_auth() {
+    let tmp = TempDir::new().unwrap();
+    let state = TestState::new(&tmp);
+    let app = build_admin_router(state);
+    let resp = app
+        .oneshot(req("GET", "/admin/killswitch/status", Some(ADMIN_TOKEN)))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+// ── Killswitch ──────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn killswitch_arm_disarm_status_round_trip() {
+    let tmp = TempDir::new().unwrap();
+    let state = TestState::new(&tmp);
+    let ks = Arc::clone(&state.kill_switch);
+    let app = build_admin_router(state);
+
+    // Initially disarmed.
+    let resp = app
+        .clone()
+        .oneshot(req("GET", "/admin/killswitch/status", Some(ADMIN_TOKEN)))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let parsed: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(parsed["armed"], false);
+
+    // Arm it via HTTP.
+    let resp = app
+        .clone()
+        .oneshot(req("POST", "/admin/killswitch/arm", Some(ADMIN_TOKEN)))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+    assert!(ks.is_armed(), "shared KillSwitch must observe HTTP arm");
+
+    // Status reflects armed.
+    let resp = app
+        .clone()
+        .oneshot(req("GET", "/admin/killswitch/status", Some(ADMIN_TOKEN)))
+        .await
+        .unwrap();
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let parsed: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(parsed["armed"], true);
+
+    // Disarm.
+    let resp = app
+        .clone()
+        .oneshot(req("POST", "/admin/killswitch/disarm", Some(ADMIN_TOKEN)))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+    assert!(!ks.is_armed());
+}
+
+// ── Policies ────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn policies_list_empty_returns_ok() {
+    let tmp = TempDir::new().unwrap();
+    let state = TestState::new(&tmp);
+    let app = build_admin_router(state);
+    let resp = app
+        .oneshot(req("GET", "/admin/policies", Some(ADMIN_TOKEN)))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let parsed: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert!(parsed["policies"].as_array().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn policies_show_returns_yaml_manifest() {
+    let tmp = TempDir::new().unwrap();
+    let state = TestState::new(&tmp);
+    let policies_dir = state.policies_dir.clone();
+    std::fs::write(
+        policies_dir.join("tier-1.yaml"),
+        "apiVersion: sera/v1\nkind: CapabilityPolicy\nmetadata:\n  name: tier-1\nallowedTools:\n  - memory_read\n",
+    )
+    .unwrap();
+    let app = build_admin_router(state);
+
+    let resp = app
+        .oneshot(req("GET", "/admin/policies/tier-1", Some(ADMIN_TOKEN)))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let parsed: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(parsed["name"], "tier-1");
+    assert_eq!(parsed["manifest"]["metadata"]["name"], "tier-1");
+}
+
+#[tokio::test]
+async fn policies_show_rejects_traversal() {
+    let tmp = TempDir::new().unwrap();
+    let state = TestState::new(&tmp);
+    let app = build_admin_router(state);
+    let resp = app
+        .oneshot(req("GET", "/admin/policies/..%2Fetc%2Fpasswd", Some(ADMIN_TOKEN)))
+        .await
+        .unwrap();
+    // axum does %xx decoding before path matching, then our handler rejects.
+    assert!(
+        resp.status() == StatusCode::BAD_REQUEST
+            || resp.status() == StatusCode::NOT_FOUND
+            || resp.status() == StatusCode::UNPROCESSABLE_ENTITY,
+        "got {}",
+        resp.status()
+    );
+}
+
+#[tokio::test]
+async fn policies_show_404_for_missing() {
+    let tmp = TempDir::new().unwrap();
+    let state = TestState::new(&tmp);
+    let app = build_admin_router(state);
+    let resp = app
+        .oneshot(req("GET", "/admin/policies/nope", Some(ADMIN_TOKEN)))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn policies_reload_swaps_registry() {
+    let tmp = TempDir::new().unwrap();
+    let state = TestState::new(&tmp);
+    let cell = Arc::clone(&state.capability_registry);
+    let policies_dir = state.policies_dir.clone();
+    std::fs::write(
+        policies_dir.join("alpha.yaml"),
+        "apiVersion: sera/v1\nkind: CapabilityPolicy\nmetadata:\n  name: alpha\nallowedTools:\n  - shell\n",
+    )
+    .unwrap();
+    let app = build_admin_router(state);
+
+    let before_count = cell.read().await.policy_count();
+    assert_eq!(before_count, 0);
+
+    let resp = app
+        .oneshot(req("POST", "/admin/policies/reload", Some(ADMIN_TOKEN)))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let after_count = cell.read().await.policy_count();
+    assert_eq!(after_count, 1);
+    assert!(cell.read().await.policy("alpha").is_some());
+}
+
+#[tokio::test]
+async fn policies_validate_reports_per_file_results() {
+    let tmp = TempDir::new().unwrap();
+    let state = TestState::new(&tmp);
+    let policies_dir = state.policies_dir.clone();
+    std::fs::write(
+        policies_dir.join("good.yaml"),
+        "apiVersion: sera/v1\nkind: CapabilityPolicy\nmetadata:\n  name: good\n",
+    )
+    .unwrap();
+    std::fs::write(policies_dir.join("bad.yaml"), "this: is: not: valid: yaml: {{").unwrap();
+    let app = build_admin_router(state);
+
+    let resp = app
+        .oneshot(req("POST", "/admin/policies/validate", Some(ADMIN_TOKEN)))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let parsed: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let results = parsed["results"].as_array().unwrap();
+    assert!(results.iter().any(|r| r["ok"] == true));
+    assert!(results.iter().any(|r| r["ok"] == false));
+    assert_eq!(parsed["ok"], false);
+}
+
+// ── Sessions ────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn sessions_list_returns_empty_initially() {
+    let tmp = TempDir::new().unwrap();
+    let state = TestState::new(&tmp);
+    let app = build_admin_router(state);
+    let resp = app
+        .oneshot(req("GET", "/admin/sessions", Some(ADMIN_TOKEN)))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn sessions_get_unknown_returns_404() {
+    let tmp = TempDir::new().unwrap();
+    let state = TestState::new(&tmp);
+    let app = build_admin_router(state);
+    let resp = app
+        .oneshot(req("GET", "/admin/sessions/abc", Some(ADMIN_TOKEN)))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn sessions_kill_fires_cancellation_token() {
+    let tmp = TempDir::new().unwrap();
+    let state = TestState::new(&tmp);
+    let token = CancellationToken::new();
+    state
+        .cancel_registry
+        .lock()
+        .unwrap()
+        .insert("session-X".to_string(), token.clone());
+    let app = build_admin_router(state);
+
+    let resp = app
+        .oneshot(req("DELETE", "/admin/sessions/session-X", Some(ADMIN_TOKEN)))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+    assert!(token.is_cancelled());
+}
+
+// ── Workflows ───────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn workflows_list_returns_empty_array() {
+    let tmp = TempDir::new().unwrap();
+    let state = TestState::new(&tmp);
+    let app = build_admin_router(state);
+    let resp = app
+        .oneshot(req("GET", "/admin/workflows", Some(ADMIN_TOKEN)))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let parsed: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert!(parsed["workflows"].as_array().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn workflows_create_returns_501() {
+    let tmp = TempDir::new().unwrap();
+    let state = TestState::new(&tmp);
+    let app = build_admin_router(state);
+    let resp = app
+        .oneshot(req_json(
+            "POST",
+            "/admin/workflows",
+            Some(ADMIN_TOKEN),
+            serde_json::json!({"kind": "WorkflowDef"}),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_IMPLEMENTED);
+}
+
+#[tokio::test]
+async fn workflows_show_unknown_404() {
+    let tmp = TempDir::new().unwrap();
+    let state = TestState::new(&tmp);
+    let app = build_admin_router(state);
+    let resp = app
+        .oneshot(req("GET", "/admin/workflows/abc", Some(ADMIN_TOKEN)))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn workflows_delete_returns_501() {
+    let tmp = TempDir::new().unwrap();
+    let state = TestState::new(&tmp);
+    let app = build_admin_router(state);
+    let resp = app
+        .oneshot(req("DELETE", "/admin/workflows/abc", Some(ADMIN_TOKEN)))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_IMPLEMENTED);
+}
+
+// ── Agents ──────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn agents_show_known_returns_metadata() {
+    let tmp = TempDir::new().unwrap();
+    let state = TestState::new(&tmp);
+    let app = build_admin_router(state);
+    let resp = app
+        .oneshot(req("GET", "/admin/agents/agent-known", Some(ADMIN_TOKEN)))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn agents_show_unknown_404() {
+    let tmp = TempDir::new().unwrap();
+    let state = TestState::new(&tmp);
+    let app = build_admin_router(state);
+    let resp = app
+        .oneshot(req("GET", "/admin/agents/missing", Some(ADMIN_TOKEN)))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn agents_spawn_returns_501() {
+    let tmp = TempDir::new().unwrap();
+    let state = TestState::new(&tmp);
+    let app = build_admin_router(state);
+    let resp = app
+        .oneshot(req_json(
+            "POST",
+            "/admin/agents/spawn",
+            Some(ADMIN_TOKEN),
+            serde_json::json!({"name": "test-agent"}),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_IMPLEMENTED);
+}
+
+#[tokio::test]
+async fn agents_kill_returns_501() {
+    let tmp = TempDir::new().unwrap();
+    let state = TestState::new(&tmp);
+    let app = build_admin_router(state);
+    let resp = app
+        .oneshot(req("DELETE", "/admin/agents/agent-known", Some(ADMIN_TOKEN)))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_IMPLEMENTED);
+}
+
+// ── Audit log ───────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn audit_log_records_successful_request() {
+    let tmp = TempDir::new().unwrap();
+    let state = TestState::new(&tmp);
+    let audit_path = state.audit_path();
+    let app = build_admin_router(state);
+
+    let resp = app
+        .oneshot(req("GET", "/admin/killswitch/status", Some(ADMIN_TOKEN)))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // Audit append happens after the response is built; give it a tick.
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    let contents = std::fs::read_to_string(&audit_path).expect("audit log written");
+    let line = contents.trim().lines().last().unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(line).unwrap();
+    assert_eq!(parsed["method"], "GET");
+    assert_eq!(parsed["path"], "/admin/killswitch/status");
+    assert_eq!(parsed["status"], 200);
+    let caller = parsed["caller"].as_str().unwrap();
+    assert_eq!(caller.len(), 8, "caller is 8-char fingerprint");
+    assert!(!caller.contains(ADMIN_TOKEN), "raw token must not appear in audit log");
+}
+
+#[tokio::test]
+async fn audit_log_records_unauthorized_request() {
+    let tmp = TempDir::new().unwrap();
+    let state = TestState::new(&tmp);
+    let audit_path = state.audit_path();
+    let app = build_admin_router(state);
+
+    let resp = app
+        .oneshot(req("GET", "/admin/sessions", Some("bogus-token")))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    let contents = std::fs::read_to_string(&audit_path).expect("audit log written");
+    let line = contents.trim().lines().last().unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(line).unwrap();
+    assert_eq!(parsed["status"], 401);
+    assert_eq!(parsed["path"], "/admin/sessions");
+}


### PR DESCRIPTION
## Summary

Adds a separate admin HTTP server that runs alongside the public API on `127.0.0.1:3002` (override via `SERA_ADMIN_BIND`/`SERA_ADMIN_PORT`). Required by L.4 (CLI verbs) and L.5 (main agent).

* New module `sera-gateway/src/admin/` with auth + audit + per-resource route handlers
* `Authorization: Bearer \$SERA_ADMIN_TOKEN` — separate from the public API key, constant-time compared via `subtle`
* `--local` mode auto-mints a random hex token at boot and prints it once to stderr; non-local mode requires `SERA_ADMIN_TOKEN` or fails to start
* JSONL audit log at `\$SERA_DATA_ROOT/admin-audit.jsonl` — every request, success or 401, with first-8-hex-chars-of-sha256(token) fingerprint instead of the raw secret
* Existing unix-socket killswitch (`/var/lib/sera/admin.sock`) preserved unchanged; HTTP arm/disarm shares the same `KillSwitch` state

## Endpoint inventory

| Method | Path | Status | Notes |
|--------|------|--------|-------|
| GET    | `/admin/workflows`          | functional | Returns `[]` initially (in-memory store) |
| POST   | `/admin/workflows`          | **501**    | Gated on L.5 scheduling integration |
| GET    | `/admin/workflows/{id}`     | functional | 404 when missing |
| DELETE | `/admin/workflows/{id}`     | **501**    | Gated on store delete API |
| GET    | `/admin/policies`           | functional | Reads from `ConfigRoot::policies_dir()` |
| GET    | `/admin/policies/{name}`    | functional | Returns parsed YAML manifest, traversal-safe |
| POST   | `/admin/policies/reload`    | functional | Atomic `Arc<CapabilityRegistry>` swap |
| POST   | `/admin/policies/validate`  | functional | Per-file parse results, no registry change |
| GET    | `/admin/sessions`           | functional | From SqliteDb session list |
| GET    | `/admin/sessions/{id}`      | functional | Matches by id or session_key |
| DELETE | `/admin/sessions/{id}`      | functional | Fires registered `CancellationToken` |
| POST   | `/admin/agents/spawn`       | **501**    | Gated on `process_manager` wire-up |
| GET    | `/admin/agents/{id}`        | functional | Reads manifest set |
| DELETE | `/admin/agents/{id}`        | **501**    | Gated on `process_manager` wire-up |
| POST   | `/admin/killswitch/arm`     | functional | 204 — shares state with unix sock |
| POST   | `/admin/killswitch/disarm`  | functional | 204 |
| GET    | `/admin/killswitch/status`  | functional | `{armed: bool}` |

## Backwards compat

* `/api/*` routes on port 3001 unchanged — every existing test still passes
* Unix-socket killswitch path unchanged (the existing `spawn_admin_socket` call site is untouched)
* Bootstrap key (`sera_bootstrap_dev_123`) explicitly rejected by admin auth — verified by `bootstrap_key_does_not_grant_admin_access` test

## Test plan

- [x] `cargo build --workspace --bins` — pass
- [x] `cargo clippy -p sera-gateway --all-targets -- -D warnings` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — only pre-existing `sera-tools` warnings (unchanged by this PR)
- [x] `cargo test -p sera-gateway` — 361 passed, 3 ignored (24 new admin integration tests + 10 admin unit tests)
- [x] `cargo test --workspace` — 3795 passed, 17 ignored
- [x] Auth: missing token → 401, bootstrap key → 401, random token → 401, valid token → 200/204/501 as appropriate
- [x] Killswitch HTTP arm observed on shared `KillSwitch` instance
- [x] Audit log written to `<data_root>/admin-audit.jsonl` for both 200 and 401 requests; raw token never logged

## Notes

* `AppState.capability_registry` is now `Arc<RwLock<Arc<CapabilityRegistry>>>` so policy reload can swap atomically. Readers (4 call sites in `execute_turn`/`execute_steer`) clone the inner `Arc` under a brief read lock — no blocking on the swap.
* No module exceeds 500 LOC; `admin/` is split into `audit.rs`, `auth.rs`, `state.rs`, `server.rs`, `mod.rs`, plus `routes/{workflows,policies,sessions,agents,killswitch}.rs`.

Closes sera-nrn9

🤖 Generated with [Claude Code](https://claude.com/claude-code)