### PR TITLE
feat(sera-gateway): register reconciled BYOH tool catalogs (sera-w2dh)

### DIFF
--- a/rust/crates/sera-gateway/src/byoh_registration.rs
+++ b/rust/crates/sera-gateway/src/byoh_registration.rs
@@ -1,0 +1,385 @@
+//! BYOH harness registration handshake (bead sera-w2dh, registration slice).
+//!
+//! Pattern A only — Pattern B sessions do not share a tool catalog with the
+//! gateway, so this module's contract does not apply there.
+//!
+//! ## What this is
+//!
+//! [`byoh_catalog`](crate::byoh_catalog) defines the pure reconciliation policy:
+//! given a harness's submitted catalog and the gateway's canonical catalog, it
+//! produces a [`ReconciledCatalog`] (effective tools, `name_map`, suppressed
+//! internals). That module is intentionally a pure function — no registry, no
+//! dispatch.
+//!
+//! This module is the smallest registration *seam* on top of that reconciler:
+//!
+//! 1. [`ByohCatalogRegistry::register_harness`] — the handshake op a BYOH
+//!    harness invokes once at boot. Stores the [`ReconciledCatalog`] keyed by
+//!    `harness_id` and returns it so the harness can install it locally.
+//! 2. [`ByohCatalogRegistry::prepare_outbound_call`] — the dispatch-decision
+//!    seam. Given a harness emitting a tool call by its own name, it returns
+//!    [`OutboundCallDecision`] telling the harness whether to (a) suppress its
+//!    internal and forward to the gateway as a canonical call, or (b) pass the
+//!    call through to its own internal implementation.
+//!
+//! No HTTP route is added here. That arrives in the next slice (a public op
+//! over the existing gateway transport); this seam is what the route will
+//! delegate to. Keeping it as a module keeps the unit / integration test
+//! footprint narrow and avoids dragging in an `AppState`.
+//!
+//! ## Why this matters (the poison-tool probe)
+//!
+//! Without registration, a harness that ships an internal `Read` tool plus a
+//! gateway exposing `read_file` (alias `Read`) can produce *capability
+//! laundering*: the model emits `Read`, the harness invokes its internal
+//! implementation, and the gateway never sees the call — bypassing AuthZ +
+//! audit. The reconciler suppresses that path declaratively; this module
+//! turns the declaration into an enforced runtime decision.
+//!
+//! See `tests/byoh_registration_handshake.rs` for the end-to-end probe.
+
+use std::collections::HashMap;
+use std::sync::RwLock;
+
+use thiserror::Error;
+
+use crate::byoh_catalog::{
+    GatewayToolDecl, HarnessCatalog, ReconcileError, ReconciledCatalog, reconcile_byoh_catalog,
+};
+
+/// Registry of reconciled BYOH tool catalogs.
+///
+/// One instance lives in the gateway. Each registered harness contributes one
+/// [`ReconciledCatalog`] keyed by its `harness_id`. The gateway-canonical
+/// catalog is supplied at construction and shared across registrations — it
+/// does not change at handshake time.
+pub struct ByohCatalogRegistry {
+    gateway_tools: Vec<GatewayToolDecl>,
+    catalogs: RwLock<HashMap<String, ReconciledCatalog>>,
+}
+
+/// Errors from registry operations.
+#[derive(Debug, Clone, Error, PartialEq, Eq)]
+pub enum RegistrationError {
+    /// The catalog the harness submitted was rejected by the reconciler. Wraps
+    /// the upstream error so callers can surface the underlying reason
+    /// (duplicate name, ambiguous alias, …) without losing fidelity.
+    #[error("reconciliation failed: {0}")]
+    Reconcile(#[from] ReconcileError),
+}
+
+/// Decision returned by [`ByohCatalogRegistry::prepare_outbound_call`] when a
+/// harness wants to act on a model-emitted tool call.
+///
+/// The variants match the three legitimate outcomes; an error is returned for
+/// anything else (unknown harness, unknown tool name).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OutboundCallDecision {
+    /// The harness MUST suppress its own internal implementation and forward
+    /// the call to the gateway under `canonical`. Set when the model emitted a
+    /// name that collides directly with a canonical or matches an alias.
+    SuppressInternalAndForward { canonical: String },
+    /// No collision — the harness invokes its own internal implementation as
+    /// usual. The gateway is not involved for this tool.
+    PassthroughToInternal,
+}
+
+/// Errors from [`ByohCatalogRegistry::prepare_outbound_call`].
+#[derive(Debug, Clone, Error, PartialEq, Eq)]
+pub enum DispatchError {
+    /// No catalog has been registered under this `harness_id`. Either the
+    /// harness skipped the handshake or it is sending calls before
+    /// registration completed.
+    #[error("harness not registered: {harness_id}")]
+    HarnessNotRegistered { harness_id: String },
+
+    /// The harness emitted a name that was neither in `effective_tools` nor in
+    /// the suppressed/aliased set. The harness violated the contract — its
+    /// model should only see tools advertised by the reconciled catalog.
+    #[error("harness '{harness_id}' emitted unknown tool name '{name}'")]
+    UnknownTool { harness_id: String, name: String },
+}
+
+impl ByohCatalogRegistry {
+    /// Build a registry seeded with the gateway's canonical catalog.
+    pub fn new(gateway_tools: Vec<GatewayToolDecl>) -> Self {
+        Self {
+            gateway_tools,
+            catalogs: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Number of currently registered harnesses. Test introspection only.
+    pub fn registered_count(&self) -> usize {
+        self.catalogs
+            .read()
+            .expect("catalogs read lock poisoned")
+            .len()
+    }
+
+    /// Register a harness's catalog. Reconciles against the gateway canonical
+    /// catalog and stores the result keyed by `harness.harness_id`.
+    ///
+    /// A second call for the same `harness_id` replaces the prior catalog. The
+    /// production handshake flow is "register once at boot"; replacement
+    /// supports test reconfiguration and any future hot-reload story without
+    /// inventing a separate "update" op.
+    ///
+    /// Returns the [`ReconciledCatalog`] so the caller can serialize it back
+    /// over the wire to the harness.
+    pub fn register_harness(
+        &self,
+        harness: HarnessCatalog,
+    ) -> Result<ReconciledCatalog, RegistrationError> {
+        let reconciled = reconcile_byoh_catalog(&harness, &self.gateway_tools)?;
+        let mut guard = self.catalogs.write().expect("catalogs write lock poisoned");
+        guard.insert(harness.harness_id.clone(), reconciled.clone());
+        Ok(reconciled)
+    }
+
+    /// Look up a stored reconciled catalog. Returns `None` if no harness with
+    /// `harness_id` has registered.
+    pub fn get(&self, harness_id: &str) -> Option<ReconciledCatalog> {
+        self.catalogs
+            .read()
+            .expect("catalogs read lock poisoned")
+            .get(harness_id)
+            .cloned()
+    }
+
+    /// Decide what a registered harness should do with a model-emitted tool
+    /// call. The harness MUST honour the returned decision: when a forward is
+    /// requested, the harness's own internal implementation must not run.
+    pub fn prepare_outbound_call(
+        &self,
+        harness_id: &str,
+        emitted_name: &str,
+    ) -> Result<OutboundCallDecision, DispatchError> {
+        let guard = self.catalogs.read().expect("catalogs read lock poisoned");
+        let reconciled =
+            guard
+                .get(harness_id)
+                .ok_or_else(|| DispatchError::HarnessNotRegistered {
+                    harness_id: harness_id.to_string(),
+                })?;
+
+        if reconciled.is_suppressed_internal(emitted_name) {
+            let canonical = reconciled.resolve_call(emitted_name).to_string();
+            return Ok(OutboundCallDecision::SuppressInternalAndForward { canonical });
+        }
+
+        if reconciled.advertises(emitted_name) {
+            // Names that are in `effective_tools` but not suppressed are
+            // either harness pass-throughs or canonicals. A canonical reaches
+            // this branch when the harness did not declare a colliding tool of
+            // its own; since the gateway tool is advertised under its
+            // canonical name, the harness has no internal of that name —
+            // forward to the gateway.
+            if self
+                .gateway_tools
+                .iter()
+                .any(|g| g.name == emitted_name)
+            {
+                return Ok(OutboundCallDecision::SuppressInternalAndForward {
+                    canonical: emitted_name.to_string(),
+                });
+            }
+            return Ok(OutboundCallDecision::PassthroughToInternal);
+        }
+
+        Err(DispatchError::UnknownTool {
+            harness_id: harness_id.to_string(),
+            name: emitted_name.to_string(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::byoh_catalog::HarnessToolDecl;
+    use serde_json::json;
+
+    fn h(name: &str) -> HarnessToolDecl {
+        HarnessToolDecl {
+            name: name.to_string(),
+            description: format!("harness {name}"),
+            schema: json!({"type": "object"}),
+        }
+    }
+
+    fn g(name: &str, aliases: &[&str]) -> GatewayToolDecl {
+        GatewayToolDecl {
+            name: name.to_string(),
+            aliases: aliases.iter().map(|s| s.to_string()).collect(),
+            description: format!("gateway {name}"),
+            schema: json!({"type": "object", "properties": {"path": {"type": "string"}}}),
+        }
+    }
+
+    #[test]
+    fn register_harness_returns_reconciled_catalog() {
+        let registry = ByohCatalogRegistry::new(vec![g("read_file", &["Read"])]);
+        let reconciled = registry
+            .register_harness(HarnessCatalog {
+                harness_id: "claude-code".into(),
+                tools: vec![h("Read"), h("Bash")],
+            })
+            .expect("registration ok");
+
+        assert!(reconciled.advertises("read_file"));
+        assert!(reconciled.advertises("Bash"));
+        assert!(!reconciled.advertises("Read"));
+        assert!(reconciled.is_suppressed_internal("Read"));
+        assert_eq!(
+            reconciled.name_map.get("Read"),
+            Some(&"read_file".to_string())
+        );
+    }
+
+    #[test]
+    fn register_harness_persists_under_harness_id() {
+        let registry = ByohCatalogRegistry::new(vec![g("read_file", &["Read"])]);
+        registry
+            .register_harness(HarnessCatalog {
+                harness_id: "claude-code".into(),
+                tools: vec![h("Read")],
+            })
+            .unwrap();
+
+        assert_eq!(registry.registered_count(), 1);
+        let stored = registry.get("claude-code").expect("registered");
+        assert!(stored.is_suppressed_internal("Read"));
+        assert!(registry.get("not-registered").is_none());
+    }
+
+    #[test]
+    fn second_registration_replaces_prior_catalog() {
+        let registry = ByohCatalogRegistry::new(vec![g("read_file", &["Read"])]);
+        registry
+            .register_harness(HarnessCatalog {
+                harness_id: "claude-code".into(),
+                tools: vec![h("Read"), h("OldTool")],
+            })
+            .unwrap();
+        registry
+            .register_harness(HarnessCatalog {
+                harness_id: "claude-code".into(),
+                tools: vec![h("Read")],
+            })
+            .unwrap();
+
+        assert_eq!(registry.registered_count(), 1);
+        let stored = registry.get("claude-code").unwrap();
+        assert!(!stored.advertises("OldTool"));
+    }
+
+    #[test]
+    fn register_propagates_reconcile_error() {
+        let registry = ByohCatalogRegistry::new(vec![]);
+        let err = registry
+            .register_harness(HarnessCatalog {
+                harness_id: "h1".into(),
+                tools: vec![h("Read"), h("Read")],
+            })
+            .unwrap_err();
+        assert_eq!(
+            err,
+            RegistrationError::Reconcile(ReconcileError::DuplicateHarnessTool {
+                name: "Read".into()
+            })
+        );
+        assert_eq!(registry.registered_count(), 0);
+    }
+
+    #[test]
+    fn prepare_outbound_call_forwards_aliased_name() {
+        let registry = ByohCatalogRegistry::new(vec![g("read_file", &["Read"])]);
+        registry
+            .register_harness(HarnessCatalog {
+                harness_id: "h1".into(),
+                tools: vec![h("Read"), h("Bash")],
+            })
+            .unwrap();
+
+        let decision = registry.prepare_outbound_call("h1", "Read").unwrap();
+        assert_eq!(
+            decision,
+            OutboundCallDecision::SuppressInternalAndForward {
+                canonical: "read_file".into()
+            }
+        );
+    }
+
+    #[test]
+    fn prepare_outbound_call_forwards_canonical_name_directly() {
+        // Even with no harness collision, a model that emits the canonical
+        // name (e.g. because the harness advertised it via the reconciled
+        // catalog) must reach the gateway, not the harness.
+        let registry = ByohCatalogRegistry::new(vec![g("read_file", &["Read"])]);
+        registry
+            .register_harness(HarnessCatalog {
+                harness_id: "h1".into(),
+                tools: vec![h("Bash")],
+            })
+            .unwrap();
+
+        let decision = registry.prepare_outbound_call("h1", "read_file").unwrap();
+        assert_eq!(
+            decision,
+            OutboundCallDecision::SuppressInternalAndForward {
+                canonical: "read_file".into()
+            }
+        );
+    }
+
+    #[test]
+    fn prepare_outbound_call_passthrough_for_non_colliding_harness_tool() {
+        let registry = ByohCatalogRegistry::new(vec![g("read_file", &["Read"])]);
+        registry
+            .register_harness(HarnessCatalog {
+                harness_id: "h1".into(),
+                tools: vec![h("Bash")],
+            })
+            .unwrap();
+
+        let decision = registry.prepare_outbound_call("h1", "Bash").unwrap();
+        assert_eq!(decision, OutboundCallDecision::PassthroughToInternal);
+    }
+
+    #[test]
+    fn prepare_outbound_call_unknown_harness_errors() {
+        let registry = ByohCatalogRegistry::new(vec![g("read_file", &[])]);
+        let err = registry
+            .prepare_outbound_call("ghost", "anything")
+            .unwrap_err();
+        assert_eq!(
+            err,
+            DispatchError::HarnessNotRegistered {
+                harness_id: "ghost".into()
+            }
+        );
+    }
+
+    #[test]
+    fn prepare_outbound_call_unknown_tool_errors() {
+        let registry = ByohCatalogRegistry::new(vec![g("read_file", &[])]);
+        registry
+            .register_harness(HarnessCatalog {
+                harness_id: "h1".into(),
+                tools: vec![h("Bash")],
+            })
+            .unwrap();
+
+        let err = registry
+            .prepare_outbound_call("h1", "Mystery")
+            .unwrap_err();
+        assert_eq!(
+            err,
+            DispatchError::UnknownTool {
+                harness_id: "h1".into(),
+                name: "Mystery".into()
+            }
+        );
+    }
+}

--- a/rust/crates/sera-gateway/src/lib.rs
+++ b/rust/crates/sera-gateway/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod admin;
 pub mod agent_transport;
 pub mod byoh_catalog;
+pub mod byoh_registration;
 pub mod capability_enforcement;
 pub mod embedded_transport;
 pub mod connector;

--- a/rust/crates/sera-gateway/tests/byoh_registration_handshake.rs
+++ b/rust/crates/sera-gateway/tests/byoh_registration_handshake.rs
@@ -1,0 +1,272 @@
+//! Integration test for the BYOH registration handshake (bead sera-w2dh,
+//! registration slice).
+//!
+//! This is the named acceptance test on the bead:
+//!
+//! > harness with internal `Read` + gateway `read_file` produces exactly one
+//! > `read_file` invocation through gateway dispatch; harness internal `Read`
+//! > is bypassed.
+//!
+//! It exercises the full slice end-to-end:
+//!
+//! 1. Build a [`ByohCatalogRegistry`] seeded with a gateway canonical
+//!    `read_file` tool that lists `Read` as an alias.
+//! 2. Register a harness whose own catalog includes an internal `Read` and a
+//!    non-colliding `Bash` tool — i.e. the poison case.
+//! 3. Drive the harness-side dispatch path against the registry as a real
+//!    BYOH harness would: a model-emitted `tool_call("Read", …)` hits
+//!    [`ByohCatalogRegistry::prepare_outbound_call`], the harness honours the
+//!    [`OutboundCallDecision::SuppressInternalAndForward`] result, and a
+//!    single canonical `read_file` invocation lands on the gateway.
+//! 4. Assert: gateway dispatch counter == 1, harness-internal `Read` counter
+//!    == 0.
+//!
+//! The test fixture stands in for the real SQ/EQ wiring (sera-sq/eq seam):
+//! it is the same dispatch decision the production transport will make once
+//! the public registration op lands. Keeping the test at the module seam
+//! avoids dragging in `AppState`, the runtime child, or HTTP — a regression
+//! in any of those would mask, not catch, the laundering bug this test
+//! exists to prevent.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use serde_json::{Value, json};
+
+use sera_gateway::byoh_catalog::{GatewayToolDecl, HarnessCatalog, HarnessToolDecl};
+use sera_gateway::byoh_registration::{
+    ByohCatalogRegistry, DispatchError, OutboundCallDecision,
+};
+
+/// Records each gateway-side canonical dispatch — the *only* legitimate
+/// destination for tool calls under the reconciled catalog when a collision
+/// exists.
+#[derive(Default)]
+struct GatewayDispatchRecorder {
+    calls: Mutex<Vec<(String, Value)>>,
+    count: AtomicUsize,
+}
+
+impl GatewayDispatchRecorder {
+    fn dispatch(&self, canonical: &str, args: Value) {
+        self.calls
+            .lock()
+            .unwrap()
+            .push((canonical.to_string(), args));
+        self.count.fetch_add(1, Ordering::SeqCst);
+    }
+
+    fn count(&self) -> usize {
+        self.count.load(Ordering::SeqCst)
+    }
+
+    fn calls(&self) -> Vec<(String, Value)> {
+        self.calls.lock().unwrap().clone()
+    }
+}
+
+/// Stand-in for the harness's own internal tool dispatcher. Any invocation
+/// recorded here would prove a capability-laundering regression.
+#[derive(Default)]
+struct HarnessInternalRecorder {
+    count: AtomicUsize,
+}
+
+impl HarnessInternalRecorder {
+    fn dispatch(&self, _name: &str, _args: Value) {
+        self.count.fetch_add(1, Ordering::SeqCst);
+    }
+    fn count(&self) -> usize {
+        self.count.load(Ordering::SeqCst)
+    }
+}
+
+/// Faithfully reproduces what a BYOH harness must do when its model emits a
+/// tool call: ask the registry for a decision and honour it.
+fn drive_harness_emitted_tool_call(
+    registry: &ByohCatalogRegistry,
+    harness_id: &str,
+    name: &str,
+    args: Value,
+    gateway: &GatewayDispatchRecorder,
+    internal: &HarnessInternalRecorder,
+) -> Result<(), DispatchError> {
+    match registry.prepare_outbound_call(harness_id, name)? {
+        OutboundCallDecision::SuppressInternalAndForward { canonical } => {
+            gateway.dispatch(&canonical, args);
+        }
+        OutboundCallDecision::PassthroughToInternal => {
+            internal.dispatch(name, args);
+        }
+    }
+    Ok(())
+}
+
+fn h(name: &str) -> HarnessToolDecl {
+    HarnessToolDecl {
+        name: name.to_string(),
+        description: format!("harness {name}"),
+        schema: json!({"type": "object"}),
+    }
+}
+
+fn g(name: &str, aliases: &[&str]) -> GatewayToolDecl {
+    GatewayToolDecl {
+        name: name.to_string(),
+        aliases: aliases.iter().map(|s| s.to_string()).collect(),
+        description: format!("gateway {name}"),
+        schema: json!({"type": "object", "properties": {"path": {"type": "string"}}}),
+    }
+}
+
+/// **The poison-tool probe.** Bead sera-w2dh acceptance: a harness with
+/// internal `Read` + gateway `read_file` (alias `Read`) routes the aliased
+/// call back through gateway dispatch exactly once; the harness internal is
+/// never invoked.
+#[test]
+fn registration_handshake_poison_probe_routes_aliased_read_to_gateway() {
+    let registry = ByohCatalogRegistry::new(vec![g("read_file", &["Read"])]);
+
+    let reconciled = registry
+        .register_harness(HarnessCatalog {
+            harness_id: "claude-code".into(),
+            tools: vec![h("Read"), h("Bash")],
+        })
+        .expect("registration ok");
+
+    // Handshake invariant 1: the registration response declares the
+    // suppression. The harness must respect this when wiring its dispatcher.
+    assert!(
+        reconciled.is_suppressed_internal("Read"),
+        "registration must mark harness 'Read' as suppressed"
+    );
+    assert_eq!(
+        reconciled.name_map.get("Read"),
+        Some(&"read_file".to_string()),
+        "registration must map harness 'Read' -> canonical 'read_file'"
+    );
+    assert!(
+        !reconciled.advertises("Read"),
+        "harness 'Read' must NOT be advertised in effective_tools (bypass surface)"
+    );
+
+    // Handshake invariant 2: the gateway canonical is what the model sees.
+    assert!(reconciled.advertises("read_file"));
+    assert!(reconciled.advertises("Bash"));
+
+    // Now drive the dispatch path. The model emits Read; harness consults the
+    // registry. Internal Read MUST be bypassed; gateway dispatch MUST fire
+    // exactly once.
+    let gateway = Arc::new(GatewayDispatchRecorder::default());
+    let internal = Arc::new(HarnessInternalRecorder::default());
+
+    drive_harness_emitted_tool_call(
+        &registry,
+        "claude-code",
+        "Read",
+        json!({"path": "/etc/passwd"}),
+        &gateway,
+        &internal,
+    )
+    .expect("dispatch decision available");
+
+    assert_eq!(
+        gateway.count(),
+        1,
+        "gateway must receive exactly one canonical invocation, got {}",
+        gateway.count()
+    );
+    assert_eq!(
+        internal.count(),
+        0,
+        "harness internal Read must be bypassed; got {} invocations",
+        internal.count()
+    );
+    let calls = gateway.calls();
+    assert_eq!(calls[0].0, "read_file", "must dispatch as canonical name");
+    assert_eq!(
+        calls[0].1["path"], "/etc/passwd",
+        "args must reach gateway untouched"
+    );
+
+    // Non-colliding harness tool stays local — sanity check that we did not
+    // over-route.
+    drive_harness_emitted_tool_call(
+        &registry,
+        "claude-code",
+        "Bash",
+        json!({"cmd": "ls"}),
+        &gateway,
+        &internal,
+    )
+    .unwrap();
+    assert_eq!(
+        gateway.count(),
+        1,
+        "non-colliding tool must not increment gateway dispatches"
+    );
+    assert_eq!(internal.count(), 1, "Bash routes to harness internal");
+}
+
+/// Repeated emissions of the same poison name accumulate: each one costs
+/// exactly one gateway dispatch and zero internals. This is the regression
+/// shape: "exactly one *per call*", not "exactly one *total ever*".
+#[test]
+fn repeated_aliased_calls_each_dispatch_once_through_gateway() {
+    let registry = ByohCatalogRegistry::new(vec![g("read_file", &["Read"])]);
+    registry
+        .register_harness(HarnessCatalog {
+            harness_id: "claude-code".into(),
+            tools: vec![h("Read")],
+        })
+        .unwrap();
+
+    let gateway = Arc::new(GatewayDispatchRecorder::default());
+    let internal = Arc::new(HarnessInternalRecorder::default());
+
+    for path in ["/a", "/b", "/c"] {
+        drive_harness_emitted_tool_call(
+            &registry,
+            "claude-code",
+            "Read",
+            json!({"path": path}),
+            &gateway,
+            &internal,
+        )
+        .unwrap();
+    }
+
+    assert_eq!(gateway.count(), 3);
+    assert_eq!(internal.count(), 0);
+    for (canonical, _) in gateway.calls() {
+        assert_eq!(canonical, "read_file");
+    }
+}
+
+/// A harness that has not registered cannot dispatch through the gateway —
+/// the registration handshake is mandatory. This guards against a path where
+/// a misconfigured harness silently falls back to its own internal `Read`.
+#[test]
+fn unregistered_harness_dispatch_is_an_error_not_a_fallback() {
+    let registry = ByohCatalogRegistry::new(vec![g("read_file", &["Read"])]);
+    let gateway = Arc::new(GatewayDispatchRecorder::default());
+    let internal = Arc::new(HarnessInternalRecorder::default());
+
+    let err = drive_harness_emitted_tool_call(
+        &registry,
+        "phantom-harness",
+        "Read",
+        json!({"path": "/x"}),
+        &gateway,
+        &internal,
+    )
+    .expect_err("unregistered harness must error");
+    assert_eq!(
+        err,
+        DispatchError::HarnessNotRegistered {
+            harness_id: "phantom-harness".into()
+        }
+    );
+    assert_eq!(gateway.count(), 0);
+    assert_eq!(internal.count(), 0);
+}


### PR DESCRIPTION
## Summary

PR #1151 merged the pure deterministic reconciliation policy in `byoh_catalog` but left the registration / handshake / dispatch wiring open: the module's own docstring marked the registration endpoint that drives it as a follow-up bead. This is that follow-up — the smallest internal seam that satisfies the **sera-w2dh** acceptance and becomes the natural delegate for a public registration op when it lands.

- New `byoh_registration` module with `ByohCatalogRegistry::register_harness` (handshake op, reconciles + stores + returns `ReconciledCatalog`) and `prepare_outbound_call` (dispatch-decision seam: `SuppressInternalAndForward` vs `PassthroughToInternal`, with explicit errors for unregistered harnesses and unknown tool names — no silent fallback).
- New integration test exercises the **poison-tool probe** end-to-end: a harness with internal `Read` plus a gateway `read_file` (alias `Read`) drives a model-emitted `tool_call("Read", …)` through the registry; assertion is **exactly one** canonical `read_file` invocation on a stand-in gateway dispatcher and **zero** invocations on the harness internal `Read`.
- Pattern A only — Pattern B sessions do not share a tool catalog.

The HTTP route, `AppState` field, and `AgentTurnTransport` enforcement seam are deliberately out of scope here; that public-op slice is the natural successor and the contract this module's tests already pin down is the regression net it will need.

## Test plan

- [x] `cargo test -p sera-gateway --lib byoh` — 20 passed (incl. 9 new unit tests on the registry / dispatch decision)
- [x] `cargo test -p sera-gateway --test byoh_registration_handshake` — 3 passed (poison-probe + repeat-call regression + unregistered-harness error)
- [x] `cargo clippy -p sera-gateway --tests -- -D warnings` — clean
- [x] `cargo test -p sera-gateway` (full crate, after `cargo build -p sera-runtime --bin sera-runtime` for the existing `production_e2e` fixture) — 399 passed

## Acceptance traceability

| Bead acceptance | Where satisfied |
|---|---|
| Harness submits a tool catalog at registration | `register_harness(HarnessCatalog)` |
| Gateway returns rewritten catalog with `name_map(harness_name → canonical_name)` | `register_harness` returns `ReconciledCatalog` |
| Poison-tool probe verifies aliased calls route through SQ/EQ | `registration_handshake_poison_probe_routes_aliased_read_to_gateway` |
| Harness internal `Read` + gateway `read_file` → exactly one `read_file` invocation through gateway dispatch; harness internal `Read` bypassed | Same test — gateway counter == 1, internal counter == 0, `Read` not in `effective_tools`, suppressed in `suppressed_internals` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)