### PR TITLE
feat(sera-gateway): wire AppServerTransport::Stdio factory (sera-5mbr)

### DIFF
--- a/rust/crates/sera-gateway/src/transport/mod.rs
+++ b/rust/crates/sera-gateway/src/transport/mod.rs
@@ -69,6 +69,39 @@ pub trait Transport: Send + Sync {
     async fn close(&self) -> Result<(), TransportError>;
 }
 
+impl AppServerTransport {
+    /// Connect or spawn the underlying transport.
+    ///
+    /// `InProcess` cannot be reached this way — callers needing it must
+    /// construct an [`in_process::InProcessTransport`] directly with paired
+    /// channels, since the runtime end of the channel must be wired up by
+    /// the same process.
+    ///
+    /// `Stdio` requires the `stdio` Cargo feature.
+    pub async fn connect(&self) -> Result<Box<dyn Transport>, TransportError> {
+        match self {
+            #[cfg(feature = "stdio")]
+            Self::Stdio { command, args, env } => {
+                let t = stdio::StdioTransport::spawn(command, args, env).await?;
+                Ok(Box::new(t))
+            }
+            #[cfg(not(feature = "stdio"))]
+            Self::Stdio { .. } => Err(TransportError::ConnectionFailed(
+                "stdio transport not enabled (build with --features stdio)".into(),
+            )),
+            Self::InProcess => Err(TransportError::ConnectionFailed(
+                "in_process transport must be constructed via InProcessTransport::new() with paired channels".into(),
+            )),
+            Self::WebSocket { .. } | Self::Grpc { .. } | Self::WebhookBack { .. } => {
+                Err(TransportError::ConnectionFailed(
+                    "transport variant not yet wired".into(),
+                ))
+            }
+            Self::Off => Err(TransportError::Closed),
+        }
+    }
+}
+
 /// Configuration for transport, deserializable from agent manifest.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TransportConfig {

