### PR TITLE
chore(rust): reduce dev dependency debuginfo bloat

### DIFF
--- a/rust/CLAUDE.md
+++ b/rust/CLAUDE.md
@@ -97,14 +97,17 @@ sera-types (leaf)
 - Incremental compilation is on by default in dev profile
 - First build downloads + compiles all deps (~30s); subsequent checks are ~1-3s
 
-### sccache Compiler Cache
+### sccache Compiler Cache + Debug Artifact Control
 
-**Problem:** `rust/target/debug` grows to 52GB+ and `cargo clean` frees it but it rebuilds immediately on next compile.
+**Problem:** `rust/target/debug` can grow past 50GB because dependency debuginfo and incremental artifacts dominate `target/debug/deps` and `target/debug/incremental`. A plain `cargo clean` frees space but rebuilds the same bloated artifacts on the next compile.
 
-**Solution:** sccache + selective incremental clean:
+**Solution:** sccache + selective incremental clean + reduced dependency debuginfo:
 - `rust/.cargo/config.toml` sets `RUSTC_WRAPPER=sccache` for all workspace builds
+- `rust/Cargo.toml` sets `[profile.dev] debug = 1` and `[profile.dev.package."*"] debug = false` so SERA crates keep useful line tables while dependencies do not emit huge debug sections
+- `rust/Cargo.toml` also keeps release artifacts stripped with `debug = false` and `incremental = false`
 - `rust/build.sh` cleans `incremental/` only when >1GB, keeps `deps/` warm
 - `rust/docker-compose.sera.yml` mounts named volumes for cargo-registry, cargo-cache, sccache-cache
+- After changing profile/debug settings, delete the old `target/` or at least stale `target/debug/{deps,incremental}` artifacts; old bloated files stay on disk until removed
 
 **Setup:**
 ```bash

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -226,7 +226,19 @@ oci-distribution = { version = "0.11", default-features = false, features = ["ru
 # HTTP mocking (dev-only — mock OCI registry in tests)
 wiremock = "0.6"
 
+# Keep dev/test artifacts from ballooning on large dependency graphs.
+# Workspace crates retain line-table debug info; dependencies are built without
+# debuginfo, which avoids multi-GB target/deps growth while preserving useful
+# local stack traces for SERA code.
+[profile.dev]
+debug = 1
+
+[profile.dev.package."*"]
+debug = false
+
 [profile.release]
 lto = true
 codegen-units = 1
 strip = true
+debug = false
+incremental = false


### PR DESCRIPTION
## Summary
- Adds dev profile settings to keep line-table debug info for workspace crates while disabling debuginfo for dependencies.
- Makes release profile debug/incremental behavior explicit.
- Updates Rust workspace docs with the debug-artifact cleanup pattern.

## Verification
- `cargo metadata --no-deps --format-version 1`
- Cleaned only the primary checkout target dir after the profile change: `cargo clean` removed 66.1GiB.
- Did not touch active OMC worktree targets.

## Notes
- `cargo tree -d --workspace --no-default-features` currently produces 1324 lines; duplicate dependency cleanup is separate work.