### PR TITLE
fix(sera-web): use 127.0.0.1 in compose healthcheck (sera-l3lf)

### DIFF
--- a/docker-compose.rust.yaml
+++ b/docker-compose.rust.yaml
@@ -108,8 +108,12 @@ services:
       - "5173:80"
     networks:
       - sera_net
+    # Use 127.0.0.1 explicitly: on Windows/WSL Docker setups `localhost` can
+    # resolve to `::1` first, but the nginx `listen 80` directive in this
+    # image only binds IPv4 inside the container, producing a false
+    # unhealthy state when wget tries the IPv6 address first.
     healthcheck:
-      test: ["CMD-SHELL", "wget -q -O /dev/null http://localhost:80/ || exit 1"]
+      test: ["CMD-SHELL", "wget -q -O /dev/null http://127.0.0.1:80/ || exit 1"]
       interval: 30s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
## Summary
- Compose healthcheck for `sera-web` was probing `http://localhost:80/` from inside the nginx container. On Windows/WSL Docker setups, `localhost` resolves to `::1` first; nginx's default `listen 80` only binds IPv4, so the probe fails with ECONNREFUSED and Docker reports the container as unhealthy even while the host can reach `http://localhost:5173/` normally.
- Switch the probe target to `127.0.0.1:80` and add a brief comment explaining the IPv6 ambiguity so it is not regressed.

## Tests
- `docker compose -f docker-compose.rust.yaml config` validates the rendered service and shows the new probe (`wget -q -O /dev/null http://127.0.0.1:80/ || exit 1`).
- Live container probe was not run: no `sera-web` container was up locally, and the task scope explicitly avoids restarting broad stacks for verification.

## Follow-ups
- None. Single-file, single-line behaviour fix; the comment captures the rationale for future readers.

Closes sera-l3lf.