### PR TITLE
feat(sera-tui): pin chat-dominant layout to spec (sera-ckw5)

### DIFF
--- a/rust/crates/sera-tui/src/client.rs
+++ b/rust/crates/sera-tui/src/client.rs
@@ -36,6 +36,11 @@ pub enum ConnectionState {
 }
 
 impl ConnectionState {
+    /// Human-readable connection-state label.  Currently only consumed by
+    /// unit tests; `views::status_bar` carries its own coloured rendering.
+    /// Kept as the canonical mapping so downstream code (debug overlays,
+    /// future status banners) has one source of truth.
+    #[allow(dead_code)]
     pub fn label(self) -> &'static str {
         match self {
             Self::Connected => "connected",
@@ -123,6 +128,11 @@ impl Agent {
 #[derive(Debug, Clone)]
 pub struct SessionSummary {
     pub id: String,
+    /// Owning agent id from the gateway response.  Not currently rendered
+    /// — the top status bar reads `App::active_agent_id` directly — but
+    /// kept on the parsed struct so the wire format stays honest and the
+    /// session picker / debug overlays can reuse it without a re-fetch.
+    #[allow(dead_code)]
     pub agent_id: String,
     /// ISO-8601 timestamp of session creation.  Not yet rendered in the
     /// TUI but parsed for future "Age" column support — keep the field

--- a/rust/crates/sera-tui/src/ui.rs
+++ b/rust/crates/sera-tui/src/ui.rs
@@ -1,18 +1,20 @@
-//! Central render entry point — **chat-dominant** layout (J.0.1).
+//! Central render entry point — **chat-dominant** layout (J.0.1, sera-ckw5).
 //!
 //! The screen is one big transcript canvas with a composer pinned at the
-//! bottom and a single-line status/hint footer.  Agents, HITL queue, and
-//! evolve status are accessed as modal overlays via Ctrl+A/H/E.
+//! bottom.  A single-line status bar sits on top (agent · session · conn)
+//! and a single-line key-hint footer sits at the bottom.  Agents, HITL
+//! queue, and evolve status are accessed as modal overlays via Ctrl+A/H/E.
 //!
-//! Layout:
+//! Layout (matches `docs/plan/SPEC-chat-tui.md`):
 //! ```text
 //! ┌──────────────────────────────────────────────┐
-//! │ main (Min(3))         — Session chat canvas  │
+//! │ status   (Length(1))  — agent/session/conn   │
+//! ├──────────────────────────────────────────────┤
+//! │ main     (Min(3))     — Session chat canvas  │
 //! ├──────────────────────────────────────────────┤
 //! │ composer (Length(5))  — multi-line input     │
 //! ├──────────────────────────────────────────────┤
-//! │ status (Length(1))    — agent/session/conn   │
-//! │ hint   (Length(1))    — contextual keys      │
+//! │ hint     (Length(1))  — contextual keys      │
 //! └──────────────────────────────────────────────┘
 //! ```
 
@@ -31,18 +33,12 @@ pub fn render(frame: &mut Frame, app: &mut App) {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
+            Constraint::Length(1), // status bar (top)
             Constraint::Min(3),    // main chat canvas
             Constraint::Length(5), // composer
-            Constraint::Length(1), // status bar
-            Constraint::Length(1), // key hint
+            Constraint::Length(1), // key-hint footer
         ])
         .split(frame.area());
-
-    // Main canvas: Session chat (metadata + transcript + tool log).
-    app.session.render_chat(frame, chunks[0], true);
-
-    // Composer — always visible, regardless of modal state.
-    app.session.render_composer_only(frame, chunks[1]);
 
     // Status bar: agent name + session short-id + connection state.
     let agent = app.active_agent_id.as_deref();
@@ -52,7 +48,13 @@ pub fn render(frame: &mut Frame, app: &mut App) {
         session_id,
         conn: app.connection,
     }
-    .render(frame, chunks[2]);
+    .render(frame, chunks[0]);
+
+    // Main canvas: Session chat (transcript + tool log).
+    app.session.render_chat(frame, chunks[1], true);
+
+    // Composer — always visible, regardless of modal state.
+    app.session.render_composer_only(frame, chunks[2]);
 
     // Key hint footer — context-sensitive.
     render_hint(frame, chunks[3], app);
@@ -225,6 +227,16 @@ mod tests {
         .unwrap()
     }
 
+    /// Read the rendered text of `row` (0-indexed) from the test backend.
+    fn row_text(term: &Terminal<TestBackend>, row: u16) -> String {
+        let buf = term.backend().buffer();
+        let area = buf.area();
+        (0..area.width)
+            .map(|x| buf[(x, row)].symbol())
+            .collect::<Vec<_>>()
+            .join("")
+    }
+
     #[test]
     fn render_chat_canvas_produces_output() {
         let mut app = App::new(client(), TuiKeybindings::defaults());
@@ -238,8 +250,49 @@ mod tests {
             .map(|c| c.symbol())
             .collect::<Vec<_>>()
             .join("");
-        // Chat-dominant canvas shows the Session header text.
-        assert!(rendered.contains("No session selected"));
+        // Chat-dominant transcript area shows its empty-state hint when no
+        // events have arrived.
+        assert!(
+            rendered.contains("no transcript yet"),
+            "expected transcript empty-state, got: {rendered:?}"
+        );
+        // Composer placeholder is visible inside the composer pane.
+        assert!(
+            rendered.contains("Composer"),
+            "expected composer block title to render, got: {rendered:?}"
+        );
+    }
+
+    #[test]
+    fn chat_dominant_layout_pins_status_to_top_and_composer_above_hint() {
+        // sera-ckw5: lock the chat-dominant slot order — status bar at the
+        // top, transcript filling the middle, composer above a one-line
+        // key-hint footer.  If a future change reshuffles `Layout::default`
+        // away from the spec, this test catches it.
+        let mut app = App::new(client(), TuiKeybindings::defaults());
+        let backend = TestBackend::new(80, 20);
+        let mut term = Terminal::new(backend).unwrap();
+        term.draw(|f| render(f, &mut app)).unwrap();
+
+        let top = row_text(&term, 0);
+        let composer_title = row_text(&term, 14);
+        let footer = row_text(&term, 19);
+
+        assert!(
+            top.contains("agent=") && top.contains("session="),
+            "status bar must render on row 0, got: {top:?}"
+        );
+        assert!(
+            composer_title.contains("Composer"),
+            "composer block title must render on row 14 (above the footer), got: {composer_title:?}"
+        );
+        // Footer is the key-hint line; when status text is "ready" the hint
+        // payload may be empty for the default state, but the row itself
+        // exists and never overlaps the composer border.
+        assert!(
+            !footer.contains("Composer"),
+            "key-hint footer row must not contain composer chrome, got: {footer:?}"
+        );
     }
 
     #[test]

--- a/rust/crates/sera-tui/src/views/session.rs
+++ b/rust/crates/sera-tui/src/views/session.rs
@@ -4,7 +4,7 @@ use crossterm::event::KeyEvent;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph};
+use ratatui::widgets::{Block, Borders, List, ListItem};
 use ratatui::Frame;
 use tui_textarea::TextArea;
 
@@ -217,23 +217,24 @@ impl SessionView {
         }
     }
 
-    /// **J.0.1**: render the chat canvas (metadata + transcript + tool log)
-    /// without the composer.  The chat-dominant layout draws the composer
-    /// in a dedicated strip of the root layout, so the Session view must
-    /// skip it to avoid double rendering.
+    /// **J.0.1 (sera-ckw5)**: render the chat canvas — transcript filling
+    /// the dominant area with a small tool-log strip pinned at the bottom.
+    /// Composer is owned by the root layout, and the agent/session
+    /// metadata previously rendered as a header is now carried by the
+    /// top-of-screen status bar in `ui::render`.  The tool log is retained
+    /// here as a transitional pane; J.0.3 will fold tool calls into inline
+    /// collapsible blocks within the transcript itself.
     pub fn render_chat(&self, frame: &mut Frame, area: Rect, focused: bool) {
         let chunks = Layout::default()
             .direction(Direction::Vertical)
             .constraints([
-                Constraint::Length(3), // metadata header
                 Constraint::Min(3),    // transcript
-                Constraint::Length(7), // tool log
+                Constraint::Length(7), // tool log (transitional)
             ])
             .split(area);
 
-        self.render_metadata(frame, chunks[0], focused);
-        self.render_transcript(frame, chunks[1], focused);
-        self.render_tool_log(frame, chunks[2], focused);
+        self.render_transcript(frame, chunks[0], focused);
+        self.render_tool_log(frame, chunks[1], focused);
     }
 
     /// **J.0.1**: render only the composer into `area`.  Paired with
@@ -241,23 +242,6 @@ impl SessionView {
     /// its own slot in the root layout.
     pub fn render_composer_only(&self, frame: &mut Frame, area: Rect) {
         self.render_composer(frame, area);
-    }
-
-    fn render_metadata(&self, frame: &mut Frame, area: Rect, focused: bool) {
-        let text = match &self.session {
-            Some(s) => format!(
-                "session={}  agent={}  state={}  conn={}",
-                truncate_or_dash(&s.id, 12),
-                truncate_or_dash(&s.agent_id, 12),
-                s.state,
-                self.conn.label()
-            ),
-            None => "No session selected — choose an agent and press Enter".to_owned(),
-        };
-        let p = Paragraph::new(text)
-            .style(Style::default().fg(Color::White))
-            .block(make_block("Session", focused));
-        frame.render_widget(p, area);
     }
 
     fn render_transcript(&self, frame: &mut Frame, area: Rect, focused: bool) {
@@ -356,17 +340,6 @@ impl SessionView {
 impl Default for SessionView {
     fn default() -> Self {
         Self::new()
-    }
-}
-
-fn truncate_or_dash(s: &str, max: usize) -> String {
-    if s.is_empty() {
-        "—".to_owned()
-    } else if s.chars().count() <= max {
-        s.to_owned()
-    } else {
-        let head: String = s.chars().take(max.saturating_sub(1)).collect();
-        format!("{head}…")
     }
 }
 
@@ -472,13 +445,6 @@ mod tests {
         });
         assert!(!updated);
         assert!(v.transcript.is_empty());
-    }
-
-    #[test]
-    fn truncate_or_dash_behaves() {
-        assert_eq!(truncate_or_dash("", 5), "—");
-        assert_eq!(truncate_or_dash("abc", 5), "abc");
-        assert_eq!(truncate_or_dash("abcdefgh", 5), "abcd…");
     }
 
     // --- Composer-specific tests (G.0.1) ---


### PR DESCRIPTION
## Summary

First reviewable slice of the TUI chat-dominant layout pivot from
[`docs/plan/SPEC-chat-tui.md`](docs/plan/SPEC-chat-tui.md). The previous
layout already had the modal hooks (Ctrl+A/H/E/P) but rendered the
agent/session metadata twice and put the status bar near the bottom of
the screen instead of the top.

* `ui::render` — status bar moves to row 0 (`Length(1)` at top), main
  canvas / composer / hint footer follow. Module docs updated to match
  the spec layout.
* `views::session::render_chat` — drops the in-canvas metadata `Block`;
  the transcript now fills the dominant area with the existing tool-log
  strip pinned at the bottom (transitional — J.0.3 will fold tool calls
  into inline collapsible blocks within the transcript).
* Adds a layout-pin test in `ui::tests` that asserts row 0 carries
  `agent=`/`session=` and that the composer block sits above the
  one-line key-hint footer, so any future reshuffle of the slot order
  is caught.
* Drops the now-orphaned `truncate_or_dash` helper + its test (only
  used by the deleted metadata header).
* Annotates `ConnectionState::label` and `SessionSummary::agent_id`
  with `#[allow(dead_code)]` + explanatory comments — kept for
  wire-format fidelity and a future debug overlay rather than yanked.

Composer functionality and bracketed-paste behaviour (sera-p5rn,
G.0.1/G.2.1) are untouched and still drained through the existing
`render_composer_only` slot.

## Out of scope (precise follow-ups)

* **J.0.2** — block-based transcript (`Vec<Block>` replacing role+text
  pairs) so tool / approval / task blocks are first-class.
* **J.0.3** — fold tool calls into inline collapsible blocks and retire
  the transitional bottom tool-log strip kept here.
* Pre-existing `cargo fmt --check` drift across the workspace was left
  untouched (verified that `rustfmt --check` reports the same diff
  count on `origin/main` as on this branch — not introduced here).

## Test plan

- [x] `cargo test -p sera-tui` — 120 passed
- [x] `cargo clippy -p sera-tui -- -D warnings` — clean
- [x] `cargo check -p sera-tui` — clean
- [x] New `chat_dominant_layout_pins_status_to_top_and_composer_above_hint`
  test asserts the slot order matches the spec.

## Refs

* Bead: sera-ckw5 (tui-layout)
* Spec: `docs/plan/SPEC-chat-tui.md` (Wave J, J.0.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)