### PR TITLE
feat(sera-types,sera-auth): add ToolScope vocabulary + ToolMetadata.scope (sera-u4gj)

### DIFF
--- a/rust/crates/sera-auth/src/lib.rs
+++ b/rust/crates/sera-auth/src/lib.rs
@@ -13,6 +13,7 @@ pub mod casbin_adapter;
 pub mod error;
 pub mod jwt;
 pub mod middleware;
+pub mod scope;
 pub mod types;
 
 // Re-export commonly used types
@@ -30,4 +31,5 @@ pub use casbin_adapter::{CasbinAuthzAdapter, CasbinError};
 pub use error::AuthError;
 pub use jwt::{JwtClaims, JwtService};
 pub use middleware::auth_middleware;
+pub use scope::ToolScope;
 pub use types::{ActingContext, AuthMethod};

--- a/rust/crates/sera-auth/src/scope.rs
+++ b/rust/crates/sera-auth/src/scope.rs
@@ -1,0 +1,29 @@
+//! Re-export of [`sera_types::tool::ToolScope`] (sera-u4gj).
+//!
+//! The enum lives in `sera-types` to preserve the leaf-crate property —
+//! adding `sera-types -> sera-auth` would invert the workspace dep
+//! graph. This module gives policy code in `sera-auth` (and downstream
+//! callers reaching for the auth surface) a stable
+//! `sera_auth::scope::ToolScope` import path.
+//!
+//! No additional behavior lives here yet. Helpers (intersection, narrowing,
+//! preset construction) land alongside `PrincipalPolicy` in PR2.
+
+pub use sera_types::tool::ToolScope;
+
+#[cfg(test)]
+mod tests {
+    use super::ToolScope;
+
+    /// sera-u4gj — the re-export must preserve type identity with the
+    /// leaf-crate definition. Without this, downstream crates that import
+    /// `sera_auth::ToolScope` and `sera_types::tool::ToolScope` would see
+    /// two distinct types.
+    #[test]
+    fn reexport_is_same_type_as_sera_types_tool_toolscope() {
+        let from_auth: ToolScope = ToolScope::Execute;
+        let from_types: sera_types::tool::ToolScope =
+            sera_types::tool::ToolScope::Execute;
+        assert_eq!(from_auth, from_types);
+    }
+}

--- a/rust/crates/sera-runtime/src/tools/agent_tools.rs
+++ b/rust/crates/sera-runtime/src/tools/agent_tools.rs
@@ -19,7 +19,7 @@ use sera_types::agent_tool::AgentToolKind;
 use sera_types::capability::ResolvedCapabilities;
 use sera_types::tool::{
     ExecutionTarget, FunctionParameters, ParameterSchema, RiskLevel, Tool, ToolContext, ToolError,
-    ToolInput, ToolMetadata, ToolOutput, ToolSchema,
+    ToolInput, ToolMetadata, ToolOutput, ToolSchema, ToolScope,
 };
 
 use crate::agent_tool_registry::{
@@ -130,6 +130,9 @@ impl Tool for DelegateTaskTool {
             risk_level: RiskLevel::Execute,
             execution_target: ExecutionTarget::InProcess,
             tags: vec!["agent-tool".to_string(), "subagent".to_string()],
+            // sera-u4gj: delegation is the canonical `Agent` scope per
+            // design report §5.4.
+            scope: ToolScope::Agent,
         }
     }
 
@@ -207,6 +210,8 @@ impl Tool for AskAgentTool {
             risk_level: RiskLevel::Execute,
             execution_target: ExecutionTarget::InProcess,
             tags: vec!["agent-tool".to_string(), "subagent".to_string()],
+            // sera-u4gj: agent-to-agent question routing is `Agent` scope.
+            scope: ToolScope::Agent,
         }
     }
 
@@ -276,6 +281,9 @@ impl Tool for BackgroundTaskTool {
             risk_level: RiskLevel::Execute,
             execution_target: ExecutionTarget::InProcess,
             tags: vec!["agent-tool".to_string(), "subagent".to_string()],
+            // sera-u4gj: spawning a background task on another agent is
+            // `Agent` scope per design report §5.4.
+            scope: ToolScope::Agent,
         }
     }
 
@@ -344,6 +352,18 @@ mod tests {
         for meta in [d.metadata(), a.metadata(), b.metadata()] {
             assert_eq!(meta.risk_level, RiskLevel::Execute);
             assert!(meta.tags.iter().any(|t| t == "agent-tool"));
+        }
+    }
+
+    /// sera-u4gj — every agent-as-tool entry declares `ToolScope::Agent`
+    /// per design report §5.4 so the dispatcher gate (PR3) can reject
+    /// agents whose policy lacks `Agent` scope.
+    #[test]
+    fn metadata_scopes_are_agent() {
+        let r = Arc::new(AgentToolRegistry::new());
+        let (d, a, b) = build_agent_tools(r);
+        for meta in [d.metadata(), a.metadata(), b.metadata()] {
+            assert_eq!(meta.scope, ToolScope::Agent);
         }
     }
 

