### PR TITLE
feat(sera-cli): L.4 unified CLI verb shells (sera-sssf)

### DIFF
--- a/rust/crates/sera-cli/src/admin_client.rs
+++ b/rust/crates/sera-cli/src/admin_client.rs
@@ -1,0 +1,335 @@
+//! Admin HTTP client used by the L.4 CLI verbs.
+//!
+//! Wraps a `reqwest::Client` that injects `Authorization: Bearer <admin-token>`
+//! on every request. Endpoint + token come from the L.2 Instance manifest at
+//! `<config-root>/config.yaml`:
+//! - `gateway.mode == "local"`  → endpoint `http://127.0.0.1:3002`, token from
+//!   `SERA_ADMIN_TOKEN` (matches the gateway's local-mode regenerate-each-boot
+//!   token print) or, if absent, the `KeyringRef` at `gateway.admin_token_ref`
+//!   when one was stored by `sera init`.
+//! - `gateway.mode == "remote"` → endpoint from `gateway.endpoint`, token from
+//!   `gateway.admin_token_ref` via the `SecretStore`.
+//!
+//! Override at call time with the `--endpoint` / `--admin-token` flags wired
+//! through `CommandArgs`.
+
+use std::path::Path;
+
+use anyhow::{Context, Result, anyhow};
+use reqwest::Client;
+use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue};
+use sera_config::ConfigRoot;
+use sera_config::provider_wizard::{KeyringRef, KeyringSecretStore, SecretStore};
+
+/// Default admin port — matches `sera_gateway::admin::DEFAULT_ADMIN_PORT`.
+pub const DEFAULT_ADMIN_PORT: u16 = 3002;
+
+/// Resolved gateway connection.
+#[derive(Debug, Clone)]
+pub struct AdminTarget {
+    pub endpoint: String,
+    pub token: String,
+}
+
+/// Thin wrapper around a `reqwest::Client` with the admin auth header pre-set.
+#[derive(Debug, Clone)]
+pub struct AdminClient {
+    endpoint: String,
+    client: Client,
+}
+
+impl AdminClient {
+    /// Build a client from a resolved [`AdminTarget`].
+    pub fn new(target: AdminTarget) -> Result<Self> {
+        let mut headers = HeaderMap::new();
+        let mut value = HeaderValue::from_str(&format!("Bearer {}", target.token))
+            .context("invalid admin token value")?;
+        value.set_sensitive(true);
+        headers.insert(AUTHORIZATION, value);
+        let client = Client::builder()
+            .default_headers(headers)
+            .build()
+            .context("failed to build admin HTTP client")?;
+        Ok(Self {
+            endpoint: target.endpoint,
+            client,
+        })
+    }
+
+    /// Endpoint base URL (no trailing slash).
+    pub fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+
+    /// Underlying reqwest client (auth header is pre-applied).
+    pub fn http(&self) -> &Client {
+        &self.client
+    }
+
+    /// Build a full URL for an `/admin/...` path fragment.
+    pub fn url(&self, path: &str) -> String {
+        let path = path.trim_start_matches('/');
+        format!("{}/{path}", self.endpoint.trim_end_matches('/'))
+    }
+}
+
+/// Resolve the admin target from the L.2 Instance manifest under `root`.
+///
+/// `endpoint_override` and `token_override` come from per-command CLI flags
+/// (`--endpoint`, `--admin-token`) and short-circuit the manifest lookup.
+pub fn resolve_target(
+    root: &ConfigRoot,
+    endpoint_override: Option<&str>,
+    token_override: Option<&str>,
+    secrets: &dyn SecretStore,
+) -> Result<AdminTarget> {
+    // Skip the manifest read entirely when both pieces are overridden — this
+    // keeps tests and ad-hoc invocations from needing a config.yaml on disk.
+    if let (Some(e), Some(t)) = (endpoint_override, token_override) {
+        return Ok(AdminTarget {
+            endpoint: e.trim_end_matches('/').to_string(),
+            token: t.to_string(),
+        });
+    }
+
+    let manifest_path = root.path().join("config.yaml");
+    let parsed = read_instance_manifest(&manifest_path)?;
+
+    let endpoint = match endpoint_override {
+        Some(e) => e.trim_end_matches('/').to_string(),
+        None => resolve_endpoint(&parsed)?,
+    };
+
+    let token = match token_override {
+        Some(t) => t.to_string(),
+        None => resolve_token(&parsed, secrets)?,
+    };
+
+    Ok(AdminTarget { endpoint, token })
+}
+
+/// Production helper that uses the system keyring as the secret store.
+pub fn resolve_target_default(
+    root: &ConfigRoot,
+    endpoint_override: Option<&str>,
+    token_override: Option<&str>,
+) -> Result<AdminTarget> {
+    resolve_target(root, endpoint_override, token_override, &KeyringSecretStore)
+}
+
+#[derive(Debug, Clone)]
+struct InstanceManifest {
+    mode: String,
+    endpoint: Option<String>,
+    admin_token_ref: Option<KeyringRef>,
+}
+
+fn read_instance_manifest(path: &Path) -> Result<InstanceManifest> {
+    let raw = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read instance manifest: {}", path.display()))?;
+    let doc: serde_yaml::Value = serde_yaml::from_str(&raw)
+        .with_context(|| format!("failed to parse instance manifest: {}", path.display()))?;
+    let gateway = doc
+        .get("spec")
+        .and_then(|s| s.get("gateway"))
+        .ok_or_else(|| {
+            anyhow!(
+                "instance manifest at {} is missing spec.gateway",
+                path.display()
+            )
+        })?;
+
+    let mode = gateway
+        .get("mode")
+        .and_then(|v| v.as_str())
+        .unwrap_or("local")
+        .to_string();
+    let endpoint = gateway
+        .get("endpoint")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+    let admin_token_ref = gateway
+        .get("admin_token_ref")
+        .and_then(|v| {
+            let svc = v.get("keyring_service")?.as_str()?.to_string();
+            let entry = v.get("keyring_entry")?.as_str()?.to_string();
+            Some(KeyringRef {
+                keyring_service: svc,
+                keyring_entry: entry,
+            })
+        });
+
+    Ok(InstanceManifest {
+        mode,
+        endpoint,
+        admin_token_ref,
+    })
+}
+
+fn resolve_endpoint(m: &InstanceManifest) -> Result<String> {
+    if m.mode == "local" {
+        return Ok(format!("http://127.0.0.1:{DEFAULT_ADMIN_PORT}"));
+    }
+    let raw = m
+        .endpoint
+        .as_deref()
+        .ok_or_else(|| anyhow!("remote gateway has no endpoint configured"))?;
+    Ok(raw.trim_end_matches('/').to_string())
+}
+
+fn resolve_token(m: &InstanceManifest, secrets: &dyn SecretStore) -> Result<String> {
+    if let Ok(t) = std::env::var("SERA_ADMIN_TOKEN")
+        && !t.trim().is_empty()
+    {
+        return Ok(t);
+    }
+    let kref = m
+        .admin_token_ref
+        .as_ref()
+        .ok_or_else(|| anyhow!(
+            "no admin token configured: set SERA_ADMIN_TOKEN or run `sera init` to store one"
+        ))?;
+    secrets
+        .get(&kref.keyring_service, &kref.keyring_entry)
+        .map_err(|e| anyhow!("failed to read admin token from secret store: {e}"))?
+        .ok_or_else(|| {
+            anyhow!(
+                "admin token reference {}::{} resolved to nothing",
+                kref.keyring_service,
+                kref.keyring_entry
+            )
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sera_config::provider_wizard::test_support::MockSecretStore;
+    use std::env;
+    use std::sync::{Mutex, OnceLock};
+
+    /// Serialise tests that mutate `SERA_ADMIN_TOKEN` — Rust runs unit tests
+    /// concurrently within one binary, and process-global env vars race
+    /// without a guard.
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    fn write_manifest(dir: &Path, body: &str) {
+        std::fs::create_dir_all(dir).unwrap();
+        std::fs::write(dir.join("config.yaml"), body).unwrap();
+    }
+
+    struct EnvGuard {
+        saved: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn new(set_to: Option<&str>) -> Self {
+            let saved = env::var("SERA_ADMIN_TOKEN").ok();
+            // SAFETY: tests serialise via env_lock().
+            unsafe {
+                match set_to {
+                    Some(v) => env::set_var("SERA_ADMIN_TOKEN", v),
+                    None => env::remove_var("SERA_ADMIN_TOKEN"),
+                }
+            }
+            Self { saved }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            unsafe {
+                match &self.saved {
+                    Some(v) => env::set_var("SERA_ADMIN_TOKEN", v),
+                    None => env::remove_var("SERA_ADMIN_TOKEN"),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn local_mode_uses_loopback_admin_port() {
+        let _guard = env_lock().lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        write_manifest(
+            dir.path(),
+            "apiVersion: sera.dev/v1\nkind: Instance\nmetadata:\n  name: default\nspec:\n  gateway:\n    mode: local\n  data_dir: /tmp\n",
+        );
+        let _env = EnvGuard::new(Some("tok-xyz"));
+        let root = ConfigRoot::new(dir.path());
+        let target =
+            resolve_target(&root, None, None, &MockSecretStore::default()).unwrap();
+        assert_eq!(target.endpoint, format!("http://127.0.0.1:{DEFAULT_ADMIN_PORT}"));
+        assert_eq!(target.token, "tok-xyz");
+    }
+
+    #[test]
+    fn remote_mode_uses_endpoint_and_secret_store() {
+        let _guard = env_lock().lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        write_manifest(
+            dir.path(),
+            "apiVersion: sera.dev/v1\nkind: Instance\nmetadata:\n  name: default\nspec:\n  gateway:\n    mode: remote\n    endpoint: https://gw.example.com\n    admin_token_ref:\n      keyring_service: sera-gateway\n      keyring_entry: default\n  data_dir: /tmp\n",
+        );
+        let _env = EnvGuard::new(None);
+        let secrets = MockSecretStore::default();
+        secrets
+            .set("sera-gateway", "default", "remote-token")
+            .unwrap();
+        let root = ConfigRoot::new(dir.path());
+        let target = resolve_target(&root, None, None, &secrets).unwrap();
+        assert_eq!(target.endpoint, "https://gw.example.com");
+        assert_eq!(target.token, "remote-token");
+    }
+
+    #[test]
+    fn endpoint_override_short_circuits_manifest() {
+        let _guard = env_lock().lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        write_manifest(
+            dir.path(),
+            "apiVersion: sera.dev/v1\nkind: Instance\nmetadata:\n  name: default\nspec:\n  gateway:\n    mode: local\n  data_dir: /tmp\n",
+        );
+        let _env = EnvGuard::new(None);
+        let root = ConfigRoot::new(dir.path());
+        let target = resolve_target(
+            &root,
+            Some("http://override.local:9999/"),
+            Some("explicit-token"),
+            &MockSecretStore::default(),
+        )
+        .unwrap();
+        assert_eq!(target.endpoint, "http://override.local:9999");
+        assert_eq!(target.token, "explicit-token");
+    }
+
+    #[test]
+    fn missing_token_returns_helpful_error() {
+        let _guard = env_lock().lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        write_manifest(
+            dir.path(),
+            "apiVersion: sera.dev/v1\nkind: Instance\nmetadata:\n  name: default\nspec:\n  gateway:\n    mode: local\n  data_dir: /tmp\n",
+        );
+        let _env = EnvGuard::new(None);
+        let root = ConfigRoot::new(dir.path());
+        let err = resolve_target(&root, None, None, &MockSecretStore::default())
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("SERA_ADMIN_TOKEN"), "got: {err}");
+    }
+
+    #[test]
+    fn url_joins_admin_path() {
+        let target = AdminTarget {
+            endpoint: "http://127.0.0.1:3002".into(),
+            token: "t".into(),
+        };
+        let client = AdminClient::new(target).unwrap();
+        assert_eq!(client.url("/admin/workflows"), "http://127.0.0.1:3002/admin/workflows");
+        assert_eq!(client.url("admin/workflows"), "http://127.0.0.1:3002/admin/workflows");
+    }
+}

--- a/rust/crates/sera-cli/src/commands/config.rs
+++ b/rust/crates/sera-cli/src/commands/config.rs
@@ -1,0 +1,314 @@
+//! `sera config` — local YAML get/set/edit/path against the L.2 Instance
+//! manifest. These verbs never round-trip through the gateway.
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use serde_json::json;
+
+use sera_commands::{
+    Command, CommandArgSchema, CommandArgs, CommandCategory, CommandContext, CommandDescription,
+    CommandError, CommandResult,
+};
+use sera_config::ConfigRoot;
+
+fn map_err<E: std::fmt::Display>(e: E) -> CommandError {
+    CommandError::Execution(e.to_string())
+}
+
+fn config_root_from_args(args: &CommandArgs) -> ConfigRoot {
+    args.get("config-root")
+        .map(|s| ConfigRoot::new(s.to_string()))
+        .unwrap_or_else(ConfigRoot::from_env)
+}
+
+fn config_yaml_path(root: &ConfigRoot) -> PathBuf {
+    root.path().join("config.yaml")
+}
+
+// ── path ────────────────────────────────────────────────────────────────────
+
+pub struct ConfigPathCommand;
+
+#[async_trait]
+impl Command for ConfigPathCommand {
+    fn name(&self) -> &str {
+        "config:path"
+    }
+
+    fn describe(&self) -> CommandDescription {
+        CommandDescription {
+            summary: "Print the path of the resolved config.yaml".into(),
+            help: "Resolves the active ConfigRoot (respecting SERA_CONFIG_ROOT) \
+                   and prints the path to its config.yaml."
+                .into(),
+            category: CommandCategory::System,
+        }
+    }
+
+    fn argument_schema(&self) -> CommandArgSchema {
+        CommandArgSchema(clap::Command::new("path").about("Print config.yaml path"))
+    }
+
+    async fn execute(
+        &self,
+        args: CommandArgs,
+        _ctx: &CommandContext,
+    ) -> Result<CommandResult, CommandError> {
+        let root = config_root_from_args(&args);
+        let path = config_yaml_path(&root);
+        println!("{}", path.display());
+        Ok(CommandResult::ok(json!({ "path": path.display().to_string() })))
+    }
+}
+
+// ── get ─────────────────────────────────────────────────────────────────────
+
+pub struct ConfigGetCommand;
+
+#[async_trait]
+impl Command for ConfigGetCommand {
+    fn name(&self) -> &str {
+        "config:get"
+    }
+
+    fn describe(&self) -> CommandDescription {
+        CommandDescription {
+            summary: "Read a value by dotted path from config.yaml".into(),
+            help: "Walks the YAML body. Example: `sera config get spec.gateway.mode`."
+                .into(),
+            category: CommandCategory::System,
+        }
+    }
+
+    fn argument_schema(&self) -> CommandArgSchema {
+        CommandArgSchema(
+            clap::Command::new("get")
+                .about("Read a value")
+                .arg(clap::Arg::new("key").required(true).help("Dotted path")),
+        )
+    }
+
+    async fn execute(
+        &self,
+        args: CommandArgs,
+        _ctx: &CommandContext,
+    ) -> Result<CommandResult, CommandError> {
+        let key = args
+            .get("key")
+            .ok_or_else(|| CommandError::InvalidArgs("key required".into()))?
+            .to_owned();
+        let root = config_root_from_args(&args);
+        let path = config_yaml_path(&root);
+        let raw = std::fs::read_to_string(&path).map_err(|e| {
+            CommandError::Execution(format!("failed to read {}: {e}", path.display()))
+        })?;
+        let doc: serde_yaml::Value = serde_yaml::from_str(&raw).map_err(map_err)?;
+        let value = lookup_dotted(&doc, &key).ok_or_else(|| {
+            CommandError::Execution(format!("key not found: {key}"))
+        })?;
+        println!("{}", scalar_to_string(value));
+        Ok(CommandResult::ok(serde_yaml_value_to_json(value)))
+    }
+}
+
+// ── set ─────────────────────────────────────────────────────────────────────
+
+pub struct ConfigSetCommand;
+
+#[async_trait]
+impl Command for ConfigSetCommand {
+    fn name(&self) -> &str {
+        "config:set"
+    }
+
+    fn describe(&self) -> CommandDescription {
+        CommandDescription {
+            summary: "Write a string value at a dotted path in config.yaml".into(),
+            help: "Creates intermediate maps as needed. Numbers/booleans must be \
+                   quoted by the user — values are stored as strings to keep this \
+                   command predictable."
+                .into(),
+            category: CommandCategory::System,
+        }
+    }
+
+    fn argument_schema(&self) -> CommandArgSchema {
+        CommandArgSchema(
+            clap::Command::new("set")
+                .about("Write a value")
+                .arg(clap::Arg::new("key").required(true).help("Dotted path"))
+                .arg(clap::Arg::new("value").required(true).help("Value (string)")),
+        )
+    }
+
+    async fn execute(
+        &self,
+        args: CommandArgs,
+        _ctx: &CommandContext,
+    ) -> Result<CommandResult, CommandError> {
+        let key = args
+            .get("key")
+            .ok_or_else(|| CommandError::InvalidArgs("key required".into()))?
+            .to_owned();
+        let value = args
+            .get("value")
+            .ok_or_else(|| CommandError::InvalidArgs("value required".into()))?
+            .to_owned();
+        let root = config_root_from_args(&args);
+        let path = config_yaml_path(&root);
+        let raw = std::fs::read_to_string(&path).map_err(|e| {
+            CommandError::Execution(format!("failed to read {}: {e}", path.display()))
+        })?;
+        let mut doc: serde_yaml::Value = serde_yaml::from_str(&raw).map_err(map_err)?;
+        set_dotted(&mut doc, &key, serde_yaml::Value::String(value.clone()))?;
+        let serialised = serde_yaml::to_string(&doc).map_err(map_err)?;
+        std::fs::write(&path, &serialised).map_err(|e| {
+            CommandError::Execution(format!("failed to write {}: {e}", path.display()))
+        })?;
+        println!("Set {key} = {value} in {}", path.display());
+        Ok(CommandResult::ok(json!({ "key": key, "value": value })))
+    }
+}
+
+// ── edit ────────────────────────────────────────────────────────────────────
+
+pub struct ConfigEditCommand;
+
+#[async_trait]
+impl Command for ConfigEditCommand {
+    fn name(&self) -> &str {
+        "config:edit"
+    }
+
+    fn describe(&self) -> CommandDescription {
+        CommandDescription {
+            summary: "Open config.yaml in $EDITOR (fallback: vi)".into(),
+            help: "Spawns the user's editor against config.yaml. Returns once the \
+                   editor exits."
+                .into(),
+            category: CommandCategory::System,
+        }
+    }
+
+    fn argument_schema(&self) -> CommandArgSchema {
+        CommandArgSchema(clap::Command::new("edit").about("Edit config.yaml"))
+    }
+
+    async fn execute(
+        &self,
+        args: CommandArgs,
+        _ctx: &CommandContext,
+    ) -> Result<CommandResult, CommandError> {
+        let root = config_root_from_args(&args);
+        let path = config_yaml_path(&root);
+        let editor = std::env::var("EDITOR").unwrap_or_else(|_| "vi".to_string());
+        let status = std::process::Command::new(&editor)
+            .arg(&path)
+            .status()
+            .map_err(|e| CommandError::Execution(format!("failed to launch {editor}: {e}")))?;
+        if !status.success() {
+            return Err(CommandError::Execution(format!(
+                "editor exited with status {status}"
+            )));
+        }
+        Ok(CommandResult::ok(json!({
+            "editor": editor,
+            "path": path.display().to_string(),
+        })))
+    }
+}
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+fn lookup_dotted<'a>(doc: &'a serde_yaml::Value, key: &str) -> Option<&'a serde_yaml::Value> {
+    let mut node = doc;
+    for part in key.split('.') {
+        node = node.get(part)?;
+    }
+    Some(node)
+}
+
+fn set_dotted(
+    doc: &mut serde_yaml::Value,
+    key: &str,
+    value: serde_yaml::Value,
+) -> Result<(), CommandError> {
+    let parts: Vec<&str> = key.split('.').collect();
+    if parts.iter().any(|p| p.is_empty()) {
+        return Err(CommandError::InvalidArgs("empty key segment".into()));
+    }
+    if !doc.is_mapping() {
+        *doc = serde_yaml::Value::Mapping(serde_yaml::Mapping::new());
+    }
+    let mut cursor = doc;
+    for (idx, part) in parts.iter().enumerate() {
+        let map = cursor
+            .as_mapping_mut()
+            .ok_or_else(|| CommandError::Execution(format!("path '{key}' traverses a non-map")))?;
+        let ykey = serde_yaml::Value::String((*part).to_string());
+        let last = idx + 1 == parts.len();
+        if last {
+            map.insert(ykey, value);
+            return Ok(());
+        }
+        let entry = map
+            .entry(ykey)
+            .or_insert_with(|| serde_yaml::Value::Mapping(serde_yaml::Mapping::new()));
+        if !entry.is_mapping() {
+            *entry = serde_yaml::Value::Mapping(serde_yaml::Mapping::new());
+        }
+        cursor = entry;
+    }
+    Ok(())
+}
+
+fn scalar_to_string(v: &serde_yaml::Value) -> String {
+    match v {
+        serde_yaml::Value::String(s) => s.clone(),
+        serde_yaml::Value::Number(n) => n.to_string(),
+        serde_yaml::Value::Bool(b) => b.to_string(),
+        serde_yaml::Value::Null => String::new(),
+        other => serde_yaml::to_string(other).unwrap_or_default().trim().to_string(),
+    }
+}
+
+fn serde_yaml_value_to_json(v: &serde_yaml::Value) -> serde_json::Value {
+    serde_json::to_value(v).unwrap_or(serde_json::Value::Null)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lookup_dotted_walks_nested_maps() {
+        let doc: serde_yaml::Value = serde_yaml::from_str("a:\n  b:\n    c: hi\n").unwrap();
+        assert_eq!(
+            lookup_dotted(&doc, "a.b.c").and_then(|v| v.as_str()),
+            Some("hi"),
+        );
+        assert!(lookup_dotted(&doc, "a.b.missing").is_none());
+    }
+
+    #[test]
+    fn set_dotted_creates_intermediate_maps() {
+        let mut doc: serde_yaml::Value = serde_yaml::from_str("a: 1\n").unwrap();
+        set_dotted(&mut doc, "x.y.z", serde_yaml::Value::String("v".into())).unwrap();
+        assert_eq!(
+            lookup_dotted(&doc, "x.y.z").and_then(|v| v.as_str()),
+            Some("v"),
+        );
+    }
+
+    #[test]
+    fn set_dotted_overwrites_existing_value() {
+        let mut doc: serde_yaml::Value = serde_yaml::from_str("a:\n  b: old\n").unwrap();
+        set_dotted(&mut doc, "a.b", serde_yaml::Value::String("new".into())).unwrap();
+        assert_eq!(
+            lookup_dotted(&doc, "a.b").and_then(|v| v.as_str()),
+            Some("new"),
+        );
+    }
+}

--- a/rust/crates/sera-cli/src/commands/killswitch.rs
+++ b/rust/crates/sera-cli/src/commands/killswitch.rs
@@ -1,0 +1,161 @@
+//! `sera killswitch` — arm/disarm/status via the L.3 admin endpoints.
+
+use anyhow::Result;
+use async_trait::async_trait;
+use serde_json::json;
+
+use sera_commands::{
+    Command, CommandArgSchema, CommandArgs, CommandCategory, CommandContext, CommandDescription,
+    CommandError, CommandResult,
+};
+use sera_config::ConfigRoot;
+
+use crate::admin_client::{AdminClient, resolve_target_default};
+
+fn map_err<E: std::fmt::Display>(e: E) -> CommandError {
+    CommandError::Execution(e.to_string())
+}
+
+fn build_client(args: &CommandArgs) -> Result<AdminClient, CommandError> {
+    let root = args
+        .get("config-root")
+        .map(|s| ConfigRoot::new(s.to_string()))
+        .unwrap_or_else(ConfigRoot::from_env);
+    let target = resolve_target_default(&root, args.get("endpoint"), args.get("admin-token"))
+        .map_err(map_err)?;
+    AdminClient::new(target).map_err(map_err)
+}
+
+async fn post_killswitch(
+    args: &CommandArgs,
+    path: &'static str,
+    success_msg: &'static str,
+) -> Result<CommandResult, CommandError> {
+    let client = build_client(args)?;
+    let resp = client
+        .http()
+        .post(client.url(path))
+        .send()
+        .await
+        .map_err(|e| CommandError::Execution(format!("request failed: {e}")))?;
+    if !resp.status().is_success() {
+        return Err(CommandError::Execution(format!(
+            "gateway returned HTTP {}",
+            resp.status()
+        )));
+    }
+    println!("{success_msg}");
+    Ok(CommandResult::ok(json!({ "ok": true })))
+}
+
+// ── arm ─────────────────────────────────────────────────────────────────────
+
+pub struct KillswitchArmCommand;
+
+#[async_trait]
+impl Command for KillswitchArmCommand {
+    fn name(&self) -> &str {
+        "killswitch:arm"
+    }
+
+    fn describe(&self) -> CommandDescription {
+        CommandDescription {
+            summary: "Arm the gateway killswitch (POST /admin/killswitch/arm)".into(),
+            help: "Halts new tool dispatch; existing turns finish.".into(),
+            category: CommandCategory::System,
+        }
+    }
+
+    fn argument_schema(&self) -> CommandArgSchema {
+        CommandArgSchema(clap::Command::new("arm").about("Arm the killswitch"))
+    }
+
+    async fn execute(
+        &self,
+        args: CommandArgs,
+        _ctx: &CommandContext,
+    ) -> Result<CommandResult, CommandError> {
+        post_killswitch(&args, "/admin/killswitch/arm", "Killswitch armed").await
+    }
+}
+
+// ── disarm ──────────────────────────────────────────────────────────────────
+
+pub struct KillswitchDisarmCommand;
+
+#[async_trait]
+impl Command for KillswitchDisarmCommand {
+    fn name(&self) -> &str {
+        "killswitch:disarm"
+    }
+
+    fn describe(&self) -> CommandDescription {
+        CommandDescription {
+            summary: "Disarm the gateway killswitch (POST /admin/killswitch/disarm)".into(),
+            help: "Restores normal dispatch.".into(),
+            category: CommandCategory::System,
+        }
+    }
+
+    fn argument_schema(&self) -> CommandArgSchema {
+        CommandArgSchema(clap::Command::new("disarm").about("Disarm the killswitch"))
+    }
+
+    async fn execute(
+        &self,
+        args: CommandArgs,
+        _ctx: &CommandContext,
+    ) -> Result<CommandResult, CommandError> {
+        post_killswitch(&args, "/admin/killswitch/disarm", "Killswitch disarmed").await
+    }
+}
+
+// ── status ──────────────────────────────────────────────────────────────────
+
+pub struct KillswitchStatusCommand;
+
+#[async_trait]
+impl Command for KillswitchStatusCommand {
+    fn name(&self) -> &str {
+        "killswitch:status"
+    }
+
+    fn describe(&self) -> CommandDescription {
+        CommandDescription {
+            summary: "Print killswitch state (GET /admin/killswitch/status)".into(),
+            help: "Reports `armed: true|false`.".into(),
+            category: CommandCategory::System,
+        }
+    }
+
+    fn argument_schema(&self) -> CommandArgSchema {
+        CommandArgSchema(clap::Command::new("status").about("Killswitch status"))
+    }
+
+    async fn execute(
+        &self,
+        args: CommandArgs,
+        _ctx: &CommandContext,
+    ) -> Result<CommandResult, CommandError> {
+        let client = build_client(&args)?;
+        let resp = client
+            .http()
+            .get(client.url("/admin/killswitch/status"))
+            .send()
+            .await
+            .map_err(|e| CommandError::Execution(format!("request failed: {e}")))?;
+        if !resp.status().is_success() {
+            return Err(CommandError::Execution(format!(
+                "gateway returned HTTP {}",
+                resp.status()
+            )));
+        }
+        let body: serde_json::Value = resp
+            .json()
+            .await
+            .map_err(|e| CommandError::Execution(format!("failed to parse response: {e}")))?;
+        let armed = body.get("armed").and_then(|v| v.as_bool()).unwrap_or(false);
+        println!("Killswitch: {}", if armed { "ARMED" } else { "disarmed" });
+        Ok(CommandResult::ok(body))
+    }
+}

--- a/rust/crates/sera-cli/src/commands/mod.rs
+++ b/rust/crates/sera-cli/src/commands/mod.rs
@@ -6,16 +6,32 @@
 pub mod agent;
 pub mod auth;
 pub mod chat;
+pub mod config;
 pub mod init;
+pub mod killswitch;
 pub mod ping;
+pub mod policy;
 pub mod provider;
+pub mod session;
+pub mod workflow;
 
 pub use agent::{AgentListCommand, AgentRunCommand, AgentShowCommand};
 pub use auth::{LoginCommand, LogoutCommand, WhoamiCommand};
 pub use chat::ChatCommand;
+pub use config::{ConfigEditCommand, ConfigGetCommand, ConfigPathCommand, ConfigSetCommand};
 pub use init::InitCommand;
+pub use killswitch::{KillswitchArmCommand, KillswitchDisarmCommand, KillswitchStatusCommand};
 pub use ping::HealthCheckCommand;
+pub use policy::{
+    PolicyListCommand, PolicyReloadCommand, PolicyShowCommand, PolicyValidateCommand,
+};
 pub use provider::{
     ProviderAddCommand, ProviderConfigureCommand, ProviderListCommand, ProviderRemoveCommand,
     ProviderSelectCommand,
+};
+pub use session::{
+    SessionBrowseCommand, SessionKillCommand, SessionListCommand, SessionShowCommand,
+};
+pub use workflow::{
+    WorkflowCreateCommand, WorkflowDeleteCommand, WorkflowListCommand, WorkflowShowCommand,
 };

--- a/rust/crates/sera-cli/src/commands/policy.rs
+++ b/rust/crates/sera-cli/src/commands/policy.rs
@@ -1,0 +1,288 @@
+//! `sera policy` — list/show/reload/validate via the L.3 admin endpoints.
+
+use anyhow::Result;
+use async_trait::async_trait;
+use comfy_table::{Table, presets::UTF8_FULL};
+use reqwest::StatusCode;
+use serde_json::json;
+
+use sera_commands::{
+    Command, CommandArgSchema, CommandArgs, CommandCategory, CommandContext, CommandDescription,
+    CommandError, CommandResult,
+};
+use sera_config::ConfigRoot;
+
+use crate::admin_client::{AdminClient, resolve_target_default};
+
+fn map_err<E: std::fmt::Display>(e: E) -> CommandError {
+    CommandError::Execution(e.to_string())
+}
+
+fn build_client(args: &CommandArgs) -> Result<AdminClient, CommandError> {
+    let root = args
+        .get("config-root")
+        .map(|s| ConfigRoot::new(s.to_string()))
+        .unwrap_or_else(ConfigRoot::from_env);
+    let target = resolve_target_default(&root, args.get("endpoint"), args.get("admin-token"))
+        .map_err(map_err)?;
+    AdminClient::new(target).map_err(map_err)
+}
+
+// ── list ────────────────────────────────────────────────────────────────────
+
+pub struct PolicyListCommand;
+
+#[async_trait]
+impl Command for PolicyListCommand {
+    fn name(&self) -> &str {
+        "policy:list"
+    }
+
+    fn describe(&self) -> CommandDescription {
+        CommandDescription {
+            summary: "List capability policies (GET /admin/policies)".into(),
+            help: "Lists every YAML policy under the gateway's policies directory."
+                .into(),
+            category: CommandCategory::System,
+        }
+    }
+
+    fn argument_schema(&self) -> CommandArgSchema {
+        CommandArgSchema(clap::Command::new("list").about("List capability policies"))
+    }
+
+    async fn execute(
+        &self,
+        args: CommandArgs,
+        _ctx: &CommandContext,
+    ) -> Result<CommandResult, CommandError> {
+        let client = build_client(&args)?;
+        let resp = client
+            .http()
+            .get(client.url("/admin/policies"))
+            .send()
+            .await
+            .map_err(|e| CommandError::Execution(format!("request failed: {e}")))?;
+        if !resp.status().is_success() {
+            return Err(CommandError::Execution(format!(
+                "gateway returned HTTP {}",
+                resp.status()
+            )));
+        }
+        let body: serde_json::Value = resp
+            .json()
+            .await
+            .map_err(|e| CommandError::Execution(format!("failed to parse response: {e}")))?;
+
+        let dir = body
+            .get("dir")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_owned();
+        let names = body
+            .get("policies")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default();
+
+        if !dir.is_empty() {
+            println!("Policies directory: {dir}");
+        }
+        if names.is_empty() {
+            println!("(no policies configured)");
+        } else {
+            for n in &names {
+                if let Some(s) = n.as_str() {
+                    println!("- {s}");
+                }
+            }
+        }
+        Ok(CommandResult::ok(body))
+    }
+}
+
+// ── show ────────────────────────────────────────────────────────────────────
+
+pub struct PolicyShowCommand;
+
+#[async_trait]
+impl Command for PolicyShowCommand {
+    fn name(&self) -> &str {
+        "policy:show"
+    }
+
+    fn describe(&self) -> CommandDescription {
+        CommandDescription {
+            summary: "Show a policy manifest (GET /admin/policies/{name})".into(),
+            help: "Fetches a single policy and prints the manifest as JSON.".into(),
+            category: CommandCategory::System,
+        }
+    }
+
+    fn argument_schema(&self) -> CommandArgSchema {
+        CommandArgSchema(
+            clap::Command::new("show")
+                .about("Show a policy manifest")
+                .arg(clap::Arg::new("name").required(true).help("Policy name (file stem)")),
+        )
+    }
+
+    async fn execute(
+        &self,
+        args: CommandArgs,
+        _ctx: &CommandContext,
+    ) -> Result<CommandResult, CommandError> {
+        let name = args
+            .get("name")
+            .ok_or_else(|| CommandError::InvalidArgs("policy name required".into()))?
+            .to_owned();
+        let client = build_client(&args)?;
+        let resp = client
+            .http()
+            .get(client.url(&format!("/admin/policies/{name}")))
+            .send()
+            .await
+            .map_err(|e| CommandError::Execution(format!("request failed: {e}")))?;
+        match resp.status() {
+            StatusCode::NOT_FOUND => Err(CommandError::Execution(format!("policy not found: {name}"))),
+            s if !s.is_success() => Err(CommandError::Execution(format!("gateway returned HTTP {s}"))),
+            _ => {
+                let body: serde_json::Value = resp.json().await.map_err(|e| {
+                    CommandError::Execution(format!("failed to parse response: {e}"))
+                })?;
+                println!("{}", serde_json::to_string_pretty(&body).unwrap_or_default());
+                Ok(CommandResult::ok(body))
+            }
+        }
+    }
+}
+
+// ── reload ──────────────────────────────────────────────────────────────────
+
+pub struct PolicyReloadCommand;
+
+#[async_trait]
+impl Command for PolicyReloadCommand {
+    fn name(&self) -> &str {
+        "policy:reload"
+    }
+
+    fn describe(&self) -> CommandDescription {
+        CommandDescription {
+            summary: "Reload all policies from disk (POST /admin/policies/reload)".into(),
+            help: "Re-reads the policies directory and atomically swaps the live registry."
+                .into(),
+            category: CommandCategory::System,
+        }
+    }
+
+    fn argument_schema(&self) -> CommandArgSchema {
+        CommandArgSchema(clap::Command::new("reload").about("Reload policies"))
+    }
+
+    async fn execute(
+        &self,
+        args: CommandArgs,
+        _ctx: &CommandContext,
+    ) -> Result<CommandResult, CommandError> {
+        let client = build_client(&args)?;
+        let resp = client
+            .http()
+            .post(client.url("/admin/policies/reload"))
+            .send()
+            .await
+            .map_err(|e| CommandError::Execution(format!("request failed: {e}")))?;
+        let status = resp.status();
+        let body: serde_json::Value = resp
+            .json()
+            .await
+            .unwrap_or_else(|_| json!({}));
+        if !status.is_success() {
+            let detail = body
+                .get("detail")
+                .and_then(|v| v.as_str())
+                .unwrap_or("(no detail)");
+            return Err(CommandError::Execution(format!(
+                "policy reload failed: HTTP {status}: {detail}"
+            )));
+        }
+        let loaded = body.get("loaded").and_then(|v| v.as_u64()).unwrap_or(0);
+        println!("Reloaded {loaded} policies");
+        Ok(CommandResult::ok(body))
+    }
+}
+
+// ── validate ────────────────────────────────────────────────────────────────
+
+pub struct PolicyValidateCommand;
+
+#[async_trait]
+impl Command for PolicyValidateCommand {
+    fn name(&self) -> &str {
+        "policy:validate"
+    }
+
+    fn describe(&self) -> CommandDescription {
+        CommandDescription {
+            summary: "Validate every policy YAML on disk (POST /admin/policies/validate)".into(),
+            help: "Parses each policy file and reports per-file ok/error status."
+                .into(),
+            category: CommandCategory::System,
+        }
+    }
+
+    fn argument_schema(&self) -> CommandArgSchema {
+        CommandArgSchema(clap::Command::new("validate").about("Validate policies"))
+    }
+
+    async fn execute(
+        &self,
+        args: CommandArgs,
+        _ctx: &CommandContext,
+    ) -> Result<CommandResult, CommandError> {
+        let client = build_client(&args)?;
+        let resp = client
+            .http()
+            .post(client.url("/admin/policies/validate"))
+            .send()
+            .await
+            .map_err(|e| CommandError::Execution(format!("request failed: {e}")))?;
+        if !resp.status().is_success() {
+            return Err(CommandError::Execution(format!(
+                "gateway returned HTTP {}",
+                resp.status()
+            )));
+        }
+        let body: serde_json::Value = resp
+            .json()
+            .await
+            .map_err(|e| CommandError::Execution(format!("failed to parse response: {e}")))?;
+
+        let results = body
+            .get("results")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default();
+        let all_ok = body
+            .get("ok")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+
+        let mut table = Table::new();
+        table.load_preset(UTF8_FULL);
+        table.set_header(["FILE", "STATUS", "ERROR"]);
+        for r in &results {
+            let file = r.get("file").and_then(|v| v.as_str()).unwrap_or("");
+            let ok = r.get("ok").and_then(|v| v.as_bool()).unwrap_or(false);
+            let err = r.get("error").and_then(|v| v.as_str()).unwrap_or("");
+            table.add_row([file, if ok { "ok" } else { "error" }, err]);
+        }
+        println!("{table}");
+
+        let mut result = CommandResult::ok(body);
+        if !all_ok {
+            result.exit_code = 1;
+        }
+        Ok(result)
+    }
+}

--- a/rust/crates/sera-cli/src/commands/session.rs
+++ b/rust/crates/sera-cli/src/commands/session.rs
@@ -1,0 +1,300 @@
+//! `sera session` — list/show/kill/browse via the L.3 admin endpoints.
+
+use anyhow::Result;
+use async_trait::async_trait;
+use comfy_table::{Table, presets::UTF8_FULL};
+use reqwest::StatusCode;
+use serde_json::json;
+
+use sera_commands::{
+    Command, CommandArgSchema, CommandArgs, CommandCategory, CommandContext, CommandDescription,
+    CommandError, CommandResult,
+};
+use sera_config::ConfigRoot;
+
+use crate::admin_client::{AdminClient, resolve_target_default};
+
+fn map_err<E: std::fmt::Display>(e: E) -> CommandError {
+    CommandError::Execution(e.to_string())
+}
+
+fn build_client(args: &CommandArgs) -> Result<AdminClient, CommandError> {
+    let root = args
+        .get("config-root")
+        .map(|s| ConfigRoot::new(s.to_string()))
+        .unwrap_or_else(ConfigRoot::from_env);
+    let target = resolve_target_default(&root, args.get("endpoint"), args.get("admin-token"))
+        .map_err(map_err)?;
+    AdminClient::new(target).map_err(map_err)
+}
+
+fn render_sessions_table(sessions: &[serde_json::Value]) {
+    let mut table = Table::new();
+    table.load_preset(UTF8_FULL);
+    table.set_header(["ID", "AGENT", "SESSION KEY", "STATE"]);
+    for s in sessions {
+        table.add_row([
+            s.get("id").and_then(|v| v.as_str()).unwrap_or(""),
+            s.get("agent_id").and_then(|v| v.as_str()).unwrap_or(""),
+            s.get("session_key").and_then(|v| v.as_str()).unwrap_or(""),
+            s.get("state").and_then(|v| v.as_str()).unwrap_or(""),
+        ]);
+    }
+    println!("{table}");
+}
+
+async fn fetch_sessions(client: &AdminClient) -> Result<Vec<serde_json::Value>, CommandError> {
+    let resp = client
+        .http()
+        .get(client.url("/admin/sessions"))
+        .send()
+        .await
+        .map_err(|e| CommandError::Execution(format!("request failed: {e}")))?;
+    if !resp.status().is_success() {
+        return Err(CommandError::Execution(format!(
+            "gateway returned HTTP {}",
+            resp.status()
+        )));
+    }
+    let body: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| CommandError::Execution(format!("failed to parse response: {e}")))?;
+    Ok(body.as_array().cloned().unwrap_or_default())
+}
+
+// ── list ────────────────────────────────────────────────────────────────────
+
+pub struct SessionListCommand;
+
+#[async_trait]
+impl Command for SessionListCommand {
+    fn name(&self) -> &str {
+        "session:list"
+    }
+
+    fn describe(&self) -> CommandDescription {
+        CommandDescription {
+            summary: "List active sessions (GET /admin/sessions)".into(),
+            help: "Renders a table of active sessions.".into(),
+            category: CommandCategory::System,
+        }
+    }
+
+    fn argument_schema(&self) -> CommandArgSchema {
+        CommandArgSchema(clap::Command::new("list").about("List active sessions"))
+    }
+
+    async fn execute(
+        &self,
+        args: CommandArgs,
+        _ctx: &CommandContext,
+    ) -> Result<CommandResult, CommandError> {
+        let client = build_client(&args)?;
+        let sessions = fetch_sessions(&client).await?;
+        render_sessions_table(&sessions);
+        Ok(CommandResult::ok(json!(sessions)))
+    }
+}
+
+// ── show ────────────────────────────────────────────────────────────────────
+
+pub struct SessionShowCommand;
+
+#[async_trait]
+impl Command for SessionShowCommand {
+    fn name(&self) -> &str {
+        "session:show"
+    }
+
+    fn describe(&self) -> CommandDescription {
+        CommandDescription {
+            summary: "Show one session (GET /admin/sessions/{id})".into(),
+            help: "Pretty-prints a single session record.".into(),
+            category: CommandCategory::System,
+        }
+    }
+
+    fn argument_schema(&self) -> CommandArgSchema {
+        CommandArgSchema(
+            clap::Command::new("show")
+                .about("Show a session")
+                .arg(clap::Arg::new("id").required(true).help("Session id")),
+        )
+    }
+
+    async fn execute(
+        &self,
+        args: CommandArgs,
+        _ctx: &CommandContext,
+    ) -> Result<CommandResult, CommandError> {
+        let id = args
+            .get("id")
+            .ok_or_else(|| CommandError::InvalidArgs("session id required".into()))?
+            .to_owned();
+        let client = build_client(&args)?;
+        let resp = client
+            .http()
+            .get(client.url(&format!("/admin/sessions/{id}")))
+            .send()
+            .await
+            .map_err(|e| CommandError::Execution(format!("request failed: {e}")))?;
+        match resp.status() {
+            StatusCode::NOT_FOUND => Err(CommandError::Execution(format!("session not found: {id}"))),
+            s if !s.is_success() => Err(CommandError::Execution(format!("gateway returned HTTP {s}"))),
+            _ => {
+                let body: serde_json::Value = resp.json().await.map_err(|e| {
+                    CommandError::Execution(format!("failed to parse response: {e}"))
+                })?;
+                println!("{}", serde_json::to_string_pretty(&body).unwrap_or_default());
+                Ok(CommandResult::ok(body))
+            }
+        }
+    }
+}
+
+// ── kill ────────────────────────────────────────────────────────────────────
+
+pub struct SessionKillCommand;
+
+#[async_trait]
+impl Command for SessionKillCommand {
+    fn name(&self) -> &str {
+        "session:kill"
+    }
+
+    fn describe(&self) -> CommandDescription {
+        CommandDescription {
+            summary: "Cancel a session (DELETE /admin/sessions/{id})".into(),
+            help: "Fires the session's cancellation token. Idempotent.".into(),
+            category: CommandCategory::System,
+        }
+    }
+
+    fn argument_schema(&self) -> CommandArgSchema {
+        CommandArgSchema(
+            clap::Command::new("kill")
+                .about("Kill a session")
+                .arg(clap::Arg::new("id").required(true).help("Session id")),
+        )
+    }
+
+    async fn execute(
+        &self,
+        args: CommandArgs,
+        _ctx: &CommandContext,
+    ) -> Result<CommandResult, CommandError> {
+        let id = args
+            .get("id")
+            .ok_or_else(|| CommandError::InvalidArgs("session id required".into()))?
+            .to_owned();
+        let client = build_client(&args)?;
+        let resp = client
+            .http()
+            .delete(client.url(&format!("/admin/sessions/{id}")))
+            .send()
+            .await
+            .map_err(|e| CommandError::Execution(format!("request failed: {e}")))?;
+        if !resp.status().is_success() {
+            return Err(CommandError::Execution(format!(
+                "gateway returned HTTP {}",
+                resp.status()
+            )));
+        }
+        println!("Cancelled session {id}");
+        Ok(CommandResult::ok(json!({ "cancelled": id })))
+    }
+}
+
+// ── browse ──────────────────────────────────────────────────────────────────
+
+const BROWSE_PAGE_SIZE: usize = 20;
+
+pub struct SessionBrowseCommand;
+
+#[async_trait]
+impl Command for SessionBrowseCommand {
+    fn name(&self) -> &str {
+        "session:browse"
+    }
+
+    fn describe(&self) -> CommandDescription {
+        CommandDescription {
+            summary: "Paginated browser for active sessions".into(),
+            help: "On a TTY, prints sessions a page at a time and prompts for \
+                   ENTER (next page) or `q` (quit). On a non-TTY (pipe, CI, test), \
+                   behaves like `session list`."
+                .into(),
+            category: CommandCategory::System,
+        }
+    }
+
+    fn argument_schema(&self) -> CommandArgSchema {
+        CommandArgSchema(clap::Command::new("browse").about("Paginated session browser"))
+    }
+
+    async fn execute(
+        &self,
+        args: CommandArgs,
+        _ctx: &CommandContext,
+    ) -> Result<CommandResult, CommandError> {
+        let client = build_client(&args)?;
+        let sessions = fetch_sessions(&client).await?;
+
+        if !is_tty() {
+            render_sessions_table(&sessions);
+            return Ok(CommandResult::ok(json!(sessions)));
+        }
+
+        if sessions.is_empty() {
+            println!("(no active sessions)");
+            return Ok(CommandResult::ok(json!(sessions)));
+        }
+
+        for (idx, page) in sessions.chunks(BROWSE_PAGE_SIZE).enumerate() {
+            println!(
+                "── page {}/{} ──────────────────────────────",
+                idx + 1,
+                sessions.len().div_ceil(BROWSE_PAGE_SIZE)
+            );
+            render_sessions_table(page);
+            if (idx + 1) * BROWSE_PAGE_SIZE >= sessions.len() {
+                break;
+            }
+            println!("[ENTER] next page, [q ENTER] quit");
+            let mut buf = String::new();
+            std::io::stdin()
+                .read_line(&mut buf)
+                .map_err(|e| CommandError::Execution(format!("stdin: {e}")))?;
+            if buf.trim().eq_ignore_ascii_case("q") {
+                break;
+            }
+        }
+
+        Ok(CommandResult::ok(json!(sessions)))
+    }
+}
+
+#[cfg(unix)]
+fn is_tty() -> bool {
+    use std::os::fd::AsRawFd;
+    // Safe: AsRawFd returns a valid fd; isatty has no UB on invalid fd, just returns 0.
+    unsafe { libc_isatty(std::io::stdin().as_raw_fd()) == 1 }
+}
+
+#[cfg(not(unix))]
+fn is_tty() -> bool {
+    // Conservative on non-Unix: skip pagination so non-TTY environments
+    // (Windows CI, piped tests) take the list-only path.
+    false
+}
+
+#[cfg(unix)]
+unsafe extern "C" {
+    fn isatty(fd: i32) -> i32;
+}
+
+#[cfg(unix)]
+unsafe fn libc_isatty(fd: i32) -> i32 {
+    unsafe { isatty(fd) }
+}

--- a/rust/crates/sera-cli/src/commands/workflow.rs
+++ b/rust/crates/sera-cli/src/commands/workflow.rs
@@ -1,0 +1,299 @@
+//! `sera workflow` — list/show/create/delete via the L.3 admin endpoints.
+//!
+//! `create` and `delete` hit `/admin/workflows[/{id}]` which return HTTP 501
+//! today (write paths are gated on L.5 wiring); we surface that as a clear
+//! error rather than a hard failure. `list` and `show` work end-to-end.
+
+use anyhow::Result;
+use async_trait::async_trait;
+use comfy_table::{Table, presets::UTF8_FULL};
+use reqwest::StatusCode;
+use serde_json::json;
+
+use sera_commands::{
+    Command, CommandArgSchema, CommandArgs, CommandCategory, CommandContext, CommandDescription,
+    CommandError, CommandResult,
+};
+use sera_config::ConfigRoot;
+
+use crate::admin_client::{AdminClient, resolve_target_default};
+
+fn map_err<E: std::fmt::Display>(e: E) -> CommandError {
+    CommandError::Execution(e.to_string())
+}
+
+fn build_client(args: &CommandArgs) -> Result<AdminClient, CommandError> {
+    let root = args
+        .get("config-root")
+        .map(|s| ConfigRoot::new(s.to_string()))
+        .unwrap_or_else(ConfigRoot::from_env);
+    let target = resolve_target_default(&root, args.get("endpoint"), args.get("admin-token"))
+        .map_err(map_err)?;
+    AdminClient::new(target).map_err(map_err)
+}
+
+fn not_implemented_message() -> CommandError {
+    CommandError::Execution(
+        "gateway returned 501 Not Implemented — workflow create/delete is L.5 not yet wired"
+            .into(),
+    )
+}
+
+// ── list ────────────────────────────────────────────────────────────────────
+
+pub struct WorkflowListCommand;
+
+#[async_trait]
+impl Command for WorkflowListCommand {
+    fn name(&self) -> &str {
+        "workflow:list"
+    }
+
+    fn describe(&self) -> CommandDescription {
+        CommandDescription {
+            summary: "List workflows (GET /admin/workflows)".into(),
+            help: "Calls the gateway admin endpoint and prints a table of \
+                   active workflows."
+                .into(),
+            category: CommandCategory::System,
+        }
+    }
+
+    fn argument_schema(&self) -> CommandArgSchema {
+        CommandArgSchema(clap::Command::new("list").about("List workflows"))
+    }
+
+    async fn execute(
+        &self,
+        args: CommandArgs,
+        _ctx: &CommandContext,
+    ) -> Result<CommandResult, CommandError> {
+        let client = build_client(&args)?;
+        let resp = client
+            .http()
+            .get(client.url("/admin/workflows"))
+            .send()
+            .await
+            .map_err(|e| CommandError::Execution(format!("request failed: {e}")))?;
+        if !resp.status().is_success() {
+            return Err(CommandError::Execution(format!(
+                "gateway returned HTTP {}",
+                resp.status()
+            )));
+        }
+        let body: serde_json::Value = resp
+            .json()
+            .await
+            .map_err(|e| CommandError::Execution(format!("failed to parse response: {e}")))?;
+
+        let workflows = body
+            .get("workflows")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default();
+
+        let mut table = Table::new();
+        table.load_preset(UTF8_FULL);
+        table.set_header(["ID", "AGENT", "STATUS", "TITLE"]);
+        for w in &workflows {
+            table.add_row([
+                w.get("id").and_then(|v| v.as_str()).unwrap_or(""),
+                w.get("agent_id").and_then(|v| v.as_str()).unwrap_or(""),
+                w.get("status").and_then(|v| v.as_str()).unwrap_or(""),
+                w.get("title").and_then(|v| v.as_str()).unwrap_or(""),
+            ]);
+        }
+        println!("{table}");
+        Ok(CommandResult::ok(json!({ "workflows": workflows })))
+    }
+}
+
+// ── show ────────────────────────────────────────────────────────────────────
+
+pub struct WorkflowShowCommand;
+
+#[async_trait]
+impl Command for WorkflowShowCommand {
+    fn name(&self) -> &str {
+        "workflow:show"
+    }
+
+    fn describe(&self) -> CommandDescription {
+        CommandDescription {
+            summary: "Show workflow detail (GET /admin/workflows/{id})".into(),
+            help: "Fetches one workflow's record by id and pretty-prints it.".into(),
+            category: CommandCategory::System,
+        }
+    }
+
+    fn argument_schema(&self) -> CommandArgSchema {
+        CommandArgSchema(
+            clap::Command::new("show")
+                .about("Show workflow detail")
+                .arg(clap::Arg::new("id").required(true).help("Workflow ID")),
+        )
+    }
+
+    async fn execute(
+        &self,
+        args: CommandArgs,
+        _ctx: &CommandContext,
+    ) -> Result<CommandResult, CommandError> {
+        let id = args
+            .get("id")
+            .ok_or_else(|| CommandError::InvalidArgs("workflow id required".into()))?
+            .to_owned();
+        let client = build_client(&args)?;
+        let resp = client
+            .http()
+            .get(client.url(&format!("/admin/workflows/{id}")))
+            .send()
+            .await
+            .map_err(|e| CommandError::Execution(format!("request failed: {e}")))?;
+        match resp.status() {
+            StatusCode::NOT_FOUND => Err(CommandError::Execution(format!("workflow not found: {id}"))),
+            s if !s.is_success() => Err(CommandError::Execution(format!("gateway returned HTTP {s}"))),
+            _ => {
+                let body: serde_json::Value = resp.json().await.map_err(|e| {
+                    CommandError::Execution(format!("failed to parse response: {e}"))
+                })?;
+                println!("{}", serde_json::to_string_pretty(&body).unwrap_or_default());
+                Ok(CommandResult::ok(body))
+            }
+        }
+    }
+}
+
+// ── create ──────────────────────────────────────────────────────────────────
+
+pub struct WorkflowCreateCommand;
+
+#[async_trait]
+impl Command for WorkflowCreateCommand {
+    fn name(&self) -> &str {
+        "workflow:create"
+    }
+
+    fn describe(&self) -> CommandDescription {
+        CommandDescription {
+            summary: "Create a workflow from a YAML manifest file (deferred to L.5)".into(),
+            help: "Reads <file> as YAML and POSTs it to /admin/workflows. The L.3 \
+                   gateway returns 501 today — write paths land in L.5."
+                .into(),
+            category: CommandCategory::System,
+        }
+    }
+
+    fn argument_schema(&self) -> CommandArgSchema {
+        CommandArgSchema(
+            clap::Command::new("create")
+                .about("Create a workflow from a manifest file")
+                .arg(
+                    clap::Arg::new("file")
+                        .required(true)
+                        .help("Path to a workflow manifest (YAML)"),
+                ),
+        )
+    }
+
+    async fn execute(
+        &self,
+        args: CommandArgs,
+        _ctx: &CommandContext,
+    ) -> Result<CommandResult, CommandError> {
+        let path = args
+            .get("file")
+            .ok_or_else(|| CommandError::InvalidArgs("file path required".into()))?
+            .to_owned();
+        let raw = std::fs::read_to_string(&path)
+            .map_err(|e| CommandError::Execution(format!("failed to read {path}: {e}")))?;
+        let parsed: serde_yaml::Value = serde_yaml::from_str(&raw)
+            .map_err(|e| CommandError::Execution(format!("failed to parse {path}: {e}")))?;
+        let body = serde_json::to_value(&parsed)
+            .map_err(|e| CommandError::Execution(format!("failed to convert YAML: {e}")))?;
+
+        let client = build_client(&args)?;
+        let resp = client
+            .http()
+            .post(client.url("/admin/workflows"))
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| CommandError::Execution(format!("request failed: {e}")))?;
+        if resp.status() == StatusCode::NOT_IMPLEMENTED {
+            return Err(not_implemented_message());
+        }
+        if !resp.status().is_success() {
+            return Err(CommandError::Execution(format!(
+                "gateway returned HTTP {}",
+                resp.status()
+            )));
+        }
+        let response: serde_json::Value = resp
+            .json()
+            .await
+            .map_err(|e| CommandError::Execution(format!("failed to parse response: {e}")))?;
+        println!("{}", serde_json::to_string_pretty(&response).unwrap_or_default());
+        Ok(CommandResult::ok(response))
+    }
+}
+
+// ── delete ──────────────────────────────────────────────────────────────────
+
+pub struct WorkflowDeleteCommand;
+
+#[async_trait]
+impl Command for WorkflowDeleteCommand {
+    fn name(&self) -> &str {
+        "workflow:delete"
+    }
+
+    fn describe(&self) -> CommandDescription {
+        CommandDescription {
+            summary: "Delete a workflow (deferred to L.5)".into(),
+            help: "DELETEs /admin/workflows/{id}. The L.3 gateway returns 501 today."
+                .into(),
+            category: CommandCategory::System,
+        }
+    }
+
+    fn argument_schema(&self) -> CommandArgSchema {
+        CommandArgSchema(
+            clap::Command::new("delete")
+                .about("Delete a workflow")
+                .arg(clap::Arg::new("id").required(true).help("Workflow ID")),
+        )
+    }
+
+    async fn execute(
+        &self,
+        args: CommandArgs,
+        _ctx: &CommandContext,
+    ) -> Result<CommandResult, CommandError> {
+        let id = args
+            .get("id")
+            .ok_or_else(|| CommandError::InvalidArgs("workflow id required".into()))?
+            .to_owned();
+        let client = build_client(&args)?;
+        let resp = client
+            .http()
+            .delete(client.url(&format!("/admin/workflows/{id}")))
+            .send()
+            .await
+            .map_err(|e| CommandError::Execution(format!("request failed: {e}")))?;
+        if resp.status() == StatusCode::NOT_IMPLEMENTED {
+            return Err(not_implemented_message());
+        }
+        if resp.status() == StatusCode::NOT_FOUND {
+            return Err(CommandError::Execution(format!("workflow not found: {id}")));
+        }
+        if !resp.status().is_success() {
+            return Err(CommandError::Execution(format!(
+                "gateway returned HTTP {}",
+                resp.status()
+            )));
+        }
+        println!("Deleted workflow {id}");
+        Ok(CommandResult::ok(json!({ "deleted": id })))
+    }
+}

--- a/rust/crates/sera-cli/src/lib.rs
+++ b/rust/crates/sera-cli/src/lib.rs
@@ -1,5 +1,6 @@
 //! `sera-cli` library — exposes internals for integration tests.
 
+pub mod admin_client;
 pub mod commands;
 pub mod config;
 pub mod http;
@@ -25,5 +26,24 @@ pub fn build_registry() -> CommandRegistry {
     registry.register(commands::ProviderSelectCommand);
     registry.register(commands::ProviderConfigureCommand::new());
     registry.register(commands::InitCommand::new());
+    registry.register(commands::WorkflowListCommand);
+    registry.register(commands::WorkflowShowCommand);
+    registry.register(commands::WorkflowCreateCommand);
+    registry.register(commands::WorkflowDeleteCommand);
+    registry.register(commands::PolicyListCommand);
+    registry.register(commands::PolicyShowCommand);
+    registry.register(commands::PolicyReloadCommand);
+    registry.register(commands::PolicyValidateCommand);
+    registry.register(commands::SessionListCommand);
+    registry.register(commands::SessionShowCommand);
+    registry.register(commands::SessionKillCommand);
+    registry.register(commands::SessionBrowseCommand);
+    registry.register(commands::KillswitchArmCommand);
+    registry.register(commands::KillswitchDisarmCommand);
+    registry.register(commands::KillswitchStatusCommand);
+    registry.register(commands::ConfigGetCommand);
+    registry.register(commands::ConfigSetCommand);
+    registry.register(commands::ConfigEditCommand);
+    registry.register(commands::ConfigPathCommand);
     registry
 }

--- a/rust/crates/sera-cli/src/main.rs
+++ b/rust/crates/sera-cli/src/main.rs
@@ -57,6 +57,11 @@ enum Commands {
         #[command(subcommand)]
         command: ProviderCommand,
     },
+    /// Alias for `provider select <name>` (one-shot dispatch).
+    Model {
+        /// Provider instance name to set as default
+        name: String,
+    },
     /// First-run bootstrap wizard — produces a working SERA config
     Init {
         /// Ingest a YAML manifest set non-interactively
@@ -69,6 +74,106 @@ enum Commands {
         #[arg(long)]
         force: bool,
     },
+    /// Inspect or mutate workflows via the gateway admin port
+    Workflow {
+        #[command(subcommand)]
+        command: WorkflowCommand,
+    },
+    /// Manage capability policies
+    Policy {
+        #[command(subcommand)]
+        command: PolicyCommand,
+    },
+    /// Inspect / cancel active sessions
+    Session {
+        #[command(subcommand)]
+        command: SessionCommand,
+    },
+    /// Arm / disarm / inspect the gateway killswitch
+    Killswitch {
+        #[command(subcommand)]
+        command: KillswitchCommand,
+    },
+    /// Read or modify config.yaml locally (no gateway round-trip)
+    Config {
+        #[command(subcommand)]
+        command: ConfigCommand,
+    },
+}
+
+#[derive(Subcommand)]
+enum WorkflowCommand {
+    /// List workflows
+    List,
+    /// Show one workflow by id
+    Show {
+        id: String,
+    },
+    /// Create a workflow from a manifest file (deferred to L.5)
+    Create {
+        file: PathBuf,
+    },
+    /// Delete a workflow by id (deferred to L.5)
+    Delete {
+        id: String,
+    },
+}
+
+#[derive(Subcommand)]
+enum PolicyCommand {
+    /// List capability policies
+    List,
+    /// Show one policy by name
+    Show {
+        name: String,
+    },
+    /// Reload policies from disk
+    Reload,
+    /// Validate every policy YAML
+    Validate,
+}
+
+#[derive(Subcommand)]
+enum SessionCommand {
+    /// List active sessions
+    List,
+    /// Show one session by id
+    Show {
+        id: String,
+    },
+    /// Cancel a session
+    Kill {
+        id: String,
+    },
+    /// Paginated browser (TTY-aware)
+    Browse,
+}
+
+#[derive(Subcommand)]
+enum KillswitchCommand {
+    /// Arm the killswitch
+    Arm,
+    /// Disarm the killswitch
+    Disarm,
+    /// Print killswitch status
+    Status,
+}
+
+#[derive(Subcommand)]
+enum ConfigCommand {
+    /// Read a value by dotted path
+    Get {
+        key: String,
+    },
+    /// Write a string value at a dotted path
+    Set {
+        key: String,
+        value: String,
+    },
+    /// Open config.yaml in $EDITOR
+    Edit,
+    /// Print the resolved config.yaml path
+    Path,
 }
 
 #[derive(Subcommand)]
@@ -411,6 +516,149 @@ async fn main() -> Result<()> {
             let cmd = registry
                 .get("init")
                 .context("init command not registered")?;
+            let result = cmd
+                .execute(args, &ctx)
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+            if result.exit_code != 0 {
+                std::process::exit(result.exit_code);
+            }
+        }
+
+        Commands::Model { name } => {
+            let mut args = CommandArgs::new();
+            args.insert("name", name);
+            let cmd = registry
+                .get("provider:select")
+                .context("provider:select command not registered")?;
+            let result = cmd
+                .execute(args, &ctx)
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+            if result.exit_code != 0 {
+                std::process::exit(result.exit_code);
+            }
+        }
+
+        Commands::Workflow { command } => {
+            let (cmd_name, mut args) = match command {
+                WorkflowCommand::List => ("workflow:list", CommandArgs::new()),
+                WorkflowCommand::Show { id } => {
+                    let mut a = CommandArgs::new();
+                    a.insert("id", id);
+                    ("workflow:show", a)
+                }
+                WorkflowCommand::Create { file } => {
+                    let mut a = CommandArgs::new();
+                    a.insert("file", file.display().to_string());
+                    ("workflow:create", a)
+                }
+                WorkflowCommand::Delete { id } => {
+                    let mut a = CommandArgs::new();
+                    a.insert("id", id);
+                    ("workflow:delete", a)
+                }
+            };
+            let _ = &mut args; // (kept mut for symmetry with other dispatch arms)
+            let cmd = registry
+                .get(cmd_name)
+                .with_context(|| format!("{cmd_name} command not registered"))?;
+            let result = cmd
+                .execute(args, &ctx)
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+            if result.exit_code != 0 {
+                std::process::exit(result.exit_code);
+            }
+        }
+
+        Commands::Policy { command } => {
+            let (cmd_name, args) = match command {
+                PolicyCommand::List => ("policy:list", CommandArgs::new()),
+                PolicyCommand::Show { name } => {
+                    let mut a = CommandArgs::new();
+                    a.insert("name", name);
+                    ("policy:show", a)
+                }
+                PolicyCommand::Reload => ("policy:reload", CommandArgs::new()),
+                PolicyCommand::Validate => ("policy:validate", CommandArgs::new()),
+            };
+            let cmd = registry
+                .get(cmd_name)
+                .with_context(|| format!("{cmd_name} command not registered"))?;
+            let result = cmd
+                .execute(args, &ctx)
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+            if result.exit_code != 0 {
+                std::process::exit(result.exit_code);
+            }
+        }
+
+        Commands::Session { command } => {
+            let (cmd_name, args) = match command {
+                SessionCommand::List => ("session:list", CommandArgs::new()),
+                SessionCommand::Show { id } => {
+                    let mut a = CommandArgs::new();
+                    a.insert("id", id);
+                    ("session:show", a)
+                }
+                SessionCommand::Kill { id } => {
+                    let mut a = CommandArgs::new();
+                    a.insert("id", id);
+                    ("session:kill", a)
+                }
+                SessionCommand::Browse => ("session:browse", CommandArgs::new()),
+            };
+            let cmd = registry
+                .get(cmd_name)
+                .with_context(|| format!("{cmd_name} command not registered"))?;
+            let result = cmd
+                .execute(args, &ctx)
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+            if result.exit_code != 0 {
+                std::process::exit(result.exit_code);
+            }
+        }
+
+        Commands::Killswitch { command } => {
+            let cmd_name = match command {
+                KillswitchCommand::Arm => "killswitch:arm",
+                KillswitchCommand::Disarm => "killswitch:disarm",
+                KillswitchCommand::Status => "killswitch:status",
+            };
+            let cmd = registry
+                .get(cmd_name)
+                .with_context(|| format!("{cmd_name} command not registered"))?;
+            let result = cmd
+                .execute(CommandArgs::new(), &ctx)
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+            if result.exit_code != 0 {
+                std::process::exit(result.exit_code);
+            }
+        }
+
+        Commands::Config { command } => {
+            let (cmd_name, args) = match command {
+                ConfigCommand::Get { key } => {
+                    let mut a = CommandArgs::new();
+                    a.insert("key", key);
+                    ("config:get", a)
+                }
+                ConfigCommand::Set { key, value } => {
+                    let mut a = CommandArgs::new();
+                    a.insert("key", key);
+                    a.insert("value", value);
+                    ("config:set", a)
+                }
+                ConfigCommand::Edit => ("config:edit", CommandArgs::new()),
+                ConfigCommand::Path => ("config:path", CommandArgs::new()),
+            };
+            let cmd = registry
+                .get(cmd_name)
+                .with_context(|| format!("{cmd_name} command not registered"))?;
             let result = cmd
                 .execute(args, &ctx)
                 .await

--- a/rust/crates/sera-cli/tests/agent_test.rs
+++ b/rust/crates/sera-cli/tests/agent_test.rs
@@ -542,6 +542,6 @@ fn registry_contains_agent_commands() {
     assert!(registry.get("agent:show").is_some(), "agent:show not in registry");
     assert!(registry.get("agent:run").is_some(), "agent:run not in registry");
     assert!(registry.get("chat").is_some(), "chat not in registry");
-    // Total: 4 original + 3 agent + 1 chat + 5 provider + 1 init = 14
-    assert_eq!(registry.len(), 14);
+    // Total: 14 from L.0–L.2 + 19 L.4 admin verbs (workflow×4, policy×4, session×4, killswitch×3, config×4)
+    assert_eq!(registry.len(), 33);
 }

--- a/rust/crates/sera-cli/tests/config_test.rs
+++ b/rust/crates/sera-cli/tests/config_test.rs
@@ -1,0 +1,106 @@
+//! Integration tests for `sera config` verbs (local-only YAML).
+//!
+//! These never touch the gateway — `SERA_CONFIG_ROOT` is set to a tempdir.
+
+use std::path::Path;
+
+use sera_cli::commands::config::{ConfigGetCommand, ConfigPathCommand, ConfigSetCommand};
+use sera_commands::{Command, CommandArgs, CommandContext};
+
+fn args(pairs: &[(&str, &str)]) -> CommandArgs {
+    let mut a = CommandArgs::new();
+    for (k, v) in pairs {
+        a.insert(*k, *v);
+    }
+    a
+}
+
+fn write_manifest(dir: &Path, body: &str) {
+    std::fs::create_dir_all(dir).unwrap();
+    std::fs::write(dir.join("config.yaml"), body).unwrap();
+}
+
+#[tokio::test]
+async fn config_path_prints_resolved_config_yaml() {
+    let dir = tempfile::tempdir().unwrap();
+    let result = ConfigPathCommand
+        .execute(
+            args(&[("config-root", dir.path().to_str().unwrap())]),
+            &CommandContext::new(),
+        )
+        .await
+        .unwrap();
+    let expected = dir.path().join("config.yaml").display().to_string();
+    assert_eq!(result.data, serde_json::json!({"path": expected}));
+}
+
+#[tokio::test]
+async fn config_get_walks_dotted_path() {
+    let dir = tempfile::tempdir().unwrap();
+    write_manifest(
+        dir.path(),
+        "apiVersion: sera.dev/v1\nkind: Instance\nmetadata:\n  name: default\nspec:\n  gateway:\n    mode: local\n  data_dir: /var/lib/sera\n",
+    );
+    let result = ConfigGetCommand
+        .execute(
+            args(&[
+                ("config-root", dir.path().to_str().unwrap()),
+                ("key", "spec.gateway.mode"),
+            ]),
+            &CommandContext::new(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(result.data, serde_json::json!("local"));
+}
+
+#[tokio::test]
+async fn config_set_round_trips_through_get() {
+    let dir = tempfile::tempdir().unwrap();
+    write_manifest(
+        dir.path(),
+        "apiVersion: sera.dev/v1\nkind: Instance\nmetadata:\n  name: default\nspec:\n  gateway:\n    mode: local\n  data_dir: /tmp\n",
+    );
+
+    ConfigSetCommand
+        .execute(
+            args(&[
+                ("config-root", dir.path().to_str().unwrap()),
+                ("key", "spec.gateway.mode"),
+                ("value", "remote"),
+            ]),
+            &CommandContext::new(),
+        )
+        .await
+        .unwrap();
+
+    let result = ConfigGetCommand
+        .execute(
+            args(&[
+                ("config-root", dir.path().to_str().unwrap()),
+                ("key", "spec.gateway.mode"),
+            ]),
+            &CommandContext::new(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(result.data, serde_json::json!("remote"));
+}
+
+#[tokio::test]
+async fn config_get_missing_key_errors() {
+    let dir = tempfile::tempdir().unwrap();
+    write_manifest(dir.path(), "spec:\n  gateway:\n    mode: local\n");
+    let err = ConfigGetCommand
+        .execute(
+            args(&[
+                ("config-root", dir.path().to_str().unwrap()),
+                ("key", "spec.does.not.exist"),
+            ]),
+            &CommandContext::new(),
+        )
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("not found"), "got: {err}");
+}

--- a/rust/crates/sera-cli/tests/killswitch_test.rs
+++ b/rust/crates/sera-cli/tests/killswitch_test.rs
@@ -1,0 +1,75 @@
+//! Integration tests for `sera killswitch` verbs.
+
+use sera_cli::commands::killswitch::{
+    KillswitchArmCommand, KillswitchDisarmCommand, KillswitchStatusCommand,
+};
+use sera_commands::{Command, CommandArgs, CommandContext};
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn args(pairs: &[(&str, &str)]) -> CommandArgs {
+    let mut a = CommandArgs::new();
+    for (k, v) in pairs {
+        a.insert(*k, *v);
+    }
+    a
+}
+
+#[tokio::test]
+async fn killswitch_arm_returns_ok_payload() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/admin/killswitch/arm"))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(&server)
+        .await;
+
+    let result = KillswitchArmCommand
+        .execute(
+            args(&[("endpoint", &server.uri()), ("admin-token", "t")]),
+            &CommandContext::new(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(result.data, serde_json::json!({"ok": true}));
+}
+
+#[tokio::test]
+async fn killswitch_disarm_returns_ok_payload() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/admin/killswitch/disarm"))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(&server)
+        .await;
+
+    let result = KillswitchDisarmCommand
+        .execute(
+            args(&[("endpoint", &server.uri()), ("admin-token", "t")]),
+            &CommandContext::new(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(result.data, serde_json::json!({"ok": true}));
+}
+
+#[tokio::test]
+async fn killswitch_status_reflects_armed_flag() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/admin/killswitch/status"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "armed": true
+        })))
+        .mount(&server)
+        .await;
+
+    let result = KillswitchStatusCommand
+        .execute(
+            args(&[("endpoint", &server.uri()), ("admin-token", "t")]),
+            &CommandContext::new(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(result.data, serde_json::json!({"armed": true}));
+}

--- a/rust/crates/sera-cli/tests/ping_test.rs
+++ b/rust/crates/sera-cli/tests/ping_test.rs
@@ -42,8 +42,8 @@ async fn ping_fails_on_non_success_status() {
 fn registry_contains_ping() {
     let registry = sera_cli::build_registry();
     assert!(registry.get("ping").is_some(), "ping not found in registry");
-    // Registry also contains auth:login, auth:whoami, auth:logout,
-    // agent:list, agent:show, agent:run, chat, the five provider:*
-    // commands (list/add/remove/select/configure), and init.
-    assert_eq!(registry.len(), 14);
+    // Registry contains the L.0–L.2 commands (14) plus the L.4 admin verbs:
+    //   workflow:* (4), policy:* (4), session:* (4), killswitch:* (3), config:* (4) = 19
+    // Total = 33.
+    assert_eq!(registry.len(), 33);
 }

--- a/rust/crates/sera-cli/tests/policy_test.rs
+++ b/rust/crates/sera-cli/tests/policy_test.rs
@@ -1,0 +1,128 @@
+//! Integration tests for `sera policy` verbs.
+
+use sera_cli::commands::policy::{
+    PolicyListCommand, PolicyReloadCommand, PolicyShowCommand, PolicyValidateCommand,
+};
+use sera_commands::{Command, CommandArgs, CommandContext};
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn args(pairs: &[(&str, &str)]) -> CommandArgs {
+    let mut a = CommandArgs::new();
+    for (k, v) in pairs {
+        a.insert(*k, *v);
+    }
+    a
+}
+
+#[tokio::test]
+async fn policy_list_returns_dir_and_names() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/admin/policies"))
+        .and(header("authorization", "Bearer admin-tok"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "dir": "/etc/sera/policies",
+            "policies": ["read-only", "shell-safe"]
+        })))
+        .mount(&server)
+        .await;
+
+    let result = PolicyListCommand
+        .execute(
+            args(&[("endpoint", &server.uri()), ("admin-token", "admin-tok")]),
+            &CommandContext::new(),
+        )
+        .await
+        .unwrap();
+
+    let golden = serde_json::json!({
+        "dir": "/etc/sera/policies",
+        "policies": ["read-only", "shell-safe"]
+    });
+    assert_eq!(result.data, golden);
+}
+
+#[tokio::test]
+async fn policy_show_pretty_prints_manifest() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/admin/policies/read-only"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "name": "read-only",
+            "manifest": {
+                "apiVersion": "sera.dev/v1",
+                "kind": "CapabilityPolicy",
+                "metadata": {"name": "read-only"},
+                "spec": {"allowedTools": ["memory_read"]}
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    let result = PolicyShowCommand
+        .execute(
+            args(&[
+                ("endpoint", &server.uri()),
+                ("admin-token", "t"),
+                ("name", "read-only"),
+            ]),
+            &CommandContext::new(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(result.data["name"], "read-only");
+    assert_eq!(
+        result.data["manifest"]["kind"], "CapabilityPolicy",
+        "manifest body must round-trip"
+    );
+}
+
+#[tokio::test]
+async fn policy_reload_returns_loaded_count() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/admin/policies/reload"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "loaded": 3,
+            "policies": ["a", "b", "c"]
+        })))
+        .mount(&server)
+        .await;
+
+    let result = PolicyReloadCommand
+        .execute(
+            args(&[("endpoint", &server.uri()), ("admin-token", "t")]),
+            &CommandContext::new(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(result.data["loaded"], 3);
+}
+
+#[tokio::test]
+async fn policy_validate_marks_failure_with_nonzero_exit_code() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/admin/policies/validate"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "dir": "/etc/sera/policies",
+            "ok": false,
+            "results": [
+                {"file": "good", "ok": true},
+                {"file": "broken", "ok": false, "error": "unexpected token"}
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let result = PolicyValidateCommand
+        .execute(
+            args(&[("endpoint", &server.uri()), ("admin-token", "t")]),
+            &CommandContext::new(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(result.exit_code, 1, "validate must fail when any file errors");
+    assert_eq!(result.data["ok"], false);
+}

--- a/rust/crates/sera-cli/tests/session_test.rs
+++ b/rust/crates/sera-cli/tests/session_test.rs
@@ -1,0 +1,118 @@
+//! Integration tests for `sera session` verbs.
+
+use sera_cli::commands::session::{
+    SessionBrowseCommand, SessionKillCommand, SessionListCommand, SessionShowCommand,
+};
+use sera_commands::{Command, CommandArgs, CommandContext};
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn args(pairs: &[(&str, &str)]) -> CommandArgs {
+    let mut a = CommandArgs::new();
+    for (k, v) in pairs {
+        a.insert(*k, *v);
+    }
+    a
+}
+
+#[tokio::test]
+async fn session_list_returns_array() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/admin/sessions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+            {"id": "s-1", "agent_id": "a-1", "session_key": "k-1", "state": "running"},
+            {"id": "s-2", "agent_id": "a-2", "session_key": "k-2", "state": "idle"}
+        ])))
+        .mount(&server)
+        .await;
+
+    let result = SessionListCommand
+        .execute(
+            args(&[("endpoint", &server.uri()), ("admin-token", "t")]),
+            &CommandContext::new(),
+        )
+        .await
+        .unwrap();
+    let golden = serde_json::json!([
+        {"id": "s-1", "agent_id": "a-1", "session_key": "k-1", "state": "running"},
+        {"id": "s-2", "agent_id": "a-2", "session_key": "k-2", "state": "idle"}
+    ]);
+    assert_eq!(result.data, golden);
+}
+
+#[tokio::test]
+async fn session_show_returns_record() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/admin/sessions/s-9"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "s-9",
+            "agent_id": "agent-x",
+            "session_key": "k-9",
+            "state": "running"
+        })))
+        .mount(&server)
+        .await;
+
+    let result = SessionShowCommand
+        .execute(
+            args(&[
+                ("endpoint", &server.uri()),
+                ("admin-token", "t"),
+                ("id", "s-9"),
+            ]),
+            &CommandContext::new(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(result.data["id"], "s-9");
+    assert_eq!(result.data["state"], "running");
+}
+
+#[tokio::test]
+async fn session_kill_is_idempotent() {
+    let server = MockServer::start().await;
+    Mock::given(method("DELETE"))
+        .and(path("/admin/sessions/s-1"))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(&server)
+        .await;
+
+    let result = SessionKillCommand
+        .execute(
+            args(&[
+                ("endpoint", &server.uri()),
+                ("admin-token", "t"),
+                ("id", "s-1"),
+            ]),
+            &CommandContext::new(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(result.data, serde_json::json!({"cancelled": "s-1"}));
+}
+
+#[tokio::test]
+async fn session_browse_aliases_to_list_when_not_a_tty() {
+    // Cargo's test harness pipes stdin/stdout, so the TTY check returns false
+    // and `browse` should behave identically to `list`.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/admin/sessions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+            {"id": "x", "agent_id": "y", "session_key": "z", "state": "running"}
+        ])))
+        .mount(&server)
+        .await;
+
+    let result = SessionBrowseCommand
+        .execute(
+            args(&[("endpoint", &server.uri()), ("admin-token", "t")]),
+            &CommandContext::new(),
+        )
+        .await
+        .unwrap();
+    assert!(result.data.is_array());
+    assert_eq!(result.data[0]["id"], "x");
+}

