### PR TITLE
feat(sera-types,sera-config): add EgressEndpoint + AgentTemplate.egress (sera-xgb0)

### DIFF
--- a/rust/crates/sera-config/src/agent_template_loader.rs
+++ b/rust/crates/sera-config/src/agent_template_loader.rs
@@ -1,0 +1,205 @@
+//! Loader for `AgentTemplate` YAML files (`templates/*.yaml`).
+//!
+//! Wraps `serde_yaml::from_str::<AgentTemplate>` and runs the egress
+//! invariant check from
+//! `sera_types::manifest::AgentTemplate::validate_and_normalize_egress`:
+//! sandboxed templates get an implicit `InferenceLocal` baseline, and
+//! sandboxed templates that explicitly drop `InferenceLocal` from
+//! `egress.allowed` (without `mode = Disabled`) are rejected.
+//!
+//! Exists for `sera-eq0m` / `sera-xgb0`: the canonical entry point for
+//! callers who want their YAML parse to obey the egress contract without
+//! having to remember the validation step.
+
+use std::path::Path;
+
+use sera_types::manifest::{AgentTemplate, EgressManifestError};
+
+/// Errors raised while loading an `AgentTemplate` YAML file.
+#[derive(Debug, thiserror::Error)]
+pub enum AgentTemplateLoadError {
+    #[error("failed to read agent template file '{path}': {source}")]
+    IoError {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("YAML parse error in '{path}': {source}")]
+    ParseError {
+        path: String,
+        #[source]
+        source: serde_yaml::Error,
+    },
+    #[error("egress validation failed: {source}")]
+    EgressError {
+        #[from]
+        source: EgressManifestError,
+    },
+}
+
+/// Parse a YAML string as a single `AgentTemplate` and apply the
+/// sandboxed-egress invariant. Sandboxed templates without an `egress`
+/// block come back with `allowed = [InferenceLocal]` and `mode = Strict`.
+pub fn parse_agent_template(yaml: &str) -> Result<AgentTemplate, AgentTemplateLoadError> {
+    let mut template: AgentTemplate =
+        serde_yaml::from_str(yaml).map_err(|source| AgentTemplateLoadError::ParseError {
+            path: "<inline>".to_string(),
+            source,
+        })?;
+    template.validate_and_normalize_egress()?;
+    Ok(template)
+}
+
+/// Read an `AgentTemplate` YAML file from disk and apply the
+/// sandboxed-egress invariant.
+pub fn load_agent_template_file(path: &Path) -> Result<AgentTemplate, AgentTemplateLoadError> {
+    let content =
+        std::fs::read_to_string(path).map_err(|source| AgentTemplateLoadError::IoError {
+            path: path.display().to_string(),
+            source,
+        })?;
+    let mut template: AgentTemplate = serde_yaml::from_str(&content).map_err(|source| {
+        AgentTemplateLoadError::ParseError {
+            path: path.display().to_string(),
+            source,
+        }
+    })?;
+    template.validate_and_normalize_egress()?;
+    Ok(template)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sera_types::sandbox::{EgressEndpoint, EgressMode};
+
+    const NON_SANDBOXED: &str = r#"
+apiVersion: sera/v1
+kind: AgentTemplate
+metadata:
+  name: plain
+spec:
+  model:
+    provider: openai
+    model: gpt-4o
+"#;
+
+    const SANDBOXED_NO_EGRESS: &str = r#"
+apiVersion: sera/v1
+kind: AgentTemplate
+metadata:
+  name: sandboxed-default
+spec:
+  sandboxBoundary: tier-2
+  sandbox:
+    image: sera-byoh:latest
+"#;
+
+    const SANDBOXED_DROPS_INFERENCE_LOCAL: &str = r#"
+apiVersion: sera/v1
+kind: AgentTemplate
+metadata:
+  name: sandboxed-bad
+spec:
+  sandboxBoundary: tier-2
+  egress:
+    mode: strict
+    allowed:
+      - type: domain
+        name: api.github.com
+"#;
+
+    const SANDBOXED_DISABLED: &str = r#"
+apiVersion: sera/v1
+kind: AgentTemplate
+metadata:
+  name: sandboxed-disabled
+spec:
+  sandboxBoundary: tier-3
+  egress:
+    mode: disabled
+    allowed: []
+"#;
+
+    const SANDBOXED_AUDIT_ONLY_OK: &str = r#"
+apiVersion: sera/v1
+kind: AgentTemplate
+metadata:
+  name: sandboxed-audit
+spec:
+  sandboxBoundary: tier-2
+  egress:
+    mode: audit_only
+    allowed:
+      - type: inference_local
+      - type: domain
+        name: api.openai.com
+"#;
+
+    #[test]
+    fn parse_non_sandboxed_template_leaves_egress_none() {
+        let template = parse_agent_template(NON_SANDBOXED).unwrap();
+        assert!(template.spec.egress.is_none());
+    }
+
+    #[test]
+    fn parse_sandboxed_template_inserts_inference_local_baseline() {
+        let template = parse_agent_template(SANDBOXED_NO_EGRESS).unwrap();
+        let egress = template.spec.egress.expect("baseline must be inserted");
+        assert_eq!(egress.mode, EgressMode::Strict);
+        assert_eq!(egress.allowed.len(), 1);
+        assert!(matches!(egress.allowed[0], EgressEndpoint::InferenceLocal));
+    }
+
+    #[test]
+    fn parse_sandboxed_template_rejects_dropped_inference_local() {
+        let err = parse_agent_template(SANDBOXED_DROPS_INFERENCE_LOCAL).unwrap_err();
+        assert!(
+            matches!(err, AgentTemplateLoadError::EgressError { .. }),
+            "expected EgressError, got: {err:?}",
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.contains("InferenceLocal"),
+            "error must mention the missing endpoint; got: {msg}",
+        );
+    }
+
+    #[test]
+    fn parse_sandboxed_template_with_disabled_mode_skips_baseline_check() {
+        let template = parse_agent_template(SANDBOXED_DISABLED).unwrap();
+        let egress = template.spec.egress.unwrap();
+        assert_eq!(egress.mode, EgressMode::Disabled);
+        assert!(egress.allowed.is_empty());
+    }
+
+    #[test]
+    fn parse_sandboxed_template_audit_only_with_inference_local_passes() {
+        let template = parse_agent_template(SANDBOXED_AUDIT_ONLY_OK).unwrap();
+        let egress = template.spec.egress.unwrap();
+        assert_eq!(egress.mode, EgressMode::AuditOnly);
+        assert!(egress.allows_inference_local());
+        assert_eq!(egress.allowed.len(), 2);
+    }
+
+    #[test]
+    fn load_agent_template_file_round_trips_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("template.yaml");
+        std::fs::write(&path, SANDBOXED_NO_EGRESS).unwrap();
+        let template = load_agent_template_file(&path).unwrap();
+        assert!(template.spec.egress.unwrap().allows_inference_local());
+    }
+
+    #[test]
+    fn load_agent_template_file_missing_returns_io_error() {
+        let err = load_agent_template_file(Path::new("/nonexistent/template.yaml")).unwrap_err();
+        assert!(matches!(err, AgentTemplateLoadError::IoError { .. }));
+    }
+
+    #[test]
+    fn parse_agent_template_invalid_yaml_returns_parse_error() {
+        let err = parse_agent_template("this is: [invalid").unwrap_err();
+        assert!(matches!(err, AgentTemplateLoadError::ParseError { .. }));
+    }
+}

