### PR TITLE
docs(sera-y45a): dispatch-ownership ADR + dispatch_mode boot log

### DIFF
--- a/docs/plan/decisions/2026-04-29-dispatch-ownership.md
+++ b/docs/plan/decisions/2026-04-29-dispatch-ownership.md
@@ -76,14 +76,21 @@ Until all five hold, `dispatch_mode=runtime` remains the default and the boot lo
 
 ## 5. Boot-log contract
 
-The gateway emits `dispatch_mode` as a structured field:
+The gateway emits two structured fields so the log cannot lie about what the running binary actually does:
+
+- `dispatch_mode` — the **effective** mode (what the running code does). Today this binary always spawns `sera-runtime` via `StdioHarness`, so the effective mode is always `runtime` regardless of operator request. Future migration PRs (§4 steps 2–4) replace the constant returning `"runtime"` with a real switch wired to the dispatcher selection.
+- `dispatch_mode_configured` — the **operator-requested** mode parsed from `SERA_DISPATCH_MODE` (default `runtime`). One of `runtime | gateway | embedded`. Unrecognised values silently fall back to `runtime` so a typo cannot accidentally claim a security model the code does not implement.
+
+Both fields are emitted:
 
 - **Per process at startup**, immediately before agent harness spawn (one info-level line, even when no agents are configured).
 - **Per agent at spawn time**, alongside `agent` and `model` on the existing `"Spawned runtime harness"` line.
 
-The value is one of `runtime | gateway | embedded`, sourced from the `SERA_DISPATCH_MODE` env (default `runtime`). Unrecognised values silently fall back to `runtime` so a typo cannot accidentally claim a security model the code does not implement. The accepted set is documented here and validated by a unit test in the gateway crate; future migration PRs extend the validator and its tests in lock-step with the dispatcher implementation.
+When `dispatch_mode_configured` names a not-yet-implemented mode (`gateway` or `embedded`) and therefore differs from `dispatch_mode`, the gateway also emits a single warn-level line at process startup so operators cannot misread the request as an active deployment.
 
-The label is **declarative**, not behavioural: this PR does not change which process executes tools. It only makes the active model visible.
+The accepted configured set is documented here and validated by unit tests in the gateway crate; future migration PRs extend both the validator and the effective-mode resolver in lock-step with the dispatcher implementation.
+
+The label is **declarative**, not behavioural: this PR does not change which process executes tools. It only makes the active model visible while keeping the effective and requested modes distinguishable.
 
 ## 6. Consequences
 

