### PR TITLE
fix(gateway): handle steer completion event path

### DIFF
--- a/rust/crates/sera-gateway/src/bin/sera.rs
+++ b/rust/crates/sera-gateway/src/bin/sera.rs
@@ -2174,16 +2174,28 @@ async fn execute_steer(
             }
         }
         res = tokio::time::timeout(timeout, async {
-            // Read TurnCompleted event.
+            // Wait for the runtime to acknowledge the steer injection. The
+            // runtime emits the event type at `msg.type` (mirroring
+            // `StdioHarness::send_turn`); a stale code path read `type` at
+            // the top level and never matched, so the loop wedged the lane
+            // until `SERA_TURN_TIMEOUT_SECS` (sera-y9f8). Breaking on the
+            // first `streaming_delta` releases the lane as soon as the
+            // injected message starts producing output, and `turn_completed`
+            // covers the case where the runtime finishes before any delta.
             let mut line = String::new();
             loop {
                 match stdout.read_line(&mut line).await {
                     Ok(0) => break,
                     Ok(_) => {
-                        if let Ok(event) = serde_json::from_str::<serde_json::Value>(&line)
-                            && event.get("type").and_then(|v| v.as_str()) == Some("turn_completed")
-                        {
-                            break;
+                        if let Ok(event) = serde_json::from_str::<serde_json::Value>(&line) {
+                            let msg_type = event
+                                .get("msg")
+                                .and_then(|m| m.get("type"))
+                                .and_then(|t| t.as_str())
+                                .unwrap_or("");
+                            if matches!(msg_type, "streaming_delta" | "turn_completed") {
+                                break;
+                            }
                         }
                     }
                     Err(_) => break,
@@ -5888,6 +5900,51 @@ spec:
         assert!(
             start.elapsed() < std::time::Duration::from_secs(1),
             "timeout must fire near its bound, not after the test harness limit"
+        );
+    }
+
+    /// sera-y9f8 regression guard: `execute_steer` must read the event
+    /// type from `msg.type` (mirroring `StdioHarness::send_turn`), not from
+    /// the top-level `type` field. The mock runtime emits NDJSON frames
+    /// whose type lives under `msg.type`, so the previous code never
+    /// matched and the loop wedged the lane until the
+    /// `SERA_TURN_TIMEOUT_SECS` deadline. We pin the env var to 1 s so a
+    /// regression bounds the test to ~1 s instead of the 600 s default.
+    #[tokio::test]
+    async fn execute_steer_returns_promptly_on_runtime_msg_type() {
+        let prior = std::env::var("SERA_TURN_TIMEOUT_SECS").ok();
+        // SAFETY: test-only env mutation; `turn_timeout()` reads the var
+        // each call, so the value is observed inline. Restored before the
+        // test returns to keep parallel tests hermetic.
+        unsafe { std::env::set_var("SERA_TURN_TIMEOUT_SECS", "1") };
+
+        let harness = StdioHarness::spawn_mock().await.unwrap();
+        let cancel = CancellationToken::new();
+        let steer_messages = vec![serde_json::json!({"role": "user", "content": "hi"})];
+
+        let start = std::time::Instant::now();
+        let result =
+            execute_steer(&harness, &steer_messages, "y9f8-test-session", &cancel).await;
+        let elapsed = start.elapsed();
+
+        // SAFETY: restoring the pre-test value; same caveat as above.
+        unsafe {
+            match prior {
+                Some(v) => std::env::set_var("SERA_TURN_TIMEOUT_SECS", v),
+                None => std::env::remove_var("SERA_TURN_TIMEOUT_SECS"),
+            }
+        }
+
+        assert!(
+            elapsed < std::time::Duration::from_millis(900),
+            "execute_steer must break on the first runtime event well before \
+             the 1 s SERA_TURN_TIMEOUT_SECS deadline (elapsed={:?})",
+            elapsed
+        );
+        assert_eq!(
+            result.reply, "[steer injected]",
+            "expected the success sentinel, got: {}",
+            result.reply
         );
     }
 

--- a/rust/crates/sera-gateway/src/bin/sera.rs
+++ b/rust/crates/sera-gateway/src/bin/sera.rs
@@ -2174,14 +2174,18 @@ async fn execute_steer(
             }
         }
         res = tokio::time::timeout(timeout, async {
-            // Wait for the runtime to acknowledge the steer injection. The
-            // runtime emits the event type at `msg.type` (mirroring
+            // Drain the steer turn until its terminal `turn_completed` frame.
+            // The runtime emits the event type at `msg.type` (mirroring
             // `StdioHarness::send_turn`); a stale code path read `type` at
             // the top level and never matched, so the loop wedged the lane
-            // until `SERA_TURN_TIMEOUT_SECS` (sera-y9f8). Breaking on the
-            // first `streaming_delta` releases the lane as soon as the
-            // injected message starts producing output, and `turn_completed`
-            // covers the case where the runtime finishes before any delta.
+            // until `SERA_TURN_TIMEOUT_SECS` (sera-y9f8).
+            //
+            // We must consume every frame this steer produces — including
+            // intermediate `streaming_delta`s and the final `turn_completed`.
+            // `send_turn` reads from the same harness stdout and exits on the
+            // first `turn_completed` it sees (no `submission_id` correlation),
+            // so any leftover steer event would be misread as the next user
+            // turn's completion and short-circuit it with empty output.
             let mut line = String::new();
             loop {
                 match stdout.read_line(&mut line).await {
@@ -2193,7 +2197,7 @@ async fn execute_steer(
                                 .and_then(|m| m.get("type"))
                                 .and_then(|t| t.as_str())
                                 .unwrap_or("");
-                            if matches!(msg_type, "streaming_delta" | "turn_completed") {
+                            if msg_type == "turn_completed" {
                                 break;
                             }
                         }
@@ -5904,14 +5908,25 @@ spec:
     }
 
     /// sera-y9f8 regression guard: `execute_steer` must read the event
-    /// type from `msg.type` (mirroring `StdioHarness::send_turn`), not from
-    /// the top-level `type` field. The mock runtime emits NDJSON frames
-    /// whose type lives under `msg.type`, so the previous code never
-    /// matched and the loop wedged the lane until the
-    /// `SERA_TURN_TIMEOUT_SECS` deadline. We pin the env var to 1 s so a
-    /// regression bounds the test to ~1 s instead of the 600 s default.
+    /// type from `msg.type` (mirroring `StdioHarness::send_turn`) **and**
+    /// fully drain the steer turn through its terminal `turn_completed`.
+    ///
+    /// Two failure modes are guarded here:
+    /// 1. The original bug — reading `event.type` (top-level) never
+    ///    matched, so the loop wedged the lane until the
+    ///    `SERA_TURN_TIMEOUT_SECS` deadline. We pin the env var to 1 s so
+    ///    a regression bounds the test to ~1 s instead of the 600 s
+    ///    default.
+    /// 2. The follow-up bug flagged on PR #1117 — breaking early on
+    ///    `streaming_delta` leaves the steer's `turn_completed` unread on
+    ///    the shared harness stdout. The next `send_turn` (which does not
+    ///    correlate by `submission_id`) would then consume that leftover
+    ///    completion and return an empty response. We assert that a
+    ///    follow-up `send_turn` still observes the mock's normal
+    ///    `streaming_delta("mock response")` payload, proving no steer
+    ///    frames leaked past the steer call.
     #[tokio::test]
-    async fn execute_steer_returns_promptly_on_runtime_msg_type() {
+    async fn execute_steer_drains_until_turn_completed() {
         let prior = std::env::var("SERA_TURN_TIMEOUT_SECS").ok();
         // SAFETY: test-only env mutation; `turn_timeout()` reads the var
         // each call, so the value is observed inline. Restored before the
@@ -5927,6 +5942,15 @@ spec:
             execute_steer(&harness, &steer_messages, "y9f8-test-session", &cancel).await;
         let elapsed = start.elapsed();
 
+        // Follow-up turn on the same harness: must see the mock's normal
+        // payload, not stale steer frames. With an early `streaming_delta`
+        // break, this would observe an empty response because the steer's
+        // `turn_completed` would be the first frame `send_turn` reads.
+        let follow_up = harness
+            .send_turn(Vec::new(), "y9f8-test-session")
+            .await
+            .expect("follow-up send_turn must succeed against a fresh harness state");
+
         // SAFETY: restoring the pre-test value; same caveat as above.
         unsafe {
             match prior {
@@ -5937,14 +5961,20 @@ spec:
 
         assert!(
             elapsed < std::time::Duration::from_millis(900),
-            "execute_steer must break on the first runtime event well before \
-             the 1 s SERA_TURN_TIMEOUT_SECS deadline (elapsed={:?})",
+            "execute_steer must break on the steer's `turn_completed` well \
+             before the 1 s SERA_TURN_TIMEOUT_SECS deadline (elapsed={:?})",
             elapsed
         );
         assert_eq!(
             result.reply, "[steer injected]",
             "expected the success sentinel, got: {}",
             result.reply
+        );
+        assert_eq!(
+            follow_up.response, "mock response",
+            "follow-up turn must read the mock's fresh streaming_delta, not \
+             a leaked steer frame; got: {:?}",
+            follow_up.response
         );
     }
 


### PR DESCRIPTION
Fixes [sera-y9f8](https://github.com/TKCen/sera/issues?q=sera-y9f8).

## Summary

`execute_steer` (`rust/crates/sera-gateway/src/bin/sera.rs`) probed each NDJSON frame from the runtime with `event.get("type")`, but the runtime publishes the event type at `event.msg.type` — the same path `StdioHarness::send_turn` already walks. The mismatch meant the loop never matched a known frame, so a Discord-driven steer would hang inside the read loop until `SERA_TURN_TIMEOUT_SECS` (default 600 s) fired. The lane stayed held the whole time and a second user message looked like it had silently disappeared.

## Fix

- Walk `event.msg.type` (matching `send_turn`) and break on `streaming_delta` **or** `turn_completed`. Breaking on the first delta releases the lane as soon as the runtime acknowledges the steer; `turn_completed` covers the case where the runtime finishes before any delta is emitted.
- Comment annotated with the bug ID for future spelunking.

## Tests

- New unit test `execute_steer_returns_promptly_on_runtime_msg_type` (in the existing `#[cfg(test)] mod tests` inside `bin/sera.rs`):
  - Pins `SERA_TURN_TIMEOUT_SECS=1` (snapshot/restore around the call) so a regression bounds the test to ~1 s instead of the 600 s default.
  - Spawns `StdioHarness::spawn_mock`, calls `execute_steer`, asserts elapsed `< 900 ms` and `result.reply == "[steer injected]"`.
- Verified locally: targeted run (`execute_steer_returns_promptly_on_runtime_msg_type`, `send_turn*`, `execute_turn_aborts*`, `turn_timeout*`) — 7/7 pass in 0.16 s.
- `cargo check -p sera-gateway` clean.

## Test plan

- [x] `cargo test -p sera-gateway --bin sera-gateway -- execute_steer_returns_promptly_on_runtime_msg_type`
- [x] `cargo test -p sera-gateway --bin sera-gateway -- send_turn execute_turn_aborts turn_timeout`
- [x] `cargo check -p sera-gateway`

## Prior lane findings consulted

`/home/entity/.sera/lane-findings/README.md` only contained findings for `sera-findings-loop` and `feat/lane-b-events-config`; nothing relevant to the steer JSON-path bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)