--- a/rust/crates/sera-cli/tests/workflow_test.rs
+++ b/rust/crates/sera-cli/tests/workflow_test.rs
@@ -1,0 +1,143 @@
+//! Integration tests for `sera workflow` verbs.
+//!
+//! Each test stands up a wiremock server, points the AdminClient at it via
+//! `--endpoint` + `--admin-token` overrides, and asserts the resulting
+//! `CommandResult.data` against a small golden JSON snapshot.
+
+use sera_cli::commands::workflow::{
+    WorkflowCreateCommand, WorkflowDeleteCommand, WorkflowListCommand, WorkflowShowCommand,
+};
+use sera_commands::{Command, CommandArgs, CommandContext};
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn args(pairs: &[(&str, &str)]) -> CommandArgs {
+    let mut a = CommandArgs::new();
+    for (k, v) in pairs {
+        a.insert(*k, *v);
+    }
+    a
+}
+
+#[tokio::test]
+async fn workflow_list_renders_table_and_returns_payload() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/admin/workflows"))
+        .and(header("authorization", "Bearer test-admin"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "workflows": [
+                {"id": "wf-1", "agent_id": "agent-a", "status": "running", "title": "Recap"},
+                {"id": "wf-2", "agent_id": "agent-b", "status": "blocked", "title": "Audit"}
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let cmd = WorkflowListCommand;
+    let result = cmd
+        .execute(
+            args(&[("endpoint", &server.uri()), ("admin-token", "test-admin")]),
+            &CommandContext::new(),
+        )
+        .await
+        .unwrap();
+
+    let golden = serde_json::json!({
+        "workflows": [
+            {"id": "wf-1", "agent_id": "agent-a", "status": "running", "title": "Recap"},
+            {"id": "wf-2", "agent_id": "agent-b", "status": "blocked", "title": "Audit"}
+        ]
+    });
+    assert_eq!(result.data, golden);
+}
+
+#[tokio::test]
+async fn workflow_show_returns_record() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/admin/workflows/wf-99"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "wf-99",
+            "agent_id": "agent-x",
+            "status": "running",
+            "title": "Inspect",
+            "await_type": null,
+            "resolved_at": null,
+            "resume_token": "tok"
+        })))
+        .mount(&server)
+        .await;
+
+    let result = WorkflowShowCommand
+        .execute(
+            args(&[
+                ("endpoint", &server.uri()),
+                ("admin-token", "t"),
+                ("id", "wf-99"),
+            ]),
+            &CommandContext::new(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(result.data["id"], "wf-99");
+    assert_eq!(result.data["status"], "running");
+}
+
+#[tokio::test]
+async fn workflow_create_surfaces_l5_not_yet_wired_on_501() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/admin/workflows"))
+        .respond_with(ResponseTemplate::new(501).set_body_json(serde_json::json!({
+            "error": "workflow_store_not_ready",
+            "detail": "admin workflow CRUD is gated on L.5 wiring"
+        })))
+        .mount(&server)
+        .await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let manifest_path = dir.path().join("wf.yaml");
+    std::fs::write(&manifest_path, "name: test\n").unwrap();
+
+    let err = WorkflowCreateCommand
+        .execute(
+            args(&[
+                ("endpoint", &server.uri()),
+                ("admin-token", "t"),
+                ("file", manifest_path.to_str().unwrap()),
+            ]),
+            &CommandContext::new(),
+        )
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("L.5"), "expected L.5 marker, got: {err}");
+}
+
+#[tokio::test]
+async fn workflow_delete_surfaces_l5_not_yet_wired_on_501() {
+    let server = MockServer::start().await;
+    Mock::given(method("DELETE"))
+        .and(path("/admin/workflows/wf-1"))
+        .respond_with(ResponseTemplate::new(501).set_body_json(serde_json::json!({
+            "error": "workflow_store_not_ready"
+        })))
+        .mount(&server)
+        .await;
+
+    let err = WorkflowDeleteCommand
+        .execute(
+            args(&[
+                ("endpoint", &server.uri()),
+                ("admin-token", "t"),
+                ("id", "wf-1"),
+            ]),
+            &CommandContext::new(),
+        )
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("L.5"), "expected L.5 marker, got: {err}");
+}


