### PR TITLE
feat(sera-auth,sera-config,sera-gateway): PrincipalPolicy + resolution seam (sera-fhcr)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4956,6 +4956,7 @@ dependencies = [
  "hex",
  "jsonwebtoken",
  "rand 0.8.5",
+ "sera-config",
  "sera-db",
  "sera-errors",
  "sera-secrets",

--- a/rust/crates/sera-auth/Cargo.toml
+++ b/rust/crates/sera-auth/Cargo.toml
@@ -11,6 +11,7 @@ enterprise = []
 
 [dependencies]
 sera-types.workspace = true
+sera-config.workspace = true
 sera-db.workspace = true
 sera-errors.workspace = true
 serde.workspace = true

--- a/rust/crates/sera-auth/src/lib.rs
+++ b/rust/crates/sera-auth/src/lib.rs
@@ -13,6 +13,7 @@ pub mod casbin_adapter;
 pub mod error;
 pub mod jwt;
 pub mod middleware;
+pub mod policy;
 pub mod scope;
 pub mod types;
 
@@ -31,5 +32,8 @@ pub use casbin_adapter::{CasbinAuthzAdapter, CasbinError};
 pub use error::AuthError;
 pub use jwt::{JwtClaims, JwtService};
 pub use middleware::auth_middleware;
+pub use policy::{
+    narrow_for_subagent, InMemoryPrincipalPolicyStore, PrincipalPolicy, PrincipalPolicyStore,
+};
 pub use scope::ToolScope;
 pub use types::{ActingContext, AuthMethod};

--- a/rust/crates/sera-auth/src/policy.rs
+++ b/rust/crates/sera-auth/src/policy.rs
@@ -1,0 +1,631 @@
+//! `PrincipalPolicy` — the per-principal authorization envelope (sera-fhcr).
+//!
+//! Resolved at gateway admission and (in PR3 / sera-u4gj) threaded through
+//! `TurnContext` into every `ToolContext`. PR2 only lands the type, the
+//! per-kind defaults, the in-memory store, and the narrowing helper used by
+//! the future sub-agent dispatch path. The runtime dispatcher gate itself is
+//! deliberately not wired here.
+//!
+//! Per-kind defaults follow the design report
+//! (`artifacts/reports/claude-burn/principal-policy-tool-scope-design-2026-04-30.md`,
+//! §5.3):
+//!
+//! | Kind            | scopes                                   | depth | spawn / meta / code |
+//! |-----------------|------------------------------------------|-------|---------------------|
+//! | Human           | all                                       | 5     | true / true / true  |
+//! | Agent           | Read, Write, Execute, Network, Vcs, Agent | 2     | true / false / true |
+//! | ExternalAgent   | empty                                     | 0     | false / false / false |
+//! | Service         | empty                                     | 0     | false / false / false |
+//! | System          | all                                       | 5     | true / true / true  |
+//!
+//! `required_trust_level` mirrors `PrincipalKind::default_trust_level`:
+//! Human / Agent / Service / System default to [`TrustLevel::FirstParty`];
+//! `ExternalAgent` defaults to [`TrustLevel::Unverified`] so the policy
+//! "accepts" any external caller while the empty scope set is the actual
+//! barrier (default-deny).
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+use sera_config::principal_policy::{PrincipalPoliciesConfig, PrincipalPolicySpec};
+use sera_types::evolution::BlastRadius;
+use sera_types::principal::{Principal, PrincipalKind, TrustLevel};
+use sera_types::tool::ToolScope;
+
+/// Per-principal authorization envelope. Resolved once at gateway admission
+/// and propagated immutably through the turn (see design report §7.1 on
+/// per-turn vs per-call resolution).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PrincipalPolicy {
+    /// Maximum TTL for any capability token issued under this principal.
+    /// On-disk format is seconds (`max_token_ttl_secs`).
+    #[serde(with = "duration_secs", rename = "max_token_ttl_secs")]
+    pub max_token_ttl: Duration,
+
+    /// Coarse tool-category gate. Empty set = no tool calls allowed.
+    pub allowed_tool_scopes: HashSet<ToolScope>,
+
+    /// Maximum capability-token delegation chain depth. The runtime
+    /// enforcement point lives in `CapabilityToken::narrow()` (sera-s64j);
+    /// the field lands here so policies are correctly shaped from the start.
+    pub max_delegation_depth: u32,
+
+    /// Self-evolution proposals: which BlastRadii this principal may target.
+    /// Empty set = no proposals.
+    pub allowed_blast_radii: HashSet<BlastRadius>,
+
+    /// Whether this principal may spawn sub-agents (delegate / ask /
+    /// background). Independent of `ToolScope::Agent` because Agent-scope
+    /// tools may exist for purposes other than dispatch.
+    pub allow_subagent_spawn: bool,
+
+    /// Whether this principal may originate meta-changes (skill updates,
+    /// hook chain edits, persona mutation). Required even when the tool
+    /// in question carries `ToolScope::Admin`.
+    pub allow_meta_change: bool,
+
+    /// Whether this principal may originate code changes via the
+    /// change-proposer path. Decoupled from `allow_meta_change` so a
+    /// code-editor agent can edit files without editing tier policies.
+    pub allow_code_change: bool,
+
+    /// Minimum trust level required for the principal under this policy.
+    /// Higher levels (`FirstParty`) are stricter than lower (`Unverified`).
+    /// The narrowing helper picks the stricter of two policies' values.
+    pub required_trust_level: TrustLevel,
+}
+
+impl PrincipalPolicy {
+    /// Conservative empty policy: empty scopes / blast radii, depth 0, all
+    /// privileged booleans false, [`TrustLevel::FirstParty`] required, 5-min
+    /// TTL. Use [`PrincipalPolicy::for_kind`] for the kind-aware defaults.
+    pub fn empty() -> Self {
+        Self {
+            max_token_ttl: Duration::from_secs(300),
+            allowed_tool_scopes: HashSet::new(),
+            max_delegation_depth: 0,
+            allowed_blast_radii: HashSet::new(),
+            allow_subagent_spawn: false,
+            allow_meta_change: false,
+            allow_code_change: false,
+            required_trust_level: TrustLevel::FirstParty,
+        }
+    }
+
+    /// Per-`PrincipalKind` defaults from the design report (§5.3).
+    pub fn for_kind(kind: PrincipalKind) -> Self {
+        match kind {
+            PrincipalKind::Human => Self {
+                max_token_ttl: Duration::from_secs(3600),
+                allowed_tool_scopes: all_tool_scopes(),
+                max_delegation_depth: 5,
+                allowed_blast_radii: all_blast_radii(),
+                allow_subagent_spawn: true,
+                allow_meta_change: true,
+                allow_code_change: true,
+                required_trust_level: PrincipalKind::Human.default_trust_level(),
+            },
+            PrincipalKind::Agent => Self {
+                max_token_ttl: Duration::from_secs(1800),
+                allowed_tool_scopes: HashSet::from([
+                    ToolScope::Read,
+                    ToolScope::Write,
+                    ToolScope::Execute,
+                    ToolScope::Network,
+                    ToolScope::Vcs,
+                    ToolScope::Agent,
+                ]),
+                max_delegation_depth: 2,
+                allowed_blast_radii: agent_blast_radii(),
+                allow_subagent_spawn: true,
+                allow_meta_change: false,
+                allow_code_change: true,
+                required_trust_level: PrincipalKind::Agent.default_trust_level(),
+            },
+            PrincipalKind::ExternalAgent => Self {
+                max_token_ttl: Duration::from_secs(300),
+                allowed_tool_scopes: HashSet::new(),
+                max_delegation_depth: 0,
+                allowed_blast_radii: HashSet::new(),
+                allow_subagent_spawn: false,
+                allow_meta_change: false,
+                allow_code_change: false,
+                required_trust_level: PrincipalKind::ExternalAgent.default_trust_level(),
+            },
+            PrincipalKind::Service => Self {
+                max_token_ttl: Duration::from_secs(900),
+                allowed_tool_scopes: HashSet::new(),
+                max_delegation_depth: 0,
+                allowed_blast_radii: HashSet::new(),
+                allow_subagent_spawn: false,
+                allow_meta_change: false,
+                allow_code_change: false,
+                required_trust_level: PrincipalKind::Service.default_trust_level(),
+            },
+            PrincipalKind::System => Self {
+                max_token_ttl: Duration::from_secs(3600),
+                allowed_tool_scopes: all_tool_scopes(),
+                max_delegation_depth: 5,
+                allowed_blast_radii: all_blast_radii(),
+                allow_subagent_spawn: true,
+                allow_meta_change: true,
+                allow_code_change: true,
+                required_trust_level: PrincipalKind::System.default_trust_level(),
+            },
+        }
+    }
+
+    /// Apply override fields from a [`PrincipalPolicySpec`] on top of `self`.
+    /// Fields left unset on the spec preserve `self`'s values; this is the
+    /// merge semantics used by [`InMemoryPrincipalPolicyStore::from_config`].
+    pub fn with_spec(mut self, spec: PrincipalPolicySpec) -> Self {
+        if let Some(v) = spec.max_token_ttl {
+            self.max_token_ttl = v;
+        }
+        if let Some(v) = spec.allowed_tool_scopes {
+            self.allowed_tool_scopes = v;
+        }
+        if let Some(v) = spec.max_delegation_depth {
+            self.max_delegation_depth = v;
+        }
+        if let Some(v) = spec.allowed_blast_radii {
+            self.allowed_blast_radii = v;
+        }
+        if let Some(v) = spec.allow_subagent_spawn {
+            self.allow_subagent_spawn = v;
+        }
+        if let Some(v) = spec.allow_meta_change {
+            self.allow_meta_change = v;
+        }
+        if let Some(v) = spec.allow_code_change {
+            self.allow_code_change = v;
+        }
+        if let Some(v) = spec.required_trust_level {
+            self.required_trust_level = v;
+        }
+        self
+    }
+}
+
+mod duration_secs {
+    use std::time::Duration;
+
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    pub fn serialize<S: Serializer>(d: &Duration, s: S) -> Result<S::Ok, S::Error> {
+        d.as_secs().serialize(s)
+    }
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Duration, D::Error> {
+        u64::deserialize(d).map(Duration::from_secs)
+    }
+}
+
+fn all_tool_scopes() -> HashSet<ToolScope> {
+    [
+        ToolScope::Read,
+        ToolScope::Write,
+        ToolScope::Execute,
+        ToolScope::Network,
+        ToolScope::Agent,
+        ToolScope::Vcs,
+        ToolScope::Admin,
+    ]
+    .into_iter()
+    .collect()
+}
+
+fn all_blast_radii() -> HashSet<BlastRadius> {
+    [
+        BlastRadius::AgentMemory,
+        BlastRadius::AgentPersonaMutable,
+        BlastRadius::AgentSkill,
+        BlastRadius::AgentExperiencePool,
+        BlastRadius::SingleHookConfig,
+        BlastRadius::SingleToolPolicy,
+        BlastRadius::SingleConnector,
+        BlastRadius::SingleCircleConfig,
+        BlastRadius::AgentManifest,
+        BlastRadius::TierPolicy,
+        BlastRadius::HookChainStructure,
+        BlastRadius::ApprovalPolicy,
+        BlastRadius::SecretProvider,
+        BlastRadius::GlobalConfig,
+        BlastRadius::RuntimeCrate,
+        BlastRadius::GatewayCore,
+        BlastRadius::ProtocolSchema,
+        BlastRadius::DbMigration,
+        BlastRadius::ConstitutionalRuleSet,
+        BlastRadius::KillSwitchProtocol,
+        BlastRadius::AuditLogBackend,
+        BlastRadius::SelfEvolutionPipeline,
+    ]
+    .into_iter()
+    .collect()
+}
+
+fn agent_blast_radii() -> HashSet<BlastRadius> {
+    [
+        BlastRadius::AgentMemory,
+        BlastRadius::AgentPersonaMutable,
+        BlastRadius::AgentSkill,
+        BlastRadius::AgentExperiencePool,
+    ]
+    .into_iter()
+    .collect()
+}
+
+/// Resolves the [`PrincipalPolicy`] for a given [`Principal`].
+///
+/// Implementations may layer kind defaults, harness-profile policies, or
+/// per-id overrides; PR2 ships only the in-memory kind-default store.
+#[async_trait]
+pub trait PrincipalPolicyStore: Send + Sync + std::fmt::Debug {
+    async fn resolve(&self, principal: &Principal) -> Arc<PrincipalPolicy>;
+}
+
+/// In-memory `PrincipalPolicyStore` seeded with per-kind defaults from
+/// [`PrincipalPolicy::for_kind`]. Use [`Self::from_config`] to apply
+/// overrides loaded from `sera-config`.
+#[derive(Debug, Clone)]
+pub struct InMemoryPrincipalPolicyStore {
+    by_kind: HashMap<PrincipalKind, Arc<PrincipalPolicy>>,
+}
+
+const ALL_PRINCIPAL_KINDS: [PrincipalKind; 5] = [
+    PrincipalKind::Human,
+    PrincipalKind::Agent,
+    PrincipalKind::ExternalAgent,
+    PrincipalKind::Service,
+    PrincipalKind::System,
+];
+
+impl InMemoryPrincipalPolicyStore {
+    /// Seed the store with the per-kind defaults verbatim.
+    pub fn new() -> Self {
+        let mut by_kind = HashMap::with_capacity(ALL_PRINCIPAL_KINDS.len());
+        for kind in ALL_PRINCIPAL_KINDS {
+            by_kind.insert(kind, Arc::new(PrincipalPolicy::for_kind(kind)));
+        }
+        Self { by_kind }
+    }
+
+    /// Build a store from a config block: per-kind overrides are applied on
+    /// top of the runtime defaults; kinds absent from the config keep the
+    /// default verbatim.
+    pub fn from_config(config: &PrincipalPoliciesConfig) -> Self {
+        let mut store = Self::new();
+        for (kind, spec) in &config.policies {
+            let merged = PrincipalPolicy::for_kind(*kind).with_spec(spec.clone());
+            store.by_kind.insert(*kind, Arc::new(merged));
+        }
+        store
+    }
+
+    /// Direct lookup by kind, falling back to the per-kind default if the
+    /// store has been mutated to remove an entry. Used by the gateway
+    /// resolution seam (sera-gateway::policy_resolution).
+    pub fn policy_for(&self, kind: PrincipalKind) -> Arc<PrincipalPolicy> {
+        self.by_kind
+            .get(&kind)
+            .cloned()
+            .unwrap_or_else(|| Arc::new(PrincipalPolicy::for_kind(kind)))
+    }
+}
+
+impl Default for InMemoryPrincipalPolicyStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl PrincipalPolicyStore for InMemoryPrincipalPolicyStore {
+    async fn resolve(&self, principal: &Principal) -> Arc<PrincipalPolicy> {
+        self.policy_for(principal.kind)
+    }
+}
+
+/// Narrow a parent policy by intersection with a child policy for sub-agent
+/// dispatch (design report §6.4 / §7.2).
+///
+/// Semantics:
+/// - `allowed_tool_scopes` = parent ∩ child
+/// - `allowed_blast_radii` = parent ∩ child
+/// - `max_delegation_depth` = `min(parent.depth - 1, child.depth)` (saturating)
+/// - `allow_*` flags are AND-reduced
+/// - `required_trust_level` is the stricter of the two
+/// - `max_token_ttl` is the shorter of the two
+///
+/// PR2 ships only the helper. PR3 (sera-u4gj) wires it into
+/// `AgentToolRegistry` so sub-agent dispatch can never launder past the
+/// caller's scope set.
+pub fn narrow_for_subagent(
+    parent: &PrincipalPolicy,
+    child: &PrincipalPolicy,
+) -> PrincipalPolicy {
+    PrincipalPolicy {
+        max_token_ttl: parent.max_token_ttl.min(child.max_token_ttl),
+        allowed_tool_scopes: parent
+            .allowed_tool_scopes
+            .intersection(&child.allowed_tool_scopes)
+            .copied()
+            .collect(),
+        max_delegation_depth: parent
+            .max_delegation_depth
+            .saturating_sub(1)
+            .min(child.max_delegation_depth),
+        allowed_blast_radii: parent
+            .allowed_blast_radii
+            .intersection(&child.allowed_blast_radii)
+            .copied()
+            .collect(),
+        allow_subagent_spawn: parent.allow_subagent_spawn && child.allow_subagent_spawn,
+        allow_meta_change: parent.allow_meta_change && child.allow_meta_change,
+        allow_code_change: parent.allow_code_change && child.allow_code_change,
+        required_trust_level: stricter_trust_level(
+            parent.required_trust_level,
+            child.required_trust_level,
+        ),
+    }
+}
+
+fn trust_strictness(level: TrustLevel) -> u8 {
+    match level {
+        TrustLevel::Unverified => 0,
+        TrustLevel::VerifiedThirdParty => 1,
+        TrustLevel::FirstParty => 2,
+    }
+}
+
+/// Pick the stricter (numerically higher) of two trust requirements.
+fn stricter_trust_level(a: TrustLevel, b: TrustLevel) -> TrustLevel {
+    if trust_strictness(a) >= trust_strictness(b) {
+        a
+    } else {
+        b
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Per-kind defaults ──────────────────────────────────────────────────
+
+    #[test]
+    fn default_human_policy_has_all_scopes_depth_5() {
+        let p = PrincipalPolicy::for_kind(PrincipalKind::Human);
+        assert_eq!(p.max_delegation_depth, 5);
+        assert_eq!(p.allowed_tool_scopes, all_tool_scopes());
+        assert!(p.allow_subagent_spawn);
+        assert!(p.allow_meta_change);
+        assert!(p.allow_code_change);
+    }
+
+    #[test]
+    fn default_agent_policy_excludes_admin_depth_2() {
+        let p = PrincipalPolicy::for_kind(PrincipalKind::Agent);
+        assert_eq!(p.max_delegation_depth, 2);
+        assert!(p.allowed_tool_scopes.contains(&ToolScope::Read));
+        assert!(p.allowed_tool_scopes.contains(&ToolScope::Write));
+        assert!(p.allowed_tool_scopes.contains(&ToolScope::Execute));
+        assert!(p.allowed_tool_scopes.contains(&ToolScope::Network));
+        assert!(p.allowed_tool_scopes.contains(&ToolScope::Vcs));
+        assert!(p.allowed_tool_scopes.contains(&ToolScope::Agent));
+        assert!(
+            !p.allowed_tool_scopes.contains(&ToolScope::Admin),
+            "Agent policy must never carry the Admin scope"
+        );
+        assert!(p.allow_subagent_spawn);
+        assert!(!p.allow_meta_change);
+        assert!(p.allow_code_change);
+    }
+
+    #[test]
+    fn default_external_agent_policy_is_default_deny_depth_0() {
+        let p = PrincipalPolicy::for_kind(PrincipalKind::ExternalAgent);
+        assert_eq!(p.max_delegation_depth, 0);
+        assert!(p.allowed_tool_scopes.is_empty());
+        assert!(p.allowed_blast_radii.is_empty());
+        assert!(!p.allow_subagent_spawn);
+        assert!(!p.allow_meta_change);
+        assert!(!p.allow_code_change);
+    }
+
+    #[test]
+    fn default_service_policy_is_default_deny_depth_0() {
+        let p = PrincipalPolicy::for_kind(PrincipalKind::Service);
+        assert_eq!(p.max_delegation_depth, 0);
+        assert!(p.allowed_tool_scopes.is_empty());
+        assert!(p.allowed_blast_radii.is_empty());
+        assert!(!p.allow_subagent_spawn);
+        assert!(!p.allow_meta_change);
+        assert!(!p.allow_code_change);
+    }
+
+    #[test]
+    fn default_system_policy_has_all_scopes_depth_5() {
+        let p = PrincipalPolicy::for_kind(PrincipalKind::System);
+        assert_eq!(p.max_delegation_depth, 5);
+        assert_eq!(p.allowed_tool_scopes, all_tool_scopes());
+        assert!(p.allow_subagent_spawn);
+        assert!(p.allow_meta_change);
+        assert!(p.allow_code_change);
+    }
+
+    /// `required_trust_level` mirrors `PrincipalKind::default_trust_level` —
+    /// `ExternalAgent` keeps the conservative `Unverified` mapping; every
+    /// other kind defaults to `FirstParty`. The empty scope set on
+    /// `ExternalAgent` / `Service` is the actual default-deny barrier.
+    #[test]
+    fn required_trust_level_defaults_follow_principal_kind() {
+        for kind in ALL_PRINCIPAL_KINDS {
+            let p = PrincipalPolicy::for_kind(kind);
+            assert_eq!(
+                p.required_trust_level,
+                kind.default_trust_level(),
+                "kind {kind:?} drifted from its default trust level",
+            );
+        }
+        // Pin the explicit values so a future change to
+        // `default_trust_level` does not silently widen this policy.
+        assert_eq!(
+            PrincipalPolicy::for_kind(PrincipalKind::ExternalAgent).required_trust_level,
+            TrustLevel::Unverified,
+        );
+        assert_eq!(
+            PrincipalPolicy::for_kind(PrincipalKind::Human).required_trust_level,
+            TrustLevel::FirstParty,
+        );
+    }
+
+    // ── Store ──────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn policy_store_resolves_by_principal_kind() {
+        let store = InMemoryPrincipalPolicyStore::new();
+
+        let admin = Principal::default_admin();
+        let admin_policy = store.resolve(&admin).await;
+        assert_eq!(admin_policy.max_delegation_depth, 5);
+        assert!(admin_policy.allow_meta_change);
+
+        let agent = Principal::for_agent("a-1", "a");
+        let agent_policy = store.resolve(&agent).await;
+        assert_eq!(agent_policy.max_delegation_depth, 2);
+        assert!(!agent_policy.allow_meta_change);
+
+        let ext = Principal::external_agent("a2a", "bot");
+        let ext_policy = store.resolve(&ext).await;
+        assert_eq!(ext_policy.max_delegation_depth, 0);
+        assert!(ext_policy.allowed_tool_scopes.is_empty());
+
+        let svc = Principal::service("connector");
+        let svc_policy = store.resolve(&svc).await;
+        assert_eq!(svc_policy.max_delegation_depth, 0);
+        assert!(svc_policy.allowed_tool_scopes.is_empty());
+
+        let sys = Principal::system();
+        let sys_policy = store.resolve(&sys).await;
+        assert_eq!(sys_policy.max_delegation_depth, 5);
+        assert!(sys_policy.allow_meta_change);
+    }
+
+    /// Empty config produces the same effective policies as the
+    /// kind-default store — the "absence = defaults" invariant.
+    #[test]
+    fn empty_config_matches_in_memory_defaults() {
+        let from_default = InMemoryPrincipalPolicyStore::new();
+        let from_empty =
+            InMemoryPrincipalPolicyStore::from_config(&PrincipalPoliciesConfig::default());
+        for kind in ALL_PRINCIPAL_KINDS {
+            assert_eq!(
+                from_default.policy_for(kind),
+                from_empty.policy_for(kind),
+                "default vs empty-config drift on kind {kind:?}",
+            );
+        }
+    }
+
+    /// A single field in a per-kind spec must override only that field.
+    #[test]
+    fn config_override_only_replaces_specified_fields() {
+        let mut config = PrincipalPoliciesConfig::default();
+        let spec = PrincipalPolicySpec {
+            max_delegation_depth: Some(1),
+            ..PrincipalPolicySpec::default()
+        };
+        config.policies.insert(PrincipalKind::Agent, spec);
+
+        let store = InMemoryPrincipalPolicyStore::from_config(&config);
+        let agent = store.policy_for(PrincipalKind::Agent);
+        assert_eq!(agent.max_delegation_depth, 1);
+        // Other fields remain at the kind default.
+        assert!(agent.allowed_tool_scopes.contains(&ToolScope::Execute));
+        assert!(!agent.allowed_tool_scopes.contains(&ToolScope::Admin));
+        assert!(!agent.allow_meta_change);
+    }
+
+    // ── Narrowing ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn policy_narrowing_intersects_scopes_and_decrements_depth() {
+        let parent = PrincipalPolicy::for_kind(PrincipalKind::Human);
+        let child = PrincipalPolicy::for_kind(PrincipalKind::Agent);
+        let narrowed = narrow_for_subagent(&parent, &child);
+
+        // Human (all) ∩ Agent (no Admin) = Agent's set.
+        assert!(narrowed.allowed_tool_scopes.contains(&ToolScope::Read));
+        assert!(narrowed.allowed_tool_scopes.contains(&ToolScope::Execute));
+        assert!(!narrowed.allowed_tool_scopes.contains(&ToolScope::Admin));
+
+        // Depth: min(parent.depth - 1, child.depth) = min(4, 2) = 2.
+        assert_eq!(narrowed.max_delegation_depth, 2);
+
+        // AND-reduced flags: meta is off (child=false).
+        assert!(narrowed.allow_subagent_spawn);
+        assert!(!narrowed.allow_meta_change);
+        assert!(narrowed.allow_code_change);
+    }
+
+    /// Narrowing into an `ExternalAgent` child collapses to default-deny
+    /// regardless of the parent's permissions — the laundering attack
+    /// described in §7.2 of the design report.
+    #[test]
+    fn policy_narrowing_into_external_agent_is_default_deny() {
+        let parent = PrincipalPolicy::for_kind(PrincipalKind::Human);
+        let child = PrincipalPolicy::for_kind(PrincipalKind::ExternalAgent);
+        let narrowed = narrow_for_subagent(&parent, &child);
+
+        assert!(narrowed.allowed_tool_scopes.is_empty());
+        assert_eq!(narrowed.max_delegation_depth, 0);
+        assert!(!narrowed.allow_subagent_spawn);
+        assert!(!narrowed.allow_meta_change);
+        assert!(!narrowed.allow_code_change);
+    }
+
+    /// Depth saturates at zero so a parent at depth 0 cannot underflow into
+    /// a permissive child.
+    #[test]
+    fn policy_narrowing_depth_saturates_at_zero() {
+        let mut parent = PrincipalPolicy::for_kind(PrincipalKind::ExternalAgent);
+        parent.allowed_tool_scopes.insert(ToolScope::Read);
+        let mut child = PrincipalPolicy::for_kind(PrincipalKind::Human);
+        child.max_delegation_depth = 5;
+        let narrowed = narrow_for_subagent(&parent, &child);
+
+        assert_eq!(narrowed.max_delegation_depth, 0);
+    }
+
+    /// The narrowed policy keeps the stricter trust requirement.
+    #[test]
+    fn policy_narrowing_picks_stricter_trust_level() {
+        let mut parent = PrincipalPolicy::for_kind(PrincipalKind::Agent);
+        parent.required_trust_level = TrustLevel::Unverified;
+        let mut child = PrincipalPolicy::for_kind(PrincipalKind::Agent);
+        child.required_trust_level = TrustLevel::FirstParty;
+        let narrowed = narrow_for_subagent(&parent, &child);
+        assert_eq!(narrowed.required_trust_level, TrustLevel::FirstParty);
+
+        let mut parent2 = PrincipalPolicy::for_kind(PrincipalKind::Agent);
+        parent2.required_trust_level = TrustLevel::FirstParty;
+        let mut child2 = PrincipalPolicy::for_kind(PrincipalKind::Agent);
+        child2.required_trust_level = TrustLevel::Unverified;
+        let narrowed2 = narrow_for_subagent(&parent2, &child2);
+        assert_eq!(narrowed2.required_trust_level, TrustLevel::FirstParty);
+    }
+
+    // ── Serde roundtrip ────────────────────────────────────────────────────
+
+    #[test]
+    fn principal_policy_json_roundtrip() {
+        let p = PrincipalPolicy::for_kind(PrincipalKind::Agent);
+        let json = serde_json::to_string(&p).unwrap();
+        let parsed: PrincipalPolicy = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, p);
+    }
+}

