### PR TITLE
fix(gateway): handle Discord reconnect opcodes

### DIFF
--- a/rust/crates/sera-gateway/src/discord.rs
+++ b/rust/crates/sera-gateway/src/discord.rs
@@ -65,9 +65,12 @@ enum DisconnectReason {
     /// must clear stored session state and IDENTIFY again with a long backoff.
     SessionInvalidated,
     /// We sent RESUME on this connection and the loop ended without an opcode
-    /// signal — typically Discord rejecting RESUME via a close code (4007
-    /// invalid seq, 4009 session timeout, etc.). Clear session state so the
-    /// next attempt is a fresh IDENTIFY; otherwise we'd hot-loop on RESUME.
+    /// signal. This straddles two real cases: Discord rejecting RESUME via a
+    /// close code (4007 invalid seq, 4009 session timeout, etc.) and a flaky
+    /// transport drop before any opcode arrived. `run()` distinguishes them
+    /// by counting consecutive occurrences — a single occurrence retries
+    /// RESUME (preserving a still-valid session through transient drops),
+    /// repeated occurrences clear session state and fall back to IDENTIFY.
     ResumeFailedNoSignal,
     /// IDENTIFY-path connection ended without an opcode signal — generic
     /// transport close, IO error, or server-side close without an opcode.
@@ -201,6 +204,20 @@ pub fn parse_ready_session(payload: &Value) -> Option<(String, Option<String>)> 
         .and_then(Value::as_str)
         .map(String::from);
     Some((session_id, resume_url))
+}
+
+/// Number of consecutive RESUME-without-opcode-signal disconnects we tolerate
+/// before clearing session state and falling back to IDENTIFY. A single
+/// occurrence is treated as a likely transient transport drop and triggers a
+/// RESUME retry; further occurrences are treated as Discord rejecting RESUME
+/// via a close code and force a fresh IDENTIFY.
+const RESUME_NO_SIGNAL_CLEAR_THRESHOLD: u32 = 2;
+
+/// Returns `true` if `run()` should clear session state and IDENTIFY on the
+/// next attempt instead of retrying RESUME. Extracted so the retry policy is
+/// unit-testable without spinning up the full gateway loop.
+fn resume_no_signal_should_clear(consecutive: u32) -> bool {
+    consecutive >= RESUME_NO_SIGNAL_CLEAR_THRESHOLD
 }
 
 /// Backoff schedule for INVALID_SESSION re-IDENTIFY attempts.