--- a/rust/crates/sera-runtime/src/tools/delegation.rs
+++ b/rust/crates/sera-runtime/src/tools/delegation.rs
@@ -22,7 +22,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use sera_types::tool::{
     ExecutionTarget, FunctionParameters, ParameterSchema, RiskLevel, Tool, ToolContext, ToolError,
-    ToolInput, ToolMetadata, ToolOutput, ToolSchema,
+    ToolInput, ToolMetadata, ToolOutput, ToolSchema, ToolScope,
 };
 
 use crate::delegation_bus::{ChildSessionMeta, DelegationBus, DelegationEvent};
@@ -73,6 +73,9 @@ impl Tool for SessionSpawnTool {
             risk_level: RiskLevel::Execute,
             execution_target: ExecutionTarget::InProcess,
             tags: vec!["delegation".to_string(), "subagent".to_string()],
+            // sera-u4gj: spawning a child session under another agent is
+            // sub-agent dispatch — `Agent` scope.
+            scope: ToolScope::Agent,
         }
     }
 
@@ -193,6 +196,10 @@ impl Tool for SessionYieldTool {
             risk_level: RiskLevel::Read,
             execution_target: ExecutionTarget::InProcess,
             tags: vec!["delegation".to_string()],
+            // sera-u4gj: yielding only observes the next bus event — the
+            // child session must already exist (gated by `session_spawn`),
+            // so this surface is read-only on the parent side.
+            scope: ToolScope::Read,
         }
     }
 
@@ -295,6 +302,9 @@ impl Tool for SessionSendTool {
             risk_level: RiskLevel::Write,
             execution_target: ExecutionTarget::InProcess,
             tags: vec!["delegation".to_string()],
+            // sera-u4gj: delivering a message into another agent's session
+            // is cross-agent communication — `Agent` scope.
+            scope: ToolScope::Agent,
         }
     }
 
@@ -716,6 +726,18 @@ mod tests {
         let send_required = send.schema().parameters.required;
         assert!(send_required.contains(&"session_id".to_string()));
         assert!(send_required.contains(&"message".to_string()));
+    }
+
+    /// sera-u4gj — explicit `ToolScope` per delegation tool. Spawning and
+    /// sending into a named child session are cross-agent operations
+    /// (`Agent`); yielding only observes the next bus event (`Read`).
+    #[test]
+    fn metadata_scopes() {
+        let bus = DelegationBus::new();
+        let (spawn, yield_tool, send) = build_delegation_tools(bus);
+        assert_eq!(spawn.metadata().scope, ToolScope::Agent);
+        assert_eq!(yield_tool.metadata().scope, ToolScope::Read);
+        assert_eq!(send.metadata().scope, ToolScope::Agent);
     }
 
     #[tokio::test]

--- a/rust/crates/sera-runtime/src/tools/file_edit.rs
+++ b/rust/crates/sera-runtime/src/tools/file_edit.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use async_trait::async_trait;
 use sera_types::tool::{
     ExecutionTarget, FunctionParameters, ParameterSchema, RiskLevel, Tool, ToolContext, ToolError,
-    ToolInput, ToolMetadata, ToolOutput, ToolSchema,
+    ToolInput, ToolMetadata, ToolOutput, ToolSchema, ToolScope,
 };
 
 use crate::tools::file_write::locked_write;
@@ -28,6 +28,7 @@ impl Tool for FileEdit {
             risk_level: RiskLevel::Write,
             execution_target: ExecutionTarget::Local,
             tags: vec!["fs".to_string()],
+            scope: ToolScope::Write,
         }
     }
 
@@ -120,5 +121,11 @@ mod tests {
     fn metadata_risk_level_is_write() {
         assert_eq!(FileEdit.metadata().risk_level, RiskLevel::Write);
         assert_eq!(FileEdit.metadata().name, "file-edit");
+    }
+
+    /// sera-u4gj — file-edit mutates files, so it carries `ToolScope::Write`.
+    #[test]
+    fn metadata_scope_is_write() {
+        assert_eq!(FileEdit.metadata().scope, ToolScope::Write);
     }
 }

--- a/rust/crates/sera-runtime/src/tools/file_ops.rs
+++ b/rust/crates/sera-runtime/src/tools/file_ops.rs
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 use async_trait::async_trait;
 use sera_types::tool::{
     ExecutionTarget, FunctionParameters, ParameterSchema, RiskLevel, Tool, ToolContext, ToolError,
-    ToolInput, ToolMetadata, ToolOutput, ToolSchema,
+    ToolInput, ToolMetadata, ToolOutput, ToolSchema, ToolScope,
 };
 
 use crate::tools::file_write::locked_write;
@@ -32,6 +32,7 @@ impl Tool for FileRead {
             risk_level: RiskLevel::Read,
             execution_target: ExecutionTarget::Local,
             tags: vec!["fs".to_string()],
+            scope: ToolScope::Read,
         }
     }
 
@@ -88,6 +89,7 @@ impl Tool for FileWrite {
             risk_level: RiskLevel::Write,
             execution_target: ExecutionTarget::Local,
             tags: vec!["fs".to_string()],
+            scope: ToolScope::Write,
         }
     }
 
@@ -165,6 +167,7 @@ impl Tool for FileList {
             risk_level: RiskLevel::Read,
             execution_target: ExecutionTarget::Local,
             tags: vec!["fs".to_string()],
+            scope: ToolScope::Read,
         }
     }
 
