### PR TITLE
feat(web): dockerize operator console + run-locally docs (sera-3iib)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,16 @@ cargo run --bin sera-tui
 
 Agent list, live session view, inline HITL approvals, evolve-proposal status.
 
+### Web operator console
+
+```bash
+cd web
+bun install
+bun run dev          # http://localhost:5173 — proxies /api → :3001
+```
+
+A React 19 + Vite + Tailwind v4 SPA against the rust gateway. Five pages: dashboard (health/readiness/identity), live SSE chat, agents list/detail, sessions list + transcript, hooks registry. Sign in with `sera_bootstrap_dev_123` (or your `SERA_BOOTSTRAP_API_KEY`). See `web/CLAUDE.md` for the full local-run + Docker story.
+
 > **Demo placeholder.** A terminal-cast of the CLI + TUI flow is planned for the next release. If you record one while evaluating SERA, a PR adding `docs/media/quickstart.gif` is welcome.
 
 ## Quickstart — enterprise profile (Postgres + pgvector + Centrifugo)
@@ -122,7 +132,7 @@ Agent list, live session view, inline HITL approvals, evolve-proposal status.
 docker compose -f docker-compose.rust.yaml up --build
 ```
 
-Starts Postgres (with pgvector), Centrifugo, and `sera-gateway` on :3001. The gateway auto-detects `DATABASE_URL` and switches from SQLite to Postgres for all stores; pgvector replaces the SQLite hybrid store for Tier-1 semantic memory; Centrifugo enables multi-pod thought streaming.
+Starts Postgres (with pgvector), Centrifugo, `sera-gateway` on :3001, and the web operator console on <http://localhost:5173>. The gateway auto-detects `DATABASE_URL` and switches from SQLite to Postgres for all stores; pgvector replaces the SQLite hybrid store for Tier-1 semantic memory; Centrifugo enables multi-pod thought streaming.
 
 ## Memory tiers
 

--- a/docker-compose.rust.yaml
+++ b/docker-compose.rust.yaml
@@ -1,6 +1,6 @@
 # ── SERA 2.0 Rust Stack ───────────────────────────────────────────────────────
 # Brings up ONLY SERA-owned services:
-#   postgres (pgvector) + centrifugo + sera-gateway
+#   postgres (pgvector) + centrifugo + sera-gateway + sera-web
 #
 # LLM providers (Ollama, LM Studio, OpenAI, Anthropic, etc.) are EXTERNAL and
 # run wherever the operator chooses — host, remote API, separate compose, etc.
@@ -13,6 +13,7 @@
 #   5434  → postgres:5432       (5432 = hindsight-db internal, 5433 = radio-player)
 #   8001  → centrifugo:8000     (8000 = portainer internal, 8100 = radio-player centrifugo)
 #   3001  → sera-gateway:3001
+#   5173  → sera-web:80         (matches the dev `bun run dev` port)
 #
 # Provider endpoints default to host.docker.internal so a locally-running
 # Ollama or LM Studio on the host is reachable from inside the container.
@@ -96,6 +97,26 @@ services:
         condition: service_healthy
       centrifugo:
         condition: service_healthy
+
+  sera-web:
+    build:
+      context: ./web
+      dockerfile: Dockerfile
+    container_name: sera-web
+    restart: unless-stopped
+    ports:
+      - "5173:80"
+    networks:
+      - sera_net
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O /dev/null http://localhost:80/ || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    depends_on:
+      sera-gateway:
+        condition: service_started
 
 volumes:
   sera_pg_data:

--- a/web/.dockerignore
+++ b/web/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+dist
+.git
+.env
+.env.local
+.vite
+tsconfig.tsbuildinfo
+.omc

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -25,6 +25,36 @@ bun run lint
 bun run test
 ```
 
