### PR TITLE
feat(scripts): route OMC/OMX launches through inference.local (sera-kg3g)

### DIFF
--- a/scripts/lib/inference_proxy.sh
+++ b/scripts/lib/inference_proxy.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# scripts/lib/inference_proxy.sh — Pattern B launcher enforcement (sera-kg3g)
+#
+# Builds the env-prefix needed to route an OMC/OMX child through the SERA
+# gateway's inference.local proxy (`/v1/messages`, `/v1/chat/completions`)
+# instead of the operator's direct Anthropic/OpenAI accounts.
+#
+# Public API (all functions are pure or read env vars; none modify global env):
+#
+#   inference_proxy_endpoint
+#       Echo the gateway endpoint to use. Reads $SERA_GATEWAY_ENDPOINT
+#       (default: http://localhost:42540).
+#
+#   inference_proxy_token
+#       Echo the SERA-issued token to inject as the child's upstream key.
+#       Reads, in priority order:
+#         $SERA_LAUNCHER_TOKEN  — explicit one-shot token
+#         $SERA_API_KEY         — gateway-configured API key
+#         "sera_bootstrap_dev_123" — dev fallback (matches doctor.rs default)
+#
+#   inference_proxy_reachable <endpoint> [timeout_seconds]
+#       Return 0 if `${endpoint}/api/health` responds with HTTP 200.
+#       Default timeout: 2 seconds. The function may be overridden in tests
+#       by redefining it after sourcing.
+#
+#   inference_proxy_build_argv <mode>
+#       Populate global array INFERENCE_PROXY_ARGV with `env ... --` prefix
+#       args to splice in front of the child command. Sets global flag
+#       INFERENCE_PROXY_NONCOMPLIANT to "yes" when soft mode is degrading.
+#
+#       Modes:
+#         strict — fail (return 2) if the gateway is unreachable.
+#         soft   — warn-and-continue, mark non-compliant.
+#         off    — leave INFERENCE_PROXY_ARGV empty and return 0.
+#
+#       Returns:
+#         0 — argv built (compliant or soft-non-compliant); proceed.
+#         2 — strict mode but gateway unreachable; caller must abort.
+#
+# Provider env vars handled (scrubbed via `env -u` so the child does not
+# inherit the operator's direct-provider credentials):
+#   ANTHROPIC_API_KEY      — replaced with SERA token (kept set so SDK runs)
+#   ANTHROPIC_AUTH_TOKEN   — replaced with SERA token (Authorization: Bearer)
+#   ANTHROPIC_BASE_URL     — replaced with gateway endpoint
+#   OPENAI_API_KEY         — replaced with SERA token
+#   OPENAI_BASE_URL        — replaced with gateway endpoint + /v1
+
+# shellcheck shell=bash
+
+# Globals populated by inference_proxy_build_argv.
+INFERENCE_PROXY_ARGV=()
+INFERENCE_PROXY_NONCOMPLIANT=""
+
+inference_proxy_endpoint() {
+  echo "${SERA_GATEWAY_ENDPOINT:-http://localhost:42540}"
+}
+
+inference_proxy_token() {
+  if [[ -n "${SERA_LAUNCHER_TOKEN:-}" ]]; then
+    echo "${SERA_LAUNCHER_TOKEN}"
+  elif [[ -n "${SERA_API_KEY:-}" ]]; then
+    echo "${SERA_API_KEY}"
+  else
+    echo "sera_bootstrap_dev_123"
+  fi
+}
+
+# Reachability probe — overridable in tests.
+inference_proxy_reachable() {
+  local endpoint="$1"
+  local timeout="${2:-2}"
+  local code
+  code=$(curl -s -o /dev/null -w "%{http_code}" \
+              --max-time "${timeout}" \
+              "${endpoint%/}/api/health" 2>/dev/null || echo "000")
+  [[ "$code" == "200" ]]
+}
+
+inference_proxy_build_argv() {
+  local mode="${1:-soft}"
+  INFERENCE_PROXY_ARGV=()
+  INFERENCE_PROXY_NONCOMPLIANT=""
+
+  if [[ "$mode" == "off" ]]; then
+    return 0
+  fi
+
+  local endpoint token openai_base
+  endpoint="$(inference_proxy_endpoint)"
+  token="$(inference_proxy_token)"
+  openai_base="${endpoint%/}/v1"
+
+  if ! inference_proxy_reachable "$endpoint"; then
+    case "$mode" in
+      strict)
+        echo "[sera-launcher] FATAL: gateway unreachable at ${endpoint}; refusing to launch (strict mode)" >&2
+        echo "[sera-launcher] Start the gateway (e.g. scripts/sera-local) or set SERA_INFERENCE_PROXY_MODE=soft to override." >&2
+        return 2
+        ;;
+      soft|*)
+        INFERENCE_PROXY_NONCOMPLIANT="yes"
+        echo "[sera-launcher] WARN: gateway unreachable at ${endpoint}; session marked NON-COMPLIANT (provider keys remain scrubbed)" >&2
+        ;;
+    esac
+  fi
+
+  # `env` builds the child's environment: scrub the operator's direct-provider
+  # vars first (-u) so the child cannot inherit a stale key, then set our own
+  # base URL + SERA token so the child can talk to the gateway proxy.
+  INFERENCE_PROXY_ARGV=(
+    env
+    -u ANTHROPIC_API_KEY
+    -u ANTHROPIC_AUTH_TOKEN
+    -u ANTHROPIC_BASE_URL
+    -u OPENAI_API_KEY
+    -u OPENAI_BASE_URL
+    "ANTHROPIC_BASE_URL=${endpoint}"
+    "ANTHROPIC_API_KEY=${token}"
+    "ANTHROPIC_AUTH_TOKEN=${token}"
+    "OPENAI_BASE_URL=${openai_base}"
+    "OPENAI_API_KEY=${token}"
+    "SERA_LAUNCHER_PROXY=${endpoint}"
+  )
+
+  if [[ -n "$INFERENCE_PROXY_NONCOMPLIANT" ]]; then
+    INFERENCE_PROXY_ARGV+=("SERA_LAUNCHER_NONCOMPLIANT=yes")
+  fi
+
+  return 0
+}