--- a/docs/plan/decisions/2026-04-29-dispatch-ownership.md
+++ b/docs/plan/decisions/2026-04-29-dispatch-ownership.md
@@ -1,0 +1,111 @@
+# ADR — Tool Dispatch Ownership
+
+> **Status:** ACCEPTED — 2026-04-29
+> **Bead:** [`sera-y45a`](../../../). Anchor for the migration.
+> **Authors:** SERA architecture lane (Claude burn + OMC coordination council).
+> **Scope:** documentation + a single boot-log line. **No** runtime/gateway tool-dispatch migration in this PR.
+
+---
+
+## 1. Context
+
+`SPEC-gateway.md §1b`, `SPEC-runtime.md §1a`, `SPEC-tools.md §6` and `ARCHITECTURE-ADDENDUM-2026-04-13.md §3` all assert the same architectural target:
+
+- **Tool dispatch belongs entirely to the gateway.**
+- **Credentials never reach the harness/runtime.**
+- **Runtimes are cattle** — they may be restarted, cloned, or replaced without data loss.
+
+The shipped MVS does the opposite. The gateway spawns `sera-runtime --ndjson` as a per-agent child process via `StdioHarness` and the runtime owns:
+
+- the LLM client and `LLM_API_KEY` env (`rust/crates/sera-runtime/src/llm_client.rs`, spawn env at `rust/crates/sera-gateway/src/bin/sera.rs`),
+- the tool registry and dispatcher (`rust/crates/sera-runtime/src/tools/dispatcher.rs` — `RegistryDispatcher::dispatch`),
+- the capability gate (`with_capability_registry` + `cap_registry.check(...)` *inside the runtime process*).
+
+The gateway's `enforce_tool_events` (`rust/crates/sera-gateway/src/bin/sera.rs`) only observes `tool_call_begin/end` events post-hoc as defence-in-depth audit; the file-level comment in `rust/crates/sera-gateway/src/capability_enforcement.rs` explicitly disclaims the spec ("*Pre-dispatch enforcement now lives inside `sera-runtime`*"). This is the largest spec/code drift in the gateway↔runtime story.
+
+The drift is load-bearing because three downstream items depend on the answer:
+
+- `sera-eq0m` — netns-based egress containment for the LLM/provider; only meaningful if the gateway is the egress process.
+- `sera-plcv` — Pattern A/B BYOH delegation. M1 acceptance "all LLM cost attributed to the SERA agent's budget at the proxy" is unreachable while runtimes hold provider keys.
+- `sera-w2dh` / future BYOH tool injection — there is no shared dispatcher to inject `knowledge_query` / `memory_write` into.
+
+This ADR records the deviation, names the migration target, and adds a single boot-log marker so operators can see which model is live without reading source.
+
+## 2. Decision
+
+**Adopt gateway-owned dispatch as the canonical target. Frame today's MVS as a transitional `dispatch_mode=runtime` operating mode. No behaviour change in this PR beyond a structured boot log line per agent and per process.**
+
+Three modes are defined:
+
+| Mode | Meaning | Status |
+|---|---|---|
+| `runtime` | The runtime process owns the LLM client, tool registry, capability gate, and dispatcher. The gateway only audits `tool_call_*` events post-hoc. **This is the shipped MVS.** | **Current default.** |
+| `gateway` | The runtime forwards `tool_call` events through SQ/EQ; the gateway runs `pre_tool` chain, `CapabilityRegistry`, dispatch, `post_tool`, and returns the result. The runtime never holds credentials. | Target architecture (matches SPEC-gateway §1b, SPEC-tools §6). Not implemented. |
+| `embedded` | The gateway constructs `DefaultRuntime` in-process and calls `execute_turn` directly — no NDJSON, no child process. By process identity, "runtime crate dispatches" becomes "the gateway process dispatches"; the same hooks, `CapabilityRegistry`, and audit emission apply as for the binary path. | Library-mode entry point (matches `SPEC-runtime §1a` "Library mode (default)"). Not implemented. |
+
+The transitional `runtime` mode is **explicit, logged, and time-bounded by the migration plan in §4**. It is not a permanent second architecture.
+
+## 3. Why temporary
+
+1. **Spec consistency.** Every existing reference (SPEC-gateway §1b/§1c/§13a, SPEC-runtime §1a, SPEC-tools §6, ADDENDUM §3/§9) names the gateway as the dispatch + credentials + AuthZ + audit owner. Inverting the spec to match the MVS would also collapse the MES framing (gateway as durable boundary, workers as cattle), break the universal LLM proxy compliance claim, and remove the architectural anchor for BYOH tool injection.
+2. **Single security model.** Two production paths means two test surfaces, two threat models, and two audit pipelines. The team is not large enough to maintain that long-term.
+3. **Library mode is the quiet path.** When `sera-runtime` is embedded as a library inside the gateway process, "runtime crate dispatches" *is* "the gateway process dispatches" by virtue of process identity. The current binary `StdioHarness` is an MVS bootstrap, not the target shape.
+
+The pragmatic landing is therefore two-step: this PR records the deviation; a later PR (and a follow-up gateway-LLM-proxy PR) actually moves dispatch.
+
+## 4. Migration plan
+
+| Step | Bead | What lands |
+|---|---|---|
+| 1 (this PR) | `sera-y45a` | ADR + spec annotations + `dispatch_mode={runtime,gateway,embedded}` boot log line per agent and per process. **No** behavioural change. |
+| 2 | new bead — `feat(sera-gateway,sera-runtime): embedded-library dispatch_mode=embedded entry point` | Add `DispatchMode::Embedded`. Gateway constructs `DefaultRuntime` in-process and calls `execute_turn` directly — no NDJSON, no child. Reuses the same hook chain, `CapabilityRegistry`, and audit emission. Gated behind config flag. |
+| 3 | new bead — `feat(sera-gateway): move LlmClient to gateway as inference.local universal proxy` | Move `LlmClient` to the gateway, introduce `inference.local` virtual-host routing, strip `LLM_API_KEY` from runtime spawn env. Gated on `dispatch_mode=embedded`. Unblocks `sera-eq0m` and `sera-plcv` acceptance criterion 4. |
+| 4 | follow-up | Flip default `dispatch_mode` to `embedded` once `sera-ov7z`-equivalent E2E passes for both modes. Retire or repurpose the binary `StdioHarness` path (kept only for external BYOH harnesses if useful). |
+
+### Migration gate (acceptance for **flipping the default**)
+
+The default `dispatch_mode` flips from `runtime` to `embedded` only when **all** of the following hold:
+
+1. The embedded path passes the production-path E2E (`sera-ov7z`) — same assertions, same fixtures.
+2. The gateway-side LLM proxy is the sole egress for provider traffic; the runtime cannot dial a provider directly even if env-leaked (verified by netns enforcement test).
+3. `pre_tool` / `post_tool` hook chains fire from a single dispatcher process; no parallel dispatcher exists in the binary path.
+4. Audit emission for `tool_call_begin/end` is byte-stable across both modes (so historical audit logs remain comparable).
+5. `cargo clippy --workspace -- -D warnings` clean; `cargo test --workspace` green.
+
+Until all five hold, `dispatch_mode=runtime` remains the default and the boot log surfaces it explicitly so operators can distinguish staging from production.
+
+## 5. Boot-log contract
+
+The gateway emits `dispatch_mode` as a structured field:
+
+- **Per process at startup**, immediately before agent harness spawn (one info-level line, even when no agents are configured).
+- **Per agent at spawn time**, alongside `agent` and `model` on the existing `"Spawned runtime harness"` line.
+
+The value is one of `runtime | gateway | embedded`, sourced from the `SERA_DISPATCH_MODE` env (default `runtime`). Unrecognised values silently fall back to `runtime` so a typo cannot accidentally claim a security model the code does not implement. The accepted set is documented here and validated by a unit test in the gateway crate; future migration PRs extend the validator and its tests in lock-step with the dispatcher implementation.
+
+The label is **declarative**, not behavioural: this PR does not change which process executes tools. It only makes the active model visible.
+
+## 6. Consequences
+
+- **Specs no longer silently contradict working MVS behavior.** SPEC-gateway §1b, §1c, §13a; SPEC-runtime §1a, §3; SPEC-tools §6 each cite this ADR and name the active mode applicability.
+- **Operators can read the live security model from boot logs.** No source-diving required to know whether tool dispatch crosses a process boundary.
+- **`sera-hwny`** (already merged as PR #1119) is mandatory regardless of mode. In `runtime` mode the filter narrows the LLM-visible schema in the runtime; in `embedded`/`gateway` mode the same filter applies at the gateway-side `TraitToolRegistry` constructor.
+- **`sera-ov7z`** must observe the active `dispatch_mode` log line and assert dispatcher-side hook ordering for that mode. Test fixtures are parameterised on `dispatch_mode` so the same test exercises both paths once the embedded entry point lands.
+- **`sera-eq0m`** netns enforcement target depends on this ADR. In `runtime` mode the runtime process must run inside the egress-restricted netns. In `embedded` mode only the gateway process needs the netns.
+- **`sera-plcv`** M1 acceptance criterion 4 ("all LLM cost attributed to the SERA agent's budget at the proxy") is reachable only after step 3 of §4. Until then, M1 driver is staged with manual cost-attribution shims.
+
+## 7. Alternatives considered
+
+- **Option A — mode duality (pet keeps `runtime`, cattle gets `gateway`).** Rejected. Two production paths means two security models and two audit pipelines forever; pet-mode operators still read SPEC §1b and are still misled.
+- **Option C — accept runtime-side dispatch as canonical and rewrite the specs.** Rejected. Inverts the canonical constraint set, breaks the universal-LLM-proxy compliance claim (`sera-eq0m` becomes pointless), breaks BYOH tool injection (no shared dispatcher), and collapses the MES framing.
+
+## 8. References
+
+- `docs/plan/specs/SPEC-gateway.md` §1b, §1c, §13a
+- `docs/plan/specs/SPEC-runtime.md` §1a, §3
+- `docs/plan/specs/SPEC-tools.md` §6
+- `docs/plan/ARCHITECTURE-ADDENDUM-2026-04-13.md` §1–§3, §9
+- `artifacts/reports/research/y45a-dispatch-ownership-adr-preflight-spark-2026-04-29.md`
+- `artifacts/reports/claude-burn/gateway-runtime-dispatch-gap-2026-04-29.md`
+- `artifacts/reports/claude-burn/sera-claude-burn-synthesis-2026-04-29.md`
+- `artifacts/reports/coordination/dispatch-ownership-adr-prep-2026-04-29.md`

--- a/docs/plan/specs/SPEC-gateway.md
+++ b/docs/plan/specs/SPEC-gateway.md
@@ -40,6 +40,8 @@ The SERA gateway is a **Manufacturing Execution System for AI agents**. The MES 
 ## 1b. Tool Dispatch Ownership
 
 > **Design decision — 2026-04-13.** Tool dispatch belongs entirely to the gateway. This is not a performance consideration — it is a security and architectural boundary.
+>
+> **MVS deviation — 2026-04-29 (sera-y45a).** The shipped MVS runs in `dispatch_mode=runtime`: the `sera-runtime` child process owns the LLM client, tool registry, and capability gate, and the gateway only audits `tool_call_*` events post-hoc. This section describes the **target** architecture (`dispatch_mode=gateway` and `dispatch_mode=embedded`); see [`docs/plan/decisions/2026-04-29-dispatch-ownership.md`](../decisions/2026-04-29-dispatch-ownership.md) for the migration plan and gate.
 
 The tool execution pipeline lives at the gateway, not the harness:
 
@@ -68,6 +70,8 @@ See SPEC-tools §6 for the complete dispatch flow.
 ---
 
 ## 1c. Context Injection Responsibility
+
+> **MVS applicability — 2026-04-29 (sera-y45a).** Cattle-mode injection assumes `dispatch_mode={gateway,embedded}`. In today's `dispatch_mode=runtime` MVS the runtime child process loads its own context as a binary-mode implementation detail; see [`docs/plan/decisions/2026-04-29-dispatch-ownership.md`](../decisions/2026-04-29-dispatch-ownership.md).
 
 In **enterprise/cattle mode**, the gateway is responsible for assembling and injecting all session context into the runtime before the turn begins. The runtime does not know the source of the context it receives:
 
@@ -701,6 +705,8 @@ sera:
 ## 13a. LLM Proxy Surface
 
 > **Design decision — 2026-04-13.** The gateway CAN act as a universal LLM proxy for any connected harness.
+>
+> **MVS deviation — 2026-04-29 (sera-y45a).** In today's `dispatch_mode=runtime` MVS the `sera-runtime` child process holds `LLM_API_KEY` and dials the provider directly; the universal-proxy contract below is unreachable until step 3 of the migration plan in [`docs/plan/decisions/2026-04-29-dispatch-ownership.md`](../decisions/2026-04-29-dispatch-ownership.md) lands.
 
 When a BYOH harness (Claude Code, Codex, Hermes, external agent) connects to the gateway, all LLM calls from that harness can be routed through the gateway's LLM proxy surface. This is optional but recommended for regulated environments.
 

--- a/docs/plan/specs/SPEC-runtime.md
+++ b/docs/plan/specs/SPEC-runtime.md
@@ -39,6 +39,8 @@ The same crate compiles as an executable for two use cases:
 
 ### What the runtime does and does NOT do
 
+> **MVS deviation — 2026-04-29 (sera-y45a).** The list below describes the **target** architecture (`dispatch_mode={gateway,embedded}`). The shipped MVS runs `dispatch_mode=runtime`: the runtime child process owns the LLM client, tool registry, capability gate, and dispatcher, and holds `LLM_API_KEY`. The gateway audits `tool_call_*` events post-hoc only. See [`docs/plan/decisions/2026-04-29-dispatch-ownership.md`](../decisions/2026-04-29-dispatch-ownership.md) for the migration plan and gate.
+
 The runtime's **only responsibilities** are:
 
 1. Receive session context injected by the gateway (soul/persona, memory, tool schemas)
@@ -232,6 +234,8 @@ pub struct ConversationMessage {
 ---
 
 ## 3. Turn Loop (Default Runtime)
+
+> **MVS applicability — 2026-04-29 (sera-y45a).** The Tool Call Loop in this section assumes the gateway-owned dispatcher (`dispatch_mode={gateway,embedded}`). In today's `dispatch_mode=runtime` MVS, `pre_tool` / `post_tool` and the capability gate run inside the runtime process; the gateway sees `tool_call_*` events only as audit. See [`docs/plan/decisions/2026-04-29-dispatch-ownership.md`](../decisions/2026-04-29-dispatch-ownership.md).
 
 The turn loop follows a **four-method lifecycle** adapted from MetaGPT's Role pattern (SPEC-dependencies §10.15):
 

--- a/docs/plan/specs/SPEC-tools.md
+++ b/docs/plan/specs/SPEC-tools.md
@@ -328,6 +328,8 @@ Deny always wins over allow. The authorization system (`sera-auth`) is checked *
 ## 6. Tool Execution Flow
 
 > **Design decision — 2026-04-13.** Tool dispatch, AuthZ, and execution are **gateway responsibilities**, not harness responsibilities. The harness forwards tool call requests to the gateway and waits for results. It never executes tools directly.
+>
+> **MVS deviation — 2026-04-29 (sera-y45a).** The shipped MVS runs `dispatch_mode=runtime`: the diagram below describes the **target** flow for `dispatch_mode={gateway,embedded}`. Today the runtime process owns dispatch and the capability gate; the gateway sees `tool_call_*` events only as audit. See [`docs/plan/decisions/2026-04-29-dispatch-ownership.md`](../decisions/2026-04-29-dispatch-ownership.md) for the migration plan and gate.
 
 ```
 Harness              Gateway                         Tool Executor

--- a/rust/crates/sera-gateway/src/bin/sera.rs
+++ b/rust/crates/sera-gateway/src/bin/sera.rs
@@ -124,6 +124,29 @@ fn wants_pgvector_backend(backend_pref: Option<&str>, database_url: Option<&str>
     matches!(backend_pref, Some("pgvector")) || (backend_pref.is_none() && database_url.is_some())
 }
 
+/// sera-y45a: declares which process owns tool dispatch for the running gateway.
+///
+/// `runtime` (default) = the `sera-runtime` child owns the LLM client, tool
+/// registry, capability gate, and dispatcher; the gateway audits `tool_call_*`
+/// events post-hoc. `gateway` and `embedded` are the migration targets — see
+/// `docs/plan/decisions/2026-04-29-dispatch-ownership.md`. This is a
+/// **declarative** marker only: the value is logged at boot so operators can
+/// see the active model. Changing it does not yet change which process
+/// dispatches tools.
+fn dispatch_mode_label(raw: Option<&str>) -> &'static str {
+    match raw.map(str::trim) {
+        Some("gateway") => "gateway",
+        Some("embedded") => "embedded",
+        // default + unrecognised + empty → fail safe to the shipped MVS mode.
+        _ => "runtime",
+    }
+}
+
+fn current_dispatch_mode_label() -> &'static str {
+    let raw = std::env::var("SERA_DISPATCH_MODE").ok();
+    dispatch_mode_label(raw.as_deref())
+}
+
 // ── CLI ─────────────────────────────────────────────────────────────────────
 
 #[derive(Parser)]
@@ -3844,6 +3867,17 @@ async fn run_start(config: PathBuf, port: u16, local: bool) -> anyhow::Result<()
         exe_dir.join("sera-runtime").to_string_lossy().to_string()
     });
 
+    // sera-y45a: surface the active dispatch model in the boot log so
+    // operators can read which process owns tool dispatch without diving
+    // into source. The current MVS ships `runtime`; `gateway` and
+    // `embedded` are migration targets. See
+    // docs/plan/decisions/2026-04-29-dispatch-ownership.md.
+    let dispatch_mode = current_dispatch_mode_label();
+    tracing::info!(
+        dispatch_mode = dispatch_mode,
+        "Tool dispatch ownership (sera-y45a)"
+    );
+
     let mut harnesses = std::collections::HashMap::new();
 
     for agent_name in manifests.agent_names() {
@@ -3931,9 +3965,14 @@ async fn run_start(config: PathBuf, port: u16, local: bool) -> anyhow::Result<()
         .await
         {
             Ok(supervisor) => {
+                // sera-y45a: include the dispatch_mode marker so per-agent
+                // boot logs answer "which process owns tool dispatch for
+                // this agent?" without operators correlating against the
+                // process-level line above.
                 tracing::info!(
                     agent = %agent_name,
                     model = %model,
+                    dispatch_mode = dispatch_mode,
                     "Spawned runtime harness via supervisor (sera-ojp3)"
                 );
                 harnesses.insert(agent_name.to_string(), supervisor);
@@ -4495,6 +4534,44 @@ mod tests {
     #[test]
     fn unknown_backend_pref_falls_back_to_sqlite() {
         assert!(!wants_pgvector_backend(Some("redis"), Some("postgres://x")));
+    }
+
+    // ── sera-y45a: dispatch_mode_label() ────────────────────────────────────
+    //
+    // The label is declarative: it surfaces which process owns tool dispatch
+    // in boot logs but does not change behaviour. The default is `runtime`
+    // (the shipped MVS); `gateway` and `embedded` are migration targets.
+    // Unrecognised values fail safe to `runtime` so a typo cannot accidentally
+    // claim a security model the code does not implement.
+    // See docs/plan/decisions/2026-04-29-dispatch-ownership.md.
+
+    #[test]
+    fn dispatch_mode_defaults_to_runtime_when_unset() {
+        assert_eq!(dispatch_mode_label(None), "runtime");
+        assert_eq!(dispatch_mode_label(Some("")), "runtime");
+        assert_eq!(dispatch_mode_label(Some("   ")), "runtime");
+    }
+
+    #[test]
+    fn dispatch_mode_recognises_canonical_values() {
+        assert_eq!(dispatch_mode_label(Some("runtime")), "runtime");
+        assert_eq!(dispatch_mode_label(Some("gateway")), "gateway");
+        assert_eq!(dispatch_mode_label(Some("embedded")), "embedded");
+    }
+
+    #[test]
+    fn dispatch_mode_trims_surrounding_whitespace() {
+        assert_eq!(dispatch_mode_label(Some("  gateway  ")), "gateway");
+        assert_eq!(dispatch_mode_label(Some("\tembedded\n")), "embedded");
+    }
+
+    #[test]
+    fn dispatch_mode_unknown_falls_back_to_runtime() {
+        // case-sensitive on purpose: env values are documented lowercase, and
+        // accidental uppercase should not silently claim a different model.
+        assert_eq!(dispatch_mode_label(Some("RUNTIME")), "runtime");
+        assert_eq!(dispatch_mode_label(Some("Gateway")), "runtime");
+        assert_eq!(dispatch_mode_label(Some("foo")), "runtime");
     }
 
     fn test_manifests() -> ManifestSet {

--- a/rust/crates/sera-gateway/src/bin/sera.rs
+++ b/rust/crates/sera-gateway/src/bin/sera.rs
@@ -129,17 +129,21 @@ fn wants_pgvector_backend(backend_pref: Option<&str>, database_url: Option<&str>
 ///
 /// `runtime` (default) names the shipped MVS where the `sera-runtime` child
 /// owns the LLM client, tool registry, capability gate, and dispatcher.
-/// `gateway` and `embedded` are the migration targets — see
+/// `gateway` and `embedded` are migration *targets* — see
 /// `docs/plan/decisions/2026-04-29-dispatch-ownership.md`. Unrecognised /
 /// empty values silently fall back to `runtime` so a typo cannot accidentally
 /// claim a security model the code does not implement.
 ///
-/// **Note:** this returns the *configured/requested* mode, not the
-/// *effective* one. This binary always launches `StdioHarness::spawn` for
-/// `sera-runtime`, so the effective mode is always `runtime` until the
-/// migration steps in ADR §4 land. Use [`effective_dispatch_mode_label`] for
-/// the value that describes what the running code actually does.
-fn dispatch_mode_label(raw: Option<&str>) -> &'static str {
+/// **This returns the operator request, not an active mode.** A return of
+/// `"gateway"` or `"embedded"` means the operator *asked for* that target;
+/// it does NOT mean the running binary owns dispatch in that process. This
+/// binary always launches `StdioHarness::spawn` for `sera-runtime`, so the
+/// effective mode is always `runtime` until the migration steps in ADR §4
+/// land. Callers that report what the running code actually does must use
+/// [`effective_dispatch_mode_label`] instead, and the boot log surfaces both
+/// values under distinct field names so an unimplemented target can never be
+/// mistaken for an active dispatch model.
+fn parse_configured_dispatch_mode(raw: Option<&str>) -> &'static str {
     match raw.map(str::trim) {
         Some("gateway") => "gateway",
         Some("embedded") => "embedded",
@@ -150,7 +154,7 @@ fn dispatch_mode_label(raw: Option<&str>) -> &'static str {
 
 fn configured_dispatch_mode_label() -> &'static str {
     let raw = std::env::var("SERA_DISPATCH_MODE").ok();
-    dispatch_mode_label(raw.as_deref())
+    parse_configured_dispatch_mode(raw.as_deref())
 }
 
 /// sera-y45a: the dispatch mode that actually applies to the running code.
@@ -4577,44 +4581,46 @@ mod tests {
         assert!(!wants_pgvector_backend(Some("redis"), Some("postgres://x")));
     }
 
-    // ── sera-y45a: dispatch_mode_label() ────────────────────────────────────
+    // ── sera-y45a: dispatch mode parsing & effective-mode reporting ─────────
     //
-    // The label is declarative: it surfaces which process owns tool dispatch
-    // in boot logs but does not change behaviour. `dispatch_mode_label`
-    // parses the operator-requested (configured) mode; `effective_dispatch_mode_label`
-    // reports what the running binary actually does. They diverge today
-    // because this binary always spawns `sera-runtime` via `StdioHarness`.
-    // Unrecognised configured values fail safe to `runtime` so a typo cannot
-    // accidentally claim a security model the code does not implement.
+    // `parse_configured_dispatch_mode` parses the operator-requested mode
+    // from `SERA_DISPATCH_MODE`; `effective_dispatch_mode_label` reports what
+    // the running binary actually does. They diverge today because this
+    // binary always spawns `sera-runtime` via `StdioHarness`, so the boot log
+    // must record them under distinct fields and never let an unimplemented
+    // target masquerade as an active dispatch model.
     // See docs/plan/decisions/2026-04-29-dispatch-ownership.md.
 
     #[test]
-    fn dispatch_mode_defaults_to_runtime_when_unset() {
-        assert_eq!(dispatch_mode_label(None), "runtime");
-        assert_eq!(dispatch_mode_label(Some("")), "runtime");
-        assert_eq!(dispatch_mode_label(Some("   ")), "runtime");
+    fn parse_configured_dispatch_mode_defaults_to_runtime_when_unset() {
+        assert_eq!(parse_configured_dispatch_mode(None), "runtime");
+        assert_eq!(parse_configured_dispatch_mode(Some("")), "runtime");
+        assert_eq!(parse_configured_dispatch_mode(Some("   ")), "runtime");
     }
 
     #[test]
-    fn dispatch_mode_recognises_canonical_values() {
-        assert_eq!(dispatch_mode_label(Some("runtime")), "runtime");
-        assert_eq!(dispatch_mode_label(Some("gateway")), "gateway");
-        assert_eq!(dispatch_mode_label(Some("embedded")), "embedded");
+    fn parse_configured_dispatch_mode_recognises_canonical_values() {
+        // Canonical *requests* — the parser echoes them back as the
+        // configured request. The boot log surfaces these only under
+        // `dispatch_mode_configured`, never as the active `dispatch_mode`.
+        assert_eq!(parse_configured_dispatch_mode(Some("runtime")), "runtime");
+        assert_eq!(parse_configured_dispatch_mode(Some("gateway")), "gateway");
+        assert_eq!(parse_configured_dispatch_mode(Some("embedded")), "embedded");
     }
 
     #[test]
-    fn dispatch_mode_trims_surrounding_whitespace() {
-        assert_eq!(dispatch_mode_label(Some("  gateway  ")), "gateway");
-        assert_eq!(dispatch_mode_label(Some("\tembedded\n")), "embedded");
+    fn parse_configured_dispatch_mode_trims_surrounding_whitespace() {
+        assert_eq!(parse_configured_dispatch_mode(Some("  gateway  ")), "gateway");
+        assert_eq!(parse_configured_dispatch_mode(Some("\tembedded\n")), "embedded");
     }
 
     #[test]
-    fn dispatch_mode_unknown_falls_back_to_runtime() {
+    fn parse_configured_dispatch_mode_unknown_falls_back_to_runtime() {
         // case-sensitive on purpose: env values are documented lowercase, and
         // accidental uppercase should not silently claim a different model.
-        assert_eq!(dispatch_mode_label(Some("RUNTIME")), "runtime");
-        assert_eq!(dispatch_mode_label(Some("Gateway")), "runtime");
-        assert_eq!(dispatch_mode_label(Some("foo")), "runtime");
+        assert_eq!(parse_configured_dispatch_mode(Some("RUNTIME")), "runtime");
+        assert_eq!(parse_configured_dispatch_mode(Some("Gateway")), "runtime");
+        assert_eq!(parse_configured_dispatch_mode(Some("foo")), "runtime");
     }
 
     #[test]
@@ -4629,16 +4635,38 @@ mod tests {
     }
 
     #[test]
-    fn effective_and_configured_diverge_for_target_modes() {
-        // Even when the operator requests gateway/embedded, the effective
-        // label must not echo the request. Boot logs report effective as
-        // `runtime` and surface the configured request separately.
-        assert_eq!(effective_dispatch_mode_label(), "runtime");
-        assert_ne!(dispatch_mode_label(Some("gateway")), effective_dispatch_mode_label());
-        assert_ne!(dispatch_mode_label(Some("embedded")), effective_dispatch_mode_label());
-        // Default and explicit `runtime` request agree with effective.
-        assert_eq!(dispatch_mode_label(Some("runtime")), effective_dispatch_mode_label());
-        assert_eq!(dispatch_mode_label(None), effective_dispatch_mode_label());
+    fn effective_dispatch_mode_never_echoes_unimplemented_request() {
+        // The boot log path uses `effective_dispatch_mode_label()` for the
+        // `dispatch_mode` field. For every value an operator can put in
+        // SERA_DISPATCH_MODE — including the not-yet-implemented `gateway`
+        // and `embedded` targets — the effective mode must remain `runtime`
+        // so the active label cannot claim a security model the code does
+        // not implement.
+        for requested in [
+            None,
+            Some("runtime"),
+            Some("gateway"),
+            Some("embedded"),
+            Some("Gateway"),
+            Some("foo"),
+            Some(""),
+        ] {
+            let configured = parse_configured_dispatch_mode(requested);
+            let effective = effective_dispatch_mode_label();
+            assert_eq!(
+                effective, "runtime",
+                "effective mode must be `runtime` until ADR §4 lands (request={requested:?})"
+            );
+            // Either the request agrees with the effective mode, or the
+            // boot log is responsible for surfacing the divergence under a
+            // distinct field — never as the active `dispatch_mode`.
+            if configured != effective {
+                assert!(
+                    matches!(configured, "gateway" | "embedded"),
+                    "only known migration targets may diverge; got {configured:?}"
+                );
+            }
+        }
     }
 
     fn test_manifests() -> ManifestSet {

--- a/rust/crates/sera-gateway/src/bin/sera.rs
+++ b/rust/crates/sera-gateway/src/bin/sera.rs
@@ -124,15 +124,21 @@ fn wants_pgvector_backend(backend_pref: Option<&str>, database_url: Option<&str>
     matches!(backend_pref, Some("pgvector")) || (backend_pref.is_none() && database_url.is_some())
 }
 
-/// sera-y45a: declares which process owns tool dispatch for the running gateway.
+/// sera-y45a: parses the operator-requested dispatch mode from the
+/// `SERA_DISPATCH_MODE` env var.
 ///
-/// `runtime` (default) = the `sera-runtime` child owns the LLM client, tool
-/// registry, capability gate, and dispatcher; the gateway audits `tool_call_*`
-/// events post-hoc. `gateway` and `embedded` are the migration targets — see
-/// `docs/plan/decisions/2026-04-29-dispatch-ownership.md`. This is a
-/// **declarative** marker only: the value is logged at boot so operators can
-/// see the active model. Changing it does not yet change which process
-/// dispatches tools.
+/// `runtime` (default) names the shipped MVS where the `sera-runtime` child
+/// owns the LLM client, tool registry, capability gate, and dispatcher.
+/// `gateway` and `embedded` are the migration targets — see
+/// `docs/plan/decisions/2026-04-29-dispatch-ownership.md`. Unrecognised /
+/// empty values silently fall back to `runtime` so a typo cannot accidentally
+/// claim a security model the code does not implement.
+///
+/// **Note:** this returns the *configured/requested* mode, not the
+/// *effective* one. This binary always launches `StdioHarness::spawn` for
+/// `sera-runtime`, so the effective mode is always `runtime` until the
+/// migration steps in ADR §4 land. Use [`effective_dispatch_mode_label`] for
+/// the value that describes what the running code actually does.
 fn dispatch_mode_label(raw: Option<&str>) -> &'static str {
     match raw.map(str::trim) {
         Some("gateway") => "gateway",
@@ -142,9 +148,23 @@ fn dispatch_mode_label(raw: Option<&str>) -> &'static str {
     }
 }
 
-fn current_dispatch_mode_label() -> &'static str {
+fn configured_dispatch_mode_label() -> &'static str {
     let raw = std::env::var("SERA_DISPATCH_MODE").ok();
     dispatch_mode_label(raw.as_deref())
+}
+
+/// sera-y45a: the dispatch mode that actually applies to the running code.
+///
+/// This binary always spawns `sera-runtime` via `StdioHarness::spawn`, so
+/// dispatch ownership is always `runtime` regardless of what
+/// `SERA_DISPATCH_MODE` requests. The boot log uses this as the truthful
+/// `dispatch_mode` field; the configured value is logged separately as
+/// `dispatch_mode_configured` so operators can still see what was asked for
+/// without the log claiming a security model the code does not implement.
+/// Future migration PRs (ADR §4 steps 2–4) will replace this constant with a
+/// real switch wired to the dispatcher selection.
+fn effective_dispatch_mode_label() -> &'static str {
+    "runtime"
 }
 
 // ── CLI ─────────────────────────────────────────────────────────────────────
@@ -3867,16 +3887,32 @@ async fn run_start(config: PathBuf, port: u16, local: bool) -> anyhow::Result<()
         exe_dir.join("sera-runtime").to_string_lossy().to_string()
     });
 
-    // sera-y45a: surface the active dispatch model in the boot log so
-    // operators can read which process owns tool dispatch without diving
-    // into source. The current MVS ships `runtime`; `gateway` and
-    // `embedded` are migration targets. See
+    // sera-y45a: surface the dispatch model in the boot log so operators can
+    // read which process owns tool dispatch without diving into source.
+    // `dispatch_mode` is the *effective* mode — what the running code
+    // actually does. `dispatch_mode_configured` is what the operator
+    // requested via SERA_DISPATCH_MODE. They diverge today because this
+    // binary always spawns `sera-runtime` via `StdioHarness`, so the
+    // effective mode is `runtime` regardless of the request. When the
+    // configured mode names a not-yet-implemented target (gateway/embedded),
+    // a warning is emitted so the log cannot be mistaken for an active
+    // gateway/embedded deployment. See
     // docs/plan/decisions/2026-04-29-dispatch-ownership.md.
-    let dispatch_mode = current_dispatch_mode_label();
+    let dispatch_mode = effective_dispatch_mode_label();
+    let dispatch_mode_configured = configured_dispatch_mode_label();
     tracing::info!(
         dispatch_mode = dispatch_mode,
+        dispatch_mode_configured = dispatch_mode_configured,
         "Tool dispatch ownership (sera-y45a)"
     );
+    if dispatch_mode_configured != dispatch_mode {
+        tracing::warn!(
+            dispatch_mode = dispatch_mode,
+            dispatch_mode_configured = dispatch_mode_configured,
+            "SERA_DISPATCH_MODE requests a not-yet-implemented dispatch mode; \
+             effective mode remains `runtime` until ADR §4 migration lands"
+        );
+    }
 
     let mut harnesses = std::collections::HashMap::new();
 
@@ -3965,14 +4001,19 @@ async fn run_start(config: PathBuf, port: u16, local: bool) -> anyhow::Result<()
         .await
         {
             Ok(supervisor) => {
-                // sera-y45a: include the dispatch_mode marker so per-agent
-                // boot logs answer "which process owns tool dispatch for
-                // this agent?" without operators correlating against the
-                // process-level line above.
+                // sera-y45a: include both the effective and configured
+                // dispatch_mode markers so per-agent boot logs answer "which
+                // process owns tool dispatch for this agent?" truthfully
+                // without operators correlating against the process-level
+                // line above. `dispatch_mode` reflects what the running code
+                // does (always `runtime` while the supervisor still spawns
+                // sera-runtime as a child); `dispatch_mode_configured`
+                // reflects the operator request.
                 tracing::info!(
                     agent = %agent_name,
                     model = %model,
                     dispatch_mode = dispatch_mode,
+                    dispatch_mode_configured = dispatch_mode_configured,
                     "Spawned runtime harness via supervisor (sera-ojp3)"
                 );
                 harnesses.insert(agent_name.to_string(), supervisor);
@@ -4539,10 +4580,12 @@ mod tests {
     // ── sera-y45a: dispatch_mode_label() ────────────────────────────────────
     //
     // The label is declarative: it surfaces which process owns tool dispatch
-    // in boot logs but does not change behaviour. The default is `runtime`
-    // (the shipped MVS); `gateway` and `embedded` are migration targets.
-    // Unrecognised values fail safe to `runtime` so a typo cannot accidentally
-    // claim a security model the code does not implement.
+    // in boot logs but does not change behaviour. `dispatch_mode_label`
+    // parses the operator-requested (configured) mode; `effective_dispatch_mode_label`
+    // reports what the running binary actually does. They diverge today
+    // because this binary always spawns `sera-runtime` via `StdioHarness`.
+    // Unrecognised configured values fail safe to `runtime` so a typo cannot
+    // accidentally claim a security model the code does not implement.
     // See docs/plan/decisions/2026-04-29-dispatch-ownership.md.
 
     #[test]
@@ -4572,6 +4615,30 @@ mod tests {
         assert_eq!(dispatch_mode_label(Some("RUNTIME")), "runtime");
         assert_eq!(dispatch_mode_label(Some("Gateway")), "runtime");
         assert_eq!(dispatch_mode_label(Some("foo")), "runtime");
+    }
+
+    #[test]
+    fn effective_dispatch_mode_is_runtime_until_migration() {
+        // This binary always launches StdioHarness::spawn for sera-runtime,
+        // so the effective mode is `runtime` regardless of the configured
+        // value. When ADR §4 step 2/3 lands, this test must be updated in
+        // lock-step with the dispatcher implementation — flipping it without
+        // moving real dispatch would re-introduce the very mismatch the
+        // ADR records.
+        assert_eq!(effective_dispatch_mode_label(), "runtime");
+    }
+
+    #[test]
+    fn effective_and_configured_diverge_for_target_modes() {
+        // Even when the operator requests gateway/embedded, the effective
+        // label must not echo the request. Boot logs report effective as
+        // `runtime` and surface the configured request separately.
+        assert_eq!(effective_dispatch_mode_label(), "runtime");
+        assert_ne!(dispatch_mode_label(Some("gateway")), effective_dispatch_mode_label());
+        assert_ne!(dispatch_mode_label(Some("embedded")), effective_dispatch_mode_label());
+        // Default and explicit `runtime` request agree with effective.
+        assert_eq!(dispatch_mode_label(Some("runtime")), effective_dispatch_mode_label());
+        assert_eq!(dispatch_mode_label(None), effective_dispatch_mode_label());
     }
 
     fn test_manifests() -> ManifestSet {


### PR DESCRIPTION
## Summary

- Records the dispatch-ownership ADR for `sera-y45a` at `docs/plan/decisions/2026-04-29-dispatch-ownership.md`. Today's MVS dispatches tools inside the `sera-runtime` child process, but `SPEC-gateway §1b`, `SPEC-runtime §1a`, `SPEC-tools §6`, and `ARCHITECTURE-ADDENDUM-2026-04-13 §3` assert the gateway owns dispatch + credentials + AuthZ + audit. The ADR names this as the canonical target and frames today's behaviour as a transitional `dispatch_mode=runtime` operating mode with an explicit migration gate.
- Annotates `SPEC-gateway §1b/§1c/§13a`, `SPEC-runtime §1a/§3`, `SPEC-tools §6` with one-line ADR pointers so the specs no longer silently contradict working MVS behaviour.
- Adds a declarative `dispatch_mode={runtime,gateway,embedded}` log line per process and per agent at gateway boot, sourced from `SERA_DISPATCH_MODE` (default: `runtime`). Unrecognised values fail safe to `runtime`. **The label is declarative only** — this PR does not change which process executes tools.

## Scope (what this PR does NOT do)

- No runtime/gateway tool-dispatch migration.
- No architecture rewrite.
- No changes outside the spec annotations, the ADR, and the boot-log line.

The migration itself is sequenced in §4 of the ADR as follow-up beads (embedded-library entry point + gateway-side LLM proxy).

## Acceptance check (from `bd show sera-y45a` + scope brief)

- [x] One canonical doc section states current MVS dispatch mode, target mode, why temporary, and migration gate (`docs/plan/decisions/2026-04-29-dispatch-ownership.md`).
- [x] Specs no longer silently contradict working MVS behaviour (annotations on `SPEC-gateway §1b/§1c/§13a`, `SPEC-runtime §1a/§3`, `SPEC-tools §6`).
- [x] Gateway boot log exposes `dispatch_mode={runtime,gateway,embedded}` per process and per agent.
- [x] Tests verify the helper (`dispatch_mode_label`): default, canonical values, whitespace trimming, unknown-value fallback.
- [x] No new beads created — this PR documents the existing `sera-y45a` scope; the embedded-library + LLM-proxy migration beads will be filed once the ADR direction is confirmed by the owner.

## Test plan

- [x] `cargo test -p sera-gateway` — **383 passed**, 0 failed (4 new `dispatch_mode_*` unit tests added).
- [x] `cargo test -p sera-runtime` — **584 passed**, 0 failed.
- [x] `cargo check --workspace` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)