@@ -255,5 +258,13 @@ mod tests {
         assert_eq!(FileRead.metadata().risk_level, RiskLevel::Read);
         assert_eq!(FileWrite.metadata().risk_level, RiskLevel::Write);
         assert_eq!(FileList.metadata().risk_level, RiskLevel::Read);
+    }
+
+    /// sera-u4gj — every file-ops tool declares its `ToolScope` explicitly.
+    #[test]
+    fn metadata_scopes() {
+        assert_eq!(FileRead.metadata().scope, ToolScope::Read);
+        assert_eq!(FileWrite.metadata().scope, ToolScope::Write);
+        assert_eq!(FileList.metadata().scope, ToolScope::Read);
     }
 }

--- a/rust/crates/sera-runtime/src/tools/glob.rs
+++ b/rust/crates/sera-runtime/src/tools/glob.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 use async_trait::async_trait;
 use sera_types::tool::{
     ExecutionTarget, FunctionParameters, ParameterSchema, RiskLevel, Tool, ToolContext, ToolError,
-    ToolInput, ToolMetadata, ToolOutput, ToolSchema,
+    ToolInput, ToolMetadata, ToolOutput, ToolSchema, ToolScope,
 };
 
 pub struct Glob;
@@ -26,6 +26,7 @@ impl Tool for Glob {
             risk_level: RiskLevel::Read,
             execution_target: ExecutionTarget::Local,
             tags: vec!["fs".to_string()],
+            scope: ToolScope::Read,
         }
     }
 
@@ -173,5 +174,11 @@ mod tests {
     fn metadata_risk_level_is_read() {
         assert_eq!(Glob.metadata().risk_level, RiskLevel::Read);
         assert_eq!(Glob.metadata().name, "glob");
+    }
+
+    /// sera-u4gj — glob is pure directory traversal, so `ToolScope::Read`.
+    #[test]
+    fn metadata_scope_is_read() {
+        assert_eq!(Glob.metadata().scope, ToolScope::Read);
     }
 }

--- a/rust/crates/sera-runtime/src/tools/grep.rs
+++ b/rust/crates/sera-runtime/src/tools/grep.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 use async_trait::async_trait;
 use sera_types::tool::{
     ExecutionTarget, FunctionParameters, ParameterSchema, RiskLevel, Tool, ToolContext, ToolError,
-    ToolInput, ToolMetadata, ToolOutput, ToolSchema,
+    ToolInput, ToolMetadata, ToolOutput, ToolSchema, ToolScope,
 };
 
 pub struct Grep;
@@ -26,6 +26,7 @@ impl Tool for Grep {
             risk_level: RiskLevel::Read,
             execution_target: ExecutionTarget::Local,
             tags: vec!["fs".to_string(), "search".to_string()],
+            scope: ToolScope::Read,
         }
     }
 
@@ -159,5 +160,11 @@ mod tests {
     fn metadata_risk_level_is_read() {
         assert_eq!(Grep.metadata().risk_level, RiskLevel::Read);
         assert_eq!(Grep.metadata().name, "grep");
+    }
+
+    /// sera-u4gj — grep only reads file contents, so `ToolScope::Read`.
+    #[test]
+    fn metadata_scope_is_read() {
+        assert_eq!(Grep.metadata().scope, ToolScope::Read);
     }
 }

--- a/rust/crates/sera-runtime/src/tools/http_request.rs
+++ b/rust/crates/sera-runtime/src/tools/http_request.rs
@@ -17,7 +17,7 @@ use async_trait::async_trait;
 use sera_tools::ssrf::SsrfValidator;
 use sera_types::tool::{
     ExecutionTarget, FunctionParameters, ParameterSchema, RiskLevel, Tool, ToolContext, ToolError,
-    ToolInput, ToolMetadata, ToolOutput, ToolSchema,
+    ToolInput, ToolMetadata, ToolOutput, ToolSchema, ToolScope,
 };
 
 pub struct HttpRequest;
@@ -34,6 +34,10 @@ impl Tool for HttpRequest {
             risk_level: RiskLevel::Execute,
             execution_target: ExecutionTarget::External,
             tags: vec!["network".to_string()],
+            // sera-u4gj: outbound HTTP — `Network` scope independent of
+            // `Execute` risk so a `Network`-scoped reviewer can fetch but
+            // not shell out.
+            scope: ToolScope::Network,
         }
     }
 
@@ -185,6 +189,15 @@ mod tests {
     fn metadata_risk_level_is_execute() {
         assert_eq!(HttpRequest.metadata().risk_level, RiskLevel::Execute);
         assert_eq!(HttpRequest.metadata().name, "http-request");
+    }
+
+    /// sera-u4gj — http-request emits outbound traffic, so it carries
+    /// `ToolScope::Network` per design report §5.4. Decoupled from
+    /// `RiskLevel::Execute` so a `Network`-scoped reviewer can use it
+    /// without gaining shell exec.
+    #[test]
+    fn metadata_scope_is_network() {
+        assert_eq!(HttpRequest.metadata().scope, ToolScope::Network);
     }
 
     /// sera-udjf — IP-literal hosts in the SSRF blocklist must be rejected

--- a/rust/crates/sera-runtime/src/tools/knowledge.rs
+++ b/rust/crates/sera-runtime/src/tools/knowledge.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use async_trait::async_trait;
 use sera_types::tool::{
     ExecutionTarget, FunctionParameters, ParameterSchema, RiskLevel, Tool, ToolContext, ToolError,
-    ToolInput, ToolMetadata, ToolOutput, ToolSchema,
+    ToolInput, ToolMetadata, ToolOutput, ToolSchema, ToolScope,
 };
 
 // ── KnowledgeStore ──────────────────────────────────────────────────────────
@@ -30,6 +30,7 @@ impl Tool for KnowledgeStore {
             risk_level: RiskLevel::Write,
             execution_target: ExecutionTarget::Remote("sera-core".to_string()),
             tags: vec!["memory".to_string(), "knowledge".to_string()],
+            scope: ToolScope::Write,
         }
     }
 
