### PR TITLE
feat(sera-tools/sandbox): translate EgressManifest into Docker argv (sera-jpdu)

### DIFF
--- a/rust/crates/sera-tools/src/sandbox/docker.rs
+++ b/rust/crates/sera-tools/src/sandbox/docker.rs
@@ -68,25 +68,47 @@ struct StoredConfig {
 /// Translate an [`EgressManifest`] into the Docker argv that enforces it.
 ///
 /// Returns:
-/// - `Ok(vec![])` when egress is `Disabled`, or when `AuditOnly` is requested
-///   without a bridge (fail-open ramp; emits a warn log).
+/// - `Ok(vec![])` when egress is `Disabled` or `AuditOnly` (regardless of
+///   whether a bridge is configured). Per the [`EgressMode::AuditOnly`]
+///   contract — *log violations but do not block* — the Docker provider
+///   never attaches the sandbox to the egress bridge in audit mode; doing
+///   so would silently restrict outbound traffic via Docker's network
+///   isolation and contradict the migration-ramp semantics. Audit logging
+///   is the gateway proxy's responsibility.
 /// - `Err(SandboxError::PolicyViolation)` when `Strict` is requested without a
 ///   bridge — fail-closed.
-/// - On Strict/AuditOnly with a bridge: `--network=<name>`,
+/// - On `Strict` with a bridge: `--network=<name>`,
 ///   `--add-host=inference.local:<gateway>`, `--cap-drop=ALL`,
 ///   `--security-opt=no-new-privileges:true` in that order.
 ///
 /// `Domain` / `Cidr` entries in `egress.allowed` are not yet enforced by the
-/// Docker provider; they emit a warn log and fall through to strict bridge
-/// flags (so unlisted hosts remain unreachable — the safer failure mode).
+/// Docker provider; under `Strict` they emit a warn log and fall through to
+/// the strict bridge (so unlisted hosts remain unreachable — the safer
+/// failure mode).
 fn build_egress_args(
     egress: &EgressManifest,
     bridge: Option<&EgressBridgeConfig>,
 ) -> Result<Vec<String>, SandboxError> {
-    if egress.mode == EgressMode::Disabled {
-        return Ok(vec![]);
+    match egress.mode {
+        EgressMode::Disabled => Ok(vec![]),
+        EgressMode::AuditOnly => {
+            tracing::info!(
+                target: "sera_tools::sandbox::egress",
+                bridge_configured = bridge.is_some(),
+                "egress audit-only: no enforcement applied at the Docker \
+                 provider; gateway proxy is responsible for recording \
+                 would-have-blocked calls",
+            );
+            Ok(vec![])
+        }
+        EgressMode::Strict => build_strict_egress_args(egress, bridge),
     }
+}
 
+fn build_strict_egress_args(
+    egress: &EgressManifest,
+    bridge: Option<&EgressBridgeConfig>,
+) -> Result<Vec<String>, SandboxError> {
     for endpoint in &egress.allowed {
         match endpoint {
             EgressEndpoint::InferenceLocal => {}
@@ -109,27 +131,14 @@ fn build_egress_args(
         }
     }
 
-    let bridge = match bridge {
-        Some(b) => b,
-        None => {
-            if egress.mode == EgressMode::AuditOnly {
-                tracing::warn!(
-                    target: "sera_tools::sandbox::egress",
-                    "egress audit-only requested but no bridge configured; \
-                     sandbox will run on default bridge",
-                );
-                return Ok(vec![]);
-            }
-            return Err(SandboxError::PolicyViolation {
-                reason: "egress mode 'strict' requires an egress_bridge but \
-                         none was provisioned. To run this sandboxed agent: \
-                         (1) provision the sera-egress bridge before launching \
-                         this sandbox, or (2) set spec.egress.mode = 'disabled' \
-                         in the agent template (compliance opt-out)."
-                    .to_string(),
-            });
-        }
-    };
+    let bridge = bridge.ok_or_else(|| SandboxError::PolicyViolation {
+        reason: "egress mode 'strict' requires an egress_bridge but none \
+                 was provisioned. To run this sandboxed agent: (1) provision \
+                 the sera-egress bridge before launching this sandbox, or \
+                 (2) set spec.egress.mode = 'disabled' in the agent template \
+                 (compliance opt-out)."
+            .to_string(),
+    })?;
 
     Ok(vec![
         format!("--network={}", bridge.network_name),
@@ -609,21 +618,20 @@ mod tests {
     }
 
     #[test]
-    fn build_egress_args_audit_only_with_bridge_returns_strict_argv() {
+    fn build_egress_args_audit_only_with_bridge_does_not_enforce() {
+        // AuditOnly contract: "Log violations but do not block." Even when a
+        // bridge is provisioned, the Docker provider must not attach the
+        // sandbox to it — doing so would silently block outbound traffic via
+        // network isolation. Audit logging is the gateway proxy's job.
         let manifest = EgressManifest {
             allowed: vec![EgressEndpoint::InferenceLocal],
             mode: EgressMode::AuditOnly,
         };
         let bridge = sample_bridge();
         let args = build_egress_args(&manifest, Some(&bridge)).expect("audit-only + bridge");
-        assert_eq!(
-            args,
-            vec![
-                "--network=sera-egress".to_string(),
-                "--add-host=inference.local:172.18.0.2".to_string(),
-                "--cap-drop=ALL".to_string(),
-                "--security-opt=no-new-privileges:true".to_string(),
-            ]
+        assert!(
+            args.is_empty(),
+            "AuditOnly must not emit enforcement argv even with a bridge; got: {args:?}"
         );
     }
 

--- a/rust/crates/sera-tools/src/sandbox/docker.rs
+++ b/rust/crates/sera-tools/src/sandbox/docker.rs
@@ -29,7 +29,10 @@ use uuid::Uuid;
 
 use sera_types::sandbox::SourceMount;
 
-use super::{ExecResult, MountSpec, SandboxConfig, SandboxError, SandboxHandle, SandboxProvider};
+use super::{
+    EgressBridgeConfig, EgressEndpoint, EgressManifest, EgressMode, ExecResult, MountSpec,
+    SandboxConfig, SandboxError, SandboxHandle, SandboxProvider,
+};
 
 /// Default per-exec timeout (60 s).
 const DEFAULT_EXEC_TIMEOUT: Duration = Duration::from_secs(60);
@@ -58,6 +61,82 @@ struct StoredConfig {
     env: HashMap<String, String>,
     source_binds: Vec<String>,
     additional_binds: Vec<String>,
+    egress: Option<EgressManifest>,
+    egress_bridge: Option<EgressBridgeConfig>,
+}
+
+/// Translate an [`EgressManifest`] into the Docker argv that enforces it.
+///
+/// Returns:
+/// - `Ok(vec![])` when egress is `Disabled`, or when `AuditOnly` is requested
+///   without a bridge (fail-open ramp; emits a warn log).
+/// - `Err(SandboxError::PolicyViolation)` when `Strict` is requested without a
+///   bridge — fail-closed.
+/// - On Strict/AuditOnly with a bridge: `--network=<name>`,
+///   `--add-host=inference.local:<gateway>`, `--cap-drop=ALL`,
+///   `--security-opt=no-new-privileges:true` in that order.
+///
+/// `Domain` / `Cidr` entries in `egress.allowed` are not yet enforced by the
+/// Docker provider; they emit a warn log and fall through to strict bridge
+/// flags (so unlisted hosts remain unreachable — the safer failure mode).
+fn build_egress_args(
+    egress: &EgressManifest,
+    bridge: Option<&EgressBridgeConfig>,
+) -> Result<Vec<String>, SandboxError> {
+    if egress.mode == EgressMode::Disabled {
+        return Ok(vec![]);
+    }
+
+    for endpoint in &egress.allowed {
+        match endpoint {
+            EgressEndpoint::InferenceLocal => {}
+            EgressEndpoint::Domain { name } => {
+                tracing::warn!(
+                    target: "sera_tools::sandbox::egress",
+                    domain = %name,
+                    "domain egress not enforced by Docker provider yet; \
+                     traffic will be blocked by the strict bridge",
+                );
+            }
+            EgressEndpoint::Cidr { range } => {
+                tracing::warn!(
+                    target: "sera_tools::sandbox::egress",
+                    cidr = %range,
+                    "cidr egress not enforced by Docker provider yet; \
+                     traffic will be blocked by the strict bridge",
+                );
+            }
+        }
+    }
+
+    let bridge = match bridge {
+        Some(b) => b,
+        None => {
+            if egress.mode == EgressMode::AuditOnly {
+                tracing::warn!(
+                    target: "sera_tools::sandbox::egress",
+                    "egress audit-only requested but no bridge configured; \
+                     sandbox will run on default bridge",
+                );
+                return Ok(vec![]);
+            }
+            return Err(SandboxError::PolicyViolation {
+                reason: "egress mode 'strict' requires an egress_bridge but \
+                         none was provisioned. To run this sandboxed agent: \
+                         (1) provision the sera-egress bridge before launching \
+                         this sandbox, or (2) set spec.egress.mode = 'disabled' \
+                         in the agent template (compliance opt-out)."
+                    .to_string(),
+            });
+        }
+    };
+
+    Ok(vec![
+        format!("--network={}", bridge.network_name),
+        format!("--add-host=inference.local:{}", bridge.gateway_target),
+        "--cap-drop=ALL".to_string(),
+        "--security-opt=no-new-privileges:true".to_string(),
+    ])
 }
 
 impl DockerSandboxProvider {
@@ -145,6 +224,8 @@ impl SandboxProvider for DockerSandboxProvider {
             env: config.env.clone(),
             source_binds,
             additional_binds,
+            egress: config.egress.clone(),
+            egress_bridge: config.egress_bridge.clone(),
         };
 
         let id = format!("sera-sbx-{}", Uuid::new_v4());
@@ -169,6 +250,12 @@ impl SandboxProvider for DockerSandboxProvider {
 
         let mut cmd = Command::new(&self.docker_bin);
         cmd.arg("run").arg("--rm").arg("-i");
+
+        if let Some(egress) = &stored.egress {
+            for arg in build_egress_args(egress, stored.egress_bridge.as_ref())? {
+                cmd.arg(arg);
+            }
+        }
 
         // Merge env: stored (from create) first, per-exec overrides second.
         for (k, v) in stored.env.iter().chain(env.iter()) {
@@ -454,6 +541,162 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, SandboxError::ExecFailed { .. }));
+    }
+
+    fn strict_inference_local_manifest() -> EgressManifest {
+        EgressManifest {
+            allowed: vec![EgressEndpoint::InferenceLocal],
+            mode: EgressMode::Strict,
+        }
+    }
+
+    fn sample_bridge() -> EgressBridgeConfig {
+        EgressBridgeConfig {
+            network_name: "sera-egress".to_string(),
+            gateway_target: "172.18.0.2".to_string(),
+        }
+    }
+
+    #[test]
+    fn build_egress_args_strict_with_bridge() {
+        let manifest = strict_inference_local_manifest();
+        let bridge = sample_bridge();
+        let args = build_egress_args(&manifest, Some(&bridge)).expect("strict + bridge");
+        assert_eq!(
+            args,
+            vec![
+                "--network=sera-egress".to_string(),
+                "--add-host=inference.local:172.18.0.2".to_string(),
+                "--cap-drop=ALL".to_string(),
+                "--security-opt=no-new-privileges:true".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn build_egress_args_strict_without_bridge_fails_closed() {
+        let manifest = strict_inference_local_manifest();
+        let err = build_egress_args(&manifest, None).unwrap_err();
+        match err {
+            SandboxError::PolicyViolation { reason } => {
+                assert!(
+                    reason.contains("egress_bridge"),
+                    "reason should mention egress_bridge: {reason}"
+                );
+            }
+            other => panic!("expected PolicyViolation, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn build_egress_args_disabled_returns_empty() {
+        let manifest = EgressManifest {
+            allowed: vec![],
+            mode: EgressMode::Disabled,
+        };
+        let args = build_egress_args(&manifest, None).expect("disabled");
+        assert!(args.is_empty());
+    }
+
+    #[test]
+    fn build_egress_args_audit_only_without_bridge_fails_open() {
+        let manifest = EgressManifest {
+            allowed: vec![],
+            mode: EgressMode::AuditOnly,
+        };
+        let args = build_egress_args(&manifest, None).expect("audit-only fails open");
+        assert!(args.is_empty());
+    }
+
+    #[test]
+    fn build_egress_args_audit_only_with_bridge_returns_strict_argv() {
+        let manifest = EgressManifest {
+            allowed: vec![EgressEndpoint::InferenceLocal],
+            mode: EgressMode::AuditOnly,
+        };
+        let bridge = sample_bridge();
+        let args = build_egress_args(&manifest, Some(&bridge)).expect("audit-only + bridge");
+        assert_eq!(
+            args,
+            vec![
+                "--network=sera-egress".to_string(),
+                "--add-host=inference.local:172.18.0.2".to_string(),
+                "--cap-drop=ALL".to_string(),
+                "--security-opt=no-new-privileges:true".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn build_egress_args_domain_and_cidr_fall_through_to_strict_bridge() {
+        let manifest = EgressManifest {
+            allowed: vec![
+                EgressEndpoint::InferenceLocal,
+                EgressEndpoint::Domain {
+                    name: "api.github.com".to_string(),
+                },
+                EgressEndpoint::Cidr {
+                    range: "10.0.0.0/8".to_string(),
+                },
+            ],
+            mode: EgressMode::Strict,
+        };
+        let bridge = sample_bridge();
+        let args = build_egress_args(&manifest, Some(&bridge)).expect("strict + extras + bridge");
+        assert_eq!(
+            args,
+            vec![
+                "--network=sera-egress".to_string(),
+                "--add-host=inference.local:172.18.0.2".to_string(),
+                "--cap-drop=ALL".to_string(),
+                "--security-opt=no-new-privileges:true".to_string(),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn create_with_strict_egress_and_no_bridge_executes_fail_closed() {
+        let Ok(provider) = DockerSandboxProvider::new() else {
+            eprintln!("docker client init failed; skipping test");
+            return;
+        };
+        let config = SandboxConfig {
+            image: Some("alpine:3".to_string()),
+            egress: Some(strict_inference_local_manifest()),
+            egress_bridge: None,
+            ..Default::default()
+        };
+        let handle = provider.create(&config).await.expect("create");
+        let err = provider
+            .execute(&handle, "echo x", &HashMap::new())
+            .await
+            .unwrap_err();
+        match err {
+            SandboxError::PolicyViolation { reason } => {
+                assert!(reason.contains("egress_bridge"), "reason: {reason}");
+            }
+            other => panic!("expected PolicyViolation, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn create_stores_egress_and_bridge() {
+        let Ok(provider) = DockerSandboxProvider::new() else {
+            eprintln!("docker client init failed; skipping test");
+            return;
+        };
+        let bridge = sample_bridge();
+        let config = SandboxConfig {
+            image: Some("alpine:3".to_string()),
+            egress: Some(strict_inference_local_manifest()),
+            egress_bridge: Some(bridge.clone()),
+            ..Default::default()
+        };
+        let handle = provider.create(&config).await.expect("create");
+        let guard = provider.configs.lock().await;
+        let stored = guard.get(&handle.0).expect("stored config");
+        assert_eq!(stored.egress.as_ref().unwrap().mode, EgressMode::Strict);
+        assert_eq!(stored.egress_bridge.as_ref().unwrap(), &bridge);
     }
 
     #[tokio::test]

--- a/rust/crates/sera-tools/src/sandbox/mod.rs
+++ b/rust/crates/sera-tools/src/sandbox/mod.rs
@@ -14,6 +14,7 @@ pub use policy::{
     DockerSandboxPolicy, FileSystemSandboxPolicy, L7Protocol, L7Rule, NetworkEndpoint,
     NetworkPolicyRule, NetworkSandboxPolicy, PolicyAction, PolicyStatus, SandboxPolicy,
 };
+pub use sera_types::sandbox::{EgressEndpoint, EgressManifest, EgressMode};
 
 use std::collections::HashMap;
 
@@ -22,6 +23,20 @@ use sera_types::sandbox::SourceMount;
 use thiserror::Error;
 
 pub use policy::SandboxPolicy as SandboxPolicyType;
+
+/// Runtime location of the egress bridge that sandbox containers attach to
+/// when an [`EgressManifest`] is enforced.
+///
+/// `network_name` is the user-defined Docker bridge (e.g. `sera-egress`) and
+/// `gateway_target` is the IP or hostname the gateway listens on for
+/// `inference.local` traffic. Both are resolved by the bridge provisioning
+/// layer (a follow-up PR) and not persisted — WSL2 changes bridge IPs across
+/// daemon restarts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EgressBridgeConfig {
+    pub network_name: String,
+    pub gateway_target: String,
+}
 
 /// Opaque handle to a running sandbox.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -57,6 +72,15 @@ pub struct SandboxConfig {
     /// Additional bind mounts requested by the caller (ephemeral agents etc.).
     /// Appended after [`Self::sources`] into the Docker `-v` flag list.
     pub additional_mounts: Vec<MountSpec>,
+    /// Declared egress policy. When `Some(.)` and `mode != Disabled`, the
+    /// Docker provider translates this into `--network` / `--add-host` /
+    /// cap-drop argv. When `None`, legacy default-bridge behaviour is
+    /// preserved (no enforcement).
+    pub egress: Option<EgressManifest>,
+    /// Bridge configuration consumed when [`Self::egress`] is enforced.
+    /// Required for `EgressMode::Strict`; missing-bridge under Strict is
+    /// fail-closed at sandbox launch.
+    pub egress_bridge: Option<EgressBridgeConfig>,
 }
 
 /// Output from executing a command inside a sandbox.


### PR DESCRIPTION
## Summary

- Adds `EgressBridgeConfig` and two new `SandboxConfig` fields (`egress`, `egress_bridge`); re-exports `EgressEndpoint`/`EgressManifest`/`EgressMode` from `sera-types`.
- `DockerSandboxProvider::execute` now translates an enforced `EgressManifest` into Docker argv: `--network=<bridge>`, `--add-host=inference.local:<gateway>`, `--cap-drop=ALL`, `--security-opt=no-new-privileges:true`.
- Fail-closed when `Strict` is requested without a bridge; fail-open with `tracing::warn!` for `AuditOnly` without bridge; no-op for `Disabled` and the legacy `egress=None` path.
- `Domain` / `Cidr` exceptions in `allowed` emit a warn and fall through to strict bridge flags (the safer failure mode — they remain unreachable until the follow-up bead enforces them).

This is PR 1 of the `sera-jpdu` lane. Bridge provisioning (PR 2) and gateway wiring (`sera-eq0m` PR C) land separately. No new dependencies, no bollard calls, no gateway/policy refactors. Scope is strictly `sera-tools/src/sandbox/{mod.rs,docker.rs}`.

Blocks `sera-eq0m` PR C.

## Test plan

- [x] `cargo test -p sera-tools sandbox::docker::tests` — 18 passed (10 pre-existing + 8 new).
- [x] `cargo clippy -p sera-tools -- -D warnings` — clean.
- [x] New unit tests cover: strict + bridge, strict + no bridge (fail-closed), disabled + no bridge, audit-only + no bridge (fail-open), audit-only + bridge, domain/cidr fall-through, `execute` fail-closed end-to-end, stored fields round-trip.
- [x] Existing tests untouched; legacy `egress=None` path produces no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)