### PR TITLE
feat(sera-gateway): add embedded runtime transport (sera-ve9x)

### DIFF
--- a/rust/crates/sera-gateway/src/bin/sera.rs
+++ b/rust/crates/sera-gateway/src/bin/sera.rs
@@ -55,6 +55,7 @@ use sera_gateway::admin::{
 };
 use sera_gateway::agent_transport::{AgentTurnTransport, ToolEvent, TurnEvents, UsageInfo};
 use sera_gateway::capability_enforcement::{CapabilityRegistry, PolicyDenial};
+use sera_gateway::embedded_transport::EmbeddedRuntimeTransport;
 use sera_gateway::hitl_gateway::{
     HitlAppState, InMemoryTicketStore, TicketStore, resolve_approval_routing, resolve_hitl_mode,
 };
@@ -125,6 +126,132 @@ fn wants_pgvector_backend(backend_pref: Option<&str>, database_url: Option<&str>
     matches!(backend_pref, Some("pgvector")) || (backend_pref.is_none() && database_url.is_some())
 }
 
+/// sera-ve9x: build an in-process [`AgentTurnTransport`] backed by the
+/// gateway-bundled `DefaultRuntime` for one agent.
+///
+/// Selected when `SERA_DISPATCH_MODE=embedded`. Skips spawning a
+/// `sera-runtime --ndjson` child and avoids mutating the gateway process
+/// env (in particular: `LLM_API_KEY` is passed through `RuntimeConfig` only,
+/// so the key never enters `/proc/<gateway-pid>/environ`).
+///
+/// The capability registry is loaded with the same fail-closed semantics as
+/// the runtime binary's `load_capability_registry` (sera-eo71): a missing /
+/// unresolved `policy_ref` aborts construction so the agent is skipped
+/// rather than silently running unconstrained.
+fn build_embedded_transport(
+    agent_name: &str,
+    agent_spec: &AgentSpec,
+    base_url: &str,
+    model: &str,
+    api_key_val: &str,
+) -> anyhow::Result<Arc<dyn AgentTurnTransport>> {
+    use sera_runtime::config::RuntimeConfig;
+    use sera_runtime::context_engine::pipeline::ContextPipeline;
+    use sera_runtime::default_runtime::DefaultRuntime;
+    use sera_runtime::tools::TraitToolRegistry;
+    use sera_runtime::tools::dispatcher::RegistryDispatcher;
+    use sera_runtime::tools::filter::ToolNameFilter;
+
+    // Start from gateway-process env defaults (max_tokens, semantic_*,
+    // tool_authz_*, thinking_level) and override the per-agent fields
+    // explicitly. `llm_api_key` is in-memory; we never call
+    // `std::env::set_var("LLM_API_KEY", …)`, which closes a
+    // `/proc/<gateway-pid>/environ` exposure window.
+    let mut runtime_config = RuntimeConfig::from_env();
+    runtime_config.llm_base_url = base_url.to_string();
+    runtime_config.llm_model = model.to_string();
+    runtime_config.llm_api_key = api_key_val.to_string();
+    runtime_config.agent_id = agent_name.to_string();
+    runtime_config.lifecycle_mode = "task".to_string();
+    runtime_config.chat_port = 0;
+
+    // sera-eo71: fail-closed capability registry load (mirrors the runtime
+    // binary's `load_capability_registry`). The gateway's
+    // `/admin/policies/reload` endpoint cannot yet propagate to embedded
+    // transports — known parity caveat with the stdio child path, where the
+    // child also loads the registry once on spawn.
+    let policies_dir = sera_config::CapabilityRegistry::resolve_policies_dir();
+    let policy_ref = agent_spec
+        .policy_ref
+        .as_deref()
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+    let bindings = vec![(agent_name.to_string(), policy_ref.clone())];
+    let capability_registry = sera_config::CapabilityRegistry::load_and_bind(
+        &policies_dir,
+        bindings,
+    )
+    .map_err(|e| {
+        anyhow::anyhow!(
+            "embedded: failed to load capability registry for agent {agent_name}: {e}"
+        )
+    })?;
+    tracing::info!(
+        agent = %agent_name,
+        policy_ref = ?policy_ref,
+        loaded_policies = capability_registry.policy_count(),
+        "Embedded capability registry loaded (sera-eo71)"
+    );
+    let capability_registry = Arc::new(capability_registry);
+
+    // sera-hwny: tool schema filter from the agent manifest's allow list.
+    // Deny is read from the gateway process env directly — no env mutation
+    // needed because `ToolNameFilter::from_globs` accepts explicit lists.
+    let tools_allow: Vec<String> = agent_spec
+        .tools
+        .as_ref()
+        .map(|t| t.allow.clone())
+        .unwrap_or_default();
+    let tools_deny: Vec<String> = std::env::var("SERA_AGENT_TOOLS_DENY")
+        .ok()
+        .map(|raw| {
+            raw.split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect()
+        })
+        .unwrap_or_default();
+    let tool_filter = ToolNameFilter::from_globs(tools_allow, tools_deny);
+
+    // sera-a1u: per-agent DelegationBus, mirroring the runtime binary path.
+    let delegation_bus = sera_runtime::delegation_bus::DelegationBus::new();
+    let registry = TraitToolRegistry::with_builtins_and_authz(runtime_config.tool_authz_enabled)
+        .with_delegation(delegation_bus);
+    let registry = Arc::new(registry);
+
+    let runtime_defs = registry.definitions();
+    let filtered = tool_filter.filter_definitions(runtime_defs);
+    let tool_defs: Vec<sera_types::tool::ToolDefinition> = filtered
+        .iter()
+        .filter_map(|d| {
+            let value = serde_json::to_value(d).ok()?;
+            serde_json::from_value(value).ok()
+        })
+        .collect();
+
+    let dispatcher = RegistryDispatcher::new(Arc::clone(&registry))
+        .with_capability_registry(Arc::clone(&capability_registry), agent_name.to_string());
+
+    let authz_provider = sera_runtime::authz_builder::build_provider_from_config(&runtime_config);
+    let permissive_gate = std::env::var("SERA_ALLOW_MISSING_CONSTITUTIONAL_GATE")
+        .map(|v| v.eq_ignore_ascii_case("true") || v == "1")
+        .unwrap_or(false);
+
+    let context_engine = Box::new(ContextPipeline::new());
+    let llm_client = Box::new(sera_runtime::llm_client::build_from_config(&runtime_config));
+    let runtime = DefaultRuntime::new(context_engine)
+        .with_llm(llm_client)
+        .with_tool_dispatcher(Box::new(dispatcher))
+        .with_authz_provider(authz_provider)
+        .with_allow_missing_constitutional_gate(permissive_gate);
+
+    Ok(Arc::new(EmbeddedRuntimeTransport::new(
+        agent_name.to_string(),
+        Arc::new(runtime),
+        tool_defs,
+    )))
+}
+
 /// sera-y45a: parses the operator-requested dispatch mode from the
 /// `SERA_DISPATCH_MODE` env var.
 ///
@@ -158,18 +285,29 @@ fn configured_dispatch_mode_label() -> &'static str {
     parse_configured_dispatch_mode(raw.as_deref())
 }
 
-/// sera-y45a: the dispatch mode that actually applies to the running code.
+/// sera-y45a / sera-ve9x: the dispatch mode that actually applies to the
+/// running code.
 ///
-/// This binary always spawns `sera-runtime` via `StdioHarness::spawn`, so
-/// dispatch ownership is always `runtime` regardless of what
-/// `SERA_DISPATCH_MODE` requests. The boot log uses this as the truthful
-/// `dispatch_mode` field; the configured value is logged separately as
-/// `dispatch_mode_configured` so operators can still see what was asked for
-/// without the log claiming a security model the code does not implement.
-/// Future migration PRs (ADR §4 steps 2–4) will replace this constant with a
-/// real switch wired to the dispatcher selection.
+/// `runtime` (default) spawns `sera-runtime --ndjson` per agent and routes
+/// turns through [`crate::agent_transport::AgentTurnTransport`] backed by
+/// `RuntimeChildSupervisor`.
+///
+/// `embedded` (sera-ve9x) constructs a `DefaultRuntime` in-process per
+/// agent and routes turns through
+/// [`crate::embedded_transport::EmbeddedRuntimeTransport`] — there is no
+/// child process. Selected via `SERA_DISPATCH_MODE=embedded`.
+///
+/// `gateway` (ADR §4 step 3) is still unimplemented; the parser silently
+/// falls back to `runtime` until the gateway-owned dispatcher lands so an
+/// unimplemented target cannot masquerade as an active dispatch model.
 fn effective_dispatch_mode_label() -> &'static str {