--- a/scripts/sera-omc
+++ b/scripts/sera-omc
@@ -39,8 +39,9 @@ else
 fi
 
 PROXY_MODE="${SERA_INFERENCE_PROXY_MODE:-soft}"
+PROXY_RC=0
 inference_proxy_build_argv "${PROXY_MODE}" || PROXY_RC=$?
-if [[ -n "${PROXY_RC:-}" ]] && [[ "${PROXY_RC}" -ne 0 ]]; then
+if [[ "${PROXY_RC}" -ne 0 ]]; then
   exit "${PROXY_RC}"
 fi
 

--- a/scripts/sera-omc
+++ b/scripts/sera-omc
@@ -16,6 +16,8 @@ SERA_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null || echo 
 
 # shellcheck source=lib/beads.sh
 source "${SCRIPT_DIR}/lib/beads.sh"
+# shellcheck source=lib/inference_proxy.sh
+source "${SCRIPT_DIR}/lib/inference_proxy.sh"
 
 BEAD_ID=""
 OMC_ARGS=()
@@ -36,7 +38,18 @@ else
   SESSION="omc-sera-$(date +%s | rev | cut -c1-4)"
 fi
 
+PROXY_MODE="${SERA_INFERENCE_PROXY_MODE:-soft}"
+inference_proxy_build_argv "${PROXY_MODE}" || PROXY_RC=$?
+if [[ -n "${PROXY_RC:-}" ]] && [[ "${PROXY_RC}" -ne 0 ]]; then
+  exit "${PROXY_RC}"
+fi
+
+if [[ -n "${INFERENCE_PROXY_NONCOMPLIANT}" ]]; then
+  SESSION="${SESSION}-noncompliant"
+fi
+
 echo "[sera-omc] Starting monitored session: ${SESSION}"