@@ -143,6 +144,7 @@ impl Tool for KnowledgeQuery {
             risk_level: RiskLevel::Read,
             execution_target: ExecutionTarget::Remote("sera-core".to_string()),
             tags: vec!["memory".to_string(), "knowledge".to_string()],
+            scope: ToolScope::Read,
         }
     }
 
@@ -247,5 +249,13 @@ mod tests {
     fn metadata_risk_levels() {
         assert_eq!(KnowledgeStore.metadata().risk_level, RiskLevel::Write);
         assert_eq!(KnowledgeQuery.metadata().risk_level, RiskLevel::Read);
+    }
+
+    /// sera-u4gj — `knowledge-store` persists state (`Write`),
+    /// `knowledge-query` reads it (`Read`). Per design report §5.4.
+    #[test]
+    fn metadata_scopes() {
+        assert_eq!(KnowledgeStore.metadata().scope, ToolScope::Write);
+        assert_eq!(KnowledgeQuery.metadata().scope, ToolScope::Read);
     }
 }

--- a/rust/crates/sera-runtime/src/tools/memory_search.rs
+++ b/rust/crates/sera-runtime/src/tools/memory_search.rs
@@ -30,7 +30,7 @@ use serde::{Deserialize, Serialize};
 use sera_types::memory::{MemoryId as TierOneMemoryId, MemorySearchResult, MemoryTier, SegmentKind};
 use sera_types::tool::{
     ExecutionTarget, FunctionParameters, ParameterSchema, RiskLevel, Tool, ToolContext, ToolError,
-    ToolInput, ToolMetadata, ToolOutput, ToolSchema,
+    ToolInput, ToolMetadata, ToolOutput, ToolSchema, ToolScope,
 };
 use sera_types::EmbeddingService;
 use sera_memory::{ScoredEntry, SemanticMemoryStore, SemanticQuery};
@@ -126,6 +126,10 @@ impl Tool for MemorySearchTool {
             risk_level: RiskLevel::Read,
             execution_target: ExecutionTarget::InProcess,
             tags: vec!["memory".to_string(), "tier-2".to_string()],
+            // sera-u4gj: semantic recall is read-only from the agent's
+            // perspective; the `last_accessed_at` touch is access
+            // tracking, not material state.
+            scope: ToolScope::Read,
         }
     }
 
@@ -530,6 +534,8 @@ mod tests {
         assert_eq!(meta.name, TOOL_NAME);
         assert_eq!(meta.risk_level, RiskLevel::Read);
         assert_eq!(meta.execution_target, ExecutionTarget::InProcess);
+        // sera-u4gj — explicit `Read` scope.
+        assert_eq!(meta.scope, ToolScope::Read);
     }
 
     #[test]

--- a/rust/crates/sera-runtime/src/tools/mod.rs
+++ b/rust/crates/sera-runtime/src/tools/mod.rs
@@ -261,7 +261,7 @@ mod trait_registry_tests {
     use sera_types::tool::{
         AuditHandle, CredentialBag, ExecutionTarget, FunctionParameters, RiskLevel,
         SessionRef, Tool, ToolContext, ToolError, ToolInput, ToolMetadata, ToolOutput,
-        ToolPolicy, ToolProfile, ToolSchema,
+        ToolPolicy, ToolProfile, ToolSchema, ToolScope,
     };
     use sera_types::principal::{PrincipalId, PrincipalRef};
     use std::collections::HashMap;
@@ -281,6 +281,7 @@ mod trait_registry_tests {
                 risk_level: RiskLevel::Read,
                 execution_target: ExecutionTarget::InProcess,
                 tags: vec![],
+                scope: ToolScope::Read,
             }
         }
 
@@ -532,6 +533,89 @@ mod trait_registry_tests {
                 "risk_level mismatch for tool '{name}'"
             );
         }
