### PR TITLE
feat(web): W.3 chat page (sera-per1)

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -117,3 +117,103 @@ export type AgentDetail = Record<string, unknown> & { name?: string; provider?: 
 
 export const getAgents = () => apiFetch<AgentInfo[]>('/agents');
 export const getAgent = (id: string) => apiFetch<AgentDetail>(`/agents/${encodeURIComponent(id)}`);
+
+// ── Chat streaming ─────────────────────────────────────────────────────────
+
+export interface ChatStreamDelta {
+  type: 'delta';
+  delta: string;
+  messageId: string;
+  sessionId: string;
+}
+
+export interface ChatStreamDone {
+  type: 'done';
+  usage: { promptTokens: number; completionTokens: number; totalTokens: number };
+}
+
+export type ChatStreamEvent = ChatStreamDelta | ChatStreamDone;
+
+/** Parse a raw SSE message into a ChatStreamEvent. Returns null for unknown event types. */
+export function parseChatSseEvent(
+  eventType: string,
+  dataJson: string,
+): ChatStreamEvent | null {
+  if (eventType === 'message') {
+    const raw = JSON.parse(dataJson) as {
+      delta: string;
+      message_id: string;
+      session_id: string;
+    };
+    return {
+      type: 'delta',
+      delta: raw.delta,
+      messageId: raw.message_id,
+      sessionId: raw.session_id,
+    };
+  }
+  if (eventType === 'done') {
+    const raw = JSON.parse(dataJson) as {
+      status: string;
+      usage: { prompt_tokens: number; completion_tokens: number; total_tokens: number };
+    };
+    return {
+      type: 'done',
+      usage: {
+        promptTokens: raw.usage.prompt_tokens,
+        completionTokens: raw.usage.completion_tokens,
+        totalTokens: raw.usage.total_tokens,
+      },
+    };
+  }
+  // Unknown event type — ignore gracefully
+  return null;
+}
+
+export interface ChatStreamOptions {
+  message: string;
+  signal: AbortSignal;
+  onEvent: (event: ChatStreamEvent) => void;
+  onError: (err: unknown) => void;
+}
+
+export async function chatStream({
+  message,
+  signal,
+  onEvent,
+  onError,
+}: ChatStreamOptions): Promise<void> {
+  const { fetchEventSource } = await import('@microsoft/fetch-event-source');
+  const token = getToken();
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+  if (token) headers['Authorization'] = `Bearer ${token}`;
+
+  await fetchEventSource(`${API_BASE}/chat`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ message, stream: true }),
+    signal,
+    async onopen(response) {
+      if (!response.ok) {
+        const text = await response.text();
+        const body = text ? safeJson(text) : null;
+        const msg =
+          typeof body === 'object' && body && 'error' in body
+            ? String((body as { error: unknown }).error)
+            : response.statusText;
+        throw new ApiError(response.status, body, msg);
+      }
+    },
+    onmessage(ev) {
+      const parsed = parseChatSseEvent(ev.event ?? '', ev.data);
+      if (parsed) onEvent(parsed);
+    },
+    onerror(err) {
+      onError(err);
+      // Returning undefined lets fetchEventSource retry by default — throw to stop
+      throw err;
+    },
+  });
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -136,37 +136,42 @@ export interface ChatStreamDone {
 
 export type ChatStreamEvent = ChatStreamDelta | ChatStreamDone;
 
-/** Parse a raw SSE message into a ChatStreamEvent. Returns null for unknown event types. */
+/** Parse a raw SSE message into a ChatStreamEvent. Returns null for unknown event types or malformed JSON. */
 export function parseChatSseEvent(
   eventType: string,
   dataJson: string,
 ): ChatStreamEvent | null {
-  if (eventType === 'message') {
-    const raw = JSON.parse(dataJson) as {
-      delta: string;
-      message_id: string;
-      session_id: string;
-    };
-    return {
-      type: 'delta',
-      delta: raw.delta,
-      messageId: raw.message_id,
-      sessionId: raw.session_id,
-    };
-  }
-  if (eventType === 'done') {
-    const raw = JSON.parse(dataJson) as {
-      status: string;
-      usage: { prompt_tokens: number; completion_tokens: number; total_tokens: number };
-    };
-    return {
-      type: 'done',
-      usage: {
-        promptTokens: raw.usage.prompt_tokens,
-        completionTokens: raw.usage.completion_tokens,
-        totalTokens: raw.usage.total_tokens,
-      },
-    };
+  try {
+    if (eventType === 'message') {
+      const raw = JSON.parse(dataJson) as {
+        delta: string;
+        message_id: string;
+        session_id: string;
+      };
+      return {
+        type: 'delta',
+        delta: raw.delta,
+        messageId: raw.message_id,
+        sessionId: raw.session_id,
+      };
+    }
+    if (eventType === 'done') {
+      const raw = JSON.parse(dataJson) as {
+        status: string;
+        usage?: { prompt_tokens: number; completion_tokens: number; total_tokens: number };
+      };
+      return {
+        type: 'done',
+        usage: {
+          promptTokens: raw.usage?.prompt_tokens ?? 0,
+          completionTokens: raw.usage?.completion_tokens ?? 0,
+          totalTokens: raw.usage?.total_tokens ?? 0,
+        },
+      };
+    }
+  } catch {
+    // Malformed JSON — ignore gracefully, same contract as unknown event types
+    return null;
   }
   // Unknown event type — ignore gracefully
   return null;

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,3 +1,5 @@
+import { fetchEventSource } from '@microsoft/fetch-event-source';
+
 const API_BASE = '/api';
 const AUTH_KEY = 'sera.auth.token';
 
@@ -183,7 +185,6 @@ export async function chatStream({
   onEvent,
   onError,
 }: ChatStreamOptions): Promise<void> {
-  const { fetchEventSource } = await import('@microsoft/fetch-event-source');
   const token = getToken();
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -12,6 +12,7 @@ import { LoginView } from '@/views/LoginView';
 import { DashboardView } from '@/views/DashboardView';
 import { AgentsListView } from '@/views/AgentsListView';
 import { AgentDetailView } from '@/views/AgentDetailView';
+import { ChatView } from '@/views/ChatView';
 
 const el = document.getElementById('root');
 if (!el) throw new Error('Root element not found');
@@ -34,6 +35,7 @@ createRoot(el).render(
               <Route index element={<DashboardView />} />
               <Route path="agents" element={<AgentsListView />} />
               <Route path="agents/:id" element={<AgentDetailView />} />
+              <Route path="chat" element={<ChatView />} />
             </Route>
           </Routes>
         </BrowserRouter>

--- a/web/src/views/ChatView.test.ts
+++ b/web/src/views/ChatView.test.ts
@@ -34,6 +34,19 @@ describe('parseChatSseEvent', () => {
     expect(result).toBeNull();
   });
 
+  it('returns null for malformed JSON in a message event', () => {
+    const result = parseChatSseEvent('message', 'not-valid-json{{{');
+    expect(result).toBeNull();
+  });
+
+  it('returns done with zero usage when usage field is absent', () => {
+    const result = parseChatSseEvent('done', JSON.stringify({ status: 'complete' }));
+    expect(result).toEqual({
+      type: 'done',
+      usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+    });
+  });
+
   it('accumulates deltas correctly when applied sequentially', () => {
     const events = [
       { event: 'message', data: JSON.stringify({ delta: 'Hello ', message_id: 'm1', session_id: 's1' }) },

--- a/web/src/views/ChatView.test.ts
+++ b/web/src/views/ChatView.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { parseChatSseEvent } from '@/lib/api';
+
+describe('parseChatSseEvent', () => {
+  it('parses a message delta event', () => {
+    const result = parseChatSseEvent(
+      'message',
+      JSON.stringify({ delta: 'Hello ', message_id: 'msg_abc', session_id: 'sess_1' }),
+    );
+    expect(result).toEqual({
+      type: 'delta',
+      delta: 'Hello ',
+      messageId: 'msg_abc',
+      sessionId: 'sess_1',
+    });
+  });
+
+  it('parses a done event', () => {
+    const result = parseChatSseEvent(
+      'done',
+      JSON.stringify({
+        status: 'complete',
+        usage: { prompt_tokens: 10, completion_tokens: 20, total_tokens: 30 },
+      }),
+    );
+    expect(result).toEqual({
+      type: 'done',
+      usage: { promptTokens: 10, completionTokens: 20, totalTokens: 30 },
+    });
+  });
+
+  it('returns null for unknown event types', () => {
+    const result = parseChatSseEvent('unknown_event', JSON.stringify({ foo: 'bar' }));
+    expect(result).toBeNull();
+  });
+
+  it('accumulates deltas correctly when applied sequentially', () => {
+    const events = [
+      { event: 'message', data: JSON.stringify({ delta: 'Hello ', message_id: 'm1', session_id: 's1' }) },
+      { event: 'message', data: JSON.stringify({ delta: 'world', message_id: 'm1', session_id: 's1' }) },
+      { event: 'message', data: JSON.stringify({ delta: '!', message_id: 'm1', session_id: 's1' }) },
+      { event: 'done', data: JSON.stringify({ status: 'complete', usage: { prompt_tokens: 5, completion_tokens: 3, total_tokens: 8 } }) },
+    ];
+
+    let accumulated = '';
+    let done = false;
+    for (const ev of events) {
+      const parsed = parseChatSseEvent(ev.event, ev.data);
+      if (parsed?.type === 'delta') accumulated += parsed.delta;
+      if (parsed?.type === 'done') done = true;
+    }
+
+    expect(accumulated).toBe('Hello world!');
+    expect(done).toBe(true);
+  });
+});

--- a/web/src/views/ChatView.tsx
+++ b/web/src/views/ChatView.tsx
@@ -1,0 +1,177 @@
+import { useState, useRef, useEffect, useCallback } from 'react';
+import { Send } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { chatStream, ApiError, type ChatStreamEvent } from '@/lib/api';
+import { useAuth } from '@/contexts/auth-context';
+
+interface Message {
+  id: string;
+  role: 'user' | 'assistant';
+  content: string;
+  error?: string;
+}
+
+export function ChatView() {
+  const { signOut } = useAuth();
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState('');
+  const [thinking, setThinking] = useState(false);
+  const abortRef = useRef<AbortController | null>(null);
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  // Scroll to bottom whenever messages change
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages, thinking]);
+
+  // Abort stream on unmount
+  useEffect(() => {
+    return () => {
+      abortRef.current?.abort();
+    };
+  }, []);
+
+  const handleEvent = useCallback((msgId: string, event: ChatStreamEvent) => {
+    if (event.type === 'delta') {
+      setMessages((prev) =>
+        prev.map((m) =>
+          m.id === msgId ? { ...m, content: m.content + event.delta } : m,
+        ),
+      );
+    } else if (event.type === 'done') {
+      setThinking(false);
+    }
+  }, []);
+
+  const sendMessage = useCallback(async () => {
+    const text = input.trim();
+    if (!text || thinking) return;
+
+    const userMsg: Message = { id: crypto.randomUUID(), role: 'user', content: text };
+    const assistantMsgId = crypto.randomUUID();
+    const assistantMsg: Message = { id: assistantMsgId, role: 'assistant', content: '' };
+
+    setMessages((prev) => [...prev, userMsg, assistantMsg]);
+    setInput('');
+    setThinking(true);
+
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    try {
+      await chatStream({
+        message: text,
+        signal: controller.signal,
+        onEvent: (ev) => handleEvent(assistantMsgId, ev),
+        onError: (err) => {
+          if (err instanceof ApiError && err.status === 401) {
+            signOut();
+            return;
+          }
+          const msg = err instanceof Error ? err.message : 'Stream error';
+          setMessages((prev) =>
+            prev.map((m) =>
+              m.id === assistantMsgId ? { ...m, error: msg } : m,
+            ),
+          );
+          setThinking(false);
+        },
+      });
+    } catch (err) {
+      // AbortError is expected on unmount — ignore
+      if (err instanceof DOMException && err.name === 'AbortError') return;
+      if (err instanceof ApiError && err.status === 401) {
+        signOut();
+        return;
+      }
+      const msg = err instanceof Error ? err.message : 'Unknown error';
+      setMessages((prev) =>
+        prev.map((m) =>
+          m.id === assistantMsgId ? { ...m, error: msg } : m,
+        ),
+      );
+    } finally {
+      setThinking(false);
+    }
+  }, [input, thinking, handleEvent, signOut]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        void sendMessage();
+      }
+    },
+    [sendMessage],
+  );
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* Transcript */}
+      <div className="flex-1 overflow-y-auto p-4 space-y-4">
+        {messages.length === 0 && (
+          <div className="flex h-full items-center justify-center">
+            <p className="text-sm text-zinc-500">Send a message to start chatting.</p>
+          </div>
+        )}
+        {messages.map((msg) => (
+          <div
+            key={msg.id}
+            className={cn(
+              'flex',
+              msg.role === 'user' ? 'justify-end' : 'justify-start',
+            )}
+          >
+            <div
+              className={cn(
+                'max-w-[70%] rounded-lg px-3 py-2 text-sm',
+                msg.role === 'user'
+                  ? 'bg-zinc-700 text-zinc-100'
+                  : 'bg-zinc-900 text-zinc-200 border border-zinc-800',
+                msg.error && 'border-red-700 bg-red-950/30 text-red-300',
+              )}
+            >
+              {msg.error ? (
+                <span className="text-red-300">Error: {msg.error}</span>
+              ) : msg.role === 'assistant' && msg.content === '' && thinking ? (
+                <span className="text-zinc-500 italic">Thinking…</span>
+              ) : (
+                <span className="whitespace-pre-wrap">{msg.content}</span>
+              )}
+            </div>
+          </div>
+        ))}
+        <div ref={bottomRef} />
+      </div>
+
+      {/* Composer */}
+      <div className="border-t border-zinc-800 bg-zinc-950 p-3">
+        <div className="flex items-end gap-2">
+          <textarea
+            className="flex-1 resize-none rounded-lg border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm text-zinc-100 placeholder-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500"
+            rows={2}
+            placeholder="Message… (Enter to send, Shift+Enter for newline)"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={handleKeyDown}
+            disabled={thinking}
+          />
+          <button
+            type="button"
+            onClick={() => void sendMessage()}
+            disabled={!input.trim() || thinking}
+            className={cn(
+              'flex h-9 w-9 items-center justify-center rounded-lg transition-colors',
+              input.trim() && !thinking
+                ? 'bg-zinc-700 text-zinc-100 hover:bg-zinc-600'
+                : 'bg-zinc-800 text-zinc-600 cursor-not-allowed',
+            )}
+            aria-label="Send"
+          >
+            <Send className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/views/ChatView.tsx
+++ b/web/src/views/ChatView.tsx
@@ -18,6 +18,7 @@ export function ChatView() {
   const [thinking, setThinking] = useState(false);
   const abortRef = useRef<AbortController | null>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
+  const mountedRef = useRef(true);
 
   // Scroll to bottom whenever messages change
   useEffect(() => {
@@ -26,7 +27,9 @@ export function ChatView() {
 
   // Abort stream on unmount
   useEffect(() => {
+    mountedRef.current = true;
     return () => {
+      mountedRef.current = false;
       abortRef.current?.abort();
     };
   }, []);
@@ -65,6 +68,7 @@ export function ChatView() {
         onEvent: (ev) => handleEvent(assistantMsgId, ev),
         onError: (err) => {
           if (err instanceof ApiError && err.status === 401) {
+            setThinking(false);
             signOut();
             return;
           }
@@ -81,17 +85,20 @@ export function ChatView() {
       // AbortError is expected on unmount — ignore
       if (err instanceof DOMException && err.name === 'AbortError') return;
       if (err instanceof ApiError && err.status === 401) {
+        if (mountedRef.current) setThinking(false);
         signOut();
         return;
       }
       const msg = err instanceof Error ? err.message : 'Unknown error';
-      setMessages((prev) =>
-        prev.map((m) =>
-          m.id === assistantMsgId ? { ...m, error: msg } : m,
-        ),
-      );
+      if (mountedRef.current) {
+        setMessages((prev) =>
+          prev.map((m) =>
+            m.id === assistantMsgId ? { ...m, error: msg } : m,
+          ),
+        );
+      }
     } finally {
-      setThinking(false);
+      if (mountedRef.current) setThinking(false);
     }
   }, [input, thinking, handleEvent, signOut]);
 


### PR DESCRIPTION
## Summary

- Adds `ChatView` at `/chat` — composer pinned to bottom, transcript above, user bubbles right-aligned, assistant bubbles left-aligned accumulating SSE deltas
- Uses `@microsoft/fetch-event-source` for SSE so the `Authorization` header can be sent; adds `chatStream` + `parseChatSseEvent` helpers to `src/lib/api.ts`
- Handles 401 → `signOut()`, non-2xx → error block in transcript, stream abort on unmount
- One unit test (`ChatView.test.ts`) covering delta/done parsing, unknown event type no-op, and multi-delta accumulation (4 tests, all pass)

## Stacking note

Stacks on #1109 (W.2 auth+dashboard). Will need a 1-line rebase once the parent merges — only the `/chat` route line in `main.tsx` could conflict.

## Test plan

- [ ] `bun run typecheck` — clean
- [ ] `bun run lint` — clean
- [ ] `bun run build` — succeeds
- [ ] `bun run test` — 4/4 pass
- [ ] Dev server: `/chat` renders, composer functional, no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)