@@ -353,6 +370,7 @@ impl DiscordConnector {
     /// Exits immediately when `shutting_down` is set to `true`.
     pub async fn run(&self) -> anyhow::Result<()> {
         let mut consecutive_invalid_sessions: u32 = 0;
+        let mut consecutive_resume_no_signal: u32 = 0;
         while !self.shutting_down.load(Ordering::Relaxed) {
             let outcome = match self.connect_and_run().await {
                 Ok(reason) => Some(reason),
@@ -369,6 +387,7 @@ impl DiscordConnector {
                 Some(DisconnectReason::SessionInvalidated) => {
                     self.clear_session_state();
                     consecutive_invalid_sessions = consecutive_invalid_sessions.saturating_add(1);
+                    consecutive_resume_no_signal = 0;
                     let secs = invalid_session_backoff_secs(consecutive_invalid_sessions);
                     tracing::warn!(
                         consecutive = consecutive_invalid_sessions,
@@ -378,25 +397,41 @@ impl DiscordConnector {
                 }
                 Some(DisconnectReason::ResumeFailedNoSignal) => {
                     // RESUME-attempt connection died without an opcode signal —
-                    // typically Discord rejecting RESUME via a close code (4007
-                    // invalid seq, 4009 session timeout, etc.). Drop session
-                    // state and apply the invalid-session backoff so the next
-                    // attempt does a fresh IDENTIFY instead of hot-looping on a
-                    // RESUME the server keeps refusing.
-                    tracing::warn!(
-                        "RESUME ended without opcode signal; clearing session and falling back to IDENTIFY"
-                    );
-                    self.clear_session_state();
-                    consecutive_invalid_sessions = consecutive_invalid_sessions.saturating_add(1);
-                    let secs = invalid_session_backoff_secs(consecutive_invalid_sessions);
-                    Duration::from_secs(secs)
+                    // ambiguous: could be Discord rejecting RESUME via close
+                    // code (4007 invalid seq, 4009 session timeout) OR a flaky
+                    // transport drop before any opcode arrived. Retry RESUME
+                    // once before giving up so transient network blips don't
+                    // discard a still-valid session, but bail to IDENTIFY on
+                    // repeat failures so we don't hot-loop a RESUME the server
+                    // keeps refusing.
+                    consecutive_resume_no_signal =
+                        consecutive_resume_no_signal.saturating_add(1);
+                    if resume_no_signal_should_clear(consecutive_resume_no_signal) {
+                        tracing::warn!(
+                            consecutive = consecutive_resume_no_signal,
+                            "RESUME ended without opcode signal repeatedly; clearing session and falling back to IDENTIFY"
+                        );
+                        self.clear_session_state();
+                        consecutive_invalid_sessions =
+                            consecutive_invalid_sessions.saturating_add(1);
+                        consecutive_resume_no_signal = 0;
+                        let secs = invalid_session_backoff_secs(consecutive_invalid_sessions);
+                        Duration::from_secs(secs)
+                    } else {
+                        tracing::warn!(
+                            "RESUME ended without opcode signal; retrying RESUME before falling back to IDENTIFY"
+                        );
+                        Duration::from_secs(5)
+                    }
                 }
                 Some(DisconnectReason::OpcodeResumable) => {
                     consecutive_invalid_sessions = 0;
+                    consecutive_resume_no_signal = 0;
                     Duration::from_secs(1)
                 }
                 Some(DisconnectReason::GenericClose) | None => {
                     consecutive_invalid_sessions = 0;
+                    consecutive_resume_no_signal = 0;
                     Duration::from_secs(5)
                 }
             };
@@ -1058,14 +1093,29 @@ mod tests {
     }
 
     #[test]
-    fn classify_no_signal_after_resume_falls_back_to_identify() {
-        // The P1 review case: RESUME closed without opcode (likely close-code
-        // 4007/4009). Must classify as ResumeFailedNoSignal so run() clears
-        // session state and the next attempt is a fresh IDENTIFY.
+    fn classify_no_signal_after_resume_is_resume_failed_no_signal() {
+        // RESUME-attempt close without opcode is ambiguous: could be Discord
+        // rejecting via close-code (4007/4009) or a flaky transport drop.
+        // The classifier just labels it; `run()` decides retry-vs-clear via
+        // `resume_no_signal_should_clear`.
         assert_eq!(
             DisconnectReason::from_signal(None, true),
             DisconnectReason::ResumeFailedNoSignal
         );
+    }
+
+    #[test]
+    fn resume_no_signal_threshold_retries_once_then_clears() {
+        // First RESUME-without-signal disconnect must NOT clear session — a
+        // single transient transport drop should retry RESUME so we don't
+        // discard a still-valid session and lose replayable events.
+        assert!(!resume_no_signal_should_clear(0));
+        assert!(!resume_no_signal_should_clear(1));
+        // Second consecutive occurrence flips to clear-and-IDENTIFY so we
+        // can't hot-loop a RESUME the server keeps refusing.
+        assert!(resume_no_signal_should_clear(2));
+        assert!(resume_no_signal_should_clear(3));
+        assert!(resume_no_signal_should_clear(u32::MAX));
     }
 
     #[test]

--- a/rust/crates/sera-gateway/src/discord.rs
+++ b/rust/crates/sera-gateway/src/discord.rs
@@ -40,6 +40,39 @@ pub struct DiscordConnector {
     /// Shared shutdown flag from `AppState`. When `true` the reconnect loop
     /// exits instead of sleeping for the next attempt.
     shutting_down: Arc<AtomicBool>,
+    /// Session id captured from the most recent READY dispatch. Required to
+    /// send Resume (opcode 6) after a reconnect; cleared on Op 9 with
+    /// `d=false` so the next attempt does a fresh IDENTIFY.
+    session_id: std::sync::Mutex<Option<String>>,
+    /// Per-session reconnect URL captured from READY. When set, subsequent
+    /// reconnects target this host instead of `GATEWAY_URL`.
+    resume_gateway_url: std::sync::Mutex<Option<String>>,
+    /// Last sequence number observed from the gateway. Persists across
+    /// connections so RESUME can replay missed dispatches. `-1` means "no
+    /// sequence yet" (serializes as JSON `null`).
+    last_sequence: Arc<AtomicI64>,
+}
+
+/// Why the current gateway connection ended. Drives the backoff and IDENTIFY-vs-RESUME
+/// decision in [`DiscordConnector::run`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DisconnectReason {
+    /// Connection ended in a state where the existing session may still be
+    /// resumed: a normal close, an Op 7 RECONNECT, or an Op 9 with `d=true`.
+    Resumable,
+    /// Server told us the session is dead (Op 9 with `d=false`). The connector
+    /// must clear stored session state and IDENTIFY again with a backoff.
+    SessionInvalidated,
+}
+
+/// Signal from [`DiscordConnector::handle_payload`] back to the event loop
+/// asking it to terminate the current connection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HandlerSignal {
+    /// Op 7 RECONNECT or Op 9 with `d=true` — close and resume.
+    Reconnect,
+    /// Op 9 with `d=false` — close, drop session state, re-IDENTIFY.
+    SessionInvalidated,
 }
 
 // ---------------------------------------------------------------------------
@@ -66,11 +99,17 @@ pub const DISCORD_INTENTS: u64 =
 const OP_DISPATCH: u64 = 0;
 const OP_HEARTBEAT: u64 = 1;
 const OP_IDENTIFY: u64 = 2;
+const OP_RESUME: u64 = 6;
+const OP_RECONNECT: u64 = 7;
+const OP_INVALID_SESSION: u64 = 9;
 const OP_HELLO: u64 = 10;
-// const OP_HEARTBEAT_ACK: u64 = 11; // logged but unused
+const OP_HEARTBEAT_ACK: u64 = 11;
 
 const GATEWAY_URL: &str = "wss://gateway.discord.gg/?v=10&encoding=json";
 const DISCORD_API_BASE: &str = "https://discord.com/api/v10";
+
+/// Query string Discord requires when connecting to a `resume_gateway_url`.
+const GATEWAY_QUERY: &str = "/?v=10&encoding=json";
 
 // ---------------------------------------------------------------------------
 // Payload helpers (pure functions, tested independently)
@@ -98,6 +137,70 @@ pub fn build_heartbeat_payload(sequence: Option<i64>) -> Value {
         "op": OP_HEARTBEAT,
         "d": sequence,
     })
+}
+
+/// Build a Resume payload (opcode 6) for replaying missed events on a previously
+/// established session.
+pub fn build_resume_payload(token: &str, session_id: &str, sequence: i64) -> Value {
+    serde_json::json!({
+        "op": OP_RESUME,
+        "d": {
+            "token": token,
+            "session_id": session_id,
+            "seq": sequence,
+        }
+    })
+}
+
+/// Returns `Some(resumable)` when the payload is opcode 9 (INVALID_SESSION).
+/// Per Discord docs, `d` is a boolean: `true` means the session can be resumed,
+/// `false` means it must be re-IDENTIFYd from scratch.
+pub fn parse_invalid_session_resumable(payload: &Value) -> Option<bool> {
+    if payload.get("op")?.as_u64()? != OP_INVALID_SESSION {
+        return None;
+    }
+    Some(payload.get("d").and_then(Value::as_bool).unwrap_or(false))
+}
+
+/// Returns `true` if the payload is opcode 7 (RECONNECT) — server is asking the
+/// client to disconnect and resume.
+pub fn is_op_reconnect(payload: &Value) -> bool {
+    payload.get("op").and_then(Value::as_u64) == Some(OP_RECONNECT)
+}
+
+/// Extract `(session_id, resume_gateway_url)` from a READY dispatch payload.
+/// Both pieces are required to RESUME a session after disconnect.
+pub fn parse_ready_session(payload: &Value) -> Option<(String, Option<String>)> {
+    if payload.get("op")?.as_u64()? != OP_DISPATCH {
+        return None;
+    }
+    if payload.get("t")?.as_str()? != "READY" {
+        return None;
+    }
+    let d = payload.get("d")?;
+    let session_id = d.get("session_id")?.as_str()?.to_owned();
+    let resume_url = d
+        .get("resume_gateway_url")
+        .and_then(Value::as_str)
+        .map(String::from);
+    Some((session_id, resume_url))
+}
+
+/// Backoff schedule for INVALID_SESSION re-IDENTIFY attempts.
+///
+/// Discord's spec says clients should wait a random 1-5 seconds before sending a
+/// new IDENTIFY. We follow that for the first few attempts then escalate to a
+/// 30-second cap so a misbehaving server can't keep us in a hot loop. Caller
+/// passes the running consecutive-INVALID_SESSION count (1 for the first one).
+pub fn invalid_session_backoff_secs(consecutive: u32) -> u64 {
+    match consecutive {
+        0 | 1 => 1,
+        2 => 3,
+        3 => 5,
+        4 => 10,
+        5 => 20,
+        _ => 30,
+    }
 }
 
 /// Extract `heartbeat_interval` from a Hello (opcode 10) payload.
@@ -198,23 +301,77 @@ impl DiscordConnector {
             tx,
             bot_user_id: std::sync::Mutex::new(None),
             shutting_down,
+            session_id: std::sync::Mutex::new(None),
+            resume_gateway_url: std::sync::Mutex::new(None),
+            last_sequence: Arc::new(AtomicI64::new(-1)),
         }
     }
 
+    fn clear_session_state(&self) {
+        if let Ok(mut g) = self.session_id.lock() {
+            *g = None;
+        }
+        if let Ok(mut g) = self.resume_gateway_url.lock() {
+            *g = None;
+        }
+        self.last_sequence.store(-1, Ordering::Relaxed);
+    }
+
+    fn current_session(&self) -> Option<String> {
+        self.session_id.lock().ok().and_then(|g| g.clone())
+    }
+
+    fn current_resume_url(&self) -> Option<String> {
+        self.resume_gateway_url.lock().ok().and_then(|g| g.clone())
+    }
+
     /// Start the connector — connects to Discord Gateway, runs heartbeat loop,
-    /// dispatches MESSAGE_CREATE events. Reconnects on close after 5 seconds.
+    /// dispatches MESSAGE_CREATE events. Reconnects after a backoff that
+    /// adapts to the disconnect reason:
+    ///
+    /// * normal close / transport error → 5s, attempt RESUME
+    /// * Op 7 RECONNECT or Op 9 (`d=true`) → 1s, attempt RESUME
+    /// * Op 9 (`d=false`) → escalating 1-30s, drop session, fresh IDENTIFY
+    ///
     /// Exits immediately when `shutting_down` is set to `true`.
     pub async fn run(&self) -> anyhow::Result<()> {
+        let mut consecutive_invalid_sessions: u32 = 0;
         while !self.shutting_down.load(Ordering::Relaxed) {
-            if let Err(e) = self.connect_and_run().await {
-                tracing::error!("Discord gateway error: {e}");
-            }
+            let outcome = match self.connect_and_run().await {
+                Ok(reason) => Some(reason),
+                Err(e) => {
+                    tracing::error!("Discord gateway error: {e}");
+                    None
+                }
+            };
             if self.shutting_down.load(Ordering::Relaxed) {
                 break;
             }
-            tracing::info!("Reconnecting to Discord in 5 seconds...");
+
+            let backoff = match outcome {
+                Some(DisconnectReason::SessionInvalidated) => {
+                    self.clear_session_state();
+                    consecutive_invalid_sessions = consecutive_invalid_sessions.saturating_add(1);
+                    let secs = invalid_session_backoff_secs(consecutive_invalid_sessions);
+                    tracing::warn!(
+                        consecutive = consecutive_invalid_sessions,
+                        "Discord session invalidated; sleeping {secs}s before re-IDENTIFY"
+                    );
+                    Duration::from_secs(secs)
+                }
+                Some(DisconnectReason::Resumable) => {
+                    consecutive_invalid_sessions = 0;
+                    Duration::from_secs(1)
+                }
+                None => {
+                    consecutive_invalid_sessions = 0;
+                    Duration::from_secs(5)
+                }
+            };
+
+            tracing::info!("Reconnecting to Discord in {:?}...", backoff);
             // Sleep interruptibly: wake every 100ms and check the flag.
-            let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+            let deadline = tokio::time::Instant::now() + backoff;
             while tokio::time::Instant::now() < deadline {
                 if self.shutting_down.load(Ordering::Relaxed) {
                     return Ok(());
@@ -248,16 +405,23 @@ impl DiscordConnector {
     // Internal
     // -----------------------------------------------------------------------
 
-    async fn connect_and_run(&self) -> anyhow::Result<()> {
-        tracing::info!("Connecting to Discord Gateway...");
+    async fn connect_and_run(&self) -> anyhow::Result<DisconnectReason> {
+        // Pick host: per-session resume URL if we have one, else the canonical
+        // gateway. Both must carry the v=10/encoding=json query string.
+        let url = match self.current_resume_url() {
+            Some(base) => format!("{base}{GATEWAY_QUERY}"),
+            None => GATEWAY_URL.to_owned(),
+        };
+        tracing::info!(url = %url, "Connecting to Discord Gateway...");
 
-        let (ws_stream, _) = tokio_tungstenite::connect_async(GATEWAY_URL).await?;
+        let (ws_stream, _) = tokio_tungstenite::connect_async(&url).await?;
         let (mut write, mut read) = ws_stream.split();
 
         tracing::info!("Discord Gateway connection opened");
 
-        // Shared sequence counter for heartbeats
-        let sequence = Arc::new(AtomicI64::new(-1)); // -1 means null
+        // Sequence counter is shared across reconnects so RESUME can replay
+        // missed events. The heartbeat task gets a clone.
+        let sequence = Arc::clone(&self.last_sequence);
 
         // Read the Hello payload to get heartbeat_interval
         let hello_msg = read
@@ -273,15 +437,31 @@ impl DiscordConnector {
 
         tracing::info!("Heartbeat interval: {heartbeat_ms}ms");
 
-        // Send Identify
-        let identify = build_identify_payload(&self.token, &self.agent_name);
+        // Decide IDENTIFY vs RESUME. We can RESUME only if we have both a
+        // session id and a non-negative last sequence from a prior connection.
+        let session_for_resume = self.current_session();
+        let seq_for_resume = self.last_sequence.load(Ordering::Relaxed);
+        let initial_payload = match session_for_resume.as_deref() {
+            Some(sid) if seq_for_resume >= 0 => {
+                tracing::info!(
+                    session_id = sid,
+                    seq = seq_for_resume,
+                    "Sending RESUME to Discord Gateway"
+                );
+                build_resume_payload(&self.token, sid, seq_for_resume)
+            }
+            _ => {
+                tracing::info!("Sending IDENTIFY to Discord Gateway");
+                build_identify_payload(&self.token, &self.agent_name)
+            }
+        };
         write
-            .send(Message::Text(identify.to_string().into()))
+            .send(Message::Text(initial_payload.to_string().into()))
             .await?;
 
         // Spawn heartbeat loop — exits when hb_tx is dropped (connection closed)
         // or when the shared shutting_down flag is set.
-        let hb_sequence = sequence.clone();
+        let hb_sequence = Arc::clone(&sequence);
         let hb_shutting_down = Arc::clone(&self.shutting_down);
         let (hb_tx, mut hb_rx) = mpsc::channel::<Message>(16);
 
@@ -302,7 +482,10 @@ impl DiscordConnector {
             }
         });
 
-        // Main event loop — merge heartbeat sends with reads
+        // Main event loop — merge heartbeat sends with reads. The handler
+        // returns Some(signal) when an opcode mandates closing the connection;
+        // we propagate that as the DisconnectReason.
+        let mut signal: Option<HandlerSignal> = None;
         loop {
             tokio::select! {
                 Some(hb_msg) = hb_rx.recv() => {
@@ -316,7 +499,10 @@ impl DiscordConnector {
                         Some(Ok(Message::Text(text))) => {
                             match serde_json::from_str::<Value>(&text) {
                                 Ok(payload) => {
-                                    self.handle_payload(&payload, &sequence).await;
+                                    if let Some(sig) = self.handle_payload(&payload).await {
+                                        signal = Some(sig);
+                                        break;
+                                    }
                                 }
                                 Err(e) => {
                                     tracing::error!("Failed to parse Discord payload: {e}");
@@ -337,13 +523,17 @@ impl DiscordConnector {
             }
         }
 
-        Ok(())
+        Ok(match signal {
+            Some(HandlerSignal::SessionInvalidated) => DisconnectReason::SessionInvalidated,
+            Some(HandlerSignal::Reconnect) | None => DisconnectReason::Resumable,
+        })
     }
 
-    async fn handle_payload(&self, payload: &Value, sequence: &AtomicI64) {
-        // Update sequence number
+    async fn handle_payload(&self, payload: &Value) -> Option<HandlerSignal> {
+        // Update sequence number — written to the shared Arc so RESUME after
+        // reconnect can pick up where we left off.
         if let Some(s) = parse_sequence(payload) {
-            sequence.store(s, Ordering::Relaxed);
+            self.last_sequence.store(s, Ordering::Relaxed);
         }
 
         let op = payload
@@ -367,6 +557,17 @@ impl DiscordConnector {
                             {
                                 *guard = Some(uid.clone());
                             }
+                            // Capture session_id and resume_gateway_url so a
+                            // future reconnect can RESUME instead of dropping
+                            // events.
+                            if let Some((session_id, resume_url)) = parse_ready_session(payload) {
+                                if let Ok(mut g) = self.session_id.lock() {
+                                    *g = Some(session_id);
+                                }
+                                if let Ok(mut g) = self.resume_gateway_url.lock() {
+                                    *g = resume_url;
+                                }
+                            }
                             let username = payload
                                 .get("d")
                                 .and_then(|d| d.get("user"))
@@ -374,6 +575,9 @@ impl DiscordConnector {
                                 .and_then(Value::as_str)
                                 .unwrap_or("unknown");
                             tracing::info!("Discord adapter ready as {username}");
+                        }
+                        "RESUMED" => {
+                            tracing::info!("Discord session RESUMED");
                         }
                         "MESSAGE_CREATE" => {
                             let bot_id = self.bot_user_id.lock().ok().and_then(|g| g.clone());
@@ -388,15 +592,47 @@ impl DiscordConnector {
                         }
                     }
                 }
+                None
             }
-            11 => {
-                // Heartbeat ACK — no action needed
+            OP_RECONNECT => {
+                tracing::warn!("Discord Op 7 RECONNECT received — closing to resume");
+                Some(HandlerSignal::Reconnect)
+            }
+            OP_INVALID_SESSION => {
+                let resumable = parse_invalid_session_resumable(payload).unwrap_or(false);
+                tracing::warn!(resumable, "Discord Op 9 INVALID_SESSION received");
+                if resumable {
+                    Some(HandlerSignal::Reconnect)
+                } else {
+                    Some(HandlerSignal::SessionInvalidated)
+                }
+            }
+            OP_HEARTBEAT_ACK => {
                 tracing::trace!("Heartbeat ACK received");
+                None
             }
             _ => {
                 tracing::debug!("Unhandled opcode: {op}");
+                None
             }
         }
+    }
+
+    // -- Test-only state inspectors ------------------------------------------
+
+    #[cfg(test)]
+    fn test_session_id(&self) -> Option<String> {
+        self.current_session()
+    }
+
+    #[cfg(test)]
+    fn test_resume_gateway_url(&self) -> Option<String> {
+        self.current_resume_url()
+    }
+
+    #[cfg(test)]
+    fn test_last_sequence(&self) -> i64 {
+        self.last_sequence.load(Ordering::Relaxed)
     }
 }
 
@@ -746,5 +982,222 @@ mod tests {
 
         // Sender is still alive — channel was NOT closed.
         drop(tx);
+    }
+
+    // -----------------------------------------------------------------------
+    // Reconnect / RESUME / INVALID_SESSION coverage (sera-m0az / sera-v4fp /
+    // sera-70fs)
+    // -----------------------------------------------------------------------
+
+    fn test_connector() -> (Arc<DiscordConnector>, mpsc::Receiver<DiscordMessage>) {
+        let (tx, rx) = mpsc::channel(4);
+        let shutting_down = Arc::new(AtomicBool::new(false));
+        let connector = Arc::new(DiscordConnector::new("token", "agent", tx, shutting_down));
+        (connector, rx)
+    }
+
+    #[test]
+    fn build_resume_payload_shape() {
+        let p = build_resume_payload("tok", "sess-xyz", 42);
+        assert_eq!(p["op"], 6);
+        assert_eq!(p["d"]["token"], "tok");
+        assert_eq!(p["d"]["session_id"], "sess-xyz");
+        assert_eq!(p["d"]["seq"], 42);
+    }
+
+    #[test]
+    fn parse_invalid_session_resumable_true() {
+        let p = serde_json::json!({ "op": 9, "d": true });
+        assert_eq!(parse_invalid_session_resumable(&p), Some(true));
+    }
+
+    #[test]
+    fn parse_invalid_session_resumable_false() {
+        let p = serde_json::json!({ "op": 9, "d": false });
+        assert_eq!(parse_invalid_session_resumable(&p), Some(false));
+    }
+
+    #[test]
+    fn parse_invalid_session_wrong_opcode() {
+        let p = serde_json::json!({ "op": 7, "d": null });
+        assert_eq!(parse_invalid_session_resumable(&p), None);
+    }
+
+    #[test]
+    fn parse_invalid_session_missing_d_defaults_false() {
+        // If `d` is missing or non-bool, treat as non-resumable (safer default).
+        let p = serde_json::json!({ "op": 9 });
+        assert_eq!(parse_invalid_session_resumable(&p), Some(false));
+    }
+
+    #[test]
+    fn is_op_reconnect_true() {
+        assert!(is_op_reconnect(&serde_json::json!({ "op": 7, "d": null })));
+    }
+
+    #[test]
+    fn is_op_reconnect_false() {
+        assert!(!is_op_reconnect(&serde_json::json!({ "op": 0, "d": {} })));
+        assert!(!is_op_reconnect(
+            &serde_json::json!({ "op": 9, "d": false })
+        ));
+    }
+
+    #[test]
+    fn parse_ready_session_with_resume_url() {
+        let p = serde_json::json!({
+            "op": 0,
+            "t": "READY",
+            "s": 1,
+            "d": {
+                "session_id": "abc-123",
+                "resume_gateway_url": "wss://gateway-eu.discord.gg",
+                "user": { "id": "u1", "username": "sera" }
+            }
+        });
+        let (sid, url) = parse_ready_session(&p).expect("ready");
+        assert_eq!(sid, "abc-123");
+        assert_eq!(url.as_deref(), Some("wss://gateway-eu.discord.gg"));
+    }
+
+    #[test]
+    fn parse_ready_session_without_resume_url() {
+        // Older payloads or malformed READYs without resume_gateway_url still
+        // give us a session_id; we'll fall back to the canonical gateway.
+        let p = serde_json::json!({
+            "op": 0,
+            "t": "READY",
+            "s": 1,
+            "d": { "session_id": "sid", "user": {} }
+        });
+        let (sid, url) = parse_ready_session(&p).expect("ready");
+        assert_eq!(sid, "sid");
+        assert!(url.is_none());
+    }
+
+    #[test]
+    fn parse_ready_session_rejects_non_ready() {
+        let p = serde_json::json!({ "op": 0, "t": "GUILD_CREATE", "s": 2, "d": {} });
+        assert!(parse_ready_session(&p).is_none());
+    }
+
+    #[test]
+    fn invalid_session_backoff_schedule() {
+        // First attempts stay within Discord's "1-5 second" guidance, then
+        // escalate to a 30s cap so we can't hot-loop indefinitely.
+        assert_eq!(invalid_session_backoff_secs(0), 1);
+        assert_eq!(invalid_session_backoff_secs(1), 1);
+        assert_eq!(invalid_session_backoff_secs(2), 3);
+        assert_eq!(invalid_session_backoff_secs(3), 5);
+        assert_eq!(invalid_session_backoff_secs(4), 10);
+        assert_eq!(invalid_session_backoff_secs(5), 20);
+        assert_eq!(invalid_session_backoff_secs(6), 30);
+        assert_eq!(invalid_session_backoff_secs(100), 30);
+    }
+
+    #[tokio::test]
+    async fn handle_payload_op7_signals_reconnect() {
+        let (conn, _rx) = test_connector();
+        let p = serde_json::json!({ "op": 7, "d": null });
+        assert_eq!(
+            conn.handle_payload(&p).await,
+            Some(HandlerSignal::Reconnect)
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_payload_op9_resumable_signals_reconnect() {
+        let (conn, _rx) = test_connector();
+        let p = serde_json::json!({ "op": 9, "d": true });
+        assert_eq!(
+            conn.handle_payload(&p).await,
+            Some(HandlerSignal::Reconnect)
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_payload_op9_not_resumable_signals_invalidated() {
+        let (conn, _rx) = test_connector();
+        let p = serde_json::json!({ "op": 9, "d": false });
+        assert_eq!(
+            conn.handle_payload(&p).await,
+            Some(HandlerSignal::SessionInvalidated)
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_payload_unhandled_opcode_returns_none() {
+        // Unknown opcodes must NOT signal a reconnect — they used to fall
+        // through to a debug log and dropping connection on Op 7/9 was the
+        // bug. Here we check a genuinely unknown opcode (e.g. 99) is silent.
+        let (conn, _rx) = test_connector();
+        let p = serde_json::json!({ "op": 99, "d": null });
+        assert_eq!(conn.handle_payload(&p).await, None);
+    }
+
+    #[tokio::test]
+    async fn ready_event_captures_session_state() {
+        let (conn, _rx) = test_connector();
+        let ready = serde_json::json!({
+            "op": 0,
+            "t": "READY",
+            "s": 1,
+            "d": {
+                "session_id": "sess-1",
+                "resume_gateway_url": "wss://gateway-resume.discord.gg",
+                "user": { "id": "bot1", "username": "sera" }
+            }
+        });
+        assert_eq!(conn.handle_payload(&ready).await, None);
+
+        assert_eq!(conn.test_session_id().as_deref(), Some("sess-1"));
+        assert_eq!(
+            conn.test_resume_gateway_url().as_deref(),
+            Some("wss://gateway-resume.discord.gg")
+        );
+        assert_eq!(conn.test_last_sequence(), 1);
+    }
+
+    #[tokio::test]
+    async fn dispatch_updates_sequence_for_resume() {
+        // Even on dispatch events we don't act on (e.g. GUILD_CREATE), the
+        // sequence number must be tracked so RESUME knows where to pick up.
+        let (conn, _rx) = test_connector();
+        let evt = serde_json::json!({ "op": 0, "t": "GUILD_CREATE", "s": 17, "d": {} });
+        assert_eq!(conn.handle_payload(&evt).await, None);
+        assert_eq!(conn.test_last_sequence(), 17);
+    }
+
+    #[tokio::test]
+    async fn op9_invalidated_keeps_state_until_run_clears() {
+        // handle_payload itself just signals; the run() loop is what clears
+        // session state. Verify the signal returns and state persists at this
+        // layer (run() clears in test below via clear_session_state).
+        let (conn, _rx) = test_connector();
+        let ready = serde_json::json!({
+            "op": 0,
+            "t": "READY",
+            "s": 5,
+            "d": {
+                "session_id": "sess-keep",
+                "resume_gateway_url": "wss://gw",
+                "user": { "id": "b", "username": "n" }
+            }
+        });
+        conn.handle_payload(&ready).await;
+        assert_eq!(conn.test_session_id().as_deref(), Some("sess-keep"));
+
+        let invalid = serde_json::json!({ "op": 9, "d": false });
+        assert_eq!(
+            conn.handle_payload(&invalid).await,
+            Some(HandlerSignal::SessionInvalidated)
+        );
+        // Still set — clearing happens in run() after the connection ends.
+        assert_eq!(conn.test_session_id().as_deref(), Some("sess-keep"));
+
+        conn.clear_session_state();
+        assert!(conn.test_session_id().is_none());
+        assert!(conn.test_resume_gateway_url().is_none());
+        assert_eq!(conn.test_last_sequence(), -1);
     }
 }

--- a/rust/crates/sera-gateway/src/discord.rs
+++ b/rust/crates/sera-gateway/src/discord.rs
@@ -64,13 +64,19 @@ enum DisconnectReason {
     /// Server told us the session is dead (Op 9 with `d=false`). The connector
     /// must clear stored session state and IDENTIFY again with a long backoff.
     SessionInvalidated,
-    /// We sent RESUME on this connection and the loop ended without an opcode
-    /// signal. This straddles two real cases: Discord rejecting RESUME via a
-    /// close code (4007 invalid seq, 4009 session timeout, etc.) and a flaky
-    /// transport drop before any opcode arrived. `run()` distinguishes them
-    /// by counting consecutive occurrences — a single occurrence retries
-    /// RESUME (preserving a still-valid session through transient drops),
-    /// repeated occurrences clear session state and fall back to IDENTIFY.
+    /// We sent RESUME on this connection, the server never sent a `RESUMED`
+    /// dispatch confirming the resume succeeded, and the loop ended without
+    /// an opcode signal. This straddles two real cases: Discord rejecting
+    /// RESUME via a close code (4007 invalid seq, 4009 session timeout, etc.)
+    /// and a flaky transport drop before any opcode arrived. `run()`
+    /// distinguishes them by counting consecutive occurrences — a single
+    /// occurrence retries RESUME (preserving a still-valid session through
+    /// transient drops), repeated occurrences clear session state and fall
+    /// back to IDENTIFY.
+    ///
+    /// A close after `RESUMED` is observed is `GenericClose`, not this
+    /// variant — at that point the resume has already succeeded and the
+    /// disconnect is unrelated to resume status.
     ResumeFailedNoSignal,
     /// IDENTIFY-path connection ended without an opcode signal — generic
     /// transport close, IO error, or server-side close without an opcode.
@@ -81,12 +87,24 @@ enum DisconnectReason {
 
 impl DisconnectReason {
     /// Pure classifier so the mapping is unit-testable without a real socket.
-    fn from_signal(signal: Option<HandlerSignal>, attempted_resume: bool) -> Self {
-        match (signal, attempted_resume) {
-            (Some(HandlerSignal::SessionInvalidated), _) => Self::SessionInvalidated,
-            (Some(HandlerSignal::Reconnect), _) => Self::OpcodeResumable,
-            (None, true) => Self::ResumeFailedNoSignal,
-            (None, false) => Self::GenericClose,
+    ///
+    /// * `signal` — opcode-driven termination from the event loop.
+    /// * `attempted_resume` — `true` if this connection was opened with a RESUME
+    ///   payload (vs IDENTIFY).
+    /// * `resume_succeeded` — `true` once we have observed a `RESUMED` dispatch
+    ///   on this connection, indicating the resume was accepted by the server.
+    ///   After that point a no-signal close is just a transport drop on a
+    ///   confirmed session, not a resume failure.
+    fn from_signal(
+        signal: Option<HandlerSignal>,
+        attempted_resume: bool,
+        resume_succeeded: bool,
+    ) -> Self {
+        match signal {
+            Some(HandlerSignal::SessionInvalidated) => Self::SessionInvalidated,
+            Some(HandlerSignal::Reconnect) => Self::OpcodeResumable,
+            None if attempted_resume && !resume_succeeded => Self::ResumeFailedNoSignal,
+            None => Self::GenericClose,
         }
     }
 }
@@ -554,8 +572,11 @@ impl DiscordConnector {
 
         // Main event loop — merge heartbeat sends with reads. The handler
         // returns Some(signal) when an opcode mandates closing the connection;
-        // we propagate that as the DisconnectReason.
+        // we propagate that as the DisconnectReason. We also track whether a
+        // RESUMED dispatch was observed so that no-signal closes after a
+        // successful resume aren't misclassified as resume failures.
         let mut signal: Option<HandlerSignal> = None;
+        let mut resume_succeeded = false;
         loop {
             tokio::select! {
                 Some(hb_msg) = hb_rx.recv() => {
@@ -569,6 +590,13 @@ impl DiscordConnector {
                         Some(Ok(Message::Text(text))) => {
                             match serde_json::from_str::<Value>(&text) {
                                 Ok(payload) => {
+                                    if attempted_resume
+                                        && !resume_succeeded
+                                        && parse_dispatch_event(&payload).as_deref()
+                                            == Some("RESUMED")
+                                    {
+                                        resume_succeeded = true;
+                                    }
                                     if let Some(sig) = self.handle_payload(&payload).await {
                                         signal = Some(sig);
                                         break;
@@ -593,7 +621,11 @@ impl DiscordConnector {
             }
         }
 
-        Ok(DisconnectReason::from_signal(signal, attempted_resume))
+        Ok(DisconnectReason::from_signal(
+            signal,
+            attempted_resume,
+            resume_succeeded,
+        ))
     }
 
     async fn handle_payload(&self, payload: &Value) -> Option<HandlerSignal> {
@@ -1068,39 +1100,62 @@ mod tests {
 
     #[test]
     fn classify_session_invalidated_signal_overrides_attempted_resume() {
-        // Op 9 (d=false) must invalidate even if we'd just sent IDENTIFY.
-        assert_eq!(
-            DisconnectReason::from_signal(Some(HandlerSignal::SessionInvalidated), false),
-            DisconnectReason::SessionInvalidated
-        );
-        assert_eq!(
-            DisconnectReason::from_signal(Some(HandlerSignal::SessionInvalidated), true),
-            DisconnectReason::SessionInvalidated
-        );
+        // Op 9 (d=false) must invalidate regardless of attempted_resume /
+        // resume_succeeded.
+        for &attempted_resume in &[false, true] {
+            for &resume_succeeded in &[false, true] {
+                assert_eq!(
+                    DisconnectReason::from_signal(
+                        Some(HandlerSignal::SessionInvalidated),
+                        attempted_resume,
+                        resume_succeeded
+                    ),
+                    DisconnectReason::SessionInvalidated
+                );
+            }
+        }
     }
 
     #[test]
     fn classify_opcode_reconnect_signal_overrides_attempted_resume() {
         // Op 7 RECONNECT or Op 9 (d=true) — keep session, short backoff.
-        assert_eq!(
-            DisconnectReason::from_signal(Some(HandlerSignal::Reconnect), false),
-            DisconnectReason::OpcodeResumable
-        );
-        assert_eq!(
-            DisconnectReason::from_signal(Some(HandlerSignal::Reconnect), true),
-            DisconnectReason::OpcodeResumable
-        );
+        for &attempted_resume in &[false, true] {
+            for &resume_succeeded in &[false, true] {
+                assert_eq!(
+                    DisconnectReason::from_signal(
+                        Some(HandlerSignal::Reconnect),
+                        attempted_resume,
+                        resume_succeeded
+                    ),
+                    DisconnectReason::OpcodeResumable
+                );
+            }
+        }
     }
 
     #[test]
     fn classify_no_signal_after_resume_is_resume_failed_no_signal() {
-        // RESUME-attempt close without opcode is ambiguous: could be Discord
-        // rejecting via close-code (4007/4009) or a flaky transport drop.
-        // The classifier just labels it; `run()` decides retry-vs-clear via
+        // RESUME-attempt close without opcode AND without a prior RESUMED
+        // confirmation is ambiguous: could be Discord rejecting via
+        // close-code (4007/4009) or a flaky transport drop. The classifier
+        // just labels it; `run()` decides retry-vs-clear via
         // `resume_no_signal_should_clear`.
         assert_eq!(
-            DisconnectReason::from_signal(None, true),
+            DisconnectReason::from_signal(None, true, false),
             DisconnectReason::ResumeFailedNoSignal
+        );
+    }
+
+    #[test]
+    fn classify_no_signal_after_resumed_is_generic_close() {
+        // The Codex P1 case: once we've seen a RESUMED dispatch, the resume
+        // has already succeeded. A later transport-level close is a normal
+        // disconnect, not a resume failure — must classify as GenericClose so
+        // run() doesn't increment resume-no-signal counter and eventually
+        // clear a still-valid session.
+        assert_eq!(
+            DisconnectReason::from_signal(None, true, true),
+            DisconnectReason::GenericClose
         );
     }
 
@@ -1122,10 +1177,13 @@ mod tests {
     fn classify_no_signal_after_identify_is_generic_close() {
         // The P2 review case: a transport-level close on an IDENTIFY-path
         // connection should not get the 1s "happy path" backoff.
-        assert_eq!(
-            DisconnectReason::from_signal(None, false),
-            DisconnectReason::GenericClose
-        );
+        // resume_succeeded is irrelevant on the IDENTIFY path.
+        for &resume_succeeded in &[false, true] {
+            assert_eq!(
+                DisconnectReason::from_signal(None, false, resume_succeeded),
+                DisconnectReason::GenericClose
+            );
+        }
     }
 
     #[test]

--- a/rust/crates/sera-gateway/src/discord.rs
+++ b/rust/crates/sera-gateway/src/discord.rs
@@ -162,12 +162,6 @@ pub fn parse_invalid_session_resumable(payload: &Value) -> Option<bool> {
     Some(payload.get("d").and_then(Value::as_bool).unwrap_or(false))
 }
 
-/// Returns `true` if the payload is opcode 7 (RECONNECT) — server is asking the
-/// client to disconnect and resume.
-pub fn is_op_reconnect(payload: &Value) -> bool {
-    payload.get("op").and_then(Value::as_u64) == Some(OP_RECONNECT)
-}
-
 /// Extract `(session_id, resume_gateway_url)` from a READY dispatch payload.
 /// Both pieces are required to RESUME a session after disconnect.
 pub fn parse_ready_session(payload: &Value) -> Option<(String, Option<String>)> {
@@ -1028,19 +1022,6 @@ mod tests {
         // If `d` is missing or non-bool, treat as non-resumable (safer default).
         let p = serde_json::json!({ "op": 9 });
         assert_eq!(parse_invalid_session_resumable(&p), Some(false));
-    }
-
-    #[test]
-    fn is_op_reconnect_true() {
-        assert!(is_op_reconnect(&serde_json::json!({ "op": 7, "d": null })));
-    }
-
-    #[test]
-    fn is_op_reconnect_false() {
-        assert!(!is_op_reconnect(&serde_json::json!({ "op": 0, "d": {} })));
-        assert!(!is_op_reconnect(
-            &serde_json::json!({ "op": 9, "d": false })
-        ));
     }
 
     #[test]

--- a/rust/crates/sera-gateway/src/discord.rs
+++ b/rust/crates/sera-gateway/src/discord.rs
@@ -57,12 +57,35 @@ pub struct DiscordConnector {
 /// decision in [`DiscordConnector::run`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum DisconnectReason {
-    /// Connection ended in a state where the existing session may still be
-    /// resumed: a normal close, an Op 7 RECONNECT, or an Op 9 with `d=true`.
-    Resumable,
+    /// Server explicitly asked us to reconnect (Op 7 RECONNECT) or said the
+    /// session was invalid-but-resumable (Op 9 with `d=true`). Keep session
+    /// state and apply a short 1s backoff before reconnecting + RESUMing.
+    OpcodeResumable,
     /// Server told us the session is dead (Op 9 with `d=false`). The connector
-    /// must clear stored session state and IDENTIFY again with a backoff.
+    /// must clear stored session state and IDENTIFY again with a long backoff.
     SessionInvalidated,
+    /// We sent RESUME on this connection and the loop ended without an opcode
+    /// signal — typically Discord rejecting RESUME via a close code (4007
+    /// invalid seq, 4009 session timeout, etc.). Clear session state so the
+    /// next attempt is a fresh IDENTIFY; otherwise we'd hot-loop on RESUME.
+    ResumeFailedNoSignal,
+    /// IDENTIFY-path connection ended without an opcode signal — generic
+    /// transport close, IO error, or server-side close without an opcode.
+    /// Apply the standard 5s backoff and keep whatever session state a READY
+    /// may have populated (so the next attempt can RESUME if applicable).
+    GenericClose,
+}
+
+impl DisconnectReason {
+    /// Pure classifier so the mapping is unit-testable without a real socket.
+    fn from_signal(signal: Option<HandlerSignal>, attempted_resume: bool) -> Self {
+        match (signal, attempted_resume) {
+            (Some(HandlerSignal::SessionInvalidated), _) => Self::SessionInvalidated,
+            (Some(HandlerSignal::Reconnect), _) => Self::OpcodeResumable,
+            (None, true) => Self::ResumeFailedNoSignal,
+            (None, false) => Self::GenericClose,
+        }
+    }
 }
 
 /// Signal from [`DiscordConnector::handle_payload`] back to the event loop
@@ -353,11 +376,26 @@ impl DiscordConnector {
                     );
                     Duration::from_secs(secs)
                 }
-                Some(DisconnectReason::Resumable) => {
+                Some(DisconnectReason::ResumeFailedNoSignal) => {
+                    // RESUME-attempt connection died without an opcode signal —
+                    // typically Discord rejecting RESUME via a close code (4007
+                    // invalid seq, 4009 session timeout, etc.). Drop session
+                    // state and apply the invalid-session backoff so the next
+                    // attempt does a fresh IDENTIFY instead of hot-looping on a
+                    // RESUME the server keeps refusing.
+                    tracing::warn!(
+                        "RESUME ended without opcode signal; clearing session and falling back to IDENTIFY"
+                    );
+                    self.clear_session_state();
+                    consecutive_invalid_sessions = consecutive_invalid_sessions.saturating_add(1);
+                    let secs = invalid_session_backoff_secs(consecutive_invalid_sessions);
+                    Duration::from_secs(secs)
+                }
+                Some(DisconnectReason::OpcodeResumable) => {
                     consecutive_invalid_sessions = 0;
                     Duration::from_secs(1)
                 }
-                None => {
+                Some(DisconnectReason::GenericClose) | None => {
                     consecutive_invalid_sessions = 0;
                     Duration::from_secs(5)
                 }
@@ -435,18 +473,21 @@ impl DiscordConnector {
         // session id and a non-negative last sequence from a prior connection.
         let session_for_resume = self.current_session();
         let seq_for_resume = self.last_sequence.load(Ordering::Relaxed);
-        let initial_payload = match session_for_resume.as_deref() {
+        let (initial_payload, attempted_resume) = match session_for_resume.as_deref() {
             Some(sid) if seq_for_resume >= 0 => {
                 tracing::info!(
                     session_id = sid,
                     seq = seq_for_resume,
                     "Sending RESUME to Discord Gateway"
                 );
-                build_resume_payload(&self.token, sid, seq_for_resume)
+                (build_resume_payload(&self.token, sid, seq_for_resume), true)
             }
             _ => {
                 tracing::info!("Sending IDENTIFY to Discord Gateway");
-                build_identify_payload(&self.token, &self.agent_name)
+                (
+                    build_identify_payload(&self.token, &self.agent_name),
+                    false,
+                )
             }
         };
         write
@@ -517,10 +558,7 @@ impl DiscordConnector {
             }
         }
 
-        Ok(match signal {
-            Some(HandlerSignal::SessionInvalidated) => DisconnectReason::SessionInvalidated,
-            Some(HandlerSignal::Reconnect) | None => DisconnectReason::Resumable,
-        })
+        Ok(DisconnectReason::from_signal(signal, attempted_resume))
     }
 
     async fn handle_payload(&self, payload: &Value) -> Option<HandlerSignal> {
@@ -988,6 +1026,56 @@ mod tests {
         let shutting_down = Arc::new(AtomicBool::new(false));
         let connector = Arc::new(DiscordConnector::new("token", "agent", tx, shutting_down));
         (connector, rx)
+    }
+
+    // DisconnectReason classifier — pure mapping so we don't need a real socket
+    // to verify each (signal, attempted_resume) pair lands on the right branch.
+
+    #[test]
+    fn classify_session_invalidated_signal_overrides_attempted_resume() {
+        // Op 9 (d=false) must invalidate even if we'd just sent IDENTIFY.
+        assert_eq!(
+            DisconnectReason::from_signal(Some(HandlerSignal::SessionInvalidated), false),
+            DisconnectReason::SessionInvalidated
+        );
+        assert_eq!(
+            DisconnectReason::from_signal(Some(HandlerSignal::SessionInvalidated), true),
+            DisconnectReason::SessionInvalidated
+        );
+    }
+
+    #[test]
+    fn classify_opcode_reconnect_signal_overrides_attempted_resume() {
+        // Op 7 RECONNECT or Op 9 (d=true) — keep session, short backoff.
+        assert_eq!(
+            DisconnectReason::from_signal(Some(HandlerSignal::Reconnect), false),
+            DisconnectReason::OpcodeResumable
+        );
+        assert_eq!(
+            DisconnectReason::from_signal(Some(HandlerSignal::Reconnect), true),
+            DisconnectReason::OpcodeResumable
+        );
+    }
+
+    #[test]
+    fn classify_no_signal_after_resume_falls_back_to_identify() {
+        // The P1 review case: RESUME closed without opcode (likely close-code
+        // 4007/4009). Must classify as ResumeFailedNoSignal so run() clears
+        // session state and the next attempt is a fresh IDENTIFY.
+        assert_eq!(
+            DisconnectReason::from_signal(None, true),
+            DisconnectReason::ResumeFailedNoSignal
+        );
+    }
+
+    #[test]
+    fn classify_no_signal_after_identify_is_generic_close() {
+        // The P2 review case: a transport-level close on an IDENTIFY-path
+        // connection should not get the 1s "happy path" backoff.
+        assert_eq!(
+            DisconnectReason::from_signal(None, false),
+            DisconnectReason::GenericClose
+        );
     }
 
     #[test]

--- a/rust/crates/sera-gateway/src/discord.rs
+++ b/rust/crates/sera-gateway/src/discord.rs
@@ -238,6 +238,20 @@ fn resume_no_signal_should_clear(consecutive: u32) -> bool {
     consecutive >= RESUME_NO_SIGNAL_CLEAR_THRESHOLD
 }
 
+/// Number of consecutive connect-stage errors against `resume_gateway_url` we
+/// tolerate before falling back to the canonical gateway URL. Discord's
+/// canonical gateway accepts RESUME for the same `session_id`, so clearing
+/// only the resume host (not the session) recovers from a stale or
+/// regionally-degraded resume URL without forcing an IDENTIFY.
+const RESUME_URL_FAILURE_THRESHOLD: u32 = 2;
+
+/// Returns `true` if `run()` should clear `resume_gateway_url` and target the
+/// canonical gateway on the next attempt. A single error preserves the
+/// optimization for transient blips; repeated errors release a stuck host.
+fn resume_url_should_clear(consecutive: u32) -> bool {
+    consecutive >= RESUME_URL_FAILURE_THRESHOLD
+}
+
 /// Backoff schedule for INVALID_SESSION re-IDENTIFY attempts.
 ///
 /// Discord's spec says clients should wait a random 1-5 seconds before sending a
@@ -369,6 +383,15 @@ impl DiscordConnector {
         self.last_sequence.store(-1, Ordering::Relaxed);
     }
 
+    /// Drop only the per-session resume host so the next reconnect targets the
+    /// canonical gateway. Keeps `session_id` and `last_sequence` so RESUME on
+    /// canonical gateway can still recover the session.
+    fn clear_resume_gateway_url(&self) {
+        if let Ok(mut g) = self.resume_gateway_url.lock() {
+            *g = None;
+        }
+    }
+
     fn current_session(&self) -> Option<String> {
         self.session_id.lock().ok().and_then(|g| g.clone())
     }
@@ -389,11 +412,30 @@ impl DiscordConnector {
     pub async fn run(&self) -> anyhow::Result<()> {
         let mut consecutive_invalid_sessions: u32 = 0;
         let mut consecutive_resume_no_signal: u32 = 0;
+        let mut consecutive_resume_url_errors: u32 = 0;
         while !self.shutting_down.load(Ordering::Relaxed) {
+            let attempted_resume_url = self.current_resume_url().is_some();
             let outcome = match self.connect_and_run().await {
-                Ok(reason) => Some(reason),
+                Ok(reason) => {
+                    consecutive_resume_url_errors = 0;
+                    Some(reason)
+                }
                 Err(e) => {
                     tracing::error!("Discord gateway error: {e}");
+                    if attempted_resume_url {
+                        consecutive_resume_url_errors =
+                            consecutive_resume_url_errors.saturating_add(1);
+                        if resume_url_should_clear(consecutive_resume_url_errors) {
+                            tracing::warn!(
+                                consecutive = consecutive_resume_url_errors,
+                                "Resume gateway host has failed repeatedly; falling back to canonical gateway URL while preserving session"
+                            );
+                            self.clear_resume_gateway_url();
+                            consecutive_resume_url_errors = 0;
+                        }
+                    } else {
+                        consecutive_resume_url_errors = 0;
+                    }
                     None
                 }
             };
@@ -1157,6 +1199,50 @@ mod tests {
             DisconnectReason::from_signal(None, true, true),
             DisconnectReason::GenericClose
         );
+    }
+
+    #[test]
+    fn resume_url_failure_threshold_falls_back_after_repeats() {
+        // First connect-stage error against `resume_gateway_url` is treated as
+        // a transient blip; we keep the resume host. Repeated errors release
+        // the stuck host so `run()` falls back to the canonical gateway URL
+        // (still attempting RESUME with the cached session_id).
+        assert!(!resume_url_should_clear(0));
+        assert!(!resume_url_should_clear(1));
+        assert!(resume_url_should_clear(2));
+        assert!(resume_url_should_clear(3));
+        assert!(resume_url_should_clear(u32::MAX));
+    }
+
+    #[tokio::test]
+    async fn clear_resume_gateway_url_keeps_session_id_and_sequence() {
+        // The fallback path must clear ONLY the resume host. session_id and
+        // last_sequence persist so the next attempt RESUMEs the same session
+        // on the canonical gateway URL.
+        let (conn, _rx) = test_connector();
+        let ready = serde_json::json!({
+            "op": 0,
+            "t": "READY",
+            "s": 7,
+            "d": {
+                "session_id": "sess-fallback",
+                "resume_gateway_url": "wss://gateway-bad.discord.gg",
+                "user": { "id": "b", "username": "n" }
+            }
+        });
+        conn.handle_payload(&ready).await;
+        assert_eq!(conn.test_session_id().as_deref(), Some("sess-fallback"));
+        assert_eq!(
+            conn.test_resume_gateway_url().as_deref(),
+            Some("wss://gateway-bad.discord.gg")
+        );
+        assert_eq!(conn.test_last_sequence(), 7);
+
+        conn.clear_resume_gateway_url();
+
+        assert_eq!(conn.test_session_id().as_deref(), Some("sess-fallback"));
+        assert!(conn.test_resume_gateway_url().is_none());
+        assert_eq!(conn.test_last_sequence(), 7);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes the Discord gateway reliability P1 bundle: `sera-m0az`, `sera-v4fp`, `sera-70fs`.

- **No RESUME (sera-m0az):** every reconnect re-IDENTIFYs, dropping events between disconnect and reconnect. Now tracks `session_id`, `resume_gateway_url`, and `last_sequence` across connections and sends Op 6 RESUME when we have a valid session.
- **Op 9 INVALID_SESSION (sera-v4fp):** payload's `d` (resumable bool) was ignored — could hot-loop INVALID_SESSION → IDENTIFY. Now: `d=true` → RESUME on the next reconnect; `d=false` → clear session state and IDENTIFY with escalating 1-30s backoff (Discord spec is 1-5s; the cap prevents a noisy server from keeping us busy-looping).
- **Op 7 RECONNECT (sera-70fs):** previously fell through to a debug log. Now closes the connection and reconnects to `resume_gateway_url`, sending RESUME.

The public `DiscordConnector::new` signature is unchanged, so no edits to `bin/sera.rs` are required.

## Implementation notes

- `connect_and_run` returns a private `DisconnectReason` so the outer `run()` loop can choose IDENTIFY-vs-RESUME plus backoff.
- `handle_payload` returns `Option<HandlerSignal>` so the event loop can break with intent (Op 7 / Op 9) instead of relying on a transport close.
- READY dispatches now capture both `session_id` and `resume_gateway_url`. RESUMED is acknowledged with an info log.
- Sequence number is now an `Arc<AtomicI64>` field on the connector (was per-connection) so RESUME can replay missed events after reconnect.

## Tests

- New helper-level tests: `build_resume_payload`, `parse_invalid_session_resumable` (true/false/wrong-op/missing-d), `is_op_reconnect`, `parse_ready_session` (with/without resume URL, non-READY rejection), `invalid_session_backoff_schedule`.
- New connector-level tests: Op 7 → `Reconnect`, Op 9 d=true → `Reconnect`, Op 9 d=false → `SessionInvalidated`, READY captures session/resume URL/sequence, dispatch updates sequence for RESUME, unhandled opcodes stay silent, `clear_session_state` invariant.
- Existing shutdown-flag tests preserved.

## Test plan

- [x] `cargo fmt -p sera-gateway`
- [x] `cargo check -p sera-gateway` (clean)
- [x] `cargo test -p sera-gateway --bin sera-gateway discord::` → 45 passed
- [x] `cargo test -p sera-gateway --bin sera-gateway` → 172 passed (no regressions)
- [ ] Manual smoke against Discord (out of scope — not done in this lane)

🤖 Generated with [Claude Code](https://claude.com/claude-code)