### PR TITLE
feat(web): W.4 sessions list + transcript viewer (sera-dwq3)

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -223,3 +223,30 @@ export async function chatStream({
     },
   });
 }
+
+// ── Sessions ───────────────────────────────────────────────────────────────
+
+export interface SessionInfo {
+  id: string;
+  agent_id: string;
+  session_key: string;
+  state: string;
+  principal_id: string | null;
+  created_at: string;
+  updated_at: string | null;
+}
+
+export interface TranscriptEntry {
+  id: number;
+  session_id: string;
+  role: string;
+  content: string | null;
+  tool_calls: string | null;
+  tool_call_id: string | null;
+  created_at: string;
+}
+
+export const getSessions = () => apiFetch<SessionInfo[]>('/sessions');
+
+export const getSessionTranscript = (id: string) =>
+  apiFetch<TranscriptEntry[]>(`/sessions/${encodeURIComponent(id)}/transcript`);

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -13,6 +13,8 @@ import { DashboardView } from '@/views/DashboardView';
 import { AgentsListView } from '@/views/AgentsListView';
 import { AgentDetailView } from '@/views/AgentDetailView';
 import { ChatView } from '@/views/ChatView';
+import { SessionsListView } from '@/views/SessionsListView';
+import { SessionDetailView } from '@/views/SessionDetailView';
 
 const el = document.getElementById('root');
 if (!el) throw new Error('Root element not found');