+    }
+
+    /// sera-u4gj — per-tool `ToolScope` assignments. This is the contract
+    /// the dispatcher gate (PR3) and the persona presets (PR4) consume; if
+    /// someone changes a built-in's scope, they must update this assertion
+    /// AND the design report §5.4 mapping. Mirrors
+    /// `with_builtins_risk_levels_are_correct` so reviewers can audit both
+    /// dimensions side-by-side.
+    #[test]
+    fn with_builtins_scopes_are_correct() {
+        let registry = TraitToolRegistry::with_builtins();
+
+        let expected: &[(&str, ToolScope)] = &[
+            // Read — design report §5.4
+            ("file-read", ToolScope::Read),
+            ("file-list", ToolScope::Read),
+            ("glob", ToolScope::Read),
+            ("grep", ToolScope::Read),
+            ("knowledge-query", ToolScope::Read),
+            ("tool-search", ToolScope::Read),
+            ("skill-search", ToolScope::Read),
+            // Write
+            ("file-write", ToolScope::Write),
+            ("file-edit", ToolScope::Write),
+            ("knowledge-store", ToolScope::Write),
+            // Execute
+            ("shell-exec", ToolScope::Execute),
+            // Network — both http-request and web-fetch egress.
+            ("http-request", ToolScope::Network),
+            ("web-fetch", ToolScope::Network),
+            // Agent — sub-agent dispatch.
+            ("spawn-ephemeral", ToolScope::Agent),
+        ];
+        for (name, expected_scope) in expected {
+            let tool = registry
+                .get(name)
+                .unwrap_or_else(|| panic!("built-in tool '{name}' missing"));
+            assert_eq!(
+                tool.metadata().scope,
+                *expected_scope,
+                "scope mismatch for tool '{name}'"
+            );
+        }
+    }
+
+    /// sera-u4gj — `with_agent_tools` produces three `Agent`-scope entries
+    /// regardless of risk level. The dispatcher gate (PR3) keys off scope.
+    #[test]
+    fn with_agent_tools_scopes_are_agent() {
+        use crate::agent_tool_registry::AgentToolRegistry;
+        use std::sync::Arc;
+        let agents = Arc::new(AgentToolRegistry::new());
+        let registry = TraitToolRegistry::with_builtins().with_agent_tools(agents);
+        for name in ["delegate-task", "ask-agent", "background-task"] {
+            let tool = registry.get(name).unwrap();
+            assert_eq!(
+                tool.metadata().scope,
+                ToolScope::Agent,
+                "{name} must declare ToolScope::Agent"
+            );
+        }
+    }
+
+    /// sera-u4gj — `with_delegation` pins `Agent` for the writing surfaces
+    /// (`session_spawn`, `session_send`) and `Read` for the observe-only
+    /// `session_yield`.
+    #[test]
+    fn with_delegation_scopes_match_design() {
+        use crate::delegation_bus::DelegationBus;
+        let bus = DelegationBus::new();
+        let registry = TraitToolRegistry::with_builtins().with_delegation(bus);
+        assert_eq!(
+            registry.get("session_spawn").unwrap().metadata().scope,
+            ToolScope::Agent
+        );
+        assert_eq!(
+            registry.get("session_yield").unwrap().metadata().scope,
+            ToolScope::Read
+        );
+        assert_eq!(
+            registry.get("session_send").unwrap().metadata().scope,
+            ToolScope::Agent
+        );
     }
 
     /// `with_builtins_and_authz` must produce the same set of tools as

--- a/rust/crates/sera-runtime/src/tools/propose_correction.rs
+++ b/rust/crates/sera-runtime/src/tools/propose_correction.rs
@@ -15,7 +15,7 @@ use sera_tools::corrections::{
 };
 use sera_types::tool::{
     ExecutionTarget, FunctionParameters, ParameterSchema, RiskLevel, Tool, ToolContext, ToolError,
-    ToolInput, ToolMetadata, ToolOutput, ToolSchema,
+    ToolInput, ToolMetadata, ToolOutput, ToolSchema, ToolScope,
 };
 
 pub struct ProposeCorrection {
@@ -43,6 +43,10 @@ impl Tool for ProposeCorrection {
             risk_level: RiskLevel::Write,
             execution_target: ExecutionTarget::InProcess,
             tags: vec!["meta".to_string(), "correction".to_string()],
+            // sera-u4gj: this is a meta-tool that mutates the live rule
+            // catalog, so it carries `Admin` scope per design report §5.4
+            // (hot-reloadable rule edits).
+            scope: ToolScope::Admin,
         }
     }
 
@@ -255,6 +259,16 @@ mod tests {
 
     fn make_ctx() -> ToolContext {
         ToolContext::default()
+    }
+
+    /// sera-u4gj — `propose-correction` mutates the live correction rule
+    /// catalog, so it carries `ToolScope::Admin` per design report §5.4.
+    #[test]
+    fn metadata_scope_is_admin() {
+        let dir = TempDir::new().unwrap();
+        let cat = Arc::new(CorrectionCatalog::load(dir.path()).unwrap());
+        let tool = ProposeCorrection::new(cat);
+        assert_eq!(tool.metadata().scope, ToolScope::Admin);
     }
 
     #[tokio::test]

--- a/rust/crates/sera-runtime/src/tools/shell_exec.rs
+++ b/rust/crates/sera-runtime/src/tools/shell_exec.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use async_trait::async_trait;
 use sera_types::tool::{
     ExecutionTarget, FunctionParameters, ParameterSchema, RiskLevel, Tool, ToolContext, ToolError,
-    ToolInput, ToolMetadata, ToolOutput, ToolSchema,
+    ToolInput, ToolMetadata, ToolOutput, ToolSchema, ToolScope,
 };
 use tokio::process::Command;
 
@@ -25,6 +25,7 @@ impl Tool for ShellExec {
             risk_level: RiskLevel::Execute,
             execution_target: ExecutionTarget::Local,
             tags: vec!["shell".to_string()],
+            scope: ToolScope::Execute,
         }
     }
 
