### PR TITLE
fix(sera-gateway,web): empty-reply guard for streaming chat (sera-aepj)

### DIFF
--- a/rust/crates/sera-gateway/src/bin/sera.rs
+++ b/rust/crates/sera-gateway/src/bin/sera.rs
@@ -1440,6 +1440,34 @@ async fn chat_handler(
                             lq.complete_run(&session_key);
                         }
 
+                        // sera-aepj: empty-reply guard mirrors the sync branch
+                        // (line ~1561). Without this, the SSE stream emits zero
+                        // `message` frames followed by `done` with usage=0/0/0,
+                        // which the web client renders as a stuck "thinking…"
+                        // spinner. Surface a structured `error` event instead
+                        // so clients can show the failure.
+                        if result.reply.is_empty() {
+                            tracing::error!(
+                                session_id = %session_id,
+                                agent = %agent_name,
+                                prompt_tokens = result.usage.prompt_tokens,
+                                completion_tokens = result.usage.completion_tokens,
+                                total_tokens = result.usage.total_tokens,
+                                tool_events_count = result.tool_events.len(),
+                                tools_ran = !result.tool_events.is_empty(),
+                                "execute_turn returned empty reply (stream); runtime produced no text"
+                            );
+                            let payload = serde_json::json!({
+                                "error": "runtime returned empty reply",
+                                "session_id": session_id,
+                                "message_id": message_id,
+                            });
+                            let event = Event::default()
+                                .event("error")
+                                .data(payload.to_string());
+                            return Some((Some(Ok(event)), StreamState::Done));
+                        }
+
                         // Save tool events and assistant response.
                         {
                             let db = state.db.lock().await;
@@ -5517,6 +5545,26 @@ spec:
         let events: Vec<_> = stream.collect().await;
         // 2 chunks + 1 done event = 3 total
         assert_eq!(events.len(), 3);
+    }
+
+    /// sera-aepj: documents the SSE shape the streaming branch emits when
+    /// `execute_turn` returns an empty reply. The web client's
+    /// `parseChatSseEvent` matches on `event: error` + `data.error` to surface
+    /// the failure rather than rendering a stuck "thinking…" spinner.
+    #[test]
+    fn empty_reply_error_event_payload_shape() {
+        let session_id = "sess-empty";
+        let message_id = "msg_deadbeef";
+        let payload = serde_json::json!({
+            "error": "runtime returned empty reply",
+            "session_id": session_id,
+            "message_id": message_id,
+        });
+        let parsed: serde_json::Value =
+            serde_json::from_str(&payload.to_string()).expect("payload re-parses");
+        assert_eq!(parsed["error"], "runtime returned empty reply");
+        assert_eq!(parsed["session_id"], session_id);
+        assert_eq!(parsed["message_id"], message_id);
     }
 
     /// Verify StreamState::Done immediately terminates the stream.

--- a/rust/docker-compose.sera.yml
+++ b/rust/docker-compose.sera.yml
@@ -22,6 +22,12 @@ services:
       - RUST_LOG=${RUST_LOG:-info}
       - SERA_RUNTIME_BIN=/usr/local/bin/sera-runtime
       - SERA_ALLOW_MISSING_CONSTITUTIONAL_GATE=${SERA_ALLOW_MISSING_CONSTITUTIONAL_GATE:-1}
+      # L.3 (#1104) made the admin server gate on this in non-local mode.
+      # `--local` would auto-generate it, but `--local` also probes
+      # localhost:1234 which isn't reachable from inside this container —
+      # the host's LM Studio sits on host.docker.internal. So provide a token
+      # explicitly.
+      - SERA_ADMIN_TOKEN=${SERA_ADMIN_TOKEN:-sera-admin-dev}
     # Bridge networking so published ports reach the host on WSL2 Docker Desktop.
     # (network_mode: host binds to the Docker Desktop VM netns, not the WSL2
     # distro, so `ports:` is ignored and host curl to localhost:3001 times out.)

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -134,7 +134,14 @@ export interface ChatStreamDone {
   usage: { promptTokens: number; completionTokens: number; totalTokens: number };
 }
 