@@ -36,6 +38,8 @@ createRoot(el).render(
               <Route path="agents" element={<AgentsListView />} />
               <Route path="agents/:id" element={<AgentDetailView />} />
               <Route path="chat" element={<ChatView />} />
+              <Route path="sessions" element={<SessionsListView />} />
+              <Route path="sessions/:id" element={<SessionDetailView />} />
             </Route>
           </Routes>
         </BrowserRouter>

--- a/web/src/views/SessionDetailView.tsx
+++ b/web/src/views/SessionDetailView.tsx
@@ -1,0 +1,110 @@
+import { useQuery } from '@tanstack/react-query';
+import { Link, useParams } from 'react-router';
+import { ApiError, getSessionTranscript, type TranscriptEntry } from '@/lib/api';
+import { cn } from '@/lib/utils';
+
+export function SessionDetailView() {
+  const { id } = useParams<{ id: string }>();
+  const sessionId = id ? decodeURIComponent(id) : '';
+
+  const { isLoading, error, data } = useQuery({
+    queryKey: ['session-transcript', sessionId],
+    queryFn: () => getSessionTranscript(sessionId),
+    enabled: Boolean(sessionId),
+  });
+
+  const isNotFound = error instanceof ApiError && error.status === 404;
+
+  return (
+    <div className="space-y-6 p-6">
+      <div className="flex items-center gap-4">
+        <Link to="/sessions" className="text-sm text-zinc-400 hover:text-zinc-200">
+          ← Back to sessions
+        </Link>
+      </div>
+
+      <div>
+        <h1 className="font-mono text-xl font-semibold">{sessionId}</h1>
+        <p className="text-sm text-zinc-500">Session transcript</p>
+      </div>
+
+      {isLoading && <p className="text-sm text-zinc-400">Loading…</p>}
+
+      {isNotFound && (
+        <p className="text-sm text-zinc-500">Session not found.</p>
+      )}
+
+      {error && !isNotFound && (
+        <p className="text-sm text-red-400">
+          Failed to load transcript: {(error as Error).message}
+        </p>
+      )}
+
+      {!isLoading && !error && data?.length === 0 && (
+        <p className="text-sm text-zinc-500">No transcript entries.</p>
+      )}
+
+      {data && data.length > 0 && (
+        <div className="space-y-3">
+          {data.map((entry: TranscriptEntry) => (
+            <TranscriptRow key={entry.id} entry={entry} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function TranscriptRow({ entry }: { entry: TranscriptEntry }) {
+  const role = entry.role;
+
+  if (role === 'user' || role === 'assistant' || role === 'system' || role === 'tool') {
+    return (
+      <div
+        className={cn(
+          'rounded-lg border p-3',
+          role === 'user' && 'border-blue-800 bg-blue-950/30',
+          role === 'assistant' && 'border-emerald-800 bg-emerald-950/30',
+          role === 'system' && 'border-zinc-700 bg-zinc-900',
+          role === 'tool' && 'border-amber-800 bg-amber-950/30',
+        )}
+      >
+        <div className="mb-1 flex items-center justify-between">
+          <span
+            className={cn(
+              'text-xs font-semibold uppercase tracking-wider',
+              role === 'user' && 'text-blue-400',
+              role === 'assistant' && 'text-emerald-400',
+              role === 'system' && 'text-zinc-400',
+              role === 'tool' && 'text-amber-400',
+            )}
+          >
+            {role}
+            {entry.tool_call_id ? ` · ${entry.tool_call_id}` : ''}
+          </span>
+          <span className="text-xs text-zinc-600">{entry.created_at}</span>
+        </div>
+        {entry.content && (
+          <p className="whitespace-pre-wrap text-sm text-zinc-200">{entry.content}</p>
+        )}
+        {entry.tool_calls && (
+          <pre className="mt-1 overflow-x-auto rounded bg-zinc-800 p-2 text-xs text-zinc-300">
+            {entry.tool_calls}
+          </pre>
+        )}
+      </div>
+    );
+  }
+
+  // Unknown role — fall back to raw JSON block
+  return (
+    <div className="rounded-lg border border-zinc-700 p-3">
+      <div className="mb-1 text-xs font-semibold uppercase tracking-wider text-zinc-500">
+        {role}
+      </div>
+      <pre className="overflow-x-auto rounded bg-zinc-800 p-2 text-xs text-zinc-300">
+        {JSON.stringify(entry, null, 2)}
+      </pre>
+    </div>
+  );
+}

--- a/web/src/views/SessionsListView.tsx
+++ b/web/src/views/SessionsListView.tsx
@@ -1,0 +1,58 @@
+import { useQuery } from '@tanstack/react-query';
+import { Link } from 'react-router';
+import { getSessions, type SessionInfo } from '@/lib/api';
+
+export function SessionsListView() {
+  const { isLoading, error, data } = useQuery({
+    queryKey: ['sessions'],
+    queryFn: getSessions,
+  });
+
+  return (
+    <div className="space-y-6 p-6">
+      <div>
+        <h1 className="text-2xl font-semibold">Sessions</h1>
+        <p className="text-sm text-zinc-500">All agent sessions recorded by the gateway.</p>
+      </div>
+
+      {isLoading && <p className="text-sm text-zinc-400">Loading…</p>}
+
+      {error && (
+        <p className="text-sm text-red-400">
+          Failed to load sessions: {(error as Error).message}
+        </p>
+      )}
+
+      {!isLoading && !error && data?.length === 0 && (
+        <p className="text-sm text-zinc-500">No sessions found.</p>
+      )}
+
+      {data && data.length > 0 && (
+        <ul className="divide-y divide-zinc-800 rounded-lg border border-zinc-800">
+          {data.map((session: SessionInfo) => (
+            <li key={session.id}>
+              <Link
+                to={`/sessions/${encodeURIComponent(session.id)}`}
+                className="flex items-center justify-between px-4 py-3 hover:bg-zinc-900"
+              >
+                <div className="min-w-0">
+                  <div className="truncate font-mono text-sm text-zinc-100">{session.id}</div>
+                  <div className="mt-0.5 text-xs text-zinc-500">
+                    agent: {session.agent_id} · state: {session.state}
+                    {session.principal_id ? ` · principal: ${session.principal_id}` : ''}
+                  </div>
+                </div>
+                <div className="ml-4 shrink-0 text-right">
+                  <div className="text-xs text-zinc-400">{session.created_at}</div>
+                  {session.updated_at && (
+                    <div className="text-xs text-zinc-600">upd: {session.updated_at}</div>
+                  )}
+                </div>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `SessionInfo` and `TranscriptEntry` types + `getSessions()` / `getSessionTranscript()` helpers to `web/src/lib/api.ts`
- `SessionsListView` (`/sessions`): TanStack Query key `['sessions']`, clickable list rows with id, agent, state, timestamps; loading / error / empty states
- `SessionDetailView` (`/sessions/:id`): TanStack Query key `['session-transcript', id]`, chronological transcript with distinct role styles (user/assistant/system/tool) and `<pre>` JSON fallback for unknown roles; inline 404 handling; "Back to sessions" link
- Two new routes added inside the existing `<Layout/>` protected block in `src/main.tsx`

Stacks on #1109 (W.2 auth/dashboard); sibling of #1110 (W.3a agents) and #1111 (W.3 chat).  
Will need a rebase once parent PRs merge into `feat/web-auth-dashboard-sera-oi4d`.

## Test plan

- [ ] `bun run typecheck` — passes (0 errors)
- [ ] `bun run lint` — passes (0 warnings)
- [ ] `bun run build` — passes (350 kB bundle)
- [ ] `/sessions` renders list shell (error state without gateway — no crashes)
- [ ] `/sessions/:id` renders transcript shell (error state without gateway — no crashes)
- [ ] "Back to sessions" link navigates correctly
- [ ] 404 response shows inline "Session not found." message

🤖 Generated with [Claude Code](https://claude.com/claude-code)