+echo "[sera-omc] Inference proxy: $(inference_proxy_endpoint) (mode=${PROXY_MODE}${INFERENCE_PROXY_NONCOMPLIANT:+, NON-COMPLIANT})"
 
 exec clawhip tmux new \
   --session "${SESSION}" \
@@ -44,4 +57,4 @@ exec clawhip tmux new \
   --keywords "${KEYWORDS}" \
   --cwd "${SERA_ROOT}" \
   --attach \
-  -- omc "${OMC_ARGS[@]+"${OMC_ARGS[@]}"}"
+  -- "${INFERENCE_PROXY_ARGV[@]}" omc "${OMC_ARGS[@]+"${OMC_ARGS[@]}"}"

--- a/scripts/sera-omx
+++ b/scripts/sera-omx
@@ -39,8 +39,9 @@ else
 fi
 
 PROXY_MODE="${SERA_INFERENCE_PROXY_MODE:-soft}"
+PROXY_RC=0
 inference_proxy_build_argv "${PROXY_MODE}" || PROXY_RC=$?
-if [[ -n "${PROXY_RC:-}" ]] && [[ "${PROXY_RC}" -ne 0 ]]; then
+if [[ "${PROXY_RC}" -ne 0 ]]; then
   exit "${PROXY_RC}"
 fi
 

--- a/scripts/sera-omx
+++ b/scripts/sera-omx
@@ -16,6 +16,8 @@ SERA_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null || echo 
 
 # shellcheck source=lib/beads.sh
 source "${SCRIPT_DIR}/lib/beads.sh"
+# shellcheck source=lib/inference_proxy.sh
+source "${SCRIPT_DIR}/lib/inference_proxy.sh"
 
 BEAD_ID=""
 OMX_ARGS=()
@@ -36,7 +38,18 @@ else
   SESSION="omc-sera-$(date +%s | rev | cut -c1-4)"
 fi
 
+PROXY_MODE="${SERA_INFERENCE_PROXY_MODE:-soft}"
+inference_proxy_build_argv "${PROXY_MODE}" || PROXY_RC=$?
+if [[ -n "${PROXY_RC:-}" ]] && [[ "${PROXY_RC}" -ne 0 ]]; then
+  exit "${PROXY_RC}"
+fi
+
+if [[ -n "${INFERENCE_PROXY_NONCOMPLIANT}" ]]; then
+  SESSION="${SESSION}-noncompliant"
+fi
+
 echo "[sera-omx] Starting monitored session: ${SESSION}"
+echo "[sera-omx] Inference proxy: $(inference_proxy_endpoint) (mode=${PROXY_MODE}${INFERENCE_PROXY_NONCOMPLIANT:+, NON-COMPLIANT})"
 
 exec clawhip tmux new \
   --session "${SESSION}" \
@@ -44,4 +57,4 @@ exec clawhip tmux new \
   --keywords "${KEYWORDS}" \
   --cwd "${SERA_ROOT}" \
   --attach \
-  -- omx "${OMX_ARGS[@]+"${OMX_ARGS[@]}"}"
+  -- "${INFERENCE_PROXY_ARGV[@]}" omx "${OMX_ARGS[@]+"${OMX_ARGS[@]}"}"