--- a/rust/crates/sera-config/src/lib.rs
+++ b/rust/crates/sera-config/src/lib.rs
@@ -10,6 +10,7 @@ pub mod config_root;
 pub mod core_config;
 pub mod data_root;
 pub mod manifest_loader;
+pub mod principal_policy;
 pub mod provider_registry;
 pub mod provider_wizard;
 pub mod providers;
@@ -21,6 +22,7 @@ pub use capability_registry::{
 };
 pub use config_root::{ConfigRoot, CONFIG_ROOT_ENV};
 pub use data_root::{DataRoot, DATA_ROOT_ENV};
+pub use principal_policy::{PrincipalPoliciesConfig, PrincipalPolicySpec};
 
 pub mod config_store;
 pub mod env_override;

--- a/rust/crates/sera-config/src/principal_policy.rs
+++ b/rust/crates/sera-config/src/principal_policy.rs
@@ -1,0 +1,182 @@
+//! Wire format for `sera.auth.principal_policies` (sera-fhcr).
+//!
+//! `sera-config` deliberately stays free of any `sera-auth` dependency, so
+//! the runtime [`PrincipalPolicy`] type lives in `sera-auth::policy`. This
+//! module exposes the on-disk shadow ([`PrincipalPolicySpec`]) plus the
+//! top-level config block ([`PrincipalPoliciesConfig`]) and converts on
+//! the auth side via `PrincipalPolicy::with_spec`.
+//!
+//! Every spec field is optional. An absent field falls back to the per-kind
+//! default produced by `PrincipalPolicy::for_kind`, so an empty config
+//! produces the same effective policies as the in-memory store's defaults.
+
+use std::collections::{HashMap, HashSet};
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+use sera_types::evolution::BlastRadius;
+use sera_types::principal::{PrincipalKind, TrustLevel};
+use sera_types::tool::ToolScope;
+
+/// All-optional override of a runtime `PrincipalPolicy`. Only fields that
+/// are explicitly set in YAML take effect; everything else falls back to
+/// the per-kind default in `sera-auth`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct PrincipalPolicySpec {
+    #[serde(
+        default,
+        with = "duration_secs_opt",
+        skip_serializing_if = "Option::is_none",
+        rename = "max_token_ttl_secs"
+    )]
+    pub max_token_ttl: Option<Duration>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allowed_tool_scopes: Option<HashSet<ToolScope>>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_delegation_depth: Option<u32>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allowed_blast_radii: Option<HashSet<BlastRadius>>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allow_subagent_spawn: Option<bool>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allow_meta_change: Option<bool>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allow_code_change: Option<bool>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub required_trust_level: Option<TrustLevel>,
+}
+
+/// Top-level block under `sera.auth.principal_policies`.
+///
+/// The map is keyed by [`PrincipalKind`] (snake_case in YAML). Kinds absent
+/// from the map use the runtime per-kind defaults verbatim.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct PrincipalPoliciesConfig {
+    #[serde(default)]
+    pub policies: HashMap<PrincipalKind, PrincipalPolicySpec>,
+}
+
+impl PrincipalPoliciesConfig {
+    pub fn is_empty(&self) -> bool {
+        self.policies.is_empty()
+    }
+}
+
+mod duration_secs_opt {
+    use std::time::Duration;
+
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    pub fn serialize<S: Serializer>(d: &Option<Duration>, s: S) -> Result<S::Ok, S::Error> {
+        match d {
+            Some(d) => d.as_secs().serialize(s),
+            None => s.serialize_none(),
+        }
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Option<Duration>, D::Error> {
+        Option::<u64>::deserialize(d).map(|o| o.map(Duration::from_secs))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// sera-fhcr — a fully populated YAML block must roundtrip through
+    /// `PrincipalPoliciesConfig` so operators can authoritatively pin every
+    /// field of a per-kind policy.
+    #[test]
+    fn principal_policies_yaml_roundtrip_full() {
+        let yaml = r#"
+policies:
+  human:
+    max_token_ttl_secs: 7200
+    allowed_tool_scopes: [read, write, execute, network, agent, vcs, admin]
+    max_delegation_depth: 5
+    allowed_blast_radii: [agent_memory, agent_skill]
+    allow_subagent_spawn: true
+    allow_meta_change: true
+    allow_code_change: true
+    required_trust_level: first_party
+  external_agent:
+    allowed_tool_scopes: []
+    max_delegation_depth: 0
+    allow_subagent_spawn: false
+    allow_meta_change: false
+    allow_code_change: false
+    required_trust_level: unverified
+"#;
+        let parsed: PrincipalPoliciesConfig = serde_yaml::from_str(yaml).unwrap();
+        let human = parsed.policies.get(&PrincipalKind::Human).unwrap();
+        assert_eq!(human.max_token_ttl, Some(Duration::from_secs(7200)));
+        assert_eq!(human.max_delegation_depth, Some(5));
+        let scopes = human.allowed_tool_scopes.as_ref().unwrap();
+        assert!(scopes.contains(&ToolScope::Admin));
+        assert!(scopes.contains(&ToolScope::Read));
+        assert_eq!(human.required_trust_level, Some(TrustLevel::FirstParty));
+
+        let ext = parsed.policies.get(&PrincipalKind::ExternalAgent).unwrap();
+        assert_eq!(ext.max_delegation_depth, Some(0));
+        assert_eq!(ext.allow_subagent_spawn, Some(false));
+        assert_eq!(ext.required_trust_level, Some(TrustLevel::Unverified));
+        assert!(ext.allowed_tool_scopes.as_ref().unwrap().is_empty());
+
+        // Round back to YAML and parse again to confirm symmetry.
+        let yaml2 = serde_yaml::to_string(&parsed).unwrap();
+        let parsed2: PrincipalPoliciesConfig = serde_yaml::from_str(&yaml2).unwrap();
+        assert_eq!(parsed, parsed2);
+    }
+
+    /// sera-fhcr — partial overrides must leave omitted fields as `None`,
+    /// signalling "fall back to the runtime default" to `with_spec`.
+    #[test]
+    fn principal_policies_yaml_partial_override() {
+        let yaml = r#"
+policies:
+  agent:
+    max_delegation_depth: 1
+"#;
+        let parsed: PrincipalPoliciesConfig = serde_yaml::from_str(yaml).unwrap();
+        let agent = parsed.policies.get(&PrincipalKind::Agent).unwrap();
+        assert_eq!(agent.max_delegation_depth, Some(1));
+        assert!(agent.allowed_tool_scopes.is_none());
+        assert!(agent.allow_meta_change.is_none());
+    }
+
+    /// sera-fhcr — an absent `principal_policies` block (the common case)
+    /// deserializes to an empty map, and downstream callers must produce
+    /// the same effective policies as `InMemoryPrincipalPolicyStore::new()`.
+    #[test]
+    fn principal_policies_yaml_absent_is_empty() {
+        let yaml = "policies: {}";
+        let parsed: PrincipalPoliciesConfig = serde_yaml::from_str(yaml).unwrap();
+        assert!(parsed.is_empty());
+
+        // The default impl matches the empty-map shape too.
+        assert_eq!(parsed, PrincipalPoliciesConfig::default());
+    }
+
+    /// Unknown keys must fail closed so a typo never silently disables a
+    /// policy override (e.g. `max_delegation_dept` → 0 by default).
+    #[test]
+    fn principal_policies_yaml_rejects_unknown_fields() {
+        let yaml = r#"
+policies:
+  agent:
+    max_delegation_dept: 1
+"#;
+        let res: Result<PrincipalPoliciesConfig, _> = serde_yaml::from_str(yaml);
+        assert!(res.is_err());
+    }
+}

--- a/rust/crates/sera-gateway/src/lib.rs
+++ b/rust/crates/sera-gateway/src/lib.rs
@@ -14,6 +14,7 @@ pub mod hitl_gateway;
 pub mod kill_switch;
 pub mod party;
 pub mod plugin;
+pub mod policy_resolution;
 pub mod process_manager;
 pub mod scheduler;
 pub mod session_persist;

--- a/rust/crates/sera-gateway/src/policy_resolution.rs
+++ b/rust/crates/sera-gateway/src/policy_resolution.rs
@@ -1,0 +1,113 @@
+//! Gateway-side principal policy resolution seam (sera-fhcr / PR2).
+//!
+//! PR2 plumbs the resolution path so the gateway can ask a
+//! [`PrincipalPolicyStore`] for an `Arc<PrincipalPolicy>` given a
+//! [`Principal`]. The runtime dispatcher gate (PR3 / sera-u4gj) will
+//! consume the resolved policy via `TurnContext` — this module deliberately
+//! stops short of that wiring so PR2 stays reviewable in isolation.
+//!
+//! Where this gets wired in PR3:
+//!
+//! - `chat_handler` (`sera-gateway/src/bin/sera.rs`) constructs the
+//!   principal at admission, calls [`PolicyResolver::resolve`], and stamps
+//!   the resulting `Arc<PrincipalPolicy>` onto the lane submission so every
+//!   `ToolContext` for that turn carries the same value (turn-lifetime
+//!   immutability — see design report §7.1).
+//! - `chat_cancel_handler` does not need a policy (no tool dispatch), but
+//!   should still resolve for audit parity.
+//! - `EmbeddedRuntimeTransport::send_turn` extends `TurnContext` with the
+//!   resolved policy field.
+//!
+//! Until that wiring lands, the resolver is a thin async forwarder over the
+//! store with no per-turn caching.
+
+use std::sync::Arc;
+
+use sera_auth::policy::{
+    InMemoryPrincipalPolicyStore, PrincipalPolicy, PrincipalPolicyStore,
+};
+use sera_types::principal::Principal;
+
+/// Thin wrapper over a [`PrincipalPolicyStore`] that the gateway can pass
+/// down to admission code in PR3. Today this just forwards `resolve` to the
+/// store; PR3 can layer per-turn caching here without churning callers.
+#[derive(Clone)]
+pub struct PolicyResolver {
+    store: Arc<dyn PrincipalPolicyStore>,
+}
+
+impl PolicyResolver {
+    pub fn new(store: Arc<dyn PrincipalPolicyStore>) -> Self {
+        Self { store }
+    }
+
+    /// Construct a resolver backed by a fresh
+    /// [`InMemoryPrincipalPolicyStore`] seeded with per-kind defaults.
+    pub fn in_memory() -> Self {
+        Self::new(Arc::new(InMemoryPrincipalPolicyStore::new()))
+    }
+
+    /// Resolve the policy for a principal at gateway admission. The
+    /// returned `Arc` is meant to be cloned cheaply onto the turn
+    /// submission and propagated immutably to downstream `ToolContext`
+    /// builders in PR3.
+    pub async fn resolve(&self, principal: &Principal) -> Arc<PrincipalPolicy> {
+        self.store.resolve(principal).await
+    }
+}
+
+impl std::fmt::Debug for PolicyResolver {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PolicyResolver").finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sera_types::tool::ToolScope;
+
+    #[tokio::test]
+    async fn resolver_returns_kind_default_for_admin_human() {
+        let resolver = PolicyResolver::in_memory();
+        let admin = Principal::default_admin();
+        let policy = resolver.resolve(&admin).await;
+        assert_eq!(policy.max_delegation_depth, 5);
+        assert!(policy.allow_meta_change);
+        assert!(policy.allowed_tool_scopes.contains(&ToolScope::Admin));
+    }
+
+    #[tokio::test]
+    async fn resolver_returns_kind_default_for_agent() {
+        let resolver = PolicyResolver::in_memory();
+        let agent = Principal::for_agent("a-1", "a");
+        let policy = resolver.resolve(&agent).await;
+        assert_eq!(policy.max_delegation_depth, 2);
+        assert!(!policy.allow_meta_change);
+        assert!(!policy.allowed_tool_scopes.contains(&ToolScope::Admin));
+    }
+
+    #[tokio::test]
+    async fn resolver_returns_default_deny_for_external_agent() {
+        let resolver = PolicyResolver::in_memory();
+        let ext = Principal::external_agent("a2a", "bot");
+        let policy = resolver.resolve(&ext).await;
+        assert_eq!(policy.max_delegation_depth, 0);
+        assert!(policy.allowed_tool_scopes.is_empty());
+        assert!(!policy.allow_subagent_spawn);
+    }
+
+    /// The resolver must return a fresh `Arc` reference per call — PR2
+    /// does not yet cache, and depending on identity here would tie the
+    /// gateway to a specific implementation. PR3 will layer turn-scoped
+    /// caching at a higher level (the lane submission), not in the
+    /// resolver itself.
+    #[tokio::test]
+    async fn resolver_returns_equal_policy_across_calls() {
+        let resolver = PolicyResolver::in_memory();
+        let agent = Principal::for_agent("a-1", "a");
+        let p1 = resolver.resolve(&agent).await;
+        let p2 = resolver.resolve(&agent).await;
+        assert_eq!(*p1, *p2);
+    }
+}


### PR DESCRIPTION
## Summary

Lands PR2 of the principal-policy / tool-scope design lane (bead **sera-fhcr**). Introduces the `PrincipalPolicy` envelope + per-kind defaults + a thin gateway-side resolution seam, without yet wiring the runtime dispatcher gate (that is PR3 / sera-u4gj).

Source of truth: `artifacts/reports/claude-burn/principal-policy-tool-scope-design-2026-04-30.md` §4 PR2, §5.2, §5.3.

## What this PR adds

- **`sera-auth::policy::PrincipalPolicy`** with `max_token_ttl`, `allowed_tool_scopes`, `max_delegation_depth`, `allowed_blast_radii`, `allow_subagent_spawn`, `allow_meta_change`, `allow_code_change`, and `required_trust_level` (using the existing `sera-types::principal::TrustLevel` from sera-8w59).
- **Per-`PrincipalKind` defaults** via `PrincipalPolicy::for_kind`:
  - `Human` / `System`: all 7 tool scopes, depth 5, all privileged flags true.
  - `Agent`: Read/Write/Execute/Network/Vcs/Agent (no `Admin`), depth 2, `subagent_spawn=true`, `meta_change=false`, `code_change=true`.
  - `ExternalAgent` / `Service`: empty scopes, depth 0, all privileged flags false. Default-deny.
  - `required_trust_level` mirrors `PrincipalKind::default_trust_level` — `ExternalAgent` keeps `Unverified`, every other kind defaults to `FirstParty`.
- **`PrincipalPolicyStore`** async trait + **`InMemoryPrincipalPolicyStore`** seeded with the kind defaults; `from_config` applies per-kind YAML overrides on top.
- **`narrow_for_subagent`** helper: scope ∩ scope, depth saturating decrement (`min(parent.depth - 1, child.depth)`), AND-reduced privileged booleans, stricter-of-two `required_trust_level`. Helper only — PR3 wires it into the sub-agent dispatch path.
- **`sera-config::principal_policy::PrincipalPolicySpec` / `PrincipalPoliciesConfig`** — wire shape for `sera.auth.principal_policies`. All fields optional, `deny_unknown_fields`, YAML round-trip. Absent config produces the same effective policies as the in-memory defaults.
- **`sera-gateway::policy_resolution::PolicyResolver`** — thin wrapper over `PrincipalPolicyStore` exposing `resolve(&Principal) -> Arc<PrincipalPolicy>`. The `chat_handler` admission caller is documented in the module rustdoc; PR3 wires it in.
- Re-exports: `sera-auth::lib` exports `PrincipalPolicy`, `PrincipalPolicyStore`, `InMemoryPrincipalPolicyStore`, `narrow_for_subagent`. `sera-config::lib` re-exports the spec types.

## Tests

`cargo test -p sera-auth -p sera-config -p sera-gateway` passes. New tests:

- `default_human_policy_has_all_scopes_depth_5`
- `default_agent_policy_excludes_admin_depth_2`
- `default_external_agent_policy_is_default_deny_depth_0`
- `default_service_policy_is_default_deny_depth_0`
- `default_system_policy_has_all_scopes_depth_5`
- `policy_store_resolves_by_principal_kind`
- `policy_narrowing_intersects_scopes_and_decrements_depth`
- `policy_narrowing_into_external_agent_is_default_deny`
- `policy_narrowing_depth_saturates_at_zero`
- `policy_narrowing_picks_stricter_trust_level`
- `required_trust_level_defaults_follow_principal_kind`
- `empty_config_matches_in_memory_defaults`
- `config_override_only_replaces_specified_fields`
- `principal_policy_json_roundtrip`
- `principal_policies_yaml_roundtrip_full` / `_partial_override` / `_absent_is_empty` / `_rejects_unknown_fields` (sera-config)
- `resolver_returns_kind_default_for_admin_human` / `_for_agent` / `_default_deny_for_external_agent` / `_returns_equal_policy_across_calls` (sera-gateway)

Validation cycle locally:
- `cargo check --workspace` ✓
- `cargo test -p sera-auth` ✓ (114 passed, 4 ignored)
- `cargo test -p sera-config` ✓ (146 passed)
- `cargo test -p sera-gateway` ✓ (453 passed, 3 ignored — the `production_e2e::*_round_trip` tests need a prebuilt `sera-runtime` binary)
- `cargo clippy -p sera-auth -p sera-config -p sera-gateway --all-targets -- -D warnings` ✓

A pre-existing clippy warning in `crates/sera-tools/tests/tools_tests.rs:242` (default-constructed unit struct) is unrelated to this PR and present on `origin/main` — not addressed here per the surgical-changes rule.

## Bead

- **sera-fhcr** — feat(sera-auth): introduce PrincipalPolicy with delegation-depth cap.

## Explicitly deferred follow-ups

- **Runtime dispatcher ToolScope gate** (PR3 / sera-u4gj). The gate placement and ordering is documented in the design report §6; this PR ships the data and resolution seam, not the dispatch enforcement.
- **`CapabilityToken` delegation chain fields** (sera-s64j). The depth cap landed here; the consumer of `max_delegation_depth` lives in `CapabilityToken::narrow()`.
- **Persona presets** (`PRESET_READ_ONLY_REVIEWER`, `PRESET_CODE_EDITOR`, `PRESET_TEST_RUNNER`, `PRESET_FULL_AUTONOMY`) (PR4 / sera-u4gj).
- **Cascade revocation** (sera-2q6w), OAuth, external identity registry, `HarnessProfileRegistry`.
- The hardcoded `chat_handler` `PrincipalRef("http-chat", Human)` (`sera.rs:1898`) — covered by §7.4 of the design report; PR3 replaces it with an API-key-derived principal.

## Test plan

- [ ] CI green on this branch (build, test, clippy).
- [ ] `cargo test -p sera-auth -p sera-config -p sera-gateway` clean locally.
- [ ] Reviewer confirms the per-kind defaults table matches design §5.3.
- [ ] Reviewer confirms `narrow_for_subagent` semantics match §6.4 / §7.2.