@@ -110,5 +111,12 @@ mod tests {
     fn metadata_risk_level_is_execute() {
         assert_eq!(ShellExec.metadata().risk_level, RiskLevel::Execute);
         assert_eq!(ShellExec.metadata().name, "shell-exec");
+    }
+
+    /// sera-u4gj — shell-exec runs arbitrary processes, so its scope is
+    /// `Execute` per design report §5.4.
+    #[test]
+    fn metadata_scope_is_execute() {
+        assert_eq!(ShellExec.metadata().scope, ToolScope::Execute);
     }
 }

--- a/rust/crates/sera-runtime/src/tools/spawn.rs
+++ b/rust/crates/sera-runtime/src/tools/spawn.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use async_trait::async_trait;
 use sera_types::tool::{
     ExecutionTarget, FunctionParameters, ParameterSchema, RiskLevel, Tool, ToolContext, ToolError,
-    ToolInput, ToolMetadata, ToolOutput, ToolSchema,
+    ToolInput, ToolMetadata, ToolOutput, ToolSchema, ToolScope,
 };
 
 pub struct SpawnEphemeral;
@@ -25,6 +25,9 @@ impl Tool for SpawnEphemeral {
             risk_level: RiskLevel::Execute,
             execution_target: ExecutionTarget::Remote("sera-core".to_string()),
             tags: vec!["subagent".to_string()],
+            // sera-u4gj: spawn-ephemeral is a sub-agent dispatch tool, so
+            // `Agent` scope per design report §5.4.
+            scope: ToolScope::Agent,
         }
     }
 
@@ -118,5 +121,12 @@ mod tests {
     fn metadata_risk_level_is_execute() {
         assert_eq!(SpawnEphemeral.metadata().risk_level, RiskLevel::Execute);
         assert_eq!(SpawnEphemeral.metadata().name, "spawn-ephemeral");
+    }
+
+    /// sera-u4gj — spawn-ephemeral dispatches sub-agents, so it carries
+    /// `ToolScope::Agent` per design report §5.4.
+    #[test]
+    fn metadata_scope_is_agent() {
+        assert_eq!(SpawnEphemeral.metadata().scope, ToolScope::Agent);
     }
 }

--- a/rust/crates/sera-runtime/src/tools/tool_search.rs
+++ b/rust/crates/sera-runtime/src/tools/tool_search.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use async_trait::async_trait;
 use sera_types::tool::{
     ExecutionTarget, FunctionParameters, ParameterSchema, RiskLevel, Tool, ToolContext, ToolError,
-    ToolInput, ToolMetadata, ToolOutput, ToolSchema,
+    ToolInput, ToolMetadata, ToolOutput, ToolSchema, ToolScope,
 };
 
 // ── ToolSearch ──────────────────────────────────────────────────────────────
@@ -29,6 +29,11 @@ impl Tool for ToolSearch {
             risk_level: RiskLevel::Read,
             execution_target: ExecutionTarget::Remote("sera-core".to_string()),
             tags: vec!["discovery".to_string()],
+            // sera-u4gj: catalog discovery is read-only metadata lookup —
+            // no exfiltration risk distinct from other reads, so `Read`
+            // (not `Network`) per design report §5.4. The transport
+            // layer is internal-service-only by `safe_client`.
+            scope: ToolScope::Read,
         }
     }
 
@@ -128,6 +133,9 @@ impl Tool for SkillSearch {
             risk_level: RiskLevel::Read,
             execution_target: ExecutionTarget::Remote("sera-core".to_string()),
             tags: vec!["discovery".to_string()],
+            // sera-u4gj: same rationale as `tool-search` — internal
+            // catalog discovery, `Read` per design report §5.4.
+            scope: ToolScope::Read,
         }
     }
 
@@ -217,5 +225,12 @@ mod tests {
     fn metadata_risk_levels() {
         assert_eq!(ToolSearch.metadata().risk_level, RiskLevel::Read);
         assert_eq!(SkillSearch.metadata().risk_level, RiskLevel::Read);
+    }
+
+    /// sera-u4gj — both discovery tools are `ToolScope::Read`.
+    #[test]
+    fn metadata_scopes() {
+        assert_eq!(ToolSearch.metadata().scope, ToolScope::Read);
+        assert_eq!(SkillSearch.metadata().scope, ToolScope::Read);
     }
 }

--- a/rust/crates/sera-runtime/src/tools/web_fetch.rs
+++ b/rust/crates/sera-runtime/src/tools/web_fetch.rs
@@ -14,7 +14,7 @@ use async_trait::async_trait;
 use sera_tools::ssrf::SsrfValidator;
 use sera_types::tool::{
     ExecutionTarget, FunctionParameters, ParameterSchema, RiskLevel, Tool, ToolContext, ToolError,
-    ToolInput, ToolMetadata, ToolOutput, ToolSchema,
+    ToolInput, ToolMetadata, ToolOutput, ToolSchema, ToolScope,
 };
 
 pub struct WebFetch;
@@ -32,6 +32,10 @@ impl Tool for WebFetch {
             risk_level: RiskLevel::Read,
             execution_target: ExecutionTarget::External,
             tags: vec!["network".to_string()],
+            // sera-u4gj: web-fetch is GET-only but still produces network
+            // egress — exfiltration risk is what `Network` scope gates.
+            // Per design report §5.4.
+            scope: ToolScope::Network,
         }
     }
 
