### PR TITLE
feat(web): W.3a agents list + detail (sera-eka7)

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -102,3 +102,18 @@ function isReadiness(value: unknown): value is Readiness {
 }
 
 export const getAuthMe = () => apiFetch<AuthMe>('/auth/me');
+
+// ── Agents ─────────────────────────────────────────────────────────────────
+
+export interface AgentInfo {
+  name: string;
+  provider: string;
+  model?: string | null;
+  has_tools: boolean;
+}
+
+// Detail shape is loose JSON from the gateway — use a wide type.
+export type AgentDetail = Record<string, unknown> & { name?: string; provider?: string };
+
+export const getAgents = () => apiFetch<AgentInfo[]>('/agents');
+export const getAgent = (id: string) => apiFetch<AgentDetail>(`/agents/${encodeURIComponent(id)}`);

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -10,6 +10,8 @@ import { ProtectedRoute } from '@/components/ProtectedRoute';
 import { Layout } from '@/components/Layout';
 import { LoginView } from '@/views/LoginView';
 import { DashboardView } from '@/views/DashboardView';
+import { AgentsListView } from '@/views/AgentsListView';
+import { AgentDetailView } from '@/views/AgentDetailView';
 
 const el = document.getElementById('root');
 if (!el) throw new Error('Root element not found');
@@ -30,6 +32,8 @@ createRoot(el).render(
               }
             >
               <Route index element={<DashboardView />} />
+              <Route path="agents" element={<AgentsListView />} />
+              <Route path="agents/:id" element={<AgentDetailView />} />
             </Route>
           </Routes>
         </BrowserRouter>