+## Run locally (the two paths)
+
+**Dev server (HMR, fastest iteration):**
+
+```bash
+cd web
+bun install        # first time
+bun run dev        # http://localhost:5173 — proxies /api → http://localhost:3001
+```
+
+The gateway must be running separately (e.g. `cargo run -p sera-gateway --bin sera` from `rust/`, or `docker compose -f docker-compose.rust.yaml up sera-gateway`).
+
+**Full stack via docker compose:**
+
+```bash
+docker compose -f docker-compose.rust.yaml up --build
+```
+
+Brings up postgres + centrifugo + sera-gateway + sera-web. Browse to <http://localhost:5173> for the operator console; the gateway listens on `:3001`.
+
+Use the dev-default API key `sera_bootstrap_dev_123` (or whatever `SERA_BOOTSTRAP_API_KEY` is set to in your env) to sign in.
+
+## Docker
+
+- **Multistage build:** `oven/bun:1-alpine` runs `bun install --frozen-lockfile && bun run build`, then nginx serves the static `dist/`.
+- **`bun.lock` is committed** (root `.gitignore` was unstuck during W.1) and must stay in sync with `package.json` so `--frozen-lockfile` doesn't fail in CI.
+- **`.dockerignore` is critical** — without it the build context includes `node_modules/` (~hundreds of MB) and the build is slow.
+- **nginx proxies `/api`** to `sera-gateway:3001` on the compose network. The `/api/chat` location turns `proxy_buffering off` and bumps `proxy_read_timeout` to 1h so SSE frames flow.
+- **SPA routing** — every unknown path falls through to `index.html` so client-side routing works on hard refresh.
+
 ## Auth (v1)
 
 API-key bearer token in `localStorage` under `sera.auth.token`. The gateway dev key is `sera_bootstrap_dev_123`. `apiFetch` (`src/lib/api.ts`) attaches the header on every request. OIDC device-flow is deferred.

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,0 +1,20 @@
+# syntax=docker/dockerfile:1
+
+# ─── Builder ──────────────────────────────────────────────────────────────────
+FROM oven/bun:1-alpine AS builder
+WORKDIR /app
+
+# Install deps with the committed lockfile so `--frozen-lockfile` succeeds
+COPY package.json bun.lock ./
+RUN bun install --frozen-lockfile
+
+# Build the SPA
+COPY . .
+RUN bun run build
+
+# ─── Runner ───────────────────────────────────────────────────────────────────
+FROM nginx:alpine AS runner
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=builder /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -1,0 +1,44 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Docker's embedded DNS server resolves service names. Using a variable
+    # for proxy_pass forces nginx to resolve `sera-gateway` at request time
+    # via this resolver instead of at config-parse time, so the web service
+    # can start even when the gateway isn't up yet.
+    resolver 127.0.0.11 valid=30s ipv6=off;
+
+    # SSE-friendly proxy for the streaming chat endpoint. nginx's default
+    # proxy_buffering breaks Server-Sent Events; turn it off and extend the
+    # read timeout so the connection survives idle gaps between deltas.
+    location = /api/chat {
+        set $upstream "http://sera-gateway:3001";
+        proxy_pass $upstream/api/chat;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 1h;
+        chunked_transfer_encoding on;
+    }
+
+    location /api/ {
+        set $upstream "http://sera-gateway:3001";
+        proxy_pass $upstream;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # SPA history routing — every unknown path serves index.html.
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
## Summary

Wires the new \`web/\` into the docker-compose stack so the operator console deploys alongside postgres + centrifugo + sera-gateway, and documents both run paths.

## Changes

- **\`web/Dockerfile\`** — multistage: \`oven/bun:1-alpine\` builds (\`bun install --frozen-lockfile && bun run build\`); \`nginx:alpine\` serves the static \`dist/\`
- **\`web/nginx.conf\`** — proxies \`/api/\` to \`sera-gateway:3001\`; \`/api/chat\` turns \`proxy_buffering off\` + bumps \`proxy_read_timeout\` to 1h so SSE frames flow; SPA fallback to \`index.html\`
- **DNS gotcha**: uses a variable + Docker's embedded resolver (\`127.0.0.11\`) for the upstream so nginx defers resolution to request time. Without this the container refuses to start whenever \`sera-gateway\` is briefly down (\`emerg: host not found in upstream\` at config-parse). Hit this in verification.
- **\`web/.dockerignore\`** — excludes \`node_modules\`, \`dist\`, \`.git\`, \`.env\`, \`.vite\`, \`tsconfig.tsbuildinfo\`, \`.omc\`
- **\`docker-compose.rust.yaml\`** — new \`sera-web\` service on host port \`5173\` (matches the dev port), \`depends_on: sera-gateway (service_started)\`, healthcheck via \`wget\`
- **\`web/CLAUDE.md\`** — adds 'Run locally' (dev-server path + compose path) and 'Docker' sections
- **\`README.md\`** — 'Web operator console' subsection in the local Quickstart; mentions \`sera-web\` in the enterprise compose blurb

## Verification

- \`docker compose -f docker-compose.rust.yaml build sera-web\` ✓ (multistage build + nginx final image)
- \`docker compose up -d --no-deps sera-web\` ✓ (starts cleanly with the deferred-DNS fix; without the fix nginx refuses to start when gateway isn't up)
- \`curl -sI http://localhost:5173/\` → \`HTTP/1.1 200 OK\` (nginx/1.29.8)
- Browser load redirects \`/\` → \`/login\`, login form renders, **zero console errors**
- SPA fallback: \`curl http://localhost:5173/agents\` → \`HTTP 200\` (serves \`index.html\` so client-side routing works on hard refresh)

Closes \`sera-3iib\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)