### PR TITLE
feat(sera-gateway): persist inference proxy audit events (sera-7ivj)

### DIFF
--- a/rust/crates/sera-gateway/src/bin/sera.rs
+++ b/rust/crates/sera-gateway/src/bin/sera.rs
@@ -103,7 +103,7 @@ use route_plugins::PluginsAppState;
 use route_workflow::WorkflowAppState;
 use route_inference_proxy::{
     InferenceProxyAppState, InferenceProxyAudit, LlmBudgetGate, NoopBudgetGate,
-    TracingProxyAudit, UpstreamProvider,
+    SqliteInferenceProxyAudit, UpstreamProvider,
 };
 
 // Party-mode handler (sera-8d1.2 / GH#145) — generic over PartyAppState trait
@@ -1076,7 +1076,7 @@ impl AgentTurnTransport for RuntimeChildSupervisor {
 // ── Shared state ────────────────────────────────────────────────────────────
 
 struct AppState {
-    db: Mutex<SqliteDb>,
+    db: Arc<Mutex<SqliteDb>>,
     manifests: ManifestSet,
     /// Shared Discord connector for sending replies. `None` when no Discord
     /// connector is configured.
@@ -1463,7 +1463,12 @@ impl InferenceProxyAppState for AppState {
     }
 
     fn proxy_audit(&self) -> Arc<dyn InferenceProxyAudit> {
-        Arc::new(TracingProxyAudit)
+        // sera-7ivj PR3: persist one row per proxy call to the gateway's
+        // shared SqliteDb. Replaces the prior tracing-only sink so an
+        // operator can inspect proxy traffic via `query_audit` after the
+        // fact. Body content is never persisted — only the metadata in
+        // ProxyAuditEvent.
+        Arc::new(SqliteInferenceProxyAudit::new(Arc::clone(&self.db)))
     }
 }
 
@@ -4303,7 +4308,7 @@ async fn run_start(config: PathBuf, port: u16, local: bool) -> anyhow::Result<()
     let admin_audit = AdminAuditLogger::shared(admin_audit_path);
 
     let state = Arc::new(AppState {
-        db: Mutex::new(db),
+        db: Arc::new(Mutex::new(db)),
         manifests,
         discord: shared_discord,
         api_key,
@@ -4973,7 +4978,7 @@ mod tests {
         let hook_registry = Arc::new(HookRegistry::new());
         let chain_executor = Arc::new(ChainExecutor::new(Arc::clone(&hook_registry)));
         Arc::new(AppState {
-            db: Mutex::new(SqliteDb::open_in_memory().unwrap()),
+            db: Arc::new(Mutex::new(SqliteDb::open_in_memory().unwrap())),
             manifests: test_manifests(),
             discord: None,
             api_key: None,
@@ -5018,7 +5023,7 @@ mod tests {
         let hook_registry = Arc::new(HookRegistry::new());
         let chain_executor = Arc::new(ChainExecutor::new(Arc::clone(&hook_registry)));
         Arc::new(AppState {
-            db: Mutex::new(SqliteDb::open_in_memory().unwrap()),
+            db: Arc::new(Mutex::new(SqliteDb::open_in_memory().unwrap())),
             manifests: test_manifests(),
             discord: None,
             api_key: None,
@@ -5063,7 +5068,7 @@ mod tests {
         let hook_registry = Arc::new(HookRegistry::new());
         let chain_executor = Arc::new(ChainExecutor::new(Arc::clone(&hook_registry)));
         Arc::new(AppState {
-            db: Mutex::new(SqliteDb::open_in_memory().unwrap()),
+            db: Arc::new(Mutex::new(SqliteDb::open_in_memory().unwrap())),
             manifests: test_manifests(),
             discord: None,
             api_key: Some(key.to_owned()),
@@ -5108,7 +5113,7 @@ mod tests {
         let hook_registry = Arc::new(HookRegistry::new());
         let chain_executor = Arc::new(ChainExecutor::new(Arc::clone(&hook_registry)));
         Arc::new(AppState {
-            db: Mutex::new(SqliteDb::open_in_memory().unwrap()),
+            db: Arc::new(Mutex::new(SqliteDb::open_in_memory().unwrap())),
             manifests: test_manifests(),
             discord: None,
             api_key: Some(key.to_owned()),
@@ -5609,7 +5614,7 @@ spec:
         let hook_registry = Arc::new(HookRegistry::new());
         let chain_executor = Arc::new(ChainExecutor::new(Arc::clone(&hook_registry)));
         Arc::new(AppState {
-            db: Mutex::new(SqliteDb::open_in_memory().unwrap()),
+            db: Arc::new(Mutex::new(SqliteDb::open_in_memory().unwrap())),
             manifests: parse_manifests(STRICT_AGENT_YAML).unwrap(),
             discord: None,
             api_key: None,
@@ -6114,7 +6119,7 @@ spec:
         let hook_registry = Arc::new(HookRegistry::new());
         let chain_executor = Arc::new(ChainExecutor::new(Arc::clone(&hook_registry)));
         let state = AppState {
-            db: Mutex::new(SqliteDb::open_in_memory().unwrap()),
+            db: Arc::new(Mutex::new(SqliteDb::open_in_memory().unwrap())),
             manifests: test_manifests(),
             discord: None,
             api_key: None,
@@ -6162,7 +6167,7 @@ spec:
         let hook_registry = Arc::new(HookRegistry::new());
         let chain_executor = Arc::new(ChainExecutor::new(Arc::clone(&hook_registry)));
         let state = AppState {
-            db: Mutex::new(SqliteDb::open_in_memory().unwrap()),
+            db: Arc::new(Mutex::new(SqliteDb::open_in_memory().unwrap())),
             manifests: test_manifests(),
             discord: None,
             api_key: Some("my-key".to_owned()),
@@ -6211,7 +6216,7 @@ spec:
         let hook_registry = Arc::new(HookRegistry::new());
         let chain_executor = Arc::new(ChainExecutor::new(Arc::clone(&hook_registry)));
         let state = AppState {
-            db: Mutex::new(SqliteDb::open_in_memory().unwrap()),
+            db: Arc::new(Mutex::new(SqliteDb::open_in_memory().unwrap())),
             manifests: test_manifests(),
             discord: None,
             api_key: Some("my-key".to_owned()),
@@ -6263,7 +6268,7 @@ spec:
         let hook_registry = Arc::new(HookRegistry::new());
         let chain_executor = Arc::new(ChainExecutor::new(Arc::clone(&hook_registry)));
         let state = AppState {
-            db: Mutex::new(SqliteDb::open_in_memory().unwrap()),
+            db: Arc::new(Mutex::new(SqliteDb::open_in_memory().unwrap())),
             manifests: test_manifests(),
             discord: None,
             api_key: Some("my-key".to_owned()),
@@ -7430,7 +7435,7 @@ spec:
         let hook_registry = Arc::new(registry);
         let chain_executor = Arc::new(ChainExecutor::new(Arc::clone(&hook_registry)));
         let state = Arc::new(AppState {
-            db: Mutex::new(SqliteDb::open_in_memory().unwrap()),
+            db: Arc::new(Mutex::new(SqliteDb::open_in_memory().unwrap())),
             manifests: test_manifests(),
             discord: None,
             api_key: None,
@@ -7517,7 +7522,7 @@ spec:
             let hook_registry = Arc::new(HookRegistry::new());
             let chain_executor = Arc::new(ChainExecutor::new(Arc::clone(&hook_registry)));
             Arc::new(AppState {
-                db: Mutex::new(SqliteDb::open_in_memory().unwrap()),
+                db: Arc::new(Mutex::new(SqliteDb::open_in_memory().unwrap())),
                 manifests: test_manifests(),
                 discord: None,
                 api_key: Some("secret".to_owned()),
@@ -8241,7 +8246,7 @@ spec:
             }
 
             let state = Arc::new(AppState {
-                db: Mutex::new(SqliteDb::open_in_memory().unwrap()),
+                db: Arc::new(Mutex::new(SqliteDb::open_in_memory().unwrap())),
                 manifests,
                 discord: None,
                 api_key: None,

--- a/rust/crates/sera-gateway/src/routes/inference_proxy.rs
+++ b/rust/crates/sera-gateway/src/routes/inference_proxy.rs
@@ -154,6 +154,59 @@ impl InferenceProxyAudit for TracingProxyAudit {
     }
 }
 
+/// Event-type written to `audit_log` for every proxy call. Keeps a single
+/// stable name so operators can filter the trail with one `WHERE event_type`.
+const PROXY_AUDIT_EVENT_TYPE: &str = "inference_proxy_call";
+
+/// Actor-kind tag — distinguishes proxy events from `human` / `agent` actors.
+const PROXY_AUDIT_ACTOR_KIND: &str = "inference_proxy";
+
+/// Durable audit sink — persists one row per proxy call to the gateway's
+/// shared `SqliteDb`. Replaces [`TracingProxyAudit`] in the production
+/// `AppState` so an operator can inspect proxy traffic via `query_audit`
+/// after the fact.
+///
+/// Body content is **not** persisted — only the metadata already present in
+/// [`ProxyAuditEvent`]. Failures are best-effort: on insert error we log a
+/// warning but never fail the proxy response.
+pub struct SqliteInferenceProxyAudit {
+    db: Arc<tokio::sync::Mutex<sera_db::sqlite::SqliteDb>>,
+}
+
+impl SqliteInferenceProxyAudit {
+    pub fn new(db: Arc<tokio::sync::Mutex<sera_db::sqlite::SqliteDb>>) -> Self {
+        Self { db }
+    }
+}
+
+#[async_trait]
+impl InferenceProxyAudit for SqliteInferenceProxyAudit {
+    async fn record(&self, event: ProxyAuditEvent) {
+        let details = serde_json::json!({
+            "provider_base_url": event.provider_base_url,
+            "model_requested": event.model_requested,
+            "stream": event.stream,
+            "status": event.status,
+            "outcome": event.outcome.as_str(),
+        })
+        .to_string();
+        let db = self.db.lock().await;
+        if let Err(e) = db.append_audit(
+            PROXY_AUDIT_EVENT_TYPE,
+            &event.principal,
+            PROXY_AUDIT_ACTOR_KIND,
+            Some(&details),
+        ) {
+            tracing::warn!(
+                error = %e,
+                principal = %event.principal,
+                outcome = event.outcome.as_str(),
+                "inference_proxy: failed to persist audit row"
+            );
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // AppState abstraction
 // ---------------------------------------------------------------------------
@@ -1679,5 +1732,383 @@ data: {"type":"message_stop"}"#,
         let events = state.audit.snapshot();
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].outcome, ProxyOutcome::NoUpstream);
+    }
+
+    // ---------------------------------------------------------------------
+    // SqliteInferenceProxyAudit — sera-7ivj PR3 durable persistence
+    // ---------------------------------------------------------------------
+    //
+    // Goal: prove that the production audit sink writes one row per proxy
+    // call into the gateway's existing `audit_log` table — covering the
+    // five outcomes the previous tracing-only sink could not surface to an
+    // operator. Body content is never persisted; only metadata.
+
+    use sera_db::sqlite::SqliteDb;
+    use tokio::sync::Mutex as TokioMutex;
+
+    fn open_audit_db() -> Arc<TokioMutex<SqliteDb>> {
+        Arc::new(TokioMutex::new(
+            SqliteDb::open_in_memory().expect("in-memory sqlite"),
+        ))
+    }
+
+    /// State variant that carries an `Arc<dyn InferenceProxyAudit>` directly,
+    /// so persistence-focused tests can drive the route with a real
+    /// `SqliteInferenceProxyAudit` (the production sink) instead of the
+    /// in-memory `RecordingAudit` used by the trait-surface tests above.
+    struct PersistentTestState {
+        api_key: Option<String>,
+        upstream: Option<UpstreamProvider>,
+        anthropic_upstream: Option<UpstreamProvider>,
+        client: reqwest::Client,
+        gate: Arc<dyn LlmBudgetGate>,
+        audit: Arc<dyn InferenceProxyAudit>,
+    }
+
+    impl InferenceProxyAppState for PersistentTestState {
+        fn proxy_api_key(&self) -> &Option<String> {
+            &self.api_key
+        }
+        fn proxy_upstream(&self) -> Option<UpstreamProvider> {
+            self.upstream.clone()
+        }
+        fn proxy_anthropic_upstream(&self) -> Option<UpstreamProvider> {
+            self.anthropic_upstream.clone()
+        }
+        fn proxy_http_client(&self) -> reqwest::Client {
+            self.client.clone()
+        }
+        fn proxy_budget_gate(&self) -> Arc<dyn LlmBudgetGate> {
+            Arc::clone(&self.gate)
+        }
+        fn proxy_audit(&self) -> Arc<dyn InferenceProxyAudit> {
+            Arc::clone(&self.audit)
+        }
+    }
+
+    fn make_persistent_state(
+        api_key: Option<&str>,
+        upstream: Option<UpstreamProvider>,
+        anthropic_upstream: Option<UpstreamProvider>,
+        gate: Arc<dyn LlmBudgetGate>,
+        db: Arc<TokioMutex<SqliteDb>>,
+    ) -> Arc<PersistentTestState> {
+        Arc::new(PersistentTestState {
+            api_key: api_key.map(String::from),
+            upstream,
+            anthropic_upstream,
+            client: reqwest::Client::builder()
+                .timeout(Duration::from_secs(5))
+                .build()
+                .expect("client"),
+            gate,
+            audit: Arc::new(SqliteInferenceProxyAudit::new(db)),
+        })
+    }
+
+    fn chat_route_persistent(state: Arc<PersistentTestState>) -> Router {
+        Router::new()
+            .route(
+                "/v1/chat/completions",
+                post(chat_completions::<PersistentTestState>),
+            )
+            .with_state(state)
+    }
+
+    fn messages_route_persistent(state: Arc<PersistentTestState>) -> Router {
+        Router::new()
+            .route("/v1/messages", post(chat_messages::<PersistentTestState>))
+            .with_state(state)
+    }
+
+    /// Read every audit row out of the shared SqliteDb so tests can assert
+    /// on persisted shape without depending on row-id ordering.
+    async fn read_audit_rows(db: &Arc<TokioMutex<SqliteDb>>) -> Vec<sera_db::sqlite::AuditRow> {
+        let guard = db.lock().await;
+        guard.query_audit(50).expect("query audit")
+    }
+
+    fn parse_details(row: &sera_db::sqlite::AuditRow) -> serde_json::Value {
+        let raw = row
+            .details
+            .as_deref()
+            .expect("details json present on proxy audit row");
+        serde_json::from_str(raw).expect("details is valid JSON")
+    }
+
+    #[tokio::test]
+    async fn sqlite_audit_persists_openai_success_row() {
+        let mock = start_mock_upstream(MockResponse::Json {
+            status: StatusCode::OK,
+            body: serde_json::json!({"id": "chatcmpl-1"}),
+            retry_after: None,
+        })
+        .await;
+        let db = open_audit_db();
+        let state = make_persistent_state(
+            None,
+            Some(UpstreamProvider {
+                base_url: mock.base_url.clone(),
+                api_key: "upstream-key".into(),
+            }),
+            None,
+            Arc::new(NoopBudgetGate),
+            Arc::clone(&db),
+        );
+        let app = chat_route_persistent(Arc::clone(&state));
+
+        let resp = app
+            .oneshot(
+                Request::post("/v1/chat/completions")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(json_body(serde_json::json!({"model": "gpt-4"})))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let rows = read_audit_rows(&db).await;
+        assert_eq!(rows.len(), 1, "expected exactly one persisted audit row");
+        assert_eq!(rows[0].event_type, "inference_proxy_call");
+        assert_eq!(rows[0].actor_kind, "inference_proxy");
+        assert_eq!(rows[0].actor_id, "anonymous");
+        let details = parse_details(&rows[0]);
+        assert_eq!(details["outcome"], "success");
+        assert_eq!(details["status"], 200);
+        assert_eq!(details["model_requested"], "gpt-4");
+        assert_eq!(details["stream"], false);
+        assert_eq!(details["provider_base_url"], mock.base_url);
+    }
+
+    #[tokio::test]
+    async fn sqlite_audit_persists_anthropic_success_row() {
+        let mock = start_mock_upstream(MockResponse::Json {
+            status: StatusCode::OK,
+            body: serde_json::json!({"id": "msg_01"}),
+            retry_after: None,
+        })
+        .await;
+        let db = open_audit_db();
+        let state = make_persistent_state(
+            None,
+            None,
+            Some(UpstreamProvider {
+                base_url: mock.base_url.clone(),
+                api_key: "upstream-key".into(),
+            }),
+            Arc::new(NoopBudgetGate),
+            Arc::clone(&db),
+        );
+        let app = messages_route_persistent(Arc::clone(&state));
+
+        let resp = app
+            .oneshot(
+                Request::post("/v1/messages")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(json_body(serde_json::json!({"model": "claude-3-5-sonnet"})))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let rows = read_audit_rows(&db).await;
+        assert_eq!(rows.len(), 1);
+        let details = parse_details(&rows[0]);
+        assert_eq!(details["outcome"], "success");
+        assert_eq!(details["model_requested"], "claude-3-5-sonnet");
+    }
+
+    #[tokio::test]
+    async fn sqlite_audit_persists_budget_denied_row_and_skips_upstream() {
+        let mock = start_mock_upstream(MockResponse::Json {
+            status: StatusCode::OK,
+            body: serde_json::json!({"ok": true}),
+            retry_after: None,
+        })
+        .await;
+        let db = open_audit_db();
+        let state = make_persistent_state(
+            None,
+            Some(UpstreamProvider {
+                base_url: mock.base_url.clone(),
+                api_key: "k".into(),
+            }),
+            None,
+            Arc::new(DenyingGate {
+                reason: "monthly budget exhausted".into(),
+                retry_after: Some(Duration::from_secs(60)),
+            }),
+            Arc::clone(&db),
+        );
+        let app = chat_route_persistent(Arc::clone(&state));
+
+        let resp = app
+            .oneshot(
+                Request::post("/v1/chat/completions")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(json_body(serde_json::json!({"model": "gpt-4"})))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+
+        // Upstream must not have been called when the gate denied.
+        assert!(mock.captured.lock().unwrap().body.is_empty());
+
+        let rows = read_audit_rows(&db).await;
+        assert_eq!(rows.len(), 1);
+        let details = parse_details(&rows[0]);
+        assert_eq!(details["outcome"], "budget_exceeded");
+        assert_eq!(details["status"], 429);
+    }
+
+    #[tokio::test]
+    async fn sqlite_audit_persists_no_upstream_row() {
+        let db = open_audit_db();
+        let state =
+            make_persistent_state(None, None, None, Arc::new(NoopBudgetGate), Arc::clone(&db));
+        let app = chat_route_persistent(Arc::clone(&state));
+
+        let resp = app
+            .oneshot(
+                Request::post("/v1/chat/completions")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(json_body(serde_json::json!({"model": "gpt-4"})))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+        let rows = read_audit_rows(&db).await;
+        assert_eq!(rows.len(), 1);
+        let details = parse_details(&rows[0]);
+        assert_eq!(details["outcome"], "no_upstream");
+        assert_eq!(details["status"], 503);
+        // No upstream resolved → empty provider_base_url, not a leak.
+        assert_eq!(details["provider_base_url"], "");
+    }
+
+    #[tokio::test]
+    async fn sqlite_audit_persists_upstream_error_row() {
+        let mock = start_mock_upstream(MockResponse::Json {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            body: serde_json::json!({"error": {"message": "boom"}}),
+            retry_after: None,
+        })
+        .await;
+        let db = open_audit_db();
+        let state = make_persistent_state(
+            None,
+            Some(UpstreamProvider {
+                base_url: mock.base_url.clone(),
+                api_key: "k".into(),
+            }),
+            None,
+            Arc::new(NoopBudgetGate),
+            Arc::clone(&db),
+        );
+        let app = chat_route_persistent(Arc::clone(&state));
+
+        let resp = app
+            .oneshot(
+                Request::post("/v1/chat/completions")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(json_body(serde_json::json!({"model": "gpt-4"})))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+
+        let rows = read_audit_rows(&db).await;
+        assert_eq!(rows.len(), 1);
+        let details = parse_details(&rows[0]);
+        assert_eq!(details["outcome"], "provider_error");
+        assert_eq!(details["status"], 500);
+    }
+
+    #[tokio::test]
+    async fn sqlite_audit_persists_one_row_for_streaming_call() {
+        let mock = start_mock_upstream(MockResponse::SseChunks(vec![
+            r#"{"choices":[{"delta":{"content":"hi"}}]}"#,
+            "[DONE]",
+        ]))
+        .await;
+        let db = open_audit_db();
+        let state = make_persistent_state(
+            None,
+            Some(UpstreamProvider {
+                base_url: mock.base_url.clone(),
+                api_key: "k".into(),
+            }),
+            None,
+            Arc::new(NoopBudgetGate),
+            Arc::clone(&db),
+        );
+        let app = chat_route_persistent(Arc::clone(&state));
+
+        let resp = app
+            .oneshot(
+                Request::post("/v1/chat/completions")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(json_body(
+                        serde_json::json!({"model": "gpt-4", "stream": true}),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        // Drain the SSE body so the upstream future completes; the audit row
+        // is emitted synchronously after the upstream response is converted
+        // to a stream and before the body is returned to the caller.
+        let _ = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+
+        let rows = read_audit_rows(&db).await;
+        assert_eq!(rows.len(), 1, "streaming must emit exactly one audit row");
+        let details = parse_details(&rows[0]);
+        assert_eq!(details["outcome"], "success");
+        assert_eq!(details["stream"], true);
+    }
+
+    #[tokio::test]
+    async fn sqlite_audit_does_not_persist_for_unauthenticated_caller() {
+        // Existing 401 path must remain audit-silent — the durable sink
+        // must not change that contract.
+        let db = open_audit_db();
+        let state = make_persistent_state(
+            Some("expected-key"),
+            Some(UpstreamProvider {
+                base_url: "http://127.0.0.1:1/v1".into(),
+                api_key: "u".into(),
+            }),
+            None,
+            Arc::new(NoopBudgetGate),
+            Arc::clone(&db),
+        );
+        let app = chat_route_persistent(Arc::clone(&state));
+
+        let resp = app
+            .oneshot(
+                Request::post("/v1/chat/completions")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(json_body(serde_json::json!({"model": "gpt-4"})))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+
+        let rows = read_audit_rows(&db).await;
+        assert!(
+            rows.is_empty(),
+            "unauthenticated callers must not produce a persisted audit row"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Replaces the tracing-only `TracingProxyAudit` sink in production `AppState` with **`SqliteInferenceProxyAudit`**, which persists one row per inference proxy call to the gateway's existing `audit_log` table.
- Closes the durable-audit gap that blocked **sera-eq0m.1**: operators can now inspect proxy traffic via `query_audit` rather than grepping logs.
- Body content is **never** persisted — only metadata already in `ProxyAuditEvent` (`provider_base_url`, `model_requested`, `stream`, `status`, `outcome`).
- `AppState.db` rewrapped as `Arc<Mutex<SqliteDb>>` (was `Mutex<SqliteDb>`) so the sink can share the handle. All existing `self.db.lock()` call sites are unchanged — `Arc<Mutex<T>>` derefs to `Mutex<T>`.
- The `LlmBudgetGate` seam is preserved as a no-op default; quota-backed budget enforcement remains the next slice and is **not** in this PR — see "Follow-ups" below.

## What changed

| File | Change |
| --- | --- |
| `rust/crates/sera-gateway/src/routes/inference_proxy.rs` | New `SqliteInferenceProxyAudit` struct + `InferenceProxyAudit` impl + 7 tests |
| `rust/crates/sera-gateway/src/bin/sera.rs` | Wire `proxy_audit()` to the new sink; `db: Mutex<…>` → `Arc<Mutex<…>>` (13 construction sites, mechanical) |

## Audit row shape

```
event_type:  "inference_proxy_call"
actor_kind:  "inference_proxy"
actor_id:    <principal>             // "anonymous" when auth disabled
details:     {provider_base_url, model_requested, stream, status, outcome}
```

`outcome` is one of: `success`, `rate_limited`, `provider_error`, `budget_exceeded`, `no_upstream`, `upstream_unreachable`.

## Test plan

New tests under `routes::inference_proxy::tests::sqlite_audit_*` (7 added; 21 existing trait-surface tests remain green):

- [x] `sqlite_audit_persists_openai_success_row` — `/v1/chat/completions` 200 → one row, `outcome=success`, `status=200`, `provider_base_url` matches mock
- [x] `sqlite_audit_persists_anthropic_success_row` — `/v1/messages` 200 → one row, `model_requested=claude-3-5-sonnet`
- [x] `sqlite_audit_persists_budget_denied_row_and_skips_upstream` — denying gate → 429 row + upstream never called
- [x] `sqlite_audit_persists_no_upstream_row` — no provider configured → 503 row, `provider_base_url=""` (no leak)
- [x] `sqlite_audit_persists_upstream_error_row` — upstream 500 → row with `outcome=provider_error`, `status=500`
- [x] `sqlite_audit_persists_one_row_for_streaming_call` — SSE stream → exactly one row (never per-chunk)
- [x] `sqlite_audit_does_not_persist_for_unauthenticated_caller` — preserves existing 401-silent contract

### Local verification

- [x] `cargo check -p sera-gateway`
- [x] `cargo test -p sera-gateway --bin sera-gateway inference_proxy` → **28 passed, 0 failed**
- [x] `cargo test -p sera-gateway` → **229 passed; 2 pre-existing E2E failures unrelated** (`production_e2e::*` need `sera-runtime` binary built; same on `main`)
- [x] `cargo clippy -p sera-gateway --tests -- -D warnings` → clean
- [x] `rustfmt --edition 2024 --check` on both touched files → clean

## Follow-ups (not in this PR)

- **sera-eq0m.1**: now unblocked for the audit half — full eq0m closure can proceed against the persisted rows.
- **Real budget enforcement**: `LlmBudgetGate` is still wired to `NoopBudgetGate`. Quota-backed gate (token_usage/usage_events/token_quotas) is intentionally deferred — would require deciding the per-principal/per-model accounting policy and is a separate slice. The trait seam is unchanged so the swap will be surgical.
- **Hash-chained audit**: this lands rows in the simple `audit_log` table used by other gateway events. Migrating to the hash-chained `audit_trail` (`AuditStore`) pipeline can be a later non-breaking swap of the sink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)