### PR TITLE
feat(sera-gateway): SQLite-backed WorkflowTaskStore (sera-d2xh)

### DIFF
--- a/rust/crates/sera-gateway/src/workflow_store.rs
+++ b/rust/crates/sera-gateway/src/workflow_store.rs
@@ -1,4 +1,4 @@
-//! Workflow task store — Wave E Phase 1 (sera-kgi8).
+//! Workflow task store — Wave E Phase 1 (sera-kgi8) + persistence (sera-d2xh).
 //!
 //! Holds the set of pending [`WorkflowTask`]s the scheduler enumerates every
 //! tick. Only Timer-gated tasks are fully wired end-to-end in Phase 1; other
@@ -6,14 +6,21 @@
 //! to "resolved" until their dedicated gate beads land (Human: sera-dgk1,
 //! GhPr: sera-comg, GhRun: sera-4fel, Change: sera-7ggi, Mail: sera-0zch).
 //!
-//! Persistent storage is a follow-up; Phase 1 uses an in-memory store only.
+//! Two implementations ship today:
+//! - [`InMemoryWorkflowTaskStore`] — `HashMap`-backed, used by tests and the
+//!   default in-process gateway.
+//! - [`SqliteWorkflowTaskStore`] — `rusqlite`-backed (sera-d2xh). Survives
+//!   gateway restarts so a Timer or Human gate scheduled before a crash still
+//!   resolves after recovery.
 
 use std::collections::HashMap;
+use std::path::Path;
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
+use rusqlite::{Connection, params};
 use serde::{Deserialize, Serialize};
-use tokio::sync::RwLock;
+use tokio::sync::{Mutex, RwLock};
 
 use sera_workflow::WorkflowTask;
 
@@ -29,6 +36,23 @@ pub enum SchedulerTaskStatus {
     Pending,
     /// Gate resolved — scheduler has emitted the wake event.
     Resolved,
+}
+
+impl SchedulerTaskStatus {
+    fn as_db_str(self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::Resolved => "resolved",
+        }
+    }
+
+    fn from_db_str(s: &str) -> Option<Self> {
+        match s {
+            "pending" => Some(Self::Pending),
+            "resolved" => Some(Self::Resolved),
+            _ => None,
+        }
+    }
 }
 
 /// Envelope wrapping a [`WorkflowTask`] with the scheduler-side metadata the