### PR DESCRIPTION
## Summary

Adds thin HTTP-client CLI verbs that wrap the gateway's L.3 admin port (`/admin/*`) plus a local `sera config` verb that operates on the L.2 Instance manifest. All five new verb groups follow the existing `sera-commands::Command` registry pattern; they reuse `reqwest::Client` (workspace dep) and resolve endpoint + admin token through a new `AdminClient` helper that reads `<config-root>/config.yaml` with `--endpoint`/`--admin-token`/`SERA_ADMIN_TOKEN` overrides.

### New verbs

| Verb               | Subcommands                       | Backing endpoint                                  |
| ------------------ | --------------------------------- | ------------------------------------------------- |
| `sera workflow`    | `list`, `show`, `create`, `delete`| `GET/POST/DELETE /admin/workflows[/{id}]`         |
| `sera policy`      | `list`, `show`, `reload`, `validate` | `/admin/policies[/{name}]`, `/reload`, `/validate` |
| `sera session`     | `list`, `show`, `kill`, `browse`  | `/admin/sessions[/{id}]`                          |
| `sera killswitch`  | `arm`, `disarm`, `status`         | `/admin/killswitch/{arm,disarm,status}`           |
| `sera config`      | `get`, `set`, `edit`, `path`      | local YAML at `<config-root>/config.yaml` (no gateway round-trip) |
| `sera model <name>`| (alias)                           | dispatches to `provider:select`                   |

