### PR TITLE
fix(sera-db): persist cascade revocation descendants

### DIFF
--- a/artifacts/reports/claude-burn/2q6w-cascade-persistence-fix-2026-05-01.md
+++ b/artifacts/reports/claude-burn/2q6w-cascade-persistence-fix-2026-05-01.md
@@ -1,0 +1,33 @@
+# 2q6w Cascade Persistence Fix Handoff
+
+Date: 2026-05-01
+Branch: `fix/sera-2q6w-cascade-persistence`
+
+## Summary
+
+Fixed the cascade revocation persistence bug by separating chain metadata from revocation state in `capability_token_revocations`.
+
+- `record()` now registers unrevoked chain metadata.
+- `is_revoked()` now checks the explicit `revoked` marker.
+- `revoke_cascade()` now marks every visited descendant row revoked on InMemory, SQLite, and Postgres.
+- Postgres cascade uses a recursive CTE plus `INSERT ... SELECT ... ON CONFLICT DO NOTHING` and an in-transaction mark step, preserving tenant scope, CYCLE protection, and the full-depth `<=` cap.
+
+## Tests Added
+
+- InMemory and SQLite regressions assert `root -> child -> grandchild` descendants are unrevoked before `revoke_cascade(root)` and revoked after it.
+- Auth smoke asserts a cascaded root revocation rejects a grandchild by the grandchild `instance_id`.
+- Existing lookup failure coverage confirms store errors map to `EvolveTokenError::RevocationLookupFailed`, not `Revoked`.
+- Postgres SQL-shape tests cover descendant `INSERT ... SELECT`, idempotent `ON CONFLICT DO NOTHING`, marking existing metadata rows revoked, and `d.depth <= max-depth` behavior.
+
+## Verification
+
+- `RUSTC_WRAPPER= cargo test -p sera-db --lib capability_revocation`
+- `RUSTC_WRAPPER= cargo test -p sera-auth --lib revocation`
+- `RUSTC_WRAPPER= cargo clippy -p sera-auth -p sera-db --all-targets -- -D warnings`
+
+All passed.
+
+## Notes
+
+- The requested assessment file `artifacts/reports/claude-burn/overall-assessment-2026-05-01.md` was not present in this worktree when the fix started.
+- I did not wire `verify_revocable` into gateway admission because there is no obvious current gateway `CapabilityToken` validation path in `rust/crates/sera-gateway/src`; the only live auth middleware path found is JWT/API-key verification.