-    "runtime"
+    match configured_dispatch_mode_label() {
+        "embedded" => "embedded",
+        // "gateway" is not yet implemented; fall back to runtime so the boot
+        // log never claims a model the code does not own. The configured
+        // request is still surfaced under `dispatch_mode_configured`.
+        _ => "runtime",
+    }
 }
 
 // ── CLI ─────────────────────────────────────────────────────────────────────
@@ -3878,17 +4016,17 @@ async fn run_start(config: PathBuf, port: u16, local: bool) -> anyhow::Result<()
         exe_dir.join("sera-runtime").to_string_lossy().to_string()
     });
 
-    // sera-y45a: surface the dispatch model in the boot log so operators can
-    // read which process owns tool dispatch without diving into source.
-    // `dispatch_mode` is the *effective* mode — what the running code
-    // actually does. `dispatch_mode_configured` is what the operator
-    // requested via SERA_DISPATCH_MODE. They diverge today because this
-    // binary always spawns `sera-runtime` via `StdioHarness`, so the
-    // effective mode is `runtime` regardless of the request. When the
-    // configured mode names a not-yet-implemented target (gateway/embedded),
-    // a warning is emitted so the log cannot be mistaken for an active
-    // gateway/embedded deployment. See
-    // docs/plan/decisions/2026-04-29-dispatch-ownership.md.
+    // sera-y45a / sera-ve9x: surface the dispatch model in the boot log so
+    // operators can read which process owns tool dispatch without diving
+    // into source. `dispatch_mode` is the *effective* mode — what the
+    // running code actually does. `dispatch_mode_configured` is what the
+    // operator requested via SERA_DISPATCH_MODE.
+    //
+    // After sera-ve9x PR 2: `runtime` (default) spawns `sera-runtime --ndjson`
+    // per agent, `embedded` builds a `DefaultRuntime` in-process via
+    // `EmbeddedRuntimeTransport` (no child process), and `gateway` is still
+    // unimplemented and falls back to runtime with a warning.
+    // See docs/plan/decisions/2026-04-29-dispatch-ownership.md.
     let dispatch_mode = effective_dispatch_mode_label();
     let dispatch_mode_configured = configured_dispatch_mode_label();
     tracing::info!(
@@ -3901,7 +4039,7 @@ async fn run_start(config: PathBuf, port: u16, local: bool) -> anyhow::Result<()
             dispatch_mode = dispatch_mode,
             dispatch_mode_configured = dispatch_mode_configured,
             "SERA_DISPATCH_MODE requests a not-yet-implemented dispatch mode; \
-             effective mode remains `runtime` until ADR §4 migration lands"
+             effective mode falls back to `runtime` until ADR §4 step 3 lands"
         );
     }
 
@@ -3935,9 +4073,9 @@ async fn run_start(config: PathBuf, port: u16, local: bool) -> anyhow::Result<()
         };
 
         let mut env = std::collections::HashMap::new();
-        env.insert("LLM_BASE_URL".to_string(), base_url);
+        env.insert("LLM_BASE_URL".to_string(), base_url.clone());
         env.insert("LLM_MODEL".to_string(), model.clone());
-        env.insert("LLM_API_KEY".to_string(), api_key_val);
+        env.insert("LLM_API_KEY".to_string(), api_key_val.clone());
         env.insert("AGENT_ID".to_string(), agent_name.to_string());
         // Forward permissive-gate flag to the runtime process when the operator
         // has set SERA_ALLOW_MISSING_CONSTITUTIONAL_GATE in the environment.
@@ -3981,38 +4119,74 @@ async fn run_start(config: PathBuf, port: u16, local: bool) -> anyhow::Result<()
             env.insert("SERA_AGENT_TOOLS_DENY".to_string(), deny);
         }
 