@@ -153,6 +157,14 @@ mod tests {
     fn metadata_risk_level_is_read() {
         assert_eq!(WebFetch.metadata().risk_level, RiskLevel::Read);
         assert_eq!(WebFetch.metadata().name, "web-fetch");
+    }
+
+    /// sera-u4gj — web-fetch emits outbound network traffic, so it carries
+    /// `ToolScope::Network` per design report §5.4 even though
+    /// `RiskLevel` stays `Read` (no remote-state mutation).
+    #[test]
+    fn metadata_scope_is_network() {
+        assert_eq!(WebFetch.metadata().scope, ToolScope::Network);
     }
 
     /// sera-udjf — web-fetch must honour the same SSRF blocklist as the

--- a/rust/crates/sera-types/src/tool.rs
+++ b/rust/crates/sera-types/src/tool.rs
@@ -139,6 +139,43 @@ pub enum ExecutionTarget {
     External,
 }
 
+/// Coarse capability category for tool authorization (sera-u4gj).
+///
+/// Mirrors the ZeroID vocabulary (zeroid scout report §2.8, §6.5). A
+/// principal's `PrincipalPolicy.allowed_tool_scopes` (sera-fhcr) must
+/// contain a tool's declared scope BEFORE any tool-name allow/deny, PDP,
+/// or escalation check. PR1 only introduces the vocabulary and
+/// per-tool annotations; the dispatcher gate lands in PR3.
+///
+/// `Default` resolves to `Read` so on-disk metadata predating PR1
+/// deserializes as the safest non-empty scope. Built-in tools must
+/// declare their scope explicitly — the
+/// `with_builtins_scopes_are_correct` test in `sera-runtime` enforces
+/// this contract.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Serialize, Deserialize,
+)]
+#[serde(rename_all = "kebab-case")]
+pub enum ToolScope {
+    /// Read filesystem, fetch local data, list directories. Side-effect-free.
+    #[default]
+    Read,
+    /// Mutate filesystem, write files, edit code, persist memory.
+    Write,
+    /// Spawn processes / shells / arbitrary execution.
+    Execute,
+    /// Outbound network (HTTP, sockets) — separate from Read because
+    /// network egress carries exfiltration risk independent of read scope.
+    Network,
+    /// Spawn or call sub-agents (delegate / ask / background / spawn).
+    Agent,
+    /// Version-control operations (commit, push, branch, tag).
+    Vcs,
+    /// Privileged operations: meta-config change, kill-switch, eviction,
+    /// HITL bypass, hot-reloadable rule catalog edits.
+    Admin,
+}
+
 /// Metadata describing a tool's identity and capabilities.
 /// SPEC-tools: returned by Tool::metadata(), used for progressive disclosure.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -152,6 +189,12 @@ pub struct ToolMetadata {
     pub execution_target: ExecutionTarget,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tags: Vec<String>,
+    /// Coarse capability category consulted by the dispatcher gate
+    /// (sera-u4gj). Defaults to [`ToolScope::Read`] for backward-compatible
+    /// deserialization of pre-PR1 fixtures; built-in tools declare this
+    /// explicitly.
+    #[serde(default)]
+    pub scope: ToolScope,
 }
 
 /// Tool profile — preset allow/deny configurations.
@@ -821,11 +864,79 @@ mod tests {
             risk_level: RiskLevel::Execute,
             execution_target: ExecutionTarget::Sandbox("docker".to_string()),
             tags: vec!["compute".to_string()],
+            scope: ToolScope::Execute,
         };
         let json = serde_json::to_string(&meta).unwrap();
         let parsed: ToolMetadata = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.name, "shell");
         assert_eq!(parsed.risk_level, RiskLevel::Execute);