--- a/rust/crates/sera-auth/src/revocation.rs
+++ b/rust/crates/sera-auth/src/revocation.rs
@@ -65,8 +65,8 @@ mod tests {
     use super::*;
     use crate::capability::{CapabilityToken, DefaultCapabilityTokenIssuer, EvolveTokenSigner};
     use async_trait::async_trait;
-    use sera_db::capability_revocation::{InMemoryRevocationStore, RevocationStore};
     use sera_db::DbError;
+    use sera_db::capability_revocation::{InMemoryRevocationStore, RevocationStore};
     use sera_types::evolution::BlastRadius;
     use sera_types::principal::Principal;
     use std::collections::HashSet;
@@ -84,7 +84,9 @@ mod tests {
             _reason: &str,
             _revoked_by: &str,
         ) -> Result<bool, DbError> {
-            Err(DbError::Integrity("revocation store unavailable".to_string()))
+            Err(DbError::Integrity(
+                "revocation store unavailable".to_string(),
+            ))
         }
 
         async fn revoke_cascade(
@@ -95,11 +97,15 @@ mod tests {
             _reason: &str,
             _revoked_by: &str,
         ) -> Result<u32, DbError> {
-            Err(DbError::Integrity("revocation store unavailable".to_string()))
+            Err(DbError::Integrity(
+                "revocation store unavailable".to_string(),
+            ))
         }
 
         async fn is_revoked(&self, _tenant_id: &str, _instance_id: &str) -> Result<bool, DbError> {
-            Err(DbError::Integrity("revocation store unavailable".to_string()))
+            Err(DbError::Integrity(
+                "revocation store unavailable".to_string(),
+            ))
         }
     }
 
@@ -135,8 +141,8 @@ mod tests {
         let signer = signer_for_test();
         let tok = issue_root();
         let store = InMemoryRevocationStore::new();
-        let result = verify_revocable(&signer, &tok, BlastRadius::AgentMemory, &store, "tenant-a")
-            .await;
+        let result =
+            verify_revocable(&signer, &tok, BlastRadius::AgentMemory, &store, "tenant-a").await;
         assert!(result.is_ok(), "unrevoked token must verify: {result:?}");
     }
 
@@ -145,7 +151,10 @@ mod tests {
         let signer = signer_for_test();
         let tok = issue_root();
         let store = InMemoryRevocationStore::new();
-        let instance = tok.instance_id.clone().expect("issued tokens carry instance_id");
+        let instance = tok
+            .instance_id
+            .clone()
+            .expect("issued tokens carry instance_id");
         store
             .revoke_cascade("tenant-a", &instance, None, "operator request", "admin")
             .await
@@ -193,6 +202,66 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn cascade_persistence_rejects_grandchild_by_instance_id() {
+        let signer = signer_for_test();
+        let root = issue_root();
+        let alice = Principal::for_agent("alice", "alice");
+        let bob = Principal::for_agent("bob", "bob");
+        let child = narrow_signed(&root, &alice);
+        let grandchild = narrow_signed(&child, &bob);
+
+        let root_instance = root.instance_id.clone().unwrap();
+        let child_instance = child.instance_id.clone().unwrap();
+        let grandchild_instance = grandchild.instance_id.clone().unwrap();
+
+        let store = InMemoryRevocationStore::new();
+        store
+            .record(
+                "tenant-a",
+                &child_instance,
+                Some(&root_instance),
+                "chain metadata",
+                "issuer",
+            )
+            .await
+            .unwrap();
+        store
+            .record(
+                "tenant-a",
+                &grandchild_instance,
+                Some(&child_instance),
+                "chain metadata",
+                "issuer",
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            !store
+                .is_revoked("tenant-a", &grandchild_instance)
+                .await
+                .unwrap()
+        );
+
+        store
+            .revoke_cascade("tenant-a", &root_instance, None, "compromise", "admin")
+            .await
+            .unwrap();
+
+        let err = verify_revocable(
+            &signer,
+            &grandchild,
+            BlastRadius::AgentMemory,
+            &store,
+            "tenant-a",
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(err, EvolveTokenError::Revoked(grandchild_instance));
+    }
+
+    #[tokio::test]
     async fn revocation_in_other_tenant_does_not_reject() {
         let signer = signer_for_test();
         let tok = issue_root();
@@ -202,8 +271,8 @@ mod tests {
             .revoke_cascade("tenant-other", &instance, None, "admin", "op")
             .await
             .unwrap();
-        let result = verify_revocable(&signer, &tok, BlastRadius::AgentMemory, &store, "tenant-a")
-            .await;
+        let result =
+            verify_revocable(&signer, &tok, BlastRadius::AgentMemory, &store, "tenant-a").await;
         assert!(result.is_ok(), "cross-tenant revocations must not bleed");
     }
 

--- a/rust/crates/sera-db/src/capability_revocation.rs
+++ b/rust/crates/sera-db/src/capability_revocation.rs
@@ -1,8 +1,8 @@
 //! Cascade revocation for capability-token delegation chains (sera-2q6w).
 //!
-//! `capability_token_revocations` records every revoked capability-token
-//! instance keyed by [`CapabilityToken::instance_id`] (sera-s64j) along with
-//! the parent's instance_id captured at revocation time. The `parent_id`
+//! `capability_token_revocations` records capability-token chain rows keyed by
+//! [`CapabilityToken::instance_id`] (sera-s64j) along with the parent's
+//! instance_id captured at registration/revocation time. The `parent_id`
 //! column is indexed so the cascade walk down the delegation tree is cheap.
 //!
 //! # Surface
@@ -14,8 +14,8 @@
 //!     subtree (including the explicitly-revoked root).
 //!   - `is_revoked(instance_id, tenant_id)` — leaf lookup consulted by the
 //!     [`sera_auth::EvolveTokenSigner`] verifier.
-//!   - `record(...)` — register a single revocation row idempotently
-//!     (used by tests and by the cascade walker to materialize descendants).
+//!   - `record(...)` — register a single chain row idempotently without
+//!     revoking it (used by tests and by callers that need cascade metadata).
 //! - [`InMemoryRevocationStore`] — `Mutex<HashMap>` backend. Used in unit
 //!   tests and in deployments without a persistent DB.
 //! - [`SqliteRevocationStore`] — rusqlite backend. Cascade walks descendants
@@ -37,7 +37,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use rusqlite::{params, Connection};
+use rusqlite::{Connection, params};
 use sqlx::PgPool;
 use tokio::sync::Mutex as AsyncMutex;
 
@@ -57,6 +57,7 @@ pub struct RevocationRow {
     pub reason: String,
     pub revoked_by: String,
     pub revoked_at_ms: i64,
+    pub revoked: bool,
 }
 
 /// Async revocation store.
@@ -65,7 +66,8 @@ pub struct RevocationRow {
 /// state pattern.
 #[async_trait]
 pub trait RevocationStore: Send + Sync + std::fmt::Debug {
-    /// Idempotently insert a single revocation row. No tree walk.
+    /// Idempotently insert a single chain metadata row. No tree walk and no
+    /// revocation marker.
     ///
     /// Returns `true` when a new row was inserted, `false` when the
     /// `(tenant_id, instance_id)` pair already existed.
@@ -146,7 +148,7 @@ impl InMemoryRevocationStore {
         rows: &HashMap<(String, String), RevocationRow>,
         tenant_id: &str,
         seed: &str,
-    ) -> u32 {
+    ) -> Vec<String> {
         let mut visited: HashSet<String> = HashSet::new();
         visited.insert(seed.to_string());
         let mut frontier = vec![seed.to_string()];
@@ -169,7 +171,7 @@ impl InMemoryRevocationStore {
             frontier = next;
             depth += 1;
         }
-        visited.len() as u32
+        visited.into_iter().collect()
     }
 }
 
@@ -197,6 +199,7 @@ impl RevocationStore for InMemoryRevocationStore {
                 reason: reason.to_string(),
                 revoked_by: revoked_by.to_string(),
                 revoked_at_ms: now_ms(),
+                revoked: false,
             },
         );
         Ok(true)
@@ -219,8 +222,19 @@ impl RevocationStore for InMemoryRevocationStore {
                 reason: reason.to_string(),
                 revoked_by: revoked_by.to_string(),
                 revoked_at_ms: now_ms(),
+                revoked: false,
             });
-        let count = Self::cascade_walk(&rows, tenant_id, instance_id);
+        let visited = Self::cascade_walk(&rows, tenant_id, instance_id);
+        let revoked_at_ms = now_ms();
+        for visited_id in &visited {
+            if let Some(row) = rows.get_mut(&(tenant_id.to_string(), visited_id.clone())) {
+                row.reason = reason.to_string();
+                row.revoked_by = revoked_by.to_string();
+                row.revoked_at_ms = revoked_at_ms;
+                row.revoked = true;
+            }
+        }
+        let count = visited.len() as u32;
         drop(rows);
         emit_cascade_event(tenant_id, instance_id, revoked_by, reason, count);
         Ok(count)
@@ -228,7 +242,10 @@ impl RevocationStore for InMemoryRevocationStore {
 
     async fn is_revoked(&self, tenant_id: &str, instance_id: &str) -> Result<bool, DbError> {
         let rows = self.rows.lock().await;
-        Ok(rows.contains_key(&(tenant_id.to_string(), instance_id.to_string())))
+        Ok(rows
+            .get(&(tenant_id.to_string(), instance_id.to_string()))
+            .map(|row| row.revoked)
+            .unwrap_or(false))
     }
 }
 
@@ -255,11 +272,27 @@ impl SqliteRevocationStore {
                 reason       TEXT    NOT NULL,
                 revoked_by   TEXT    NOT NULL,
                 revoked_at   INTEGER NOT NULL,
+                revoked      INTEGER NOT NULL DEFAULT 1,
                 PRIMARY KEY (tenant_id, instance_id)
             );
             CREATE INDEX IF NOT EXISTS idx_capability_token_revocations_parent_id
                 ON capability_token_revocations (tenant_id, parent_id);",
         )?;
+        let has_revoked: bool = conn.query_row(
+            "SELECT EXISTS(
+                SELECT 1 FROM pragma_table_info('capability_token_revocations')
+                WHERE name = 'revoked'
+            )",
+            [],
+            |row| row.get(0),
+        )?;
+        if !has_revoked {
+            conn.execute(
+                "ALTER TABLE capability_token_revocations
+                 ADD COLUMN revoked INTEGER NOT NULL DEFAULT 1",
+                [],
+            )?;
+        }
         Ok(())
     }
 