`workflow create/delete` surface the gateway's HTTP 501 response with a clear "L.5 not yet wired" error. `session browse` falls back to `session list` when stdin is not a TTY.

### Shared infrastructure

- `src/admin_client.rs` — new module (~315 LOC) wrapping `reqwest::Client` with the admin bearer token. Endpoint and token resolution:
  - `gateway.mode == "local"` → `http://127.0.0.1:3002`, token from `SERA_ADMIN_TOKEN` (or `gateway.admin_token_ref` keyring lookup)
  - `gateway.mode == "remote"` → `gateway.endpoint`, token from `gateway.admin_token_ref` via the L.1 `SecretStore`
  - Per-call overrides: `--endpoint`, `--admin-token`

### Tests

- One golden-output integration test file per verb (wiremock-stubbed gateway, tempdir for the local config path).
- 501 path tested for `workflow create/delete` — asserts the user-facing error mentions L.5.
- `config path` and `config get` tests use `SERA_CONFIG_ROOT` via `--config-root`.
- Updated registry-count assertions in `tests/agent_test.rs` and `tests/ping_test.rs` (14 → 33).

### Module sizes (all ≤ 500 LOC)

| File                            | LOC |
| ------------------------------- | --- |
| `src/admin_client.rs`           | 315 |
| `src/commands/workflow.rs`      | 299 |
| `src/commands/policy.rs`        | 288 |
| `src/commands/session.rs`       | 300 |
| `src/commands/killswitch.rs`    | 161 |
| `src/commands/config.rs`        | 314 |

### Hard constraints

- Hard cutover: no compat shims, no fallback to legacy paths.
- No new top-level deps (`reqwest`, `serde_yaml`, `wiremock`, `tempfile` already present).
- Existing verbs (`auth`, `agent`, `provider`, `init`, `chat`, `ping`) untouched aside from the test-file registry-count updates.

## Test plan

- [x] `cargo build --workspace --bins` — pass
- [x] `cargo clippy --workspace -- -D warnings` — pass (no issues)
- [x] `cargo test --workspace` — 3855 passed, 17 ignored (154 suites)
- [ ] CI: `validate-rust` green
- [ ] CI: `ci-e2e-smoke` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)