--- a/rust/crates/sera-config/src/lib.rs
+++ b/rust/crates/sera-config/src/lib.rs
@@ -4,6 +4,7 @@
 //! - `SeraConfig`: BYOH agent container config (env vars per BYOH contract)
 //! - `CoreConfig`: sera-core server config (env vars + providers.json)
 
+pub mod agent_template_loader;
 pub mod capability_registry;
 pub mod config_root;
 pub mod core_config;

--- a/rust/crates/sera-types/src/manifest.rs
+++ b/rust/crates/sera-types/src/manifest.rs
@@ -6,6 +6,7 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+use crate::sandbox::{EgressEndpoint, EgressManifest, EgressMode};
 use crate::LifecycleMode;
 
 /// Top-level AgentTemplate YAML document.
@@ -73,6 +74,16 @@ pub struct TemplateSpec {
     pub context_files: Option<Vec<SpecContextFile>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sandbox: Option<SpecSandbox>,
+    /// Declared egress allow-list for sandboxed agents.
+    ///
+    /// When this template is sandboxed (`sandbox` or `sandbox_boundary` is
+    /// set) and `mode != Disabled`, [`EgressEndpoint::InferenceLocal`] must
+    /// be present in `allowed` — `validate_and_normalize_egress` either
+    /// inserts it as a baseline (when `egress` is absent) or rejects the
+    /// manifest (when `egress` is present but drops it). See `sera-eq0m`
+    /// and `sera-xgb0`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub egress: Option<EgressManifest>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -178,6 +189,68 @@ pub struct SpecContextFile {
     pub max_tokens: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub priority: Option<String>,
+}
+
+/// Errors raised by [`AgentTemplate::validate_and_normalize_egress`].
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum EgressManifestError {
+    /// Sandboxed manifest declared an `egress` block but dropped
+    /// `InferenceLocal` from `allowed` while `mode != Disabled`.
+    #[error(
+        "sandboxed AgentTemplate '{name}' must allow EgressEndpoint::InferenceLocal \
+         (the canonical inference.local proxy) unless egress.mode is 'disabled'"
+    )]
+    MissingInferenceLocalBaseline { name: String },
+}
+
+impl AgentTemplate {
+    /// Returns true when this template runs in any sandbox — either an
+    /// explicit `spec.sandbox` block or a `spec.sandboxBoundary` reference.
+    pub fn is_sandboxed(&self) -> bool {
+        self.spec.sandbox.is_some() || self.spec.sandbox_boundary.is_some()
+    }
+
+    /// Apply the implicit `InferenceLocal` baseline to a sandboxed template
+    /// and reject manifests that opt out of it without `mode = Disabled`.
+    ///
+    /// Behaviour:
+    ///
+    /// - Non-sandboxed template: no-op. `egress` is left untouched.
+    /// - Sandboxed template with no `egress`: an `EgressManifest` with
+    ///   `mode = Strict` and `allowed = [InferenceLocal]` is inserted.
+    /// - Sandboxed template with `egress.mode = Disabled`: left untouched
+    ///   (compliance opt-out — `InferenceLocal` is not required).
+    /// - Sandboxed template with `egress` and `mode != Disabled`: must
+    ///   already include `InferenceLocal` in `allowed`, or
+    ///   [`EgressManifestError::MissingInferenceLocalBaseline`] is
+    ///   returned. The `allowed` list is left exactly as the operator
+    ///   declared it (no silent re-adds beyond the absent-egress case).
+    pub fn validate_and_normalize_egress(&mut self) -> Result<(), EgressManifestError> {
+        if !self.is_sandboxed() {
+            return Ok(());
+        }
+
+        match self.spec.egress.as_mut() {
+            None => {
+                self.spec.egress = Some(EgressManifest {
+                    allowed: vec![EgressEndpoint::InferenceLocal],
+                    mode: EgressMode::Strict,
+                });
+                Ok(())
+            }
+            Some(manifest) => {
+                if manifest.mode == EgressMode::Disabled {
+                    return Ok(());
+                }
+                if manifest.allows_inference_local() {
+                    return Ok(());
+                }
+                Err(EgressManifestError::MissingInferenceLocalBaseline {
+                    name: self.metadata.name.clone(),
+                })
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -463,6 +536,189 @@ spec:
         assert_eq!(fallback[0].name, "gpt-4o");
         assert_eq!(fallback[0].max_complexity, Some(2));
         assert!(fallback[1].max_complexity.is_none());
+    }
+
+    fn make_minimal_template(name: &str) -> AgentTemplate {
+        AgentTemplate {
+            api_version: "sera/v1".to_string(),
+            kind: "AgentTemplate".to_string(),
+            metadata: TemplateMetadata {
+                name: name.to_string(),
+                display_name: None,
+                icon: None,
+                builtin: false,
+                category: None,
+                description: None,
+            },
+            spec: TemplateSpec {
+                identity: None,
+                model: None,
+                sandbox_boundary: None,
+                policy_ref: None,
+                lifecycle: None,
+                capabilities: None,
+                skills: None,
+                skill_packages: None,
+                tools: None,
+                subagents: None,
+                resources: None,
+                workspace: None,
+                memory: None,
+                schedules: None,
+                context_files: None,
+                sandbox: None,
+                egress: None,
+            },
+        }
+    }
+
+    #[test]
+    fn validate_egress_no_sandbox_is_noop() {
+        let mut t = make_minimal_template("plain");
+        assert!(!t.is_sandboxed());
+        assert!(t.validate_and_normalize_egress().is_ok());
+        assert!(t.spec.egress.is_none());
+    }
+
+    #[test]
+    fn validate_egress_sandboxed_defaults_to_inference_local_baseline() {
+        let mut t = make_minimal_template("sandboxed");
+        t.spec.sandbox = Some(SpecSandbox {
+            image: Some("img".to_string()),
+            entrypoint: None,
+            command: None,
+            chat_port: None,
+        });
+
+        assert!(t.is_sandboxed());
+        assert!(t.spec.egress.is_none());
+
+        t.validate_and_normalize_egress().unwrap();
+
+        let egress = t.spec.egress.as_ref().expect("baseline must be inserted");
+        assert_eq!(egress.mode, EgressMode::Strict);
+        assert!(egress.allows_inference_local());
+        assert_eq!(egress.allowed.len(), 1);
+    }
+
+    #[test]
+    fn validate_egress_sandbox_boundary_only_also_triggers_baseline() {
+        let mut t = make_minimal_template("boundary-only");
+        t.spec.sandbox_boundary = Some("tier-2".to_string());
+        t.validate_and_normalize_egress().unwrap();
+        assert!(
+            t.spec
+                .egress
+                .as_ref()
+                .unwrap()
+                .allows_inference_local()
+        );
+    }
+
+    #[test]
+    fn validate_egress_existing_manifest_with_inference_local_is_preserved() {
+        let mut t = make_minimal_template("explicit");
+        t.spec.sandbox_boundary = Some("tier-2".to_string());
+        t.spec.egress = Some(EgressManifest {
+            allowed: vec![
+                EgressEndpoint::InferenceLocal,
+                EgressEndpoint::Domain {
+                    name: "api.github.com".to_string(),
+                },
+            ],
+            mode: EgressMode::Strict,
+        });
+
+        let original = t.spec.egress.clone();
+        t.validate_and_normalize_egress().unwrap();
+        assert_eq!(t.spec.egress, original, "operator-declared list must not be mutated");
+    }
+
+    #[test]
+    fn validate_egress_rejects_sandboxed_manifest_missing_inference_local() {
+        let mut t = make_minimal_template("strip-inference");
+        t.spec.sandbox = Some(SpecSandbox {
+            image: Some("img".to_string()),
+            entrypoint: None,
+            command: None,
+            chat_port: None,
+        });
+        t.spec.egress = Some(EgressManifest {
+            allowed: vec![EgressEndpoint::Domain {
+                name: "api.github.com".to_string(),
+            }],
+            mode: EgressMode::Strict,
+        });
+
+        let err = t.validate_and_normalize_egress().unwrap_err();
+        assert_eq!(
+            err,
+            EgressManifestError::MissingInferenceLocalBaseline {
+                name: "strip-inference".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn validate_egress_audit_only_still_requires_inference_local() {
+        let mut t = make_minimal_template("audit-only-no-inference");
+        t.spec.sandbox_boundary = Some("tier-1".to_string());
+        t.spec.egress = Some(EgressManifest {
+            allowed: vec![EgressEndpoint::Cidr {
+                range: "10.0.0.0/8".to_string(),
+            }],
+            mode: EgressMode::AuditOnly,
+        });
+
+        assert!(t.validate_and_normalize_egress().is_err());
+    }
+
+    #[test]
+    fn validate_egress_disabled_mode_allows_dropping_inference_local() {
+        let mut t = make_minimal_template("opted-out");
+        t.spec.sandbox_boundary = Some("tier-3".to_string());
+        t.spec.egress = Some(EgressManifest {
+            allowed: vec![],
+            mode: EgressMode::Disabled,
+        });
+
+        t.validate_and_normalize_egress().unwrap();
+
+        let egress = t.spec.egress.as_ref().unwrap();
+        assert_eq!(egress.mode, EgressMode::Disabled);
+        assert!(egress.allowed.is_empty());
+    }
+
+    #[test]
+    fn template_egress_field_is_omitted_when_none_for_backwards_compat() {
+        let t = make_minimal_template("plain");
+        let json = serde_json::to_string(&t).unwrap();
+        assert!(!json.contains("egress"));
+    }
+
+    #[test]
+    fn template_with_egress_yaml_parses() {
+        let yaml = r#"
+apiVersion: sera/v1
+kind: AgentTemplate
+metadata:
+  name: with-egress
+spec:
+  sandboxBoundary: tier-2
+  egress:
+    mode: audit_only
+    allowed:
+      - type: inference_local
+      - type: domain
+        name: api.github.com
+      - type: cidr
+        range: 10.0.0.0/8
+"#;
+        let template: AgentTemplate = serde_yaml::from_str(yaml).unwrap();
+        let egress = template.spec.egress.as_ref().unwrap();
+        assert_eq!(egress.mode, EgressMode::AuditOnly);
+        assert_eq!(egress.allowed.len(), 3);
+        assert!(egress.allows_inference_local());
     }
 
     #[test]

--- a/rust/crates/sera-types/src/sandbox.rs
+++ b/rust/crates/sera-types/src/sandbox.rs
@@ -4,6 +4,69 @@ use serde::{Deserialize, Serialize};
 
 use crate::LifecycleMode;
 
+/// Declared egress endpoint for a sandboxed agent.
+///
+/// Lives in `sera-types` (rather than `sera-tools::sandbox::policy`) so the
+/// gateway, manifest layer, and runtime can all consume it without depending
+/// on `sera-tools`. Mirrors `NetworkEndpoint` from
+/// `sera-tools/src/sandbox/policy.rs`; the two enums must stay aligned.
+///
+/// `InferenceLocal` is the canonical default — it names the gateway-side
+/// `inference.local:443` proxy that sandboxed agents must use to reach any
+/// upstream LLM provider. See `sera-eq0m` and the egress scout report at
+/// `artifacts/reports/research/eq0m-egress-restriction-scout-2026-04-30.md`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum EgressEndpoint {
+    /// The gateway-managed `inference.local` LLM proxy. Always implicitly
+    /// allowed for sandboxed agents unless egress is explicitly disabled.
+    InferenceLocal,
+    /// A named DNS domain, e.g. `api.github.com`.
+    Domain { name: String },
+    /// A CIDR range, e.g. `10.0.0.0/8`.
+    Cidr { range: String },
+}
+
+/// Egress enforcement mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EgressMode {
+    /// Implicit-deny. Anything not in `allowed` is blocked at enforcement
+    /// time. The compliance posture.
+    #[default]
+    Strict,
+    /// Log violations but do not block. Used as a migration ramp before
+    /// flipping to `Strict`.
+    AuditOnly,
+    /// Egress restriction is opted out entirely. The agent runs without an
+    /// `InferenceLocal` baseline and may dial anywhere. Reserved for
+    /// non-sandboxed and dev-mode flows.
+    Disabled,
+}
+
+/// The egress manifest block declared on an `AgentTemplate.spec.egress`.
+///
+/// Implicit-deny: only endpoints in `allowed` are permitted (subject to
+/// `mode`). Sandboxed manifests must include [`EgressEndpoint::InferenceLocal`]
+/// in `allowed` unless `mode = Disabled` — this invariant is enforced by
+/// `AgentTemplate::validate_and_normalize_egress`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EgressManifest {
+    #[serde(default)]
+    pub allowed: Vec<EgressEndpoint>,
+    #[serde(default)]
+    pub mode: EgressMode,
+}
+
+impl EgressManifest {
+    /// True iff `allowed` already contains `InferenceLocal`.
+    pub fn allows_inference_local(&self) -> bool {
+        self.allowed
+            .iter()
+            .any(|e| matches!(e, EgressEndpoint::InferenceLocal))
+    }
+}
+
 /// A read-only source bind-mount for agent containers.
 /// Separates operator-provided reference material from agent-generated knowledge.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -226,6 +289,120 @@ mod tests {
         let parsed: SandboxInfo = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.sources.len(), 1);
         assert_eq!(parsed.sources[0].host_path, "/host/ref");
+    }
+
+    #[test]
+    fn egress_endpoint_inference_local_roundtrip() {
+        let endpoint = EgressEndpoint::InferenceLocal;
+        let json = serde_json::to_string(&endpoint).unwrap();
+        assert_eq!(json, r#"{"type":"inference_local"}"#);
+        let parsed: EgressEndpoint = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, EgressEndpoint::InferenceLocal);
+    }
+
+    #[test]
+    fn egress_endpoint_domain_roundtrip() {
+        let endpoint = EgressEndpoint::Domain {
+            name: "api.github.com".to_string(),
+        };
+        let json = serde_json::to_string(&endpoint).unwrap();
+        let parsed: EgressEndpoint = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, endpoint);
+        assert!(json.contains(r#""type":"domain""#));
+        assert!(json.contains(r#""name":"api.github.com""#));
+    }
+
+    #[test]
+    fn egress_endpoint_cidr_roundtrip() {
+        let endpoint = EgressEndpoint::Cidr {
+            range: "10.0.0.0/8".to_string(),
+        };
+        let json = serde_json::to_string(&endpoint).unwrap();
+        let parsed: EgressEndpoint = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, endpoint);
+        assert!(json.contains(r#""type":"cidr""#));
+        assert!(json.contains(r#""range":"10.0.0.0/8""#));
+    }
+
+    #[test]
+    fn egress_mode_default_is_strict() {
+        assert_eq!(EgressMode::default(), EgressMode::Strict);
+    }
+
+    #[test]
+    fn egress_mode_serializes_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&EgressMode::Strict).unwrap(),
+            "\"strict\"",
+        );
+        assert_eq!(
+            serde_json::to_string(&EgressMode::AuditOnly).unwrap(),
+            "\"audit_only\"",
+        );
+        assert_eq!(
+            serde_json::to_string(&EgressMode::Disabled).unwrap(),
+            "\"disabled\"",
+        );
+    }
+
+    #[test]
+    fn egress_mode_all_roundtrip() {
+        for mode in [EgressMode::Strict, EgressMode::AuditOnly, EgressMode::Disabled] {
+            let json = serde_json::to_string(&mode).unwrap();
+            let parsed: EgressMode = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, mode);
+        }
+    }
+
+    #[test]
+    fn egress_manifest_default_is_strict_with_no_allowed() {
+        let m = EgressManifest::default();
+        assert!(m.allowed.is_empty());
+        assert_eq!(m.mode, EgressMode::Strict);
+        assert!(!m.allows_inference_local());
+    }
+
+    #[test]
+    fn egress_manifest_full_roundtrip() {
+        let m = EgressManifest {
+            allowed: vec![
+                EgressEndpoint::InferenceLocal,
+                EgressEndpoint::Domain {
+                    name: "api.github.com".to_string(),
+                },
+                EgressEndpoint::Cidr {
+                    range: "10.0.0.0/8".to_string(),
+                },
+            ],
+            mode: EgressMode::AuditOnly,
+        };
+        let json = serde_json::to_string(&m).unwrap();
+        let parsed: EgressManifest = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, m);
+        assert!(parsed.allows_inference_local());
+    }
+
+    #[test]
+    fn egress_manifest_omitted_fields_default() {
+        let parsed: EgressManifest = serde_json::from_str("{}").unwrap();
+        assert_eq!(parsed.mode, EgressMode::Strict);
+        assert!(parsed.allowed.is_empty());
+    }
+
+    #[test]
+    fn egress_manifest_allows_inference_local_detects_presence() {
+        let with = EgressManifest {
+            allowed: vec![EgressEndpoint::InferenceLocal],
+            mode: EgressMode::Strict,
+        };
+        let without = EgressManifest {
+            allowed: vec![EgressEndpoint::Domain {
+                name: "x".to_string(),
+            }],
+            mode: EgressMode::Strict,
+        };
+        assert!(with.allows_inference_local());
+        assert!(!without.allows_inference_local());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Schema prerequisite for `sera-eq0m` (mandatory egress restriction for BYOH harness sandboxes). Introduces the egress vocabulary that the gateway proxy, manifest layer, and runtime will share once enforcement lands.

- **`sera-types::sandbox`** — new types:
  - `EgressEndpoint::{InferenceLocal, Domain { name }, Cidr { range }}` (tagged `type` enum, snake_case).
  - `EgressMode::{Strict (default), AuditOnly, Disabled}`.
  - `EgressManifest { allowed, mode }` with `allows_inference_local()` helper.
- **`sera-types::manifest`** — optional `spec.egress` on `TemplateSpec`, plus `AgentTemplate::validate_and_normalize_egress()` which:
  - is a no-op for non-sandboxed templates,
  - inserts `allowed = [InferenceLocal], mode = Strict` baseline when a sandboxed template omits `egress` entirely,
  - leaves `mode = Disabled` opt-outs alone (compliance off-ramp),
  - rejects sandboxed manifests that drop `InferenceLocal` from `allowed` while `mode != Disabled`.
- **`sera-config::agent_template_loader`** — new module wrapping the YAML parse with the egress invariant so callers cannot forget the validation step.

Lives in `sera-types` rather than `sera-tools` so the gateway and manifest layer can both consume it without depending on `sera-tools`. Mirrors `NetworkEndpoint` from `sera-tools/src/sandbox/policy.rs`; the two enums are intentionally aligned and must stay in sync.

Backwards compatible: `egress` is `Option`, omitted from serialized output for existing templates. **No runtime behaviour change** — enforcement lands in `sera-eq0m` PR B (gateway proxy) and PR C (Docker sandbox network policy).

Coordinates with `sera-pcvp`: the proposed `RegisterOp.declared_egress: Vec<EgressEndpoint>` will reuse this exact enum. Field naming is intentionally aligned per the `eq0m-egress-restriction-scout` report §6.

Bead: `sera-xgb0` (P2). Referenced by `sera-eq0m` (P1) and `sera-kg3g` (P2).

## Test plan

- [x] `cargo test -p sera-types` — 363 tests pass (including new sandbox + manifest cases)
- [x] `cargo test -p sera-config` — 116 tests pass (including 8 new `agent_template_loader` cases)
- [x] `cargo check --workspace` — clean
- [x] `cargo clippy -p sera-types -p sera-config --tests -- -D warnings` — clean
- [x] Serde roundtrip covered for `InferenceLocal`, `Domain`, `Cidr`
- [x] Serde roundtrip covered for `Strict`, `AuditOnly`, `Disabled`
- [x] Sandboxed manifest gets `InferenceLocal` baseline by default
- [x] Sandboxed manifest dropping `InferenceLocal` is rejected (Strict and AuditOnly)
- [x] `mode = Disabled` is the documented opt-out path
- [x] Non-sandboxed manifest: validator is a no-op (no surprise mutations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)