@@ -267,7 +300,7 @@ impl SqliteRevocationStore {
         conn: &Connection,
         tenant_id: &str,
         seed: &str,
-    ) -> rusqlite::Result<u32> {
+    ) -> rusqlite::Result<Vec<String>> {
         let mut visited: HashSet<String> = HashSet::new();
         visited.insert(seed.to_string());
         let mut frontier = vec![seed.to_string()];
@@ -279,9 +312,8 @@ impl SqliteRevocationStore {
                     "SELECT instance_id FROM capability_token_revocations
                      WHERE tenant_id = ?1 AND parent_id = ?2",
                 )?;
-                let rows = stmt.query_map(params![tenant_id, parent], |row| {
-                    row.get::<_, String>(0)
-                })?;
+                let rows =
+                    stmt.query_map(params![tenant_id, parent], |row| row.get::<_, String>(0))?;
                 for row in rows {
                     let child = row?;
                     if visited.insert(child.clone()) {
@@ -292,7 +324,7 @@ impl SqliteRevocationStore {
             frontier = next;
             depth += 1;
         }
-        Ok(visited.len() as u32)
+        Ok(visited.into_iter().collect())
     }
 }
 
@@ -310,8 +342,8 @@ impl RevocationStore for SqliteRevocationStore {
         let changed = conn
             .execute(
                 "INSERT OR IGNORE INTO capability_token_revocations
-                    (tenant_id, instance_id, parent_id, reason, revoked_by, revoked_at)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                    (tenant_id, instance_id, parent_id, reason, revoked_by, revoked_at, revoked)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, 0)",
                 params![
                     tenant_id,
                     instance_id,
@@ -333,11 +365,20 @@ impl RevocationStore for SqliteRevocationStore {
         reason: &str,
         revoked_by: &str,
     ) -> Result<u32, DbError> {
-        let conn = self.conn.lock().await;
-        conn.execute(
-            "INSERT OR IGNORE INTO capability_token_revocations
-                (tenant_id, instance_id, parent_id, reason, revoked_by, revoked_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        let mut conn = self.conn.lock().await;
+        let tx = conn
+            .transaction()
+            .map_err(|e| DbError::Integrity(format!("sqlite transaction: {e}")))?;
+        tx.execute(
+            "INSERT INTO capability_token_revocations
+                (tenant_id, instance_id, parent_id, reason, revoked_by, revoked_at, revoked)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, 1)
+             ON CONFLICT(tenant_id, instance_id) DO UPDATE SET
+                parent_id = COALESCE(excluded.parent_id, capability_token_revocations.parent_id),
+                reason = excluded.reason,
+                revoked_by = excluded.revoked_by,
+                revoked_at = excluded.revoked_at,
+                revoked = 1",
             params![
                 tenant_id,
                 instance_id,
@@ -348,9 +389,21 @@ impl RevocationStore for SqliteRevocationStore {
             ],
         )
         .map_err(|e| DbError::Integrity(format!("sqlite insert: {e}")))?;
-        let count = Self::cascade_walk(&conn, tenant_id, instance_id)
+        let visited = Self::cascade_walk(&tx, tenant_id, instance_id)
             .map_err(|e| DbError::Integrity(format!("sqlite cascade walk: {e}")))?;
-        drop(conn);
+        let revoked_at_ms = now_ms();
+        for visited_id in &visited {
+            tx.execute(
+                "UPDATE capability_token_revocations
+                 SET reason = ?1, revoked_by = ?2, revoked_at = ?3, revoked = 1
+                 WHERE tenant_id = ?4 AND instance_id = ?5",
+                params![reason, revoked_by, revoked_at_ms, tenant_id, visited_id],
+            )
+            .map_err(|e| DbError::Integrity(format!("sqlite cascade mark: {e}")))?;
+        }
+        tx.commit()
+            .map_err(|e| DbError::Integrity(format!("sqlite commit: {e}")))?;
+        let count = visited.len() as u32;
         emit_cascade_event(tenant_id, instance_id, revoked_by, reason, count);
         Ok(count)
     }
@@ -361,7 +414,7 @@ impl RevocationStore for SqliteRevocationStore {
             .query_row(
                 "SELECT EXISTS(
                     SELECT 1 FROM capability_token_revocations
-                    WHERE tenant_id = ?1 AND instance_id = ?2
+                    WHERE tenant_id = ?1 AND instance_id = ?2 AND revoked = 1
                 )",
                 params![tenant_id, instance_id],
                 |row| row.get(0),
@@ -383,13 +436,16 @@ CREATE TABLE IF NOT EXISTS capability_token_revocations (
     reason       TEXT        NOT NULL,
     revoked_by   TEXT        NOT NULL,
     revoked_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    revoked      BOOLEAN     NOT NULL DEFAULT TRUE,
     PRIMARY KEY (tenant_id, instance_id)
 );
+ALTER TABLE capability_token_revocations
+    ADD COLUMN IF NOT EXISTS revoked BOOLEAN NOT NULL DEFAULT TRUE;
 CREATE INDEX IF NOT EXISTS idx_capability_token_revocations_parent_id
     ON capability_token_revocations (tenant_id, parent_id);
 "#;
 
-const POSTGRES_CASCADE_DESCENDANTS_SQL: &str = r#"
+const POSTGRES_CASCADE_REVOKE_SQL: &str = r#"
 WITH RECURSIVE descendants AS (
     SELECT instance_id, parent_id, 1 AS depth
     FROM capability_token_revocations
@@ -398,9 +454,30 @@ WITH RECURSIVE descendants AS (
     SELECT c.instance_id, c.parent_id, d.depth + 1
     FROM capability_token_revocations c
     JOIN descendants d ON c.parent_id = d.instance_id
-    WHERE c.tenant_id = $1 AND d.depth <= $3
-) CYCLE instance_id SET is_cycle USING path
-SELECT COUNT(DISTINCT instance_id)::bigint FROM descendants
+    WHERE c.tenant_id = $1 AND d.depth <= $5
+) CYCLE instance_id SET is_cycle USING path,
+inserted AS (
+    INSERT INTO capability_token_revocations
+        (tenant_id, instance_id, parent_id, reason, revoked_by, revoked)
+    SELECT $1, d.instance_id, d.parent_id, $3, $4, TRUE
+    FROM descendants d
+    ON CONFLICT (tenant_id, instance_id) DO NOTHING
+    RETURNING instance_id
+),
+marked AS (
+    UPDATE capability_token_revocations r
+    SET reason = $3,
+        revoked_by = $4,
+        revoked_at = NOW(),
+        revoked = TRUE
+    FROM descendants d
+    WHERE r.tenant_id = $1 AND r.instance_id = d.instance_id
+    RETURNING r.instance_id
+)
+SELECT COUNT(DISTINCT d.instance_id)::bigint
+FROM descendants d
+LEFT JOIN inserted i ON i.instance_id = d.instance_id
+LEFT JOIN marked m ON m.instance_id = d.instance_id
 "#;
 
 /// Postgres-backed revocation store. Cascade walks via `WITH RECURSIVE …
@@ -433,8 +510,8 @@ impl RevocationStore for PostgresRevocationStore {
         let row: Option<(String,)> = sqlx::query_as(
             r#"
             INSERT INTO capability_token_revocations
-                (tenant_id, instance_id, parent_id, reason, revoked_by)
-            VALUES ($1, $2, $3, $4, $5)
+                (tenant_id, instance_id, parent_id, reason, revoked_by, revoked)
+            VALUES ($1, $2, $3, $4, $5, FALSE)
             ON CONFLICT (tenant_id, instance_id) DO NOTHING
             RETURNING instance_id
             "#,
@@ -458,12 +535,18 @@ impl RevocationStore for PostgresRevocationStore {
         reason: &str,
         revoked_by: &str,
     ) -> Result<u32, DbError> {
+        let mut tx = self.pool.begin().await.map_err(DbError::Sqlx)?;
         sqlx::query(
             r#"
             INSERT INTO capability_token_revocations
-                (tenant_id, instance_id, parent_id, reason, revoked_by)
-            VALUES ($1, $2, $3, $4, $5)
-            ON CONFLICT (tenant_id, instance_id) DO NOTHING
+                (tenant_id, instance_id, parent_id, reason, revoked_by, revoked)
+            VALUES ($1, $2, $3, $4, $5, TRUE)
+            ON CONFLICT (tenant_id, instance_id) DO UPDATE SET
+                parent_id = COALESCE(excluded.parent_id, capability_token_revocations.parent_id),
+                reason = excluded.reason,
+                revoked_by = excluded.revoked_by,
+                revoked_at = NOW(),
+                revoked = TRUE
             "#,
         )
         .bind(tenant_id)
@@ -471,19 +554,23 @@ impl RevocationStore for PostgresRevocationStore {
         .bind(parent_id)
         .bind(reason)
         .bind(revoked_by)
-        .execute(&self.pool)
+        .execute(&mut *tx)
         .await
         .map_err(DbError::Sqlx)?;
 
         // Recursive CTE walk down the parent_id graph. CYCLE guards against
-        // malformed cycles; the depth cap is the second mechanism.
-        let row: (i64,) = sqlx::query_as(POSTGRES_CASCADE_DESCENDANTS_SQL)
+        // malformed cycles; the depth cap is the second mechanism. The
+        // visited subtree is then marked as revoked in the same transaction.
+        let row: (i64,) = sqlx::query_as(POSTGRES_CASCADE_REVOKE_SQL)
             .bind(tenant_id)
             .bind(instance_id)
+            .bind(reason)
+            .bind(revoked_by)
             .bind(i64::from(CASCADE_MAX_DEPTH))
-            .fetch_one(&self.pool)
+            .fetch_one(&mut *tx)
             .await
             .map_err(DbError::Sqlx)?;
+        tx.commit().await.map_err(DbError::Sqlx)?;
 
         let count = row.0.max(0) as u32;
         emit_cascade_event(tenant_id, instance_id, revoked_by, reason, count);
@@ -495,7 +582,7 @@ impl RevocationStore for PostgresRevocationStore {
             r#"
             SELECT EXISTS(
                 SELECT 1 FROM capability_token_revocations
-                WHERE tenant_id = $1 AND instance_id = $2
+                WHERE tenant_id = $1 AND instance_id = $2 AND revoked = TRUE
             )
             "#,
         )
@@ -551,9 +638,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn inmem_is_revoked_round_trips() {
+    async fn inmem_record_registers_metadata_without_revoking() {
         let s = InMemoryRevocationStore::new();
         s.record("t", "a", None, "r", "p").await.unwrap();
+        assert!(!s.is_revoked("t", "a").await.unwrap());
+        s.revoke_cascade("t", "a", None, "audit", "op")
+            .await
+            .unwrap();
         assert!(s.is_revoked("t", "a").await.unwrap());
         assert!(!s.is_revoked("t", "missing").await.unwrap());
     }
@@ -563,7 +654,8 @@ mod tests {
         // root → child. Revoking root counts child as cascaded.
         let s = InMemoryRevocationStore::new();
         seed_chain(&s, "t", &["root", "child"], "r", "p").await;
-        let n = s.revoke_cascade("t", "root", None, "audit", "op")
+        let n = s
+            .revoke_cascade("t", "root", None, "audit", "op")
             .await
             .unwrap();
         assert_eq!(n, 2);
@@ -573,17 +665,37 @@ mod tests {
     async fn inmem_cascade_depth_2() {
         let s = InMemoryRevocationStore::new();
         seed_chain(&s, "t", &["a", "b", "c"], "r", "p").await;
-        let n = s.revoke_cascade("t", "a", None, "audit", "op")
+        let n = s
+            .revoke_cascade("t", "a", None, "audit", "op")
             .await
             .unwrap();
         assert_eq!(n, 3);
     }
 
     #[tokio::test]
+    async fn inmem_cascade_persists_descendant_revocations() {
+        let s = InMemoryRevocationStore::new();
+        seed_chain(&s, "t", &["root", "child", "grandchild"], "r", "p").await;
+        assert!(!s.is_revoked("t", "child").await.unwrap());
+        assert!(!s.is_revoked("t", "grandchild").await.unwrap());
+
+        let n = s
+            .revoke_cascade("t", "root", None, "audit", "op")
+            .await
+            .unwrap();
+
+        assert_eq!(n, 3);
+        assert!(s.is_revoked("t", "root").await.unwrap());
+        assert!(s.is_revoked("t", "child").await.unwrap());
+        assert!(s.is_revoked("t", "grandchild").await.unwrap());
+    }
+
+    #[tokio::test]
     async fn inmem_cascade_depth_3() {
         let s = InMemoryRevocationStore::new();
         seed_chain(&s, "t", &["a", "b", "c", "d"], "r", "p").await;
-        let n = s.revoke_cascade("t", "a", None, "audit", "op")
+        let n = s
+            .revoke_cascade("t", "a", None, "audit", "op")
             .await
             .unwrap();
         assert_eq!(n, 4);
@@ -595,7 +707,8 @@ mod tests {
         let s = InMemoryRevocationStore::new();
         s.record("t", "a", Some("b"), "r", "p").await.unwrap();
         s.record("t", "b", Some("a"), "r", "p").await.unwrap();
-        let n = s.revoke_cascade("t", "a", Some("b"), "audit", "op")
+        let n = s
+            .revoke_cascade("t", "a", Some("b"), "audit", "op")
             .await
             .unwrap();
         // Visited-set caps the walk at the two cycle members.
@@ -610,11 +723,13 @@ mod tests {
         // tenant-b's row.
         seed_chain(&s, "tenant-a", &["a", "b", "c"], "r", "p").await;
         s.record("tenant-b", "a", None, "r", "p").await.unwrap();
-        let n_a = s.revoke_cascade("tenant-a", "a", None, "audit", "op")
+        let n_a = s
+            .revoke_cascade("tenant-a", "a", None, "audit", "op")
             .await
             .unwrap();
         assert_eq!(n_a, 3);
-        let n_b = s.revoke_cascade("tenant-b", "a", None, "audit", "op")
+        let n_b = s
+            .revoke_cascade("tenant-b", "a", None, "audit", "op")
             .await
             .unwrap();
         assert_eq!(n_b, 1);
@@ -633,9 +748,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn sqlite_is_revoked_round_trips() {
+    async fn sqlite_record_registers_metadata_without_revoking() {
         let s = sqlite_store();
         s.record("t", "a", None, "r", "p").await.unwrap();
+        assert!(!s.is_revoked("t", "a").await.unwrap());
+        s.revoke_cascade("t", "a", None, "audit", "op")
+            .await
+            .unwrap();
         assert!(s.is_revoked("t", "a").await.unwrap());
         assert!(!s.is_revoked("t", "nope").await.unwrap());
     }
@@ -649,7 +768,8 @@ mod tests {
         ] {
             let s = sqlite_store();
             seed_chain(&s, "t", chain, "r", "p").await;
-            let n = s.revoke_cascade("t", "a", None, "audit", "op")
+            let n = s
+                .revoke_cascade("t", "a", None, "audit", "op")
                 .await
                 .unwrap();
             assert_eq!(n as usize, chain.len());
@@ -657,11 +777,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn sqlite_cascade_persists_descendant_revocations() {
+        let s = sqlite_store();
+        seed_chain(&s, "t", &["root", "child", "grandchild"], "r", "p").await;
+        assert!(!s.is_revoked("t", "child").await.unwrap());
+        assert!(!s.is_revoked("t", "grandchild").await.unwrap());
+
+        let n = s
+            .revoke_cascade("t", "root", None, "audit", "op")
+            .await
+            .unwrap();
+
+        assert_eq!(n, 3);
+        assert!(s.is_revoked("t", "root").await.unwrap());
+        assert!(s.is_revoked("t", "child").await.unwrap());
+        assert!(s.is_revoked("t", "grandchild").await.unwrap());
+    }
+
+    #[tokio::test]
     async fn sqlite_cascade_cycle_resilient() {
         let s = sqlite_store();
         s.record("t", "a", Some("b"), "r", "p").await.unwrap();
         s.record("t", "b", Some("a"), "r", "p").await.unwrap();
-        let n = s.revoke_cascade("t", "a", Some("b"), "audit", "op")
+        let n = s
+            .revoke_cascade("t", "a", Some("b"), "audit", "op")
             .await
             .unwrap();
         assert_eq!(n, 2);
@@ -672,11 +811,13 @@ mod tests {
         let s = sqlite_store();
         seed_chain(&s, "tenant-a", &["a", "b", "c"], "r", "p").await;
         s.record("tenant-b", "a", None, "r", "p").await.unwrap();
-        let n_a = s.revoke_cascade("tenant-a", "a", None, "audit", "op")
+        let n_a = s
+            .revoke_cascade("tenant-a", "a", None, "audit", "op")
             .await
             .unwrap();
         assert_eq!(n_a, 3);
-        let n_b = s.revoke_cascade("tenant-b", "a", None, "audit", "op")
+        let n_b = s
+            .revoke_cascade("tenant-b", "a", None, "audit", "op")
             .await
             .unwrap();
         assert_eq!(n_b, 1);
@@ -727,8 +868,28 @@ mod tests {
     #[test]
     fn postgres_cascade_walk_uses_full_edge_depth_budget() {
         assert!(
-            POSTGRES_CASCADE_DESCENDANTS_SQL.contains("d.depth <= $3"),
+            POSTGRES_CASCADE_REVOKE_SQL.contains("d.depth <= $5"),
             "Postgres cascade must include children at the configured max-hop boundary"
+        );
+    }
+
+    #[test]
+    fn postgres_cascade_revoke_inserts_and_marks_descendants() {
+        assert!(
+            POSTGRES_CASCADE_REVOKE_SQL.contains("INSERT INTO capability_token_revocations"),
+            "Postgres cascade must materialize descendant revocation rows"
+        );
+        assert!(
+            POSTGRES_CASCADE_REVOKE_SQL.contains("SELECT $1, d.instance_id, d.parent_id"),
+            "Postgres cascade insert must select discovered descendants"
+        );
+        assert!(
+            POSTGRES_CASCADE_REVOKE_SQL.contains("ON CONFLICT (tenant_id, instance_id) DO NOTHING"),
+            "Postgres cascade descendant insert must be idempotent"
+        );
+        assert!(
+            POSTGRES_CASCADE_REVOKE_SQL.contains("revoked = TRUE"),
+            "Postgres cascade must mark existing metadata rows revoked"
         );
     }
 
@@ -751,7 +912,11 @@ mod tests {
             .prepare("PRAGMA table_info(capability_token_revocations)")
             .unwrap()
             .query_map([], |row| {
-                Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?, row.get::<_, i64>(5)?))
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, i64>(5)?,
+                ))
             })
             .unwrap()
             .collect::<Result<Vec<_>, _>>()
@@ -770,11 +935,13 @@ mod tests {
         // Build a single-thread chain longer than CASCADE_MAX_DEPTH; the
         // walker must stop at the cap rather than spinning forever.
         let s = InMemoryRevocationStore::new();
-        let chain: Vec<String> =
-            (0..(CASCADE_MAX_DEPTH + 5)).map(|i| format!("n-{i}")).collect();
+        let chain: Vec<String> = (0..(CASCADE_MAX_DEPTH + 5))
+            .map(|i| format!("n-{i}"))
+            .collect();
         let chain_refs: Vec<&str> = chain.iter().map(String::as_str).collect();
         seed_chain(&s, "t", &chain_refs, "r", "p").await;
-        let n = s.revoke_cascade("t", chain_refs[0], None, "audit", "op")
+        let n = s
+            .revoke_cascade("t", chain_refs[0], None, "audit", "op")
             .await
             .unwrap();
         // BFS from depth 0 reaches up to CASCADE_MAX_DEPTH levels of children


### PR DESCRIPTION
## Summary
- Persist cascade revocation descendants instead of only counting them.
- Split chain metadata registration from revocation state with a `revoked` marker across InMemory, SQLite, and Postgres.
- Keep revocation lookup failures distinct from genuine `Revoked` errors.
- Add regression coverage proving root cascade revokes child/grandchild and auth rejects cascaded grandchild tokens.

## Verification
- `RUSTC_WRAPPER= cargo test -p sera-db --lib capability_revocation`
- `RUSTC_WRAPPER= cargo test -p sera-auth --lib revocation`
- `RUSTC_WRAPPER= cargo clippy -p sera-auth -p sera-db --all-targets -- -D warnings`

Follow-up for `sera-2q6w`; PR #1156 merged green but left cascade persistence semantic gap.