-        // sera-ojp3: wrap the runtime child in a supervisor so a panic does
-        // not permanently wedge the agent. The supervisor performs the
-        // initial spawn eagerly so a startup failure surfaces here just like
-        // the previous `StdioHarness::spawn` call did.
-        match RuntimeChildSupervisor::start(
-            agent_name.to_string(),
-            runtime_bin.clone(),
-            env,
-        )
-        .await
-        {
-            Ok(supervisor) => {
-                // sera-y45a: include both the effective and configured
-                // dispatch_mode markers so per-agent boot logs answer "which
-                // process owns tool dispatch for this agent?" truthfully
-                // without operators correlating against the process-level
-                // line above. `dispatch_mode` reflects what the running code
-                // does (always `runtime` while the supervisor still spawns
-                // sera-runtime as a child); `dispatch_mode_configured`
-                // reflects the operator request.
-                tracing::info!(
-                    agent = %agent_name,
-                    model = %model,
-                    dispatch_mode = dispatch_mode,
-                    dispatch_mode_configured = dispatch_mode_configured,
-                    "Spawned runtime harness via supervisor (sera-ojp3)"
-                );
-                harnesses.insert(agent_name.to_string(), supervisor);
+        // sera-ve9x: branch on the effective dispatch mode. `runtime` (default)
+        // spawns the existing supervised stdio child; `embedded` builds an
+        // in-process `DefaultRuntime` and routes turns through
+        // `EmbeddedRuntimeTransport`. Both yield an
+        // `Arc<dyn AgentTurnTransport>` so the rest of the gateway is
+        // backend-agnostic.
+        let transport: Option<Arc<dyn AgentTurnTransport>> = match dispatch_mode {
+            "embedded" => {
+                match build_embedded_transport(
+                    agent_name,
+                    &agent_spec,
+                    &base_url,
+                    &model,
+                    &api_key_val,
+                ) {
+                    Ok(t) => {
+                        tracing::info!(
+                            agent = %agent_name,
+                            model = %model,
+                            dispatch_mode = dispatch_mode,
+                            dispatch_mode_configured = dispatch_mode_configured,
+                            "Built embedded runtime transport (sera-ve9x)"
+                        );
+                        Some(t)
+                    }
+                    Err(e) => {
+                        tracing::error!(
+                            agent = %agent_name,
+                            error = %e,
+                            "Failed to build embedded runtime transport"
+                        );
+                        None
+                    }
+                }
             }
-            Err(e) => {
-                tracing::error!(agent = %agent_name, error = %e, "Failed to spawn runtime harness");
+            // runtime mode (default) — sera-ojp3 supervisor wrapping the
+            // long-lived `sera-runtime --ndjson` child process.
+            _ => {
+                match RuntimeChildSupervisor::start(
+                    agent_name.to_string(),
+                    runtime_bin.clone(),
+                    env,
+                )
+                .await
+                {
+                    Ok(supervisor) => {
+                        tracing::info!(
+                            agent = %agent_name,
+                            model = %model,
+                            dispatch_mode = dispatch_mode,
+                            dispatch_mode_configured = dispatch_mode_configured,
+                            "Spawned runtime harness via supervisor (sera-ojp3)"
+                        );
+                        Some(supervisor as Arc<dyn AgentTurnTransport>)
+                    }
+                    Err(e) => {
+                        tracing::error!(
+                            agent = %agent_name,
+                            error = %e,
+                            "Failed to spawn runtime harness"
+                        );
+                        None
+                    }
+                }
             }
+        };
+        if let Some(t) = transport {
+            harnesses.insert(agent_name.to_string(), t);
         }
     }
 
@@ -4611,50 +4785,85 @@ mod tests {
         assert_eq!(parse_configured_dispatch_mode(Some("foo")), "runtime");
     }
 
+    // sera-ve9x: `effective_dispatch_mode_label()` reads SERA_DISPATCH_MODE,
+    // so the tests below mutate process-global env. Holding this mutex
+    // serialises them past the cargo-test default of parallel execution.
+    static DISPATCH_MODE_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// RAII guard that sets/unsets `SERA_DISPATCH_MODE` and restores the
+    /// prior value on drop. Use under `DISPATCH_MODE_ENV_LOCK` only.
+    struct DispatchModeEnvGuard {
+        prev: Option<String>,
+    }
+
+    impl DispatchModeEnvGuard {
+        fn unset() -> Self {
+            let prev = std::env::var("SERA_DISPATCH_MODE").ok();
+            // SAFETY: callers hold DISPATCH_MODE_ENV_LOCK so no concurrent
+            // reader can observe a torn value.
+            unsafe { std::env::remove_var("SERA_DISPATCH_MODE") };
+            Self { prev }
+        }
+        fn set(value: &str) -> Self {
+            let prev = std::env::var("SERA_DISPATCH_MODE").ok();
+            // SAFETY: see DispatchModeEnvGuard::unset.
+            unsafe { std::env::set_var("SERA_DISPATCH_MODE", value) };
+            Self { prev }
+        }
+    }
+
+    impl Drop for DispatchModeEnvGuard {
+        fn drop(&mut self) {
+            // SAFETY: see DispatchModeEnvGuard::unset.
+            unsafe {
+                match &self.prev {
+                    Some(v) => std::env::set_var("SERA_DISPATCH_MODE", v),
+                    None => std::env::remove_var("SERA_DISPATCH_MODE"),
+                }
+            }
+        }
+    }
+
     #[test]
-    fn effective_dispatch_mode_is_runtime_until_migration() {
-        // This binary always launches StdioHarness::spawn for sera-runtime,
-        // so the effective mode is `runtime` regardless of the configured
-        // value. When ADR §4 step 2/3 lands, this test must be updated in
-        // lock-step with the dispatcher implementation — flipping it without
-        // moving real dispatch would re-introduce the very mismatch the
-        // ADR records.
+    fn effective_dispatch_mode_defaults_to_runtime_when_env_unset() {
+        let _lock = DISPATCH_MODE_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = DispatchModeEnvGuard::unset();
         assert_eq!(effective_dispatch_mode_label(), "runtime");
     }
 
     #[test]
-    fn effective_dispatch_mode_never_echoes_unimplemented_request() {
-        // The boot log path uses `effective_dispatch_mode_label()` for the
-        // `dispatch_mode` field. For every value an operator can put in
-        // SERA_DISPATCH_MODE — including the not-yet-implemented `gateway`
-        // and `embedded` targets — the effective mode must remain `runtime`
-        // so the active label cannot claim a security model the code does
-        // not implement.
-        for requested in [
-            None,
-            Some("runtime"),
-            Some("gateway"),
-            Some("embedded"),
-            Some("Gateway"),
-            Some("foo"),
-            Some(""),
-        ] {
-            let configured = parse_configured_dispatch_mode(requested);
-            let effective = effective_dispatch_mode_label();
+    fn effective_dispatch_mode_switches_to_embedded_when_configured() {
+        // sera-ve9x PR 2: `SERA_DISPATCH_MODE=embedded` flips the effective
+        // mode so the boot log (and per-agent log lines) report the truthful
+        // active backend. Before PR 2 this returned `"runtime"` regardless.
+        let _lock = DISPATCH_MODE_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = DispatchModeEnvGuard::set("embedded");
+        assert_eq!(effective_dispatch_mode_label(), "embedded");
+    }
+
+    #[test]
+    fn effective_dispatch_mode_falls_back_to_runtime_for_unimplemented_targets() {
+        // `gateway` is still unimplemented — until ADR §4 step 3 lands, the
+        // effective label must remain `runtime` so the active mode cannot
+        // claim a security model the code does not own.
+        let _lock = DISPATCH_MODE_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        for value in ["gateway", "Gateway", "foo", "RUNTIME", ""] {
+            let _guard = DispatchModeEnvGuard::set(value);
             assert_eq!(
-                effective, "runtime",
-                "effective mode must be `runtime` until ADR §4 lands (request={requested:?})"
+                effective_dispatch_mode_label(),
+                "runtime",
+                "effective mode for SERA_DISPATCH_MODE={value:?} must remain runtime"
             );
-            // Either the request agrees with the effective mode, or the
-            // boot log is responsible for surfacing the divergence under a
-            // distinct field — never as the active `dispatch_mode`.
-            if configured != effective {
-                assert!(
-                    matches!(configured, "gateway" | "embedded"),
-                    "only known migration targets may diverge; got {configured:?}"
-                );
-            }
         }
+    }
+
+    #[test]
+    fn effective_dispatch_mode_runtime_value_is_explicit_runtime() {
+        // The `runtime` value must round-trip through both the parser and
+        // the effective-mode switch.
+        let _lock = DISPATCH_MODE_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = DispatchModeEnvGuard::set("runtime");
+        assert_eq!(effective_dispatch_mode_label(), "runtime");
     }
 
     fn test_manifests() -> ManifestSet {

--- a/rust/crates/sera-gateway/src/embedded_transport.rs
+++ b/rust/crates/sera-gateway/src/embedded_transport.rs
@@ -60,7 +60,13 @@ pub struct EmbeddedRuntimeTransport {
     /// `turn::TurnContext.pending_steer` reads this metadata key in
     /// `DefaultRuntime::execute_turn`, mirroring the stdio backend's
     /// `Steer` Submission semantics.
-    pending_steer: Mutex<Vec<Value>>,
+    ///
+    /// Keyed by `session_key` so concurrent sessions on the same agent
+    /// (and the readiness probe's synthetic session) keep their steer
+    /// queues isolated. The stdio backend gets this scoping for free
+    /// because each `Steer` Submission carries `session_key` and the
+    /// runtime routes by it; embedded mode replicates that contract here.
+    pending_steer: Mutex<HashMap<String, Vec<Value>>>,
 }
 
 impl EmbeddedRuntimeTransport {
@@ -77,7 +83,7 @@ impl EmbeddedRuntimeTransport {
             agent_id: agent_id.into(),
             runtime,
             tool_defs,
-            pending_steer: Mutex::new(Vec::new()),
+            pending_steer: Mutex::new(HashMap::new()),
         }
     }
 
@@ -94,15 +100,24 @@ impl AgentTurnTransport for EmbeddedRuntimeTransport {
         messages: Vec<Value>,
         session_key: &str,
     ) -> anyhow::Result<TurnEvents> {
-        // Drain any staged steer items into the turn metadata. The runtime's
-        // `DefaultRuntime::execute_turn` (and `turn::TurnContext.pending_steer`)
-        // looks for them under `metadata["pending_steer"]` in the same shape
-        // an NDJSON `Steer` submission would surface.
+        // Drain any staged steer items for *this* session into the turn
+        // metadata. The runtime's `DefaultRuntime::execute_turn` (and
+        // `turn::TurnContext.pending_steer`) looks for them under
+        // `metadata["pending_steer"]` in the same shape an NDJSON `Steer`
+        // submission would surface.
+        //
+        // Keying on `session_key` matters: concurrent sessions on the same
+        // agent — including the readiness probe's
+        // `__sera_readiness_probe__` session running between a real user's
+        // steer and their next turn — must not cross-pollinate steer
+        // payloads. The stdio backend gets this for free via per-Submission
+        // `session_key` routing inside the runtime.
         let mut metadata: HashMap<String, Value> = HashMap::new();
         {
             let mut pending = self.pending_steer.lock().await;
-            if !pending.is_empty() {
-                let drained: Vec<Value> = std::mem::take(&mut *pending);
+            if let Some(drained) = pending.remove(session_key)
+                && !drained.is_empty()
+            {
                 metadata.insert("pending_steer".to_string(), Value::Array(drained));
             }
         }
@@ -131,10 +146,16 @@ impl AgentTurnTransport for EmbeddedRuntimeTransport {
     async fn send_steer(
         &self,
         items: Vec<Value>,
-        _session_key: &str,
+        session_key: &str,
     ) -> anyhow::Result<()> {
+        if items.is_empty() {
+            return Ok(());
+        }
         let mut pending = self.pending_steer.lock().await;
-        pending.extend(items);
+        pending
+            .entry(session_key.to_string())
+            .or_default()
+            .extend(items);
         Ok(())
     }
 
@@ -382,34 +403,121 @@ mod tests {
     async fn send_steer_stages_items_for_next_turn() {
         let runtime = build_runtime("ack");
         let transport = EmbeddedRuntimeTransport::new("agent-1", runtime, vec![]);
+        let session = "session:agent-1:t-1";
 
         transport
             .send_steer(
                 vec![serde_json::json!({"role": "user", "content": "steer"})],
-                "session:agent-1:t-1",
+                session,
             )
             .await
             .expect("steer ok");
 
-        // Pending queue holds exactly the staged item until drained.
+        // Pending queue holds the staged item under the session key until drained.
         {
             let pending = transport.pending_steer.lock().await;
-            assert_eq!(pending.len(), 1);
+            assert_eq!(pending.get(session).map(Vec::len), Some(1));
         }
 
-        // First send_turn drains the staged item.
+        // First send_turn on the same session drains the staged item.
         transport
             .send_turn(
                 vec![serde_json::json!({"role": "user", "content": "next"})],
-                "session:agent-1:t-1",
+                session,
             )
             .await
             .expect("turn ok");
 
         let pending = transport.pending_steer.lock().await;
         assert!(
-            pending.is_empty(),
+            !pending.contains_key(session),
             "pending steer queue should drain into TurnContext.metadata"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_steer_is_scoped_per_session() {
+        // Codex review on PR #1130: a steer staged for session A must not
+        // be drained by an unrelated turn (session B / readiness probe)
+        // running on the same agent. Stdio gets this for free via
+        // per-Submission session_key routing; embedded must replicate it.
+        let runtime = build_runtime("ack");
+        let transport = EmbeddedRuntimeTransport::new("agent-1", runtime, vec![]);
+        let session_a = "session:agent-1:alpha";
+        let session_b = "session:agent-1:beta";
+
+        transport
+            .send_steer(
+                vec![serde_json::json!({"role": "user", "content": "for-A"})],
+                session_a,
+            )
+            .await
+            .expect("steer ok");
+
+        // A turn on session B (or the readiness probe) must NOT drain
+        // session A's steer queue.
+        transport
+            .send_turn(
+                vec![serde_json::json!({"role": "user", "content": "B"})],
+                session_b,
+            )
+            .await
+            .expect("turn ok");
+
+        {
+            let pending = transport.pending_steer.lock().await;
+            assert_eq!(
+                pending.get(session_a).map(Vec::len),
+                Some(1),
+                "session A steer must survive an unrelated session's turn"
+            );
+            assert!(
+                !pending.contains_key(session_b),
+                "session B has no pending steer"
+            );
+        }
+
+        // The next turn on session A drains its own queue.
+        transport
+            .send_turn(
+                vec![serde_json::json!({"role": "user", "content": "A"})],
+                session_a,
+            )
+            .await
+            .expect("turn ok");
+
+        let pending = transport.pending_steer.lock().await;
+        assert!(
+            !pending.contains_key(session_a),
+            "session A's pending queue should drain on its own turn"
+        );
+    }
+
+    #[tokio::test]
+    async fn liveness_probe_does_not_drain_real_session_steer() {
+        // The readiness probe runs `send_turn` against the synthetic
+        // `__sera_readiness_probe__` session. It must not consume steer
+        // staged for a real user session running concurrently on the same
+        // agent.
+        let runtime = build_runtime("pong");
+        let transport = EmbeddedRuntimeTransport::new("agent-1", runtime, vec![]);
+        let user_session = "session:agent-1:user-42";
+
+        transport
+            .send_steer(
+                vec![serde_json::json!({"role": "user", "content": "guidance"})],
+                user_session,
+            )
+            .await
+            .expect("steer ok");
+
+        transport.liveness_probe().await.expect("probe ok");
+
+        let pending = transport.pending_steer.lock().await;
+        assert_eq!(
+            pending.get(user_session).map(Vec::len),
+            Some(1),
+            "readiness probe must not drain a real session's steer queue"
         );
     }
 

--- a/rust/crates/sera-gateway/src/embedded_transport.rs
+++ b/rust/crates/sera-gateway/src/embedded_transport.rs
@@ -1,0 +1,454 @@
+//! sera-ve9x: in-process [`AgentTurnTransport`] backed by a
+//! [`sera_runtime::default_runtime::DefaultRuntime`].
+//!
+//! Selected by `SERA_DISPATCH_MODE=embedded`. Replaces the stdio child path
+//! ([`crate::agent_transport::AgentTurnTransport`] backed by
+//! `RuntimeChildSupervisor`) for the gateway-bundled runtime — there is no
+//! `sera-runtime --ndjson` child process when this transport is in use.
+//!
+//! The default mode (`SERA_DISPATCH_MODE=runtime`) is unchanged.
+//!
+//! # Steer semantics
+//!
+//! Today's stdio backend writes a `Steer` Submission down the NDJSON pipe
+//! and the runtime injects it at the next tool boundary. The embedded
+//! backend stages incoming steer items in a `Mutex<Vec<Value>>` and drains
+//! them into the next `send_turn`'s `TurnContext.metadata["pending_steer"]`.
+//! Acceptable for the MVS — the runtime's `turn::TurnContext.pending_steer`
+//! field is already populated from the same metadata key by
+//! `DefaultRuntime::execute_turn`.
+//!
+//! # Audit / capability shape
+//!
+//! Tool-call audit shape (`[sera-policy] tool '…' denied …`) is produced by
+//! `RegistryDispatcher` regardless of transport, so
+//! [`crate::capability_enforcement`] does not need a parallel branch — the
+//! transcript projected here matches what stdio surfaces.
+//!
+//! # Hot reload caveat
+//!
+//! `CapabilityRegistry` is captured by reference in the bundled
+//! `RegistryDispatcher` at boot. The current stdio backend has the same
+//! property (the runtime child loads the registry once on spawn), so this
+//! is parity, not a regression. A future bead can add a
+//! `CapabilityRegistryHandle` + per-turn lookup so `/admin/policies/reload`
+//! propagates to embedded transports without a process restart.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde_json::Value;
+use tokio::sync::Mutex;
+
+use sera_runtime::default_runtime::DefaultRuntime;
+use sera_types::runtime::{AgentRuntime, TurnContext, TurnOutcome};
+use sera_types::tool::ToolDefinition;
+
+use crate::agent_transport::{AgentTurnTransport, ToolEvent, TurnEvents, UsageInfo};
+
+/// In-process transport that calls
+/// [`DefaultRuntime::execute_turn`](sera_types::runtime::AgentRuntime::execute_turn)
+/// directly — no child process, no NDJSON pipe.
+pub struct EmbeddedRuntimeTransport {
+    agent_id: String,
+    runtime: Arc<DefaultRuntime>,
+    tool_defs: Vec<ToolDefinition>,
+    /// Steer items staged by [`AgentTurnTransport::send_steer`] and drained
+    /// into the next [`AgentTurnTransport::send_turn`] via
+    /// `TurnContext.metadata["pending_steer"]`. The runtime's
+    /// `turn::TurnContext.pending_steer` reads this metadata key in
+    /// `DefaultRuntime::execute_turn`, mirroring the stdio backend's
+    /// `Steer` Submission semantics.
+    pending_steer: Mutex<Vec<Value>>,
+}
+
+impl EmbeddedRuntimeTransport {
+    /// Construct a new embedded transport. `runtime` is shared so multiple
+    /// agents *could* share an `Arc<DefaultRuntime>`, but the standard
+    /// boot path constructs one runtime per agent (mirroring today's
+    /// per-agent stdio child).
+    pub fn new(
+        agent_id: impl Into<String>,
+        runtime: Arc<DefaultRuntime>,
+        tool_defs: Vec<ToolDefinition>,
+    ) -> Self {
+        Self {
+            agent_id: agent_id.into(),
+            runtime,
+            tool_defs,
+            pending_steer: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Test introspection: number of tool definitions exposed to the LLM.
+    pub fn tool_def_count(&self) -> usize {
+        self.tool_defs.len()
+    }
+}
+
+#[async_trait]
+impl AgentTurnTransport for EmbeddedRuntimeTransport {
+    async fn send_turn(
+        &self,
+        messages: Vec<Value>,
+        session_key: &str,
+    ) -> anyhow::Result<TurnEvents> {
+        // Drain any staged steer items into the turn metadata. The runtime's
+        // `DefaultRuntime::execute_turn` (and `turn::TurnContext.pending_steer`)
+        // looks for them under `metadata["pending_steer"]` in the same shape
+        // an NDJSON `Steer` submission would surface.
+        let mut metadata: HashMap<String, Value> = HashMap::new();
+        {
+            let mut pending = self.pending_steer.lock().await;
+            if !pending.is_empty() {
+                let drained: Vec<Value> = std::mem::take(&mut *pending);
+                metadata.insert("pending_steer".to_string(), Value::Array(drained));
+            }
+        }
+
+        let ctx = TurnContext {
+            event_id: uuid::Uuid::new_v4().to_string(),
+            agent_id: self.agent_id.clone(),
+            session_key: session_key.to_string(),
+            messages,
+            available_tools: self.tool_defs.clone(),
+            metadata,
+            change_artifact: None,
+            parent_session_key: None,
+            tool_use_behavior: Default::default(),
+        };
+
+        let outcome = self
+            .runtime
+            .execute_turn(ctx)
+            .await
+            .map_err(|e| anyhow::anyhow!("embedded runtime: {e}"))?;
+
+        Ok(turn_events_from_outcome(outcome))
+    }
+
+    async fn send_steer(
+        &self,
+        items: Vec<Value>,
+        _session_key: &str,
+    ) -> anyhow::Result<()> {
+        let mut pending = self.pending_steer.lock().await;
+        pending.extend(items);
+        Ok(())
+    }
+
+    async fn shutdown(&self) -> anyhow::Result<()> {
+        // Nothing to clean up — `Arc<DefaultRuntime>` drops with the
+        // transport. There is no child process and no open IPC handle.
+        Ok(())
+    }
+
+    /// Liveness probe semantics: round-trip a trivial turn through the
+    /// in-process runtime, mirroring the stdio backend
+    /// (`RuntimeChildSupervisor::liveness_probe`). A non-empty streaming
+    /// reply proves both the runtime and its LLM provider are reachable.
+    async fn liveness_probe(&self) -> anyhow::Result<()> {
+        let messages = vec![serde_json::json!({"role": "user", "content": "ping"})];
+        let events = self
+            .send_turn(messages, "__sera_readiness_probe__")
+            .await?;
+        if events.response.trim().is_empty() {
+            anyhow::bail!("liveness probe returned empty response");
+        }
+        Ok(())
+    }
+}
+
+/// Project a runtime [`TurnOutcome`] into the gateway's [`TurnEvents`].
+///
+/// The resulting tool events match what the stdio backend yields when it
+/// reads `tool_call_begin` / `tool_call_end` frames off the NDJSON pipe —
+/// the runtime emits both shapes from the same transcript. The gateway's
+/// audit / persistence path (`enforce_tool_events`) is byte-stable across
+/// transports.
+fn turn_events_from_outcome(outcome: TurnOutcome) -> TurnEvents {
+    match outcome {
+        TurnOutcome::FinalOutput {
+            response,
+            tokens_used,
+            transcript,
+            ..
+        } => TurnEvents {
+            response,
+            tool_events: project_tool_events(&transcript),
+            usage: usage_from_tokens(&tokens_used),
+        },
+        TurnOutcome::RunAgain { tokens_used, .. } => TurnEvents {
+            response: "[run_again — tool calls dispatched]".to_string(),
+            tool_events: vec![],
+            usage: usage_from_tokens(&tokens_used),
+        },
+        TurnOutcome::Handoff {
+            target_agent_id,
+            tokens_used,
+            ..
+        } => TurnEvents {
+            response: format!("[handoff -> {target_agent_id}]"),
+            tool_events: vec![],
+            usage: usage_from_tokens(&tokens_used),
+        },
+        TurnOutcome::Compact { tokens_used, .. } => TurnEvents {
+            response: "[compact — context condensed]".to_string(),
+            tool_events: vec![],
+            usage: usage_from_tokens(&tokens_used),
+        },
+        TurnOutcome::Interruption { reason, .. } => TurnEvents {
+            response: format!("[interrupted: {reason}]"),
+            tool_events: vec![],
+            usage: UsageInfo::default(),
+        },
+        TurnOutcome::Stop {
+            summary,
+            tokens_used,
+            ..
+        } => TurnEvents {
+            response: format!("[stop: {summary}]"),
+            tool_events: vec![],
+            usage: usage_from_tokens(&tokens_used),
+        },
+        TurnOutcome::WaitingForApproval {
+            ticket_id,
+            tokens_used,
+            ..
+        } => TurnEvents {
+            response: format!("[waiting_for_approval: ticket={ticket_id}]"),
+            tool_events: vec![],
+            usage: usage_from_tokens(&tokens_used),
+        },
+        TurnOutcome::PlanEmitted {
+            plan_tool_calls,
+            rationale,
+            tokens_used,
+            ..
+        } => TurnEvents {
+            response: format!(
+                "[plan_emitted: {} tool call(s); rationale={rationale:?}]",
+                plan_tool_calls.len()
+            ),
+            tool_events: vec![],
+            usage: usage_from_tokens(&tokens_used),
+        },
+    }
+}
+
+/// Reconstruct `Begin` / `End` tool events from the runtime transcript
+/// (assistant `tool_calls` arrays + `tool` result messages). Mirrors the
+/// shape that `sera_runtime::stdio::emit_tool_events_from_transcript`
+/// produces over NDJSON, then re-parses on the stdio backend's read side.
+fn project_tool_events(transcript: &[Value]) -> Vec<ToolEvent> {
+    let mut events = Vec::new();
+    for msg in transcript {
+        let role = msg.get("role").and_then(|r| r.as_str()).unwrap_or("");
+        if role == "assistant" {
+            if let Some(tool_calls) = msg.get("tool_calls").and_then(|tc| tc.as_array()) {
+                for tc in tool_calls {
+                    let call_id = tc
+                        .get("id")
+                        .and_then(|id| id.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    let tool_name = tc
+                        .get("function")
+                        .and_then(|f| f.get("name"))
+                        .and_then(|n| n.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    let arguments_str = tc
+                        .get("function")
+                        .and_then(|f| f.get("arguments"))
+                        .and_then(|a| a.as_str())
+                        .unwrap_or("{}");
+                    let arguments = serde_json::from_str(arguments_str)
+                        .unwrap_or(Value::Object(Default::default()));
+                    events.push(ToolEvent::Begin {
+                        call_id,
+                        tool: tool_name,
+                        arguments,
+                    });
+                }
+            }
+        } else if role == "tool" {
+            let call_id = msg
+                .get("tool_call_id")
+                .and_then(|id| id.as_str())
+                .unwrap_or("")
+                .to_string();
+            let content = msg
+                .get("content")
+                .and_then(|c| c.as_str())
+                .unwrap_or("")
+                .to_string();
+            events.push(ToolEvent::End { call_id, content });
+        }
+    }
+    events
+}
+
+fn usage_from_tokens(tokens: &sera_types::runtime::TokenUsage) -> UsageInfo {
+    UsageInfo {
+        prompt_tokens: tokens.prompt_tokens as u64,
+        completion_tokens: tokens.completion_tokens as u64,
+        total_tokens: tokens.total_tokens as u64,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sera_runtime::context_engine::pipeline::ContextPipeline;
+    use sera_runtime::turn::{LlmProvider, ThinkError, ThinkResult};
+
+    /// Minimal `LlmProvider` that returns a fixed assistant reply with a
+    /// canned token count. Used to exercise the embedded transport without
+    /// depending on a network LLM.
+    struct ScriptedLlm {
+        reply: String,
+    }
+
+    #[async_trait]
+    impl LlmProvider for ScriptedLlm {
+        async fn chat(
+            &self,
+            _messages: &[Value],
+            _tools: &[Value],
+        ) -> Result<ThinkResult, ThinkError> {
+            Ok(ThinkResult {
+                response: serde_json::json!({
+                    "role": "assistant",
+                    "content": self.reply,
+                }),
+                tool_calls: vec![],
+                tokens: sera_types::runtime::TokenUsage {
+                    prompt_tokens: 7,
+                    completion_tokens: 5,
+                    total_tokens: 12,
+                },
+                plan: None,
+            })
+        }
+    }
+
+    fn build_runtime(reply: &'static str) -> Arc<DefaultRuntime> {
+        let runtime = DefaultRuntime::new(Box::new(ContextPipeline::new()))
+            .with_llm(Box::new(ScriptedLlm {
+                reply: reply.to_string(),
+            }))
+            .with_allow_missing_constitutional_gate(true);
+        Arc::new(runtime)
+    }
+
+    #[tokio::test]
+    async fn send_turn_returns_response_and_usage() {
+        let runtime = build_runtime("hello from embedded");
+        let transport = EmbeddedRuntimeTransport::new("agent-1", runtime, vec![]);
+
+        let events = transport
+            .send_turn(
+                vec![serde_json::json!({"role": "user", "content": "hi"})],
+                "session:agent-1:t-1",
+            )
+            .await
+            .expect("turn ok");
+
+        assert_eq!(events.response, "hello from embedded");
+        assert_eq!(events.usage.prompt_tokens, 7);
+        assert_eq!(events.usage.completion_tokens, 5);
+        assert_eq!(events.usage.total_tokens, 12);
+        assert!(events.tool_events.is_empty());
+    }
+
+    #[tokio::test]
+    async fn liveness_probe_succeeds_when_runtime_replies() {
+        let runtime = build_runtime("pong");
+        let transport = EmbeddedRuntimeTransport::new("agent-1", runtime, vec![]);
+        transport.liveness_probe().await.expect("liveness ok");
+    }
+
+    #[tokio::test]
+    async fn liveness_probe_fails_on_empty_response() {
+        let runtime = build_runtime("");
+        let transport = EmbeddedRuntimeTransport::new("agent-1", runtime, vec![]);
+        let res = transport.liveness_probe().await;
+        assert!(res.is_err(), "empty response should fail liveness");
+    }
+
+    #[tokio::test]
+    async fn send_steer_stages_items_for_next_turn() {
+        let runtime = build_runtime("ack");
+        let transport = EmbeddedRuntimeTransport::new("agent-1", runtime, vec![]);
+
+        transport
+            .send_steer(
+                vec![serde_json::json!({"role": "user", "content": "steer"})],
+                "session:agent-1:t-1",
+            )
+            .await
+            .expect("steer ok");
+
+        // Pending queue holds exactly the staged item until drained.
+        {
+            let pending = transport.pending_steer.lock().await;
+            assert_eq!(pending.len(), 1);
+        }
+
+        // First send_turn drains the staged item.
+        transport
+            .send_turn(
+                vec![serde_json::json!({"role": "user", "content": "next"})],
+                "session:agent-1:t-1",
+            )
+            .await
+            .expect("turn ok");
+
+        let pending = transport.pending_steer.lock().await;
+        assert!(
+            pending.is_empty(),
+            "pending steer queue should drain into TurnContext.metadata"
+        );
+    }
+
+    #[test]
+    fn project_tool_events_extracts_begin_and_end() {
+        let transcript = vec![
+            serde_json::json!({
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": "call_1",
+                    "function": {
+                        "name": "echo",
+                        "arguments": "{\"msg\":\"hello\"}",
+                    },
+                }],
+            }),
+            serde_json::json!({
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": "ok",
+            }),
+        ];
+        let events = project_tool_events(&transcript);
+        assert_eq!(events.len(), 2);
+        match &events[0] {
+            ToolEvent::Begin { call_id, tool, arguments } => {
+                assert_eq!(call_id, "call_1");
+                assert_eq!(tool, "echo");
+                assert_eq!(arguments.get("msg").and_then(|v| v.as_str()), Some("hello"));
+            }
+            other => panic!("expected Begin, got {other:?}"),
+        }
+        match &events[1] {
+            ToolEvent::End { call_id, content } => {
+                assert_eq!(call_id, "call_1");
+                assert_eq!(content, "ok");
+            }
+            other => panic!("expected End, got {other:?}"),
+        }
+    }
+}

--- a/rust/crates/sera-gateway/src/lib.rs
+++ b/rust/crates/sera-gateway/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod admin;
 pub mod agent_transport;
 pub mod capability_enforcement;
+pub mod embedded_transport;
 pub mod connector;
 pub mod constitutional_config;
 pub mod db_backend;

--- a/rust/crates/sera-runtime/src/authz_builder.rs
+++ b/rust/crates/sera-runtime/src/authz_builder.rs
@@ -1,0 +1,128 @@
+//! sera-ve9x: shared `AuthzProviderHandle` construction for the runtime
+//! binary and the gateway's embedded dispatch path.
+//!
+//! Lifted from `sera-runtime/src/main.rs` so both the standalone runtime
+//! binary and `EmbeddedRuntimeTransport` (in `sera-gateway`) build the same
+//! provider from the same `RuntimeConfig` without duplicating the env-var
+//! plumbing or the role-clause parser.
+
+use std::sync::Arc;
+
+use sera_auth::authz::{ActionKind, AuthzProviderAdapter, RoleBasedAuthzProvider};
+use sera_types::principal::PrincipalId;
+use sera_types::tool::AuthzProviderHandle;
+
+use crate::config::RuntimeConfig;
+
+/// Build an [`AuthzProviderHandle`] from `config`.
+///
+/// When `config.tool_authz_roles` is set, parses a compact role definition
+/// string and constructs a [`RoleBasedAuthzProvider`] wrapped in an
+/// [`AuthzProviderAdapter`]. Format:
+///
+/// ```text
+/// <role>:<kind>[,<kind>...][;<role>:...]
+/// ```
+///
+/// Supported `<kind>` names (case-insensitive): `read`, `write`, `execute`,
+/// `admin`, `tool_call`, `session_op`, `memory_access`, `config_change`,
+/// `propose_change`, `approve_change`.
+///
+/// When `tool_authz_roles` is `None`, returns the allow-all default stub.
+pub fn build_provider_from_config(config: &RuntimeConfig) -> Arc<dyn AuthzProviderHandle> {
+    let Some(roles_str) = &config.tool_authz_roles else {
+        return Arc::new(sera_types::tool::DefaultAuthzProviderStub);
+    };
+
+    let mut builder = RoleBasedAuthzProvider::builder();
+
+    for role_clause in roles_str.split(';') {
+        let role_clause = role_clause.trim();
+        if role_clause.is_empty() {
+            continue;
+        }
+        let Some((role, kinds_str)) = role_clause.split_once(':') else {
+            tracing::warn!(
+                "TOOL_AUTHZ_ROLES: skipping malformed clause (no ':'): {role_clause}"
+            );
+            continue;
+        };
+        let role = role.trim();
+        let kinds: Vec<ActionKind> = kinds_str
+            .split(',')
+            .filter_map(|k| parse_action_kind(k.trim()))
+            .collect();
+        builder = builder.grant(role, kinds);
+    }
+
+    // Assign the runtime's own agent-id as a full-access principal so the
+    // default single-agent deployment works without additional config.
+    if !config.agent_id.is_empty() {
+        builder = builder.assign(
+            PrincipalId::new(format!("agent:{}", config.agent_id)),
+            ["operator"],
+        );
+    }
+
+    Arc::new(AuthzProviderAdapter::new(builder.build()))
+}
+
+/// Parse a single action-kind name (case-insensitive).
+pub fn parse_action_kind(s: &str) -> Option<ActionKind> {
+    match s.to_ascii_lowercase().as_str() {
+        "read" => Some(ActionKind::Read),
+        "write" => Some(ActionKind::Write),
+        "execute" => Some(ActionKind::Execute),
+        "admin" => Some(ActionKind::Admin),
+        "tool_call" => Some(ActionKind::ToolCall),
+        "session_op" => Some(ActionKind::SessionOp),
+        "memory_access" => Some(ActionKind::MemoryAccess),
+        "config_change" => Some(ActionKind::ConfigChange),
+        "propose_change" => Some(ActionKind::ProposeChange),
+        "approve_change" => Some(ActionKind::ApproveChange),
+        other => {
+            tracing::warn!("TOOL_AUTHZ_ROLES: unknown action kind '{other}', skipping");
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg_with_roles(roles: Option<&str>) -> RuntimeConfig {
+        let mut c = RuntimeConfig::from_env();
+        c.tool_authz_roles = roles.map(|s| s.to_string());
+        c.agent_id = "test-agent".to_string();
+        c
+    }
+
+    #[test]
+    fn no_roles_yields_allow_all_stub() {
+        let cfg = cfg_with_roles(None);
+        let _provider = build_provider_from_config(&cfg);
+        // Constructed without panicking — coarse sanity check.
+    }
+
+    #[test]
+    fn role_clause_parses_without_panic() {
+        let cfg =
+            cfg_with_roles(Some("operator:tool_call,read;admin:tool_call,read,write,admin"));
+        let _provider = build_provider_from_config(&cfg);
+    }
+
+    #[test]
+    fn parse_action_kind_known_variants() {
+        assert!(matches!(parse_action_kind("read"), Some(ActionKind::Read)));
+        assert!(matches!(
+            parse_action_kind("WRITE"),
+            Some(ActionKind::Write)
+        ));
+        assert!(matches!(
+            parse_action_kind("tool_call"),
+            Some(ActionKind::ToolCall)
+        ));
+        assert!(parse_action_kind("not_a_kind").is_none());
+    }
+}

--- a/rust/crates/sera-runtime/src/lib.rs
+++ b/rust/crates/sera-runtime/src/lib.rs
@@ -54,6 +54,7 @@ pub mod stdio;
 pub mod tool_hooks;
 
 // Retained modules
+pub mod authz_builder;
 pub mod config;
 pub mod memory_budget;
 pub mod context;

--- a/rust/crates/sera-runtime/src/llm_client.rs
+++ b/rust/crates/sera-runtime/src/llm_client.rs
@@ -845,6 +845,83 @@ impl LlmClient {
 }
 
 // ---------------------------------------------------------------------------
+// Library-side construction helpers (sera-ve9x)
+// ---------------------------------------------------------------------------
+
+/// Build an [`LlmClient`] with the same opportunistic [`AccountPool`] +
+/// [`ThinkingConfig`] wiring the runtime binary uses.
+///
+/// Lifted out of `sera-runtime/src/main.rs` so the gateway's embedded
+/// dispatch path (`sera-ve9x`) can construct an in-process client without
+/// duplicating the env-var reads. The runtime stays fully backwards
+/// compatible: when `SERA_<PROVIDER>_KEYS` is not set for the inferred
+/// provider id, no pool is attached and the client falls back to the
+/// single-account `LLM_BASE_URL` / `LLM_API_KEY` path. Likewise
+/// `SERA_REASONING_LEVEL` defaults to `off` when unset.
+pub fn build_from_config(config: &RuntimeConfig) -> LlmClient {
+    use sera_config::providers::ProviderAccountsConfig;
+    use sera_models::{
+        AccountPool, CooldownConfig, ProviderAccount, ProviderKind, ReasoningLevel,
+        ThinkingConfig,
+    };
+
+    // Provider kind is inferred from LLM_MODEL (e.g. "gpt-4o" → OpenAI,
+    // "claude-3-5-sonnet" → Anthropic).  Operators can also set
+    // SERA_LLM_PROVIDER_ID to pin the inference explicitly.
+    let provider_id = std::env::var("SERA_LLM_PROVIDER_ID")
+        .unwrap_or_else(|_| config.llm_model.clone());
+    let provider_kind = ProviderKind::infer(&provider_id);
+
+    // Thinking / reasoning level.
+    let level = std::env::var("SERA_REASONING_LEVEL")
+        .ok()
+        .and_then(|v| match v.trim().to_ascii_lowercase().as_str() {
+            "off" | "none" | "" => Some(ReasoningLevel::Off),
+            "low" => Some(ReasoningLevel::Low),
+            "medium" | "med" => Some(ReasoningLevel::Medium),
+            "high" => Some(ReasoningLevel::High),
+            _ => None,
+        })
+        .unwrap_or(ReasoningLevel::Off);
+    let budget = std::env::var("SERA_REASONING_BUDGET_TOKENS")
+        .ok()
+        .and_then(|v| v.parse::<u32>().ok());
+    let mut thinking = ThinkingConfig::new(level);
+    thinking.budget_tokens = budget;
+
+    let mut client = LlmClient::new(config)
+        .with_thinking(thinking)
+        .with_provider_kind(provider_kind);
+
+    // Account pool (sera-jvi). Only attached when at least one key is
+    // configured for the active provider id.
+    let accounts_cfg = ProviderAccountsConfig::from_env();
+    if let Some(keys) = accounts_cfg.keys_for(&provider_id)
+        && !keys.is_empty()
+    {
+        let accounts: Vec<ProviderAccount> = keys
+            .iter()
+            .enumerate()
+            .map(|(idx, key)| {
+                ProviderAccount::new(format!("{provider_id}-{idx}"), key.clone(), None)
+            })
+            .collect();
+        let pool = Arc::new(
+            AccountPool::new(provider_id.clone(), accounts, CooldownConfig::default())
+                .with_default_base_url(config.llm_base_url.clone()),
+        );
+        tracing::info!(
+            provider = %provider_id,
+            account_count = keys.len(),
+            "Attached LLM account pool (sera-jvi)"
+        );
+        client = client.with_account_pool(pool);
+    }
+
+    client
+}
+
+// ---------------------------------------------------------------------------
 // LlmProvider implementation
 // ---------------------------------------------------------------------------
 

--- a/rust/crates/sera-runtime/src/main.rs
+++ b/rust/crates/sera-runtime/src/main.rs
@@ -13,19 +13,17 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use clap::Parser;
-use sera_auth::authz::{ActionKind, AuthzProviderAdapter, RoleBasedAuthzProvider};
 use sera_config::CapabilityRegistry;
+use sera_runtime::authz_builder;
 use sera_runtime::config::RuntimeConfig;
 use sera_runtime::context_engine::pipeline::ContextPipeline;
 use sera_runtime::default_runtime::DefaultRuntime;
 use sera_runtime::health;
-use sera_runtime::llm_client::LlmClient;
+use sera_runtime::llm_client;
 use sera_runtime::stdio;
 use sera_runtime::tools::TraitToolRegistry;
 use sera_runtime::tools::dispatcher::RegistryDispatcher;
-use sera_types::principal::PrincipalId;
 use sera_types::runtime::{AgentRuntime, TurnContext, TurnOutcome};
-use sera_types::tool::AuthzProviderHandle;
 
 // ── CLI ──────────────────────────────────────────────────────────────────────
 
@@ -94,85 +92,10 @@ impl Cli {
 }
 
 // ── Authz provider construction ──────────────────────────────────────────────
-
-/// Build an [`AuthzProviderHandle`] from config.
-///
-/// When `config.tool_authz_roles` is set, parses a compact role definition
-/// string and constructs a [`RoleBasedAuthzProvider`] wrapped in an
-/// [`AuthzProviderAdapter`]. Format:
-///
-/// ```text
-/// <role>:<kind>[,<kind>...][;<role>:...]
-/// ```
-///
-/// Supported `<kind>` names (case-insensitive): `read`, `write`, `execute`,
-/// `admin`, `tool_call`, `session_op`, `memory_access`, `config_change`,
-/// `propose_change`, `approve_change`.
-///
-/// Principal assignments are not parsed here — they are set per-agent via
-/// `TOOL_AUTHZ_PRINCIPALS` (future bead). For now the provider is useful for
-/// role-grant inspection and tests that inject principals directly.
-///
-/// When `tool_authz_roles` is `None`, returns the allow-all default stub.
-fn build_authz_provider(config: &RuntimeConfig) -> Arc<dyn AuthzProviderHandle> {
-    let Some(roles_str) = &config.tool_authz_roles else {
-        return Arc::new(sera_types::tool::DefaultAuthzProviderStub);
-    };
-
-    let mut builder = RoleBasedAuthzProvider::builder();
-
-    for role_clause in roles_str.split(';') {
-        let role_clause = role_clause.trim();
-        if role_clause.is_empty() {
-            continue;
-        }
-        let Some((role, kinds_str)) = role_clause.split_once(':') else {
-            tracing::warn!(
-                "TOOL_AUTHZ_ROLES: skipping malformed clause (no ':'): {role_clause}"
-            );
-            continue;
-        };
-        let role = role.trim();
-        let kinds: Vec<ActionKind> = kinds_str
-            .split(',')
-            .filter_map(|k| parse_action_kind(k.trim()))
-            .collect();
-        builder = builder.grant(role, kinds);
-    }
-
-    // Assign the runtime's own agent-id as a full-access principal so the
-    // default single-agent deployment works without additional config.
-    if let Ok(agent_id) = std::env::var("AGENT_ID")
-        && !agent_id.is_empty()
-    {
-        builder = builder.assign(
-            PrincipalId::new(format!("agent:{agent_id}")),
-            ["operator"],
-        );
-    }
-
-    Arc::new(AuthzProviderAdapter::new(builder.build()))
-}
-
-/// Parse a single action-kind name (case-insensitive).
-fn parse_action_kind(s: &str) -> Option<ActionKind> {
-    match s.to_ascii_lowercase().as_str() {
-        "read" => Some(ActionKind::Read),
-        "write" => Some(ActionKind::Write),
-        "execute" => Some(ActionKind::Execute),
-        "admin" => Some(ActionKind::Admin),
-        "tool_call" => Some(ActionKind::ToolCall),
-        "session_op" => Some(ActionKind::SessionOp),
-        "memory_access" => Some(ActionKind::MemoryAccess),
-        "config_change" => Some(ActionKind::ConfigChange),
-        "propose_change" => Some(ActionKind::ProposeChange),
-        "approve_change" => Some(ActionKind::ApproveChange),
-        other => {
-            tracing::warn!("TOOL_AUTHZ_ROLES: unknown action kind '{other}', skipping");
-            None
-        }
-    }
-}
+//
+// Construction lives in [`sera_runtime::authz_builder`] (sera-ve9x) so the
+// gateway's embedded dispatch path can build the same provider without
+// duplicating the role-clause parser.
 
 // ── Main ─────────────────────────────────────────────────────────────────────
 
@@ -209,7 +132,7 @@ async fn main() -> anyhow::Result<()> {
         });
     }
 
-    let authz_provider = build_authz_provider(&config);
+    let authz_provider = authz_builder::build_provider_from_config(&config);
 
     // sera-a1u: every runtime owns a shared DelegationBus so the three
     // delegation tools (session_spawn / session_yield / session_send) can
@@ -266,7 +189,7 @@ async fn main() -> anyhow::Result<()> {
     let permissive_gate = resolve_allow_missing_gate();
 
     let context_engine = Box::new(ContextPipeline::new());
-    let llm_client = Box::new(build_llm_client(&config));
+    let llm_client = Box::new(llm_client::build_from_config(&config));
     let runtime = DefaultRuntime::new(context_engine)
         .with_llm(llm_client)
         .with_tool_dispatcher(Box::new(dispatcher))
@@ -378,73 +301,10 @@ async fn run_interactive(
 }
 
 // ── LLM client wiring ────────────────────────────────────────────────────────
-
-/// Build an [`LlmClient`] with optional sera-jvi account pool + sera-48v
-/// thinking config attached.
-///
-/// The runtime stays fully backwards-compatible: when `SERA_<PROVIDER>_KEYS`
-/// is not set for the inferred provider id, no pool is attached and the
-/// client falls back to the single-account `LLM_BASE_URL` / `LLM_API_KEY`
-/// path.  Likewise `SERA_REASONING_LEVEL` defaults to `off` when unset.
-fn build_llm_client(config: &RuntimeConfig) -> LlmClient {
-    use sera_config::providers::ProviderAccountsConfig;
-    use sera_models::{
-        AccountPool, CooldownConfig, ProviderAccount, ProviderKind, ReasoningLevel, ThinkingConfig,
-    };
-
-    // Provider kind is inferred from LLM_MODEL (e.g. "gpt-4o" → OpenAI,
-    // "claude-3-5-sonnet" → Anthropic).  Operators can also set
-    // SERA_LLM_PROVIDER_ID to pin the inference explicitly.
-    let provider_id = std::env::var("SERA_LLM_PROVIDER_ID")
-        .unwrap_or_else(|_| config.llm_model.clone());
-    let provider_kind = ProviderKind::infer(&provider_id);
-
-    // Thinking / reasoning level.
-    let level = std::env::var("SERA_REASONING_LEVEL")
-        .ok()
-        .and_then(|v| match v.trim().to_ascii_lowercase().as_str() {
-            "off" | "none" | "" => Some(ReasoningLevel::Off),
-            "low" => Some(ReasoningLevel::Low),
-            "medium" | "med" => Some(ReasoningLevel::Medium),
-            "high" => Some(ReasoningLevel::High),
-            _ => None,
-        })
-        .unwrap_or(ReasoningLevel::Off);
-    let budget = std::env::var("SERA_REASONING_BUDGET_TOKENS")
-        .ok()
-        .and_then(|v| v.parse::<u32>().ok());
-    let mut thinking = ThinkingConfig::new(level);
-    thinking.budget_tokens = budget;
-
-    let mut client = LlmClient::new(config)
-        .with_thinking(thinking)
-        .with_provider_kind(provider_kind);
-
-    // Account pool (sera-jvi).  Only attached when at least one key is
-    // configured for the active provider id.
-    let accounts_cfg = ProviderAccountsConfig::from_env();
-    if let Some(keys) = accounts_cfg.keys_for(&provider_id)
-        && !keys.is_empty()
-    {
-        let accounts: Vec<ProviderAccount> = keys
-            .iter()
-            .enumerate()
-            .map(|(idx, key)| ProviderAccount::new(format!("{provider_id}-{idx}"), key.clone(), None))
-            .collect();
-        let pool = Arc::new(
-            AccountPool::new(provider_id.clone(), accounts, CooldownConfig::default())
-                .with_default_base_url(config.llm_base_url.clone()),
-        );
-        tracing::info!(
-            provider = %provider_id,
-            account_count = keys.len(),
-            "Attached LLM account pool (sera-jvi)"
-        );
-        client = client.with_account_pool(pool);
-    }
-
-    client
-}
+//
+// `build_llm_client` lives in [`sera_runtime::llm_client::build_from_config`]
+// (sera-ve9x) so the gateway's embedded dispatch path can construct the same
+// client without duplicating the env-var reads.
 
 // ── Constitutional gate resolution ───────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

PR 2 of the sera-ve9x slice (ADR §4 step 2). Adds `EmbeddedRuntimeTransport` behind `SERA_DISPATCH_MODE=embedded` so the gateway can construct a `DefaultRuntime` in-process per agent and route turns through it directly — no `sera-runtime --ndjson` child process. Default mode (`runtime`) is unchanged.

- New `sera-gateway::embedded_transport::EmbeddedRuntimeTransport` implements `AgentTurnTransport` using an `Arc<DefaultRuntime>` plus a `Mutex<Vec<Value>>` steer queue. `send_turn` calls `runtime.execute_turn(ctx)` and projects `TurnOutcome` → `TurnEvents`. `send_steer` stages items for the next turn via `metadata["pending_steer"]`. `liveness_probe` round-trips a trivial turn — same semantics as the stdio supervisor.
- Lifted `build_llm_client` → `sera_runtime::llm_client::build_from_config` and `build_authz_provider` → `sera_runtime::authz_builder::build_provider_from_config` so both the standalone runtime binary and the gateway's embedded path share construction.
- `effective_dispatch_mode_label()` switches to `"embedded"` when configured; `gateway` still falls back to `runtime` with a boot-log warn until ADR §4 step 3 lands.
- Per-agent boot loop branches on dispatch mode: `runtime` → existing `RuntimeChildSupervisor::start`; `embedded` → new `build_embedded_transport` helper. Embedded mode does **not** mutate the gateway process env (no `setenv` for `LLM_API_KEY`), closing a `/proc/<gateway-pid>/environ` exposure window.
- `gateway-bundled DefaultRuntime` boot uses fail-closed `CapabilityRegistry::load_and_bind` — same semantics as the runtime binary's `load_capability_registry` (sera-eo71). Tools allow/deny applies via `ToolNameFilter::from_globs`, no env round-trip.

### Out of scope (deferred)

- Default-mode flip (still gated on `sera-7ivj` proxy + `sera-ov7z` parity).
- `/admin/policies/reload` propagation to embedded transports — same parity caveat as the stdio child today.
- Full `production_e2e` parameterisation across dispatch modes — PR 3 owns that.
- Gateway LLM proxy (`sera-7ivj`) and child-env `LLM_API_KEY` strip.

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo clippy -p sera-gateway --all-targets -- -D warnings` clean
- [x] `cargo test -p sera-runtime --lib` — 573 passed
- [x] `cargo test -p sera-gateway` — 403 passed (with prebuilt `sera-runtime` for `production_e2e`)
- [x] `cargo test --workspace` — 4001 passed, 17 ignored
- [x] New unit tests in `sera-gateway`:
  - `effective_dispatch_mode_switches_to_embedded_when_configured`
  - `effective_dispatch_mode_falls_back_to_runtime_for_unimplemented_targets`
  - `effective_dispatch_mode_defaults_to_runtime_when_env_unset`
- [x] New tests in `embedded_transport`:
  - `send_turn_returns_response_and_usage` (mock LlmProvider, scripted reply)
  - `liveness_probe_succeeds_when_runtime_replies` / `_fails_on_empty_response`
  - `send_steer_stages_items_for_next_turn` (drain semantics)
  - `project_tool_events_extracts_begin_and_end` (transcript projection parity with stdio)

## Notes for PR 3

- `production_e2e_state` parameterisation on dispatch mode is the natural next step; the new `build_embedded_transport` helper plugs in cleanly.
- Capability registry hot-reload across embedded transports is the next non-obvious follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)