@@ -50,9 +74,9 @@ pub struct WorkflowTaskRecord {
 
 /// Persistence boundary for workflow tasks owned by the scheduler.
 ///
-/// Phase 1 ships [`InMemoryWorkflowTaskStore`] only; a SQLite-backed impl is
-/// the follow-up bead. The trait is `async` for forward-compatibility with
-/// that store — the in-memory impl has no real await points.
+/// The trait is `async` so backends with real I/O (e.g.
+/// [`SqliteWorkflowTaskStore`]) fit naturally; the in-memory impl has no real
+/// await points.
 #[async_trait::async_trait]
 pub trait WorkflowTaskStore: Send + Sync {
     /// Insert a freshly minted record. Returns the stored record so the
@@ -74,7 +98,8 @@ pub trait WorkflowTaskStore: Send + Sync {
     async fn mark_resolved(&self, id: &str, at: DateTime<Utc>) -> bool;
 }
 
-/// Process-local store backed by a `HashMap`. Sufficient for Phase 1.
+/// Process-local store backed by a `HashMap`. Sufficient for unit tests and
+/// the default in-process gateway when no persistence path is configured.
 #[derive(Default)]
 pub struct InMemoryWorkflowTaskStore {
     inner: RwLock<HashMap<String, WorkflowTaskRecord>>,
@@ -127,5 +152,387 @@ impl WorkflowTaskStore for InMemoryWorkflowTaskStore {
             }
             _ => false,
         }
+    }
+}
+
+// ── SQLite-backed store (sera-d2xh) ──────────────────────────────────────────
+
+/// SQLite-backed [`WorkflowTaskStore`].
+///
+/// One row per `WorkflowTaskRecord`, keyed by hex task id. The full
+/// [`WorkflowTask`] is serialised as JSON in the `task_json` column so
+/// future additions to the task shape (new `AwaitType` variants, dependency
+/// fields, …) round-trip without a schema migration. Scheduler-relevant
+/// columns (`status`, `agent_id`, `resume_token`, `resolved_at`) are pulled
+/// out as their own columns so the `list_pending` query can filter without
+/// deserialising every row.
+///
+/// Concurrency: rusqlite `Connection` is `!Sync`, so we wrap it in a
+/// `tokio::sync::Mutex` and hold the lock across the synchronous SQL call.
+/// Workflow stores see human-cadence write traffic (gate creation + scheduler
+/// resolutions every 5s), so a single shared connection is fine — no need to
+/// reach for a connection pool.
+pub struct SqliteWorkflowTaskStore {
+    conn: Mutex<Connection>,
+}
+
+impl SqliteWorkflowTaskStore {
+    /// Open (or create) a SQLite database at `path` and ensure the schema is
+    /// in place.
+    pub fn open(path: &Path) -> rusqlite::Result<Self> {
+        let conn = Connection::open(path)?;
+        Self::initialize(&conn)?;
+        Ok(Self {
+            conn: Mutex::new(conn),
+        })
+    }
+
+    /// Open an in-memory SQLite database — useful for integration tests that
+    /// want the SQLite code path without touching the filesystem.
+    pub fn open_in_memory() -> rusqlite::Result<Self> {
+        let conn = Connection::open_in_memory()?;
+        Self::initialize(&conn)?;
+        Ok(Self {
+            conn: Mutex::new(conn),
+        })
+    }
+
+    fn initialize(conn: &Connection) -> rusqlite::Result<()> {
+        conn.execute_batch(
+            "
+            CREATE TABLE IF NOT EXISTS workflow_tasks (
+                id           TEXT PRIMARY KEY,
+                agent_id     TEXT NOT NULL,
+                resume_token TEXT NOT NULL,
+                status       TEXT NOT NULL CHECK (status IN ('pending', 'resolved')),
+                resolved_at  TEXT,
+                task_json    TEXT NOT NULL,
+                created_at   TEXT NOT NULL DEFAULT (datetime('now'))
+            );
+            CREATE INDEX IF NOT EXISTS idx_workflow_tasks_status
+                ON workflow_tasks(status);
+            ",
+        )
+    }
+
+    /// Decode a row into a [`WorkflowTaskRecord`], surfacing JSON / status
+    /// parse failures as `rusqlite::Error::FromSqlConversionFailure` so the
+    /// caller doesn't need a separate error type.
+    fn record_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<WorkflowTaskRecord> {
+        let agent_id: String = row.get("agent_id")?;
+        let resume_token: String = row.get("resume_token")?;
+        let status_raw: String = row.get("status")?;
+        let resolved_at_raw: Option<String> = row.get("resolved_at")?;
+        let task_json: String = row.get("task_json")?;
+
+        let status = SchedulerTaskStatus::from_db_str(&status_raw).ok_or_else(|| {
+            rusqlite::Error::FromSqlConversionFailure(
+                3,
+                rusqlite::types::Type::Text,
+                format!("unknown scheduler status `{status_raw}`").into(),
+            )
+        })?;
+
+        let resolved_at = match resolved_at_raw {
+            None => None,
+            Some(s) => Some(parse_rfc3339(&s).map_err(|e| {
+                rusqlite::Error::FromSqlConversionFailure(
+                    4,
+                    rusqlite::types::Type::Text,
+                    e.into(),
+                )
+            })?),
+        };
+
+        let task: WorkflowTask = serde_json::from_str(&task_json).map_err(|e| {
+            rusqlite::Error::FromSqlConversionFailure(
+                5,
+                rusqlite::types::Type::Text,
+                Box::new(e),
+            )
+        })?;
+
+        Ok(WorkflowTaskRecord {
+            task,
+            agent_id,
+            resume_token,
+            status,
+            resolved_at,
+        })
+    }
+}
+
+fn parse_rfc3339(s: &str) -> Result<DateTime<Utc>, String> {
+    DateTime::parse_from_rfc3339(s)
+        .map(|dt| dt.with_timezone(&Utc))
+        .map_err(|e| format!("invalid rfc3339 timestamp `{s}`: {e}"))
+}
+
+#[async_trait::async_trait]
+impl WorkflowTaskStore for SqliteWorkflowTaskStore {
+    async fn insert(&self, record: WorkflowTaskRecord) -> WorkflowTaskRecord {
+        let conn = self.conn.lock().await;
+        let id = record.task.id.to_string();
+        let task_json = serde_json::to_string(&record.task)
+            .expect("WorkflowTask serialisation is infallible by construction");
+        let resolved_at_str = record.resolved_at.map(|t| t.to_rfc3339());
+        // INSERT OR REPLACE preserves "insert returns the stored record"
+        // semantics from the in-memory impl: the same task id replaces the
+        // previous record verbatim. Callers that want a hard "no overwrite"
+        // contract should `get` first.
+        conn.execute(
+            "INSERT OR REPLACE INTO workflow_tasks
+                (id, agent_id, resume_token, status, resolved_at, task_json)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![
+                &id,
+                &record.agent_id,
+                &record.resume_token,
+                record.status.as_db_str(),
+                resolved_at_str,
+                &task_json,
+            ],
+        )
+        .expect("workflow_tasks insert failed");
+        record
+    }
+
+    async fn get(&self, id: &str) -> Option<WorkflowTaskRecord> {
+        let conn = self.conn.lock().await;
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, agent_id, resume_token, status, resolved_at, task_json
+                 FROM workflow_tasks WHERE id = ?1",
+            )
+            .ok()?;
+        let mut rows = stmt
+            .query_map(params![id], Self::record_from_row)
+            .ok()?;
+        rows.next().and_then(|r| r.ok())
+    }
+
+    async fn list(&self) -> Vec<WorkflowTaskRecord> {
+        let conn = self.conn.lock().await;
+        let mut stmt = match conn.prepare(
+            "SELECT id, agent_id, resume_token, status, resolved_at, task_json
+             FROM workflow_tasks
+             ORDER BY created_at ASC, id ASC",
+        ) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::error!(
+                    event = "workflow_store_list_prepare_failed",
+                    error = %e,
+                    "SqliteWorkflowTaskStore::list prepare failed"
+                );
+                return Vec::new();
+            }
+        };
+        let iter = match stmt.query_map([], Self::record_from_row) {
+            Ok(it) => it,
+            Err(e) => {
+                tracing::error!(
+                    event = "workflow_store_list_query_failed",
+                    error = %e,
+                    "SqliteWorkflowTaskStore::list query failed"
+                );
+                return Vec::new();
+            }
+        };
+        iter.filter_map(|r| r.ok()).collect()
+    }
+
+    async fn list_pending(&self) -> Vec<WorkflowTaskRecord> {
+        let conn = self.conn.lock().await;
+        let mut stmt = match conn.prepare(
+            "SELECT id, agent_id, resume_token, status, resolved_at, task_json
+             FROM workflow_tasks
+             WHERE status = 'pending'
+             ORDER BY created_at ASC, id ASC",
+        ) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::error!(
+                    event = "workflow_store_list_pending_prepare_failed",
+                    error = %e,
+                    "SqliteWorkflowTaskStore::list_pending prepare failed"
+                );
+                return Vec::new();
+            }
+        };
+        let iter = match stmt.query_map([], Self::record_from_row) {
+            Ok(it) => it,
+            Err(e) => {
+                tracing::error!(
+                    event = "workflow_store_list_pending_query_failed",
+                    error = %e,
+                    "SqliteWorkflowTaskStore::list_pending query failed"
+                );
+                return Vec::new();
+            }
+        };
+        iter.filter_map(|r| r.ok()).collect()
+    }
+
+    async fn mark_resolved(&self, id: &str, at: DateTime<Utc>) -> bool {
+        let conn = self.conn.lock().await;
+        let resolved_at_str = at.to_rfc3339();
+        // Conditional UPDATE — only flip pending → resolved. The affected
+        // row count tells us whether a real transition happened, matching
+        // the in-memory impl's `Some(rec) if rec.status == Pending` arm.
+        let updated = conn
+            .execute(
+                "UPDATE workflow_tasks
+                 SET status = 'resolved', resolved_at = ?1
+                 WHERE id = ?2 AND status = 'pending'",
+                params![&resolved_at_str, id],
+            )
+            .unwrap_or(0);
+        updated > 0
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Duration as ChronoDuration;
+    use sera_workflow::task::WorkflowTaskInput;
+    use sera_workflow::{AwaitType, WorkflowTaskStatus, WorkflowTaskType};
+
+    fn make_record(token: &str, secs_offset: i64) -> WorkflowTaskRecord {
+        let now = Utc::now();
+        let mut task = WorkflowTask::new(WorkflowTaskInput {
+            title: format!("task-{token}"),
+            description: "test".into(),
+            acceptance_criteria: Vec::new(),
+            status: WorkflowTaskStatus::Open,
+            priority: 5,
+            task_type: WorkflowTaskType::Meta,
+            source_formula: None,
+            source_location: None,
+            created_at: now,
+        });
+        task.await_type = Some(AwaitType::Timer {
+            not_before: now + ChronoDuration::seconds(secs_offset),
+        });
+        WorkflowTaskRecord {
+            task,
+            agent_id: "sera".into(),
+            resume_token: token.into(),
+            status: SchedulerTaskStatus::Pending,
+            resolved_at: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn sqlite_insert_get_round_trip() {
+        let store = SqliteWorkflowTaskStore::open_in_memory().unwrap();
+        let rec = make_record("rt-1", 60);
+        let id = rec.task.id.to_string();
+        store.insert(rec.clone()).await;
+
+        let got = store.get(&id).await.expect("must round-trip");
+        assert_eq!(got.task.id, rec.task.id);
+        assert_eq!(got.agent_id, "sera");
+        assert_eq!(got.resume_token, "rt-1");
+        assert_eq!(got.status, SchedulerTaskStatus::Pending);
+        assert!(got.resolved_at.is_none());
+    }
+
+    #[tokio::test]
+    async fn sqlite_list_pending_filters_resolved() {
+        let store = SqliteWorkflowTaskStore::open_in_memory().unwrap();
+        let pending = make_record("p", 60);
+        let resolved = make_record("r", 60);
+        let resolved_id = resolved.task.id.to_string();
+        store.insert(pending.clone()).await;
+        store.insert(resolved.clone()).await;
+        let resolved_at = Utc::now();
+        assert!(store.mark_resolved(&resolved_id, resolved_at).await);
+
+        let all = store.list().await;
+        assert_eq!(all.len(), 2);
+        let pend = store.list_pending().await;
+        assert_eq!(pend.len(), 1);
+        assert_eq!(pend[0].resume_token, "p");
+    }
+
+    #[tokio::test]
+    async fn sqlite_mark_resolved_idempotent() {
+        let store = SqliteWorkflowTaskStore::open_in_memory().unwrap();
+        let rec = make_record("idem", 60);
+        let id = rec.task.id.to_string();
+        store.insert(rec).await;
+
+        let at = Utc::now();
+        assert!(store.mark_resolved(&id, at).await, "first transition wins");
+        assert!(
+            !store.mark_resolved(&id, at).await,
+            "second transition is a no-op"
+        );
+
+        let got = store.get(&id).await.unwrap();
+        assert_eq!(got.status, SchedulerTaskStatus::Resolved);
+        assert!(got.resolved_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn sqlite_mark_resolved_unknown_id_returns_false() {
+        let store = SqliteWorkflowTaskStore::open_in_memory().unwrap();
+        assert!(!store.mark_resolved("nonexistent", Utc::now()).await);
+    }
+
+    #[tokio::test]
+    async fn sqlite_get_unknown_returns_none() {
+        let store = SqliteWorkflowTaskStore::open_in_memory().unwrap();
+        assert!(store.get("nope").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn sqlite_persists_across_reopen() {
+        // Open a file-backed DB, insert a record, drop the store, reopen,
+        // confirm the record is still there with the same status. This is
+        // the load-bearing claim of sera-d2xh: a Timer or Human gate
+        // scheduled before a crash must survive recovery.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let db_path = tmp.path().join("workflow.sqlite");
+
+        let rec = make_record("survives-restart", 60);
+        let id = rec.task.id.to_string();
+        {
+            let store = SqliteWorkflowTaskStore::open(&db_path).unwrap();
+            store.insert(rec).await;
+        }
+
+        let store = SqliteWorkflowTaskStore::open(&db_path).unwrap();
+        let got = store.get(&id).await.expect("record must survive reopen");
+        assert_eq!(got.resume_token, "survives-restart");
+        assert_eq!(got.status, SchedulerTaskStatus::Pending);
+    }
+
+    #[tokio::test]
+    async fn sqlite_resolved_state_persists_across_reopen() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let db_path = tmp.path().join("workflow.sqlite");
+
+        let rec = make_record("resolved-survives", 60);
+        let id = rec.task.id.to_string();
+        let resolved_at;
+        {
+            let store = SqliteWorkflowTaskStore::open(&db_path).unwrap();
+            store.insert(rec).await;
+            resolved_at = Utc::now();
+            assert!(store.mark_resolved(&id, resolved_at).await);
+        }
+
+        let store = SqliteWorkflowTaskStore::open(&db_path).unwrap();
+        let got = store.get(&id).await.unwrap();
+        assert_eq!(got.status, SchedulerTaskStatus::Resolved);
+        let restored = got.resolved_at.expect("resolved_at must round-trip");
+        // RFC3339 round-trip is exact at the second/sub-second level for
+        // chrono::DateTime<Utc>, so equality holds.
+        assert_eq!(restored.timestamp(), resolved_at.timestamp());
     }
 }

--- a/rust/crates/sera-gateway/src/workflow_store.rs
+++ b/rust/crates/sera-gateway/src/workflow_store.rs
@@ -280,7 +280,7 @@ impl WorkflowTaskStore for SqliteWorkflowTaskStore {
         // semantics from the in-memory impl: the same task id replaces the
         // previous record verbatim. Callers that want a hard "no overwrite"
         // contract should `get` first.
-        conn.execute(
+        if let Err(e) = conn.execute(
             "INSERT OR REPLACE INTO workflow_tasks
                 (id, agent_id, resume_token, status, resolved_at, task_json)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
@@ -292,8 +292,14 @@ impl WorkflowTaskStore for SqliteWorkflowTaskStore {
                 resolved_at_str,
                 &task_json,
             ],
-        )
-        .expect("workflow_tasks insert failed");
+        ) {
+            tracing::error!(
+                event = "workflow_store_insert_failed",
+                task_id = %id,
+                error = %e,
+                "SqliteWorkflowTaskStore::insert failed; record not persisted"
+            );
+        }
         record
     }
 
@@ -339,7 +345,18 @@ impl WorkflowTaskStore for SqliteWorkflowTaskStore {
                 return Vec::new();
             }
         };
-        iter.filter_map(|r| r.ok()).collect()
+        iter.filter_map(|r| match r {
+            Ok(rec) => Some(rec),
+            Err(e) => {
+                tracing::warn!(
+                    event = "workflow_store_list_decode_failed",
+                    error = %e,
+                    "SqliteWorkflowTaskStore::list skipping undecodable row"
+                );
+                None
+            }
+        })
+        .collect()
     }
 
     async fn list_pending(&self) -> Vec<WorkflowTaskRecord> {
@@ -371,7 +388,19 @@ impl WorkflowTaskStore for SqliteWorkflowTaskStore {
                 return Vec::new();
             }
         };
-        iter.filter_map(|r| r.ok()).collect()
+        iter.filter_map(|r| match r {
+            Ok(rec) => Some(rec),
+            Err(e) => {
+                tracing::warn!(
+                    event = "workflow_store_list_pending_decode_failed",
+                    error = %e,
+                    "SqliteWorkflowTaskStore::list_pending skipping undecodable row; \
+                     task remains in DB but will not be scheduled until row is fixed"
+                );
+                None
+            }
+        })
+        .collect()
     }
 
     async fn mark_resolved(&self, id: &str, at: DateTime<Utc>) -> bool {

--- a/rust/crates/sera-gateway/tests/workflow_sqlite_persistence.rs
+++ b/rust/crates/sera-gateway/tests/workflow_sqlite_persistence.rs
@@ -1,0 +1,109 @@
+//! End-to-end integration test for the SQLite-backed WorkflowTaskStore
+//! (sera-d2xh) — verifies a Timer task survives a "restart" via tempfile
+//! reopen and resolves on the next scheduler tick, then stays resolved
+//! across another reopen.
+
+use std::sync::Arc;
+
+use chrono::{Duration as ChronoDuration, Utc};
+
+use sera_gateway::scheduler::tick;
+use sera_gateway::workflow_store::{
+    SchedulerTaskStatus, SqliteWorkflowTaskStore, WorkflowTaskRecord, WorkflowTaskStore,
+};
+use sera_workflow::task::WorkflowTaskInput;
+use sera_workflow::{AwaitType, WorkflowTask, WorkflowTaskStatus, WorkflowTaskType};
+
+fn make_timer_task(secs_offset: i64) -> WorkflowTask {
+    let now = Utc::now();
+    let mut task = WorkflowTask::new(WorkflowTaskInput {
+        title: "sqlite-persistence-test".into(),
+        description: "Wave E — sera-d2xh integration".into(),
+        acceptance_criteria: Vec::new(),
+        status: WorkflowTaskStatus::Open,
+        priority: 5,
+        task_type: WorkflowTaskType::Meta,
+        source_formula: None,
+        source_location: None,
+        created_at: now,
+    });
+    task.await_type = Some(AwaitType::Timer {
+        not_before: now + ChronoDuration::seconds(secs_offset),
+    });
+    task
+}
+
+#[tokio::test]
+async fn sqlite_store_round_trips_through_scheduler_tick() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let db_path = tmp.path().join("workflow.sqlite");
+
+    // Create a Timer task with a deadline already in the past so the very
+    // next tick must resolve it.
+    let task = make_timer_task(-2);
+    let task_id = task.id.to_string();
+
+    // Phase 1 — first "process": insert into the persistent store.
+    {
+        let store = SqliteWorkflowTaskStore::open(&db_path).unwrap();
+        store
+            .insert(WorkflowTaskRecord {
+                task,
+                agent_id: "sera".into(),
+                resume_token: "tok-persistent".into(),
+                status: SchedulerTaskStatus::Pending,
+                resolved_at: None,
+            })
+            .await;
+    }
+
+    // Phase 2 — "restart": reopen the same DB, run a single tick, confirm
+    // the gate resolved.
+    let store = Arc::new(SqliteWorkflowTaskStore::open(&db_path).unwrap());
+    let resolved = tick(Arc::clone(&store) as Arc<dyn WorkflowTaskStore>).await;
+    assert_eq!(resolved, 1, "elapsed timer must resolve on reopened store");
+
+    let rec = store.get(&task_id).await.expect("record present");
+    assert_eq!(rec.status, SchedulerTaskStatus::Resolved);
+    assert!(rec.resolved_at.is_some());
+    assert_eq!(rec.resume_token, "tok-persistent");
+    drop(store);
+
+    // Phase 3 — "second restart": resolved state must round-trip.
+    let store = SqliteWorkflowTaskStore::open(&db_path).unwrap();
+    let rec = store.get(&task_id).await.expect("record still present");
+    assert_eq!(rec.status, SchedulerTaskStatus::Resolved);
+    let pending = store.list_pending().await;
+    assert!(pending.is_empty(), "resolved task must not appear in list_pending");
+}
+
+#[tokio::test]
+async fn sqlite_store_blocks_future_timer_across_restart() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let db_path = tmp.path().join("workflow.sqlite");
+
+    // Deadline 60s in the future — must stay pending across restart and tick.
+    let task = make_timer_task(60);
+    let task_id = task.id.to_string();
+
+    {
+        let store = SqliteWorkflowTaskStore::open(&db_path).unwrap();
+        store
+            .insert(WorkflowTaskRecord {
+                task,
+                agent_id: "sera".into(),
+                resume_token: "tok-future".into(),
+                status: SchedulerTaskStatus::Pending,
+                resolved_at: None,
+            })
+            .await;
+    }
+
+    let store = Arc::new(SqliteWorkflowTaskStore::open(&db_path).unwrap());
+    let resolved = tick(Arc::clone(&store) as Arc<dyn WorkflowTaskStore>).await;
+    assert_eq!(resolved, 0, "future-deadline timer must not resolve");
+
+    let rec = store.get(&task_id).await.unwrap();
+    assert_eq!(rec.status, SchedulerTaskStatus::Pending);
+    assert!(rec.resolved_at.is_none());
+}


### PR DESCRIPTION
## Summary

- Adds `SqliteWorkflowTaskStore` — a `rusqlite`-backed implementation of the existing `WorkflowTaskStore` trait that survives gateway restarts.
- Schema is one row per task keyed by hex task id, with the full `WorkflowTask` serialised as JSON in `task_json` so future `AwaitType` variants round-trip without a schema migration. Scheduler-relevant fields (`status`, `agent_id`, `resume_token`, `resolved_at`) live in their own columns so `list_pending` filters in SQL without deserialising every row.
- Trait surface unchanged from sera-kgi8 — drop-in for the existing in-memory store. `mark_resolved` uses a conditional `UPDATE ... WHERE status = 'pending'` to preserve the in-memory impl's "transition only on pending" contract.
- Concurrency: `tokio::sync::Mutex<rusqlite::Connection>` — sufficient given workflow stores see human-cadence write traffic (gate creation + scheduler resolutions every 5s).

## Why

This is the persistence foundation for **Wave E Phase 2**. The five gate beads landing on top of this PR (sera-dgk1 Human, sera-7ggi Change, sera-comg GhPr, sera-4fel GhRun, sera-0zch Mail) all extend the same trait surface — making the trait persistent first means gates are durable on day one rather than requiring a per-gate persistence retrofit.

Bead: [sera-d2xh](.beads/issues.jsonl)

## Test plan

- [x] `cargo test -p sera-gateway --lib workflow_store` — 7 sqlite_* tests cover insert/get round-trip, `list_pending` filtering, `mark_resolved` idempotency, unknown id behaviour, and reopen survival for both pending and resolved states.
- [x] `cargo test -p sera-gateway --test workflow_sqlite_persistence` — 2 tests that exercise the SQLite store through the real `scheduler::tick` path: create → close → reopen → tick → verify resolved (and the future-deadline counterpart).
- [x] `cargo clippy -p sera-gateway -- -D warnings` — clean.
- [x] In-memory store + existing `workflow_timer` tests still pass; the trait surface is unchanged.