--- a/rust/crates/sera-gateway/src/transport/stdio.rs
+++ b/rust/crates/sera-gateway/src/transport/stdio.rs
@@ -22,6 +22,11 @@ pub struct StdioTransport {
 
 impl StdioTransport {
     /// Spawn a child process for stdio transport.
+    ///
+    /// `kill_on_drop` is enabled so a dropped transport reaps its child even
+    /// on a cancellation path that bypasses [`Transport::close`]. Tighter
+    /// reaping semantics (signal-aware shutdown, drain budgets) live in
+    /// sera-40y3.
     pub async fn spawn(
         command: &str,
         args: &[String],
@@ -30,6 +35,7 @@ impl StdioTransport {
         let mut cmd = Command::new(command);
         cmd.args(args)
             .envs(env.iter())
+            .kill_on_drop(true)
             .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped());

--- a/rust/crates/sera-gateway/tests/transport_stdio_roundtrip.rs
+++ b/rust/crates/sera-gateway/tests/transport_stdio_roundtrip.rs
@@ -1,0 +1,160 @@
+//! sera-5mbr: round-trip a UserTurn submission through `AppServerTransport::Stdio`.
+//!
+//! Verifies the wiring between the [`AppServerTransport::connect`] factory
+//! and the [`StdioTransport`] implementation by spawning a minimal bash
+//! child that emits canned `TurnStarted` / `StreamingDelta` /
+//! `TurnCompleted` NDJSON events and asserting they decode into typed
+//! `Event` frames.
+
+#![cfg(feature = "stdio")]
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use tokio_stream::StreamExt;
+use uuid::Uuid;
+
+use sera_gateway::envelope::{EventMsg, Op, Submission};
+use sera_gateway::transport::AppServerTransport;
+
+/// Bash one-shot that consumes a single NDJSON submission and replies with
+/// the canonical three-event sequence the gateway expects on a successful
+/// turn. The submission_id field on the events is fixed (the round-trip
+/// test does not require correlation in this layer).
+const REPLY_SCRIPT: &str = r#"
+read line
+echo '{"id":"00000000-0000-0000-0000-000000000001","submission_id":"00000000-0000-0000-0000-000000000000","msg":{"type":"turn_started","turn_id":"00000000-0000-0000-0000-000000000002"},"timestamp":"2024-01-01T00:00:00Z"}'
+echo '{"id":"00000000-0000-0000-0000-000000000003","submission_id":"00000000-0000-0000-0000-000000000000","msg":{"type":"streaming_delta","delta":"hello"},"timestamp":"2024-01-01T00:00:00Z"}'
+echo '{"id":"00000000-0000-0000-0000-000000000004","submission_id":"00000000-0000-0000-0000-000000000000","msg":{"type":"turn_completed","turn_id":"00000000-0000-0000-0000-000000000002","tokens":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}},"timestamp":"2024-01-01T00:00:00Z"}'
+"#;
+
+fn user_turn_submission() -> Submission {
+    Submission {
+        id: Uuid::new_v4(),
+        op: Op::UserTurn {
+            items: vec![serde_json::json!({"role":"user","content":"hi"})],
+            cwd: None,
+            approval_policy: None,
+            sandbox_policy: None,
+            model_override: None,
+            effort: None,
+            final_output_schema: None,
+        },
+        trace: Default::default(),
+        change_artifact: None,
+        session_key: Some("session-1".to_string()),
+        parent_session_key: None,
+    }
+}
+
+#[tokio::test]
+async fn stdio_factory_round_trips_user_turn_envelope() {
+    let cfg = AppServerTransport::Stdio {
+        command: "bash".to_string(),
+        args: vec!["-c".to_string(), REPLY_SCRIPT.to_string()],
+        env: HashMap::new(),
+    };
+
+    let transport = cfg
+        .connect()
+        .await
+        .expect("Stdio variant should reach a real transport implementation");
+
+    transport
+        .send_submission(user_turn_submission())
+        .await
+        .expect("send_submission");
+
+    let mut stream = transport.recv_events().await.expect("recv_events");
+
+    let mut saw_turn_started = false;
+    let mut accumulated = String::new();
+    let mut saw_completed = false;
+    let mut total_tokens = 0u64;
+
+    let timeout = tokio::time::sleep(Duration::from_secs(5));
+    tokio::pin!(timeout);
+
+    loop {
+        tokio::select! {
+            _ = &mut timeout => panic!("timed out waiting for turn_completed"),
+            evt = stream.next() => {
+                let Some(evt) = evt else { break };
+                match evt.msg {
+                    EventMsg::TurnStarted { .. } => saw_turn_started = true,
+                    EventMsg::StreamingDelta { delta } => accumulated.push_str(&delta),
+                    EventMsg::TurnCompleted { tokens, .. } => {
+                        total_tokens = tokens.total_tokens as u64;
+                        saw_completed = true;
+                        break;
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    assert!(saw_turn_started, "expected TurnStarted event");
+    assert_eq!(accumulated, "hello", "streamed text should accumulate");
+    assert!(saw_completed, "expected TurnCompleted event");
+    assert_eq!(total_tokens, 2, "TurnCompleted.tokens should decode");
+
+    transport.close().await.expect("close");
+}
+
+#[tokio::test]
+async fn stdio_factory_close_is_idempotent_on_exited_child() {
+    // The reply script exits after emitting events; close() should still
+    // succeed because Tokio's Child::kill is well-defined on a finished
+    // child (sera-5mbr regression guard for cancellation paths).
+    let cfg = AppServerTransport::Stdio {
+        command: "bash".to_string(),
+        args: vec!["-c".to_string(), REPLY_SCRIPT.to_string()],
+        env: HashMap::new(),
+    };
+
+    let transport = cfg.connect().await.expect("spawn");
+    transport
+        .send_submission(user_turn_submission())
+        .await
+        .expect("send");
+
+    let mut stream = transport.recv_events().await.expect("recv");
+    while let Some(evt) = stream.next().await {
+        if matches!(evt.msg, EventMsg::TurnCompleted { .. }) {
+            break;
+        }
+    }
+    drop(stream);
+
+    transport.close().await.expect("first close");
+    transport.close().await.expect("second close");
+}
+
+#[tokio::test]
+async fn off_variant_returns_closed_error() {
+    let cfg = AppServerTransport::Off;
+    let result = cfg.connect().await;
+    assert!(
+        matches!(
+            result.as_ref().map(|_| ()),
+            Err(sera_gateway::transport::TransportError::Closed)
+        ),
+        "Off variant must surface as Closed, got {result:?}",
+        result = result.as_ref().map(|_| "<transport>"),
+    );
+}
+
+#[tokio::test]
+async fn in_process_variant_cannot_be_reached_via_factory() {
+    let cfg = AppServerTransport::InProcess;
+    let result = cfg.connect().await;
+    assert!(
+        matches!(
+            result.as_ref().map(|_| ()),
+            Err(sera_gateway::transport::TransportError::ConnectionFailed(_))
+        ),
+        "InProcess must require explicit channel pairing, got {result:?}",
+        result = result.as_ref().map(|_| "<transport>"),
+    );
+}


### PR DESCRIPTION
## Summary

- Add `AppServerTransport::connect()` so the `Stdio { command, args, env }` config variant reaches a real `StdioTransport` (rust/crates/sera-gateway/src/transport/mod.rs).
- Enable `kill_on_drop` on the spawned child so cancellation paths that bypass `Transport::close` still reap the subprocess (rust/crates/sera-gateway/src/transport/stdio.rs).
- Other variants return precise errors: `InProcess` says "use `InProcessTransport::new()` with paired channels", `Off` maps to `Closed`, remote variants return `"transport variant not yet wired"`.

## Why this PR is bounded

The bin's `StdioHarness` (rust/crates/sera-gateway/src/bin/sera.rs:401) is intentionally **not** folded in. It speaks a different abstraction (`AgentTurnTransport`, per-turn dispatch with untyped JSON) than the transport-layer `Transport` trait (raw Submission/Event framing). Unifying them means migrating the production runtime supervisor — bigger than a 5mbr-shaped PR. Documented as a follow-up below.

Reaping is covered by `kill_on_drop` for the cancellation/drop path; tighter signal-forwarding + drain budgets remain owned by **sera-40y3**.

## Tests

- New `tests/transport_stdio_roundtrip.rs` (4 tests, all passing under `--features stdio`):
  - `stdio_factory_round_trips_user_turn_envelope`: spawns a minimal bash child that emits canned events, sends a `UserTurn` Submission, asserts decoded `TurnStarted` / `StreamingDelta` / `TurnCompleted` and token usage.
  - `stdio_factory_close_is_idempotent_on_exited_child`: regression guard for cancellation paths calling `close()` after the child has exited.
  - `off_variant_returns_closed_error` + `in_process_variant_cannot_be_reached_via_factory`: cover the non-stdio arms of `connect()`.
- `cargo check -p sera-gateway` (default features) — clean
- `cargo check -p sera-gateway --features stdio` — clean
- `cargo clippy -p sera-gateway --features stdio --tests -- -D warnings` — clean
- `cargo test -p sera-gateway --features stdio --test transport_stdio_roundtrip` — 4/4 pass

## Follow-ups

- Unify the bin's `StdioHarness` (sera-runtime-specific, `AgentTurnTransport`-shaped) with `transport::stdio::StdioTransport` (typed envelope, `Transport`-shaped). Requires migrating the production `RuntimeChildSupervisor` and isolating sera-runtime's NDJSON dialect from the generic transport. New bead recommended.
- Wire WebSocket / Grpc / WebhookBack arms in `AppServerTransport::connect()` (currently return "not yet wired").
- Tighter child reaping (signal-aware shutdown, drain budgets) in **sera-40y3**.

Refs: sera-5mbr