-export type ChatStreamEvent = ChatStreamDelta | ChatStreamDone;
+export interface ChatStreamError {
+  type: 'error';
+  error: string;
+  sessionId?: string;
+  messageId?: string;
+}
+
+export type ChatStreamEvent = ChatStreamDelta | ChatStreamDone | ChatStreamError;
 
 /** Parse a raw SSE message into a ChatStreamEvent. Returns null for unknown event types or malformed JSON. */
 export function parseChatSseEvent(
@@ -167,6 +174,19 @@ export function parseChatSseEvent(
           completionTokens: raw.usage?.completion_tokens ?? 0,
           totalTokens: raw.usage?.total_tokens ?? 0,
         },
+      };
+    }
+    if (eventType === 'error') {
+      const raw = JSON.parse(dataJson) as {
+        error: string;
+        session_id?: string;
+        message_id?: string;
+      };
+      return {
+        type: 'error',
+        error: raw.error,
+        sessionId: raw.session_id,
+        messageId: raw.message_id,
       };
     }
   } catch {

--- a/web/src/views/ChatView.test.ts
+++ b/web/src/views/ChatView.test.ts
@@ -47,6 +47,41 @@ describe('parseChatSseEvent', () => {
     });
   });
 
+  it('parses an error event with session/message ids', () => {
+    const result = parseChatSseEvent(
+      'error',
+      JSON.stringify({
+        error: 'runtime returned empty reply',
+        session_id: 'sess_1',
+        message_id: 'msg_abc',
+      }),
+    );
+    expect(result).toEqual({
+      type: 'error',
+      error: 'runtime returned empty reply',
+      sessionId: 'sess_1',
+      messageId: 'msg_abc',
+    });
+  });
+
+  it('parses an error event without optional ids', () => {
+    const result = parseChatSseEvent(
+      'error',
+      JSON.stringify({ error: 'runtime timed out' }),
+    );
+    expect(result).toEqual({
+      type: 'error',
+      error: 'runtime timed out',
+      sessionId: undefined,
+      messageId: undefined,
+    });
+  });
+
+  it('returns null for malformed JSON in an error event', () => {
+    const result = parseChatSseEvent('error', 'not-json');
+    expect(result).toBeNull();
+  });
+
   it('accumulates deltas correctly when applied sequentially', () => {
     const events = [
       { event: 'message', data: JSON.stringify({ delta: 'Hello ', message_id: 'm1', session_id: 's1' }) },

--- a/web/src/views/ChatView.tsx
+++ b/web/src/views/ChatView.tsx
@@ -43,6 +43,15 @@ export function ChatView() {
       );
     } else if (event.type === 'done') {
       setThinking(false);
+    } else if (event.type === 'error') {
+      // sera-aepj: gateway emits an `error` SSE frame when the runtime
+      // returned an empty reply (or otherwise failed mid-turn). Surface
+      // it on the assistant placeholder so the user sees the failure
+      // instead of a stuck "thinking…" spinner.
+      setMessages((prev) =>
+        prev.map((m) => (m.id === msgId ? { ...m, error: event.error } : m)),
+      );
+      setThinking(false);
     }
   }, []);
 


### PR DESCRIPTION
## Summary

Reproduces the user-reported "chat sometimes gets stuck in the web UI" symptom and fixes both the silent-failure mode and the underlying container regression.

- **Streaming chat empty-reply guard** — the `/api/chat` `stream:true` branch silently emitted `event: done` with `usage=0/0/0` and zero `message` frames when `execute_turn` returned `reply=""`. The web client renders that as a perpetual "thinking…" spinner. Now mirrors the sync branch's 502 by emitting an `event: error` SSE frame with a structured payload.
- **Web client surfaces the failure** — `parseChatSseEvent` learns the new `error` variant; `ChatView.handleEvent` sets the assistant message's `error` field (already rendered as a red box) and clears the spinner.
- **rust-sera container unblock** — L.3 (#1104) gates the admin server on `SERA_ADMIN_TOKEN` outside `--local` mode. `--local` would auto-mint one, but it also probes `localhost:1234` for LM Studio which isn't reachable from inside the container (LM Studio sits on `host.docker.internal`). Set the token explicitly in `rust/docker-compose.sera.yml`.

Diagnosed root-cause for the "sometimes empty" reply: the rust-sera image in use was built 2026-04-23 21:23, predating the sera-8h23 fix in commit `24a98492` (2026-04-24 09:10) that rejects assistant messages with neither content nor tool_calls. Rebuilding the image restores well-formed replies; the streaming guard ensures any future regression of that class surfaces cleanly instead of silently.

## Test plan

- [x] `cargo check -p sera-gateway` clean
- [x] `cargo clippy -p sera-gateway -- -D warnings` clean
- [x] `cargo test -p sera-gateway --bin sera-gateway empty_reply_error_event_payload_shape` passes (new unit test)
- [x] `bun run typecheck` (web) clean
- [x] `bun run lint` (web) clean
- [x] `bun run test` ChatView.test.ts: 9/9 (3 new — error event with ids, error event without ids, malformed JSON)
- [x] End-to-end: 3 streaming chat probes against rebuilt rust-sera, replies stream back word-by-word; same via the nginx proxy on :5173.

🤖 Generated with [Claude Code](https://claude.com/claude-code)