--- a/web/src/views/AgentDetailView.tsx
+++ b/web/src/views/AgentDetailView.tsx
@@ -1,0 +1,91 @@
+import { useQuery } from '@tanstack/react-query';
+import { useParams, Link } from 'react-router';
+import { getAgent, ApiError } from '@/lib/api';
+
+export function AgentDetailView() {
+  const { id } = useParams<{ id: string }>();
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['agent', id],
+    queryFn: () => getAgent(id!),
+    enabled: !!id,
+  });
+
+  const backLink = (
+    <Link to="/agents" className="text-sm text-zinc-400 hover:text-zinc-200">
+      ← Back to agents
+    </Link>
+  );
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4 p-6">
+        {backLink}
+        <p className="text-sm text-zinc-400">Loading…</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    if (error instanceof ApiError && error.status === 404) {
+      return (
+        <div className="space-y-4 p-6">
+          {backLink}
+          <p className="text-sm text-zinc-400">Agent not found.</p>
+        </div>
+      );
+    }
+    const msg = error instanceof ApiError ? error.message : (error as Error).message;
+    return (
+      <div className="space-y-4 p-6">
+        {backLink}
+        <p className="text-sm text-red-400">Failed to load agent: {msg}</p>
+      </div>
+    );
+  }
+
+  const scalar: [string, string][] = [];
+  const nested: [string, unknown][] = [];
+
+  if (data) {
+    for (const [key, value] of Object.entries(data)) {
+      if (value === null || value === undefined) {
+        scalar.push([key, '—']);
+      } else if (typeof value === 'object') {
+        nested.push([key, value]);
+      } else {
+        scalar.push([key, String(value)]);
+      }
+    }
+  }
+
+  return (
+    <div className="space-y-6 p-6">
+      {backLink}
+      <div>
+        <h1 className="text-2xl font-semibold">{data?.name ?? id}</h1>
+        <p className="text-sm text-zinc-500">Agent detail</p>
+      </div>
+
+      {scalar.length > 0 && (
+        <dl className="divide-y divide-zinc-800 rounded-lg border border-zinc-800">
+          {scalar.map(([key, value]) => (
+            <div key={key} className="flex gap-4 px-4 py-3">
+              <dt className="w-32 shrink-0 text-xs uppercase tracking-wider text-zinc-500">{key}</dt>
+              <dd className="text-sm text-zinc-100">{value}</dd>
+            </div>
+          ))}
+        </dl>
+      )}
+
+      {nested.map(([key, value]) => (
+        <div key={key}>
+          <div className="mb-1 text-xs uppercase tracking-wider text-zinc-500">{key}</div>
+          <pre className="overflow-auto rounded border border-zinc-800 bg-zinc-900 p-3 font-mono text-xs text-zinc-300">
+            {JSON.stringify(value, null, 2)}
+          </pre>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/web/src/views/AgentsListView.tsx
+++ b/web/src/views/AgentsListView.tsx
@@ -38,7 +38,7 @@ export function AgentsListView() {
             <li key={agent.name}>
               <button
                 type="button"
-                onClick={() => void navigate(`/agents/${agent.name}`)}
+                onClick={() => void navigate(`/agents/${encodeURIComponent(agent.name)}`)}
                 className="w-full rounded-lg border border-zinc-800 bg-zinc-900 p-4 text-left hover:border-zinc-700 hover:bg-zinc-800"
               >
                 <div className="font-medium text-zinc-100">{agent.name}</div>

--- a/web/src/views/AgentsListView.tsx
+++ b/web/src/views/AgentsListView.tsx
@@ -1,0 +1,57 @@
+import { useQuery } from '@tanstack/react-query';
+import { useNavigate } from 'react-router';
+import { getAgents, ApiError } from '@/lib/api';
+
+export function AgentsListView() {
+  const navigate = useNavigate();
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['agents'],
+    queryFn: getAgents,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="p-6 text-sm text-zinc-400">Loading agents…</div>
+    );
+  }
+
+  if (error) {
+    const msg = error instanceof ApiError ? error.message : (error as Error).message;
+    return (
+      <div className="p-6 text-sm text-red-400">Failed to load agents: {msg}</div>
+    );
+  }
+
+  return (
+    <div className="space-y-6 p-6">
+      <div>
+        <h1 className="text-2xl font-semibold">Agents</h1>
+        <p className="text-sm text-zinc-500">Registered agent manifests.</p>
+      </div>
+
+      {data && data.length === 0 ? (
+        <p className="text-sm text-zinc-500">No agents registered.</p>
+      ) : (
+        <ul className="space-y-2">
+          {data?.map((agent) => (
+            <li key={agent.name}>
+              <button
+                type="button"
+                onClick={() => void navigate(`/agents/${agent.name}`)}
+                className="w-full rounded-lg border border-zinc-800 bg-zinc-900 p-4 text-left hover:border-zinc-700 hover:bg-zinc-800"
+              >
+                <div className="font-medium text-zinc-100">{agent.name}</div>
+                <div className="mt-1 text-xs text-zinc-500">
+                  provider: {agent.provider || '—'}
+                  {agent.model ? ` · model: ${agent.model}` : ''}
+                  {` · tools: ${agent.has_tools ? 'yes' : 'no'}`}
+                </div>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `AgentInfo` type, `AgentDetail` type, `getAgents()`, and `getAgent(id)` helpers to `src/lib/api.ts`
- Adds `/agents` route → `AgentsListView`: TanStack Query `['agents']`, list of agent rows (name + provider/model/tools metadata), click-to-navigate, loading/error/empty states
- Adds `/agents/:id` route → `AgentDetailView`: TanStack Query `['agent', id]`, scalar fields in a `<dl>`, nested JSON in `<pre>` blocks, 404 inline message, "Back to agents" link
- Registers both routes inside the existing protected `<Route element={<Layout/>}>` block in `main.tsx`

Stacks on #1109 (W.2 auth+dashboard) — will need a 1-line rebase once the parent merges.

## Test plan

- [ ] `bun run typecheck` → pass
- [ ] `bun run lint` → pass (0 warnings)
- [ ] `bun run build` → pass
- [ ] Dev server: `/agents` renders list shell (error state without gateway — no console errors)
- [ ] Dev server: `/agents/foo` renders detail shell (404 error state without gateway — no console errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)