+        assert_eq!(parsed.scope, ToolScope::Execute);
+    }
+
+    /// sera-u4gj — every ToolScope variant serializes to its kebab-case
+    /// vocabulary token. The dispatcher gate (PR3) and config schema
+    /// (sera-config follow-up) match against these exact strings, so a
+    /// rename here is a wire-incompatible change.
+    #[test]
+    fn tool_scope_serde_kebab_case() {
+        let cases = [
+            (ToolScope::Read, "\"read\""),
+            (ToolScope::Write, "\"write\""),
+            (ToolScope::Execute, "\"execute\""),
+            (ToolScope::Network, "\"network\""),
+            (ToolScope::Agent, "\"agent\""),
+            (ToolScope::Vcs, "\"vcs\""),
+            (ToolScope::Admin, "\"admin\""),
+        ];
+        for (scope, expected) in cases {
+            let json = serde_json::to_string(&scope).unwrap();
+            assert_eq!(json, expected, "scope {scope:?} serialized as {json}");
+            let parsed: ToolScope = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, scope);
+        }
+    }
+
+    /// sera-u4gj — `Default::default()` resolves to `Read` so missing
+    /// `scope` fields in legacy fixtures deserialize to the safest
+    /// non-empty scope.
+    #[test]
+    fn tool_scope_default_is_read() {
+        assert_eq!(ToolScope::default(), ToolScope::Read);
+    }
+
+    /// sera-u4gj — when a serialized `ToolMetadata` lacks the `scope`
+    /// field (pre-PR1 fixtures, on-disk metadata cached before this PR),
+    /// deserialization fills in `Read`.
+    #[test]
+    fn tool_metadata_scope_default_when_missing() {
+        let json = r#"{
+            "name": "legacy-tool",
+            "description": "no scope field",
+            "version": "1.0.0",
+            "risk_level": "read",
+            "execution_target": "in_process"
+        }"#;
+        let meta: ToolMetadata = serde_json::from_str(json).unwrap();
+        assert_eq!(meta.scope, ToolScope::Read);
+    }
+
+    /// sera-u4gj — serializing `ToolMetadata` always emits `scope` so
+    /// downstream consumers (dispatcher gate, audit pipeline) can rely
+    /// on the field being present.
+    #[test]
+    fn tool_metadata_scope_field_serialized() {
+        let meta = ToolMetadata {
+            name: "shell-exec".to_string(),
+            description: "exec".to_string(),
+            version: "1.0.0".to_string(),
+            author: None,
+            risk_level: RiskLevel::Execute,
+            execution_target: ExecutionTarget::Local,
+            tags: vec![],
+            scope: ToolScope::Execute,
+        };
+        let value = serde_json::to_value(&meta).unwrap();
+        assert_eq!(value["scope"], serde_json::Value::String("execute".into()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implements **PR1** of the principal-policy / tool-scope design (`artifacts/reports/claude-burn/principal-policy-tool-scope-design-2026-04-30.md`, §4 PR1 + §5.1 + §5.4) for bead **sera-u4gj**.

This PR is **annotations only** — no dispatcher gate, no `PrincipalPolicy`, no persona presets. Runtime dispatch behavior is unchanged.

- Adds `sera_types::tool::ToolScope` (Read | Write | Execute | Network | Agent | Vcs | Admin), `serde(rename_all = \"kebab-case\")`, `Default = Read`. The enum lives in the leaf crate `sera-types` so `sera-auth` does **not** invert the workspace dep graph.
- Re-exports as `sera_auth::scope::ToolScope` for the auth-side import path.
- Adds `ToolMetadata.scope: ToolScope` with `#[serde(default)]` so legacy on-disk fixtures (which lack the field) deserialize to `Read`.
- Annotates every built-in tool with an explicit, reviewer-justified scope per design report §5.4.

## Per-tool ToolScope mapping

| Scope | Tools |
|---|---|
| `Read` | file-read, file-list, glob, grep, knowledge-query, tool-search, skill-search, memory_search |
| `Write` | file-write, file-edit, knowledge-store |
| `Execute` | shell-exec |
| `Network` | http-request, web-fetch |
| `Agent` | spawn-ephemeral, delegate-task, ask-agent, background-task, session_spawn, session_send |
| `Read` (observer) | session_yield |
| `Admin` | propose-correction (live rule-catalog mutation — hot-reloadable) |

`Vcs`-scope built-ins do **not** exist today, so no `Vcs` annotations land. (Design §5.4 lists them as \"when added\".)

## Tests

Added focused tests:

- `sera_types::tool::tool_scope_serde_kebab_case` — covers `read | write | execute | network | agent | vcs | admin`
- `sera_types::tool::tool_scope_default_is_read`
- `sera_types::tool::tool_metadata_scope_default_when_missing` — backwards-compatible serde for pre-PR1 fixtures
- `sera_types::tool::tool_metadata_scope_field_serialized` — `scope` is always emitted
- `sera_auth::scope::reexport_is_same_type_as_sera_types_tool_toolscope` — re-export type-identity
- `sera_runtime::tools::with_builtins_scopes_are_correct` — single-source-of-truth contract for the 14-builtin scope mapping (mirrors the existing `with_builtins_risk_levels_are_correct` audit)
- `sera_runtime::tools::with_agent_tools_scopes_are_agent`
- `sera_runtime::tools::with_delegation_scopes_match_design`
- per-tool `metadata_scope_*` assertions in file_ops / file_edit / shell_exec / http_request / web_fetch / glob / grep / tool_search / knowledge / spawn / agent_tools / memory_search / delegation / propose_correction

## Validation

```
cargo check --workspace                       # green
cargo test -p sera-types                      # 442 passed
cargo test -p sera-auth                       # 100 passed, 4 ignored
cargo test -p sera-runtime --lib              # 595 passed
cargo clippy --workspace -- -D warnings       # clean
```

## Test plan

- [x] Targeted tests for changed crates (sera-types, sera-auth, sera-runtime)
- [x] `cargo check --workspace`
- [x] `cargo clippy --workspace -- -D warnings`

## Bead

- `sera-u4gj` — partial (this PR is the smallest correct PR1 slice)

## Deferred to follow-up PRs

- **PR2**: `PrincipalPolicy` + `PrincipalPolicyStore` + resolution seam (`sera-fhcr`)
- **PR3**: dispatcher gate — `ToolContext` policy propagation, sub-agent narrowing (`sera-u4gj` + `sera-fhcr`)
- **PR4**: persona presets (`read-only-reviewer`, `code-editor`, `test-runner`, `full-autonomy`) + acceptance hardening

🤖 Generated with [Claude Code](https://claude.com/claude-code)