--- a/scripts/tests/inference_proxy_test.sh
+++ b/scripts/tests/inference_proxy_test.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+# scripts/tests/inference_proxy_test.sh — Unit tests for sera-kg3g launcher
+# enforcement library.
+#
+# Pure bash, no external deps. Runs as: bash scripts/tests/inference_proxy_test.sh
+# Prints PASS/FAIL per assertion and exits non-zero on any failure.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB="${SCRIPT_DIR}/../lib/inference_proxy.sh"
+
+# shellcheck source=../lib/inference_proxy.sh
+source "$LIB"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local name="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo "  ✓ $name"
+    PASS=$((PASS + 1))
+  else
+    echo "  ✗ $name"
+    echo "      expected: $expected"
+    echo "      actual:   $actual"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_contains() {
+  local name="$1" haystack="$2" needle="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo "  ✓ $name"
+    PASS=$((PASS + 1))
+  else
+    echo "  ✗ $name"
+    echo "      haystack: $haystack"
+    echo "      needle:   $needle"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_not_contains() {
+  local name="$1" haystack="$2" needle="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    echo "  ✓ $name"
+    PASS=$((PASS + 1))
+  else
+    echo "  ✗ $name"
+    echo "      haystack: $haystack"
+    echo "      should NOT contain: $needle"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Reset env state between cases so leftovers from a prior case can't leak.
+reset_env() {
+  unset SERA_GATEWAY_ENDPOINT SERA_LAUNCHER_TOKEN SERA_API_KEY \
+        ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN ANTHROPIC_BASE_URL \
+        OPENAI_API_KEY OPENAI_BASE_URL
+  INFERENCE_PROXY_ARGV=()
+  INFERENCE_PROXY_NONCOMPLIANT=""
+}
+
+# Override the reachability probe so we never hit a real network in tests.
+inference_proxy_reachable() {
+  [[ "${TEST_REACHABLE:-no}" == "yes" ]]
+}
+
+echo "── inference_proxy_endpoint ────────────────────────────────────────────"
+reset_env
+assert_eq "default endpoint" "http://localhost:42540" "$(inference_proxy_endpoint)"
+SERA_GATEWAY_ENDPOINT="http://inference.local" \
+  assert_eq "endpoint override" "http://inference.local" "$(SERA_GATEWAY_ENDPOINT=http://inference.local inference_proxy_endpoint)"
+
+echo
+echo "── inference_proxy_token ───────────────────────────────────────────────"
+reset_env
+assert_eq "default to dev bootstrap token" "sera_bootstrap_dev_123" "$(inference_proxy_token)"
+SERA_API_KEY="abc-key" \
+  assert_eq "SERA_API_KEY beats default" "abc-key" "$(SERA_API_KEY=abc-key inference_proxy_token)"
+SERA_LAUNCHER_TOKEN="one-shot" SERA_API_KEY="abc-key" \
+  assert_eq "SERA_LAUNCHER_TOKEN beats SERA_API_KEY" "one-shot" \
+    "$(SERA_LAUNCHER_TOKEN=one-shot SERA_API_KEY=abc-key inference_proxy_token)"
+
+echo
+echo "── inference_proxy_build_argv: soft, reachable ─────────────────────────"
+reset_env
+TEST_REACHABLE=yes
+inference_proxy_build_argv soft
+rc=$?
+assert_eq "soft+reachable returns 0" "0" "$rc"
+assert_eq "compliant: NONCOMPLIANT flag empty" "" "$INFERENCE_PROXY_NONCOMPLIANT"
+joined="${INFERENCE_PROXY_ARGV[*]}"
+assert_contains "argv starts with env"             "$joined" "env "
+assert_contains "argv scrubs ANTHROPIC_API_KEY"    "$joined" "-u ANTHROPIC_API_KEY"
+assert_contains "argv scrubs ANTHROPIC_AUTH_TOKEN" "$joined" "-u ANTHROPIC_AUTH_TOKEN"
+assert_contains "argv scrubs ANTHROPIC_BASE_URL"   "$joined" "-u ANTHROPIC_BASE_URL"
+assert_contains "argv scrubs OPENAI_API_KEY"       "$joined" "-u OPENAI_API_KEY"
+assert_contains "argv scrubs OPENAI_BASE_URL"      "$joined" "-u OPENAI_BASE_URL"
+assert_contains "argv sets ANTHROPIC_BASE_URL to gateway" \
+  "$joined" "ANTHROPIC_BASE_URL=http://localhost:42540"
+assert_contains "argv sets OPENAI_BASE_URL to gateway/v1" \
+  "$joined" "OPENAI_BASE_URL=http://localhost:42540/v1"
+assert_contains "argv sets ANTHROPIC_API_KEY to SERA token" \
+  "$joined" "ANTHROPIC_API_KEY=sera_bootstrap_dev_123"
+assert_contains "argv sets ANTHROPIC_AUTH_TOKEN to SERA token" \
+  "$joined" "ANTHROPIC_AUTH_TOKEN=sera_bootstrap_dev_123"
+assert_contains "argv sets OPENAI_API_KEY to SERA token" \
+  "$joined" "OPENAI_API_KEY=sera_bootstrap_dev_123"
+assert_contains "argv tags SERA_LAUNCHER_PROXY for child visibility" \
+  "$joined" "SERA_LAUNCHER_PROXY=http://localhost:42540"
+assert_not_contains "compliant argv has no NONCOMPLIANT tag" \
+  "$joined" "SERA_LAUNCHER_NONCOMPLIANT"
+
+echo
+echo "── inference_proxy_build_argv: strict, unreachable ─────────────────────"
+reset_env
+TEST_REACHABLE=no
+inference_proxy_build_argv strict 2>/dev/null
+rc=$?
+assert_eq "strict+unreachable returns 2" "2" "$rc"
+assert_eq "strict failure leaves argv empty" "0" "${#INFERENCE_PROXY_ARGV[@]}"
+
+echo
+echo "── inference_proxy_build_argv: strict, reachable ───────────────────────"
+reset_env
+TEST_REACHABLE=yes
+inference_proxy_build_argv strict
+rc=$?
+assert_eq "strict+reachable returns 0" "0" "$rc"
+assert_eq "strict success: NONCOMPLIANT empty" "" "$INFERENCE_PROXY_NONCOMPLIANT"
+joined="${INFERENCE_PROXY_ARGV[*]}"
+assert_contains "strict argv still scrubs OPENAI_API_KEY" "$joined" "-u OPENAI_API_KEY"
+
+echo
+echo "── inference_proxy_build_argv: soft, unreachable (degraded) ────────────"
+reset_env
+TEST_REACHABLE=no
+inference_proxy_build_argv soft 2>/dev/null
+rc=$?
+assert_eq "soft+unreachable returns 0" "0" "$rc"
+assert_eq "soft+unreachable marks NONCOMPLIANT" "yes" "$INFERENCE_PROXY_NONCOMPLIANT"
+joined="${INFERENCE_PROXY_ARGV[*]}"
+assert_contains "degraded argv still scrubs ANTHROPIC_API_KEY" \
+  "$joined" "-u ANTHROPIC_API_KEY"
+assert_contains "degraded argv tags SERA_LAUNCHER_NONCOMPLIANT=yes" \
+  "$joined" "SERA_LAUNCHER_NONCOMPLIANT=yes"
+
+echo
+echo "── inference_proxy_build_argv: off ─────────────────────────────────────"
+reset_env
+TEST_REACHABLE=no
+inference_proxy_build_argv off
+rc=$?
+assert_eq "off mode returns 0 even when unreachable" "0" "$rc"
+assert_eq "off mode leaves argv empty" "0" "${#INFERENCE_PROXY_ARGV[@]}"
+
+echo
+echo "── token + endpoint propagation ────────────────────────────────────────"
+reset_env
+TEST_REACHABLE=yes
+SERA_GATEWAY_ENDPOINT="http://inference.local"
+SERA_LAUNCHER_TOKEN="sera-mint-9aa"
+inference_proxy_build_argv soft
+joined="${INFERENCE_PROXY_ARGV[*]}"
+assert_contains "custom endpoint flows into ANTHROPIC_BASE_URL" \
+  "$joined" "ANTHROPIC_BASE_URL=http://inference.local"
+assert_contains "custom endpoint flows into OPENAI_BASE_URL" \
+  "$joined" "OPENAI_BASE_URL=http://inference.local/v1"
+assert_contains "custom token flows into ANTHROPIC_AUTH_TOKEN" \
+  "$joined" "ANTHROPIC_AUTH_TOKEN=sera-mint-9aa"
+assert_contains "custom token flows into OPENAI_API_KEY" \
+  "$joined" "OPENAI_API_KEY=sera-mint-9aa"
+# Belt-and-braces: prove the operator's real provider key is never echoed.
+assert_not_contains "no leaked operator anthropic key in argv" \
+  "$joined" "sk-ant-"
+assert_not_contains "no leaked operator openai key in argv" \
+  "$joined" "sk-proj-"
+
+echo
+echo "── env scrubbing actually wipes inherited child env ────────────────────"
+# Belt-and-braces: prove that running `env ${INFERENCE_PROXY_ARGV[@]} -- env`
+# really does drop the operator's keys before the child sees them.
+reset_env
+TEST_REACHABLE=yes
+ANTHROPIC_API_KEY="sk-ant-leaked-OPERATOR-KEY"
+OPENAI_API_KEY="sk-proj-leaked-OPERATOR-KEY"
+inference_proxy_build_argv soft
+child_env="$("${INFERENCE_PROXY_ARGV[@]}" env)"
+assert_not_contains "operator ANTHROPIC_API_KEY value not visible to child" \
+  "$child_env" "sk-ant-leaked-OPERATOR-KEY"
+assert_not_contains "operator OPENAI_API_KEY value not visible to child" \
+  "$child_env" "sk-proj-leaked-OPERATOR-KEY"
+assert_contains "child sees SERA-injected ANTHROPIC_BASE_URL" \
+  "$child_env" "ANTHROPIC_BASE_URL=http://localhost:42540"
+assert_contains "child sees SERA-injected OPENAI_BASE_URL" \
+  "$child_env" "OPENAI_BASE_URL=http://localhost:42540/v1"
+
+echo
+echo "──────────────────────────────────────────────────────────────────"
+echo "  Passed: $PASS"
+echo "  Failed: $FAIL"
+echo "──────────────────────────────────────────────────────────────────"
+
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/scripts/tests/inference_proxy_test.sh
+++ b/scripts/tests/inference_proxy_test.sh
@@ -200,6 +200,55 @@ assert_contains "child sees SERA-injected OPENAI_BASE_URL" \
   "$child_env" "OPENAI_BASE_URL=http://localhost:42540/v1"
 
 echo
+echo "── launcher integration: inherited PROXY_RC must not abort ─────────────"
+# Regression for PR #1152 codex review (P2): a non-zero PROXY_RC inherited
+# from the parent environment must not leak through `|| PROXY_RC=$?` and
+# cause the launcher to exit with that stale code on a successful proxy
+# build. We invoke each launcher with PROXY_RC=7 in the env and assert the
+# script completes (exit 0) after invoking the stubbed clawhip.
+SCRIPTS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+launcher_stub_dir="$(mktemp -d)"
+cat > "${launcher_stub_dir}/clawhip" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "${launcher_stub_dir}/clawhip"
+
+run_launcher() {
+  local launcher="$1" mode="$2"
+  PATH="${launcher_stub_dir}:$PATH" \
+    PROXY_RC=7 \
+    SERA_INFERENCE_PROXY_MODE="${mode}" \
+    SERA_GATEWAY_ENDPOINT="http://127.0.0.1:1" \
+    bash "${SCRIPTS_DIR}/${launcher}" </dev/null >/dev/null 2>&1
+}
+
+run_launcher sera-omc off
+assert_eq "sera-omc off mode ignores inherited PROXY_RC=7" "0" "$?"
+run_launcher sera-omx off
+assert_eq "sera-omx off mode ignores inherited PROXY_RC=7" "0" "$?"
+run_launcher sera-omc soft
+assert_eq "sera-omc soft mode ignores inherited PROXY_RC=7 (degraded)" "0" "$?"
+run_launcher sera-omx soft
+assert_eq "sera-omx soft mode ignores inherited PROXY_RC=7 (degraded)" "0" "$?"
+
+# Strict mode + unreachable must still exit 2, not the inherited 7.
+PATH="${launcher_stub_dir}:$PATH" \
+  PROXY_RC=7 \
+  SERA_INFERENCE_PROXY_MODE=strict \
+  SERA_GATEWAY_ENDPOINT="http://127.0.0.1:1" \
+  bash "${SCRIPTS_DIR}/sera-omc" </dev/null >/dev/null 2>&1
+assert_eq "sera-omc strict-fail returns own rc=2 (not inherited 7)" "2" "$?"
+PATH="${launcher_stub_dir}:$PATH" \
+  PROXY_RC=7 \
+  SERA_INFERENCE_PROXY_MODE=strict \
+  SERA_GATEWAY_ENDPOINT="http://127.0.0.1:1" \
+  bash "${SCRIPTS_DIR}/sera-omx" </dev/null >/dev/null 2>&1
+assert_eq "sera-omx strict-fail returns own rc=2 (not inherited 7)" "2" "$?"
+
+rm -rf "${launcher_stub_dir}"
+
+echo
 echo "──────────────────────────────────────────────────────────────────"
 echo "  Passed: $PASS"
 echo "  Failed: $FAIL"


### PR DESCRIPTION
## Summary
- `scripts/sera-omc` and `scripts/sera-omx` now spawn their Claude Code / Codex
  child through an `env -u … KEY=VAL …` prefix that scrubs the operator's
  `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / etc. and redirects
  `ANTHROPIC_BASE_URL` / `OPENAI_BASE_URL` to the SERA gateway's universal
  inference proxy (Pattern B for sera-kg3g, paired with sera-eq0m for the
  in-sandbox variant).
- New `scripts/lib/inference_proxy.sh` is a small pure-bash helper with three
  modes — `strict` (refuse to launch when the gateway is unreachable),
  `soft` (default; warn-and-continue, mark the session NON-COMPLIANT in the
  child env and tmux session name), and `off` (escape hatch, no injection).
- New `scripts/tests/inference_proxy_test.sh` runs **41 / 41 PASS**: env
  construction, key scrubbing, strict-fail (`rc=2`), soft-degraded marking,
  off mode, and a real `env "${INFERENCE_PROXY_ARGV[@]}" -- env` round-trip
  that proves a `sk-ant-leaked-OPERATOR-KEY` set in the parent shell does
  not reach the child process. Pure bash, no external deps, no root, no
  network mutation — safe in CI.

Bead: `sera-kg3g`. Depends on already-merged `sera-7ivj`, `sera-eq0m`,
`sera-xgb0`. Acceptance handoff (local-only): `artifacts/reports/claude-burn/kg3g-launcher-inference-proxy-2026-05-01.md`.

## Test plan
- [x] `bash scripts/tests/inference_proxy_test.sh` — 41/41 pass
- [x] `bash -n scripts/{sera-omc,sera-omx,lib/inference_proxy.sh}` — clean parse
- [x] Strict + unreachable gateway with stubbed clawhip — exits 2, never invokes child
- [x] Soft + unreachable gateway with stubbed clawhip — non-compliant marker, key scrub intact, child argv carries no operator credential
- [ ] Live end-to-end with a running gateway: launch `sera-omc`, run a turn, verify a row in `audit_log` with `event_type='inference_proxy_call'` (deferred — requires gateway + Claude Code locally)

## Out of scope / follow-ups
- Real one-shot mint endpoint behind `SERA_LAUNCHER_TOKEN` (seam present; gated on `sera-plcv` per-principal token bucket).
- Anthropic `x-api-key` header parity in `check_auth` (gateway-side; we set `ANTHROPIC_AUTH_TOKEN` so the SDK sends `Authorization: Bearer` and that path already works).
- Adding `NON-COMPLIANT` to the clawhip Discord keyword list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)