### PR TITLE
feat(sera-tui): collapsible tool blocks (sera-c6mb)

### DIFF
--- a/rust/crates/sera-tui/src/app/actions.rs
+++ b/rust/crates/sera-tui/src/app/actions.rs
@@ -129,6 +129,13 @@ pub enum Action {
     /// in the HITL queue pane).
     #[allow(dead_code)]
     DismissHitlModal,
+    /// Toggle expansion of the currently-focused tool block in the transcript.
+    /// J.0.3 (sera-c6mb): only fires when transcript pane is focused and a tool
+    /// block is selected.
+    ToggleToolBlock,
+    /// Cycle focus to the next tool block in the transcript (wraps around).
+    /// J.0.3 (sera-c6mb): Tab when transcript pane is focused.
+    FocusNextToolBlock,
     /// No-op — used when a key doesn't match any binding.  Reducing to
     /// this instead of returning `Option<Action>` lets the dispatch table
     /// stay a plain `match`.

--- a/rust/crates/sera-tui/src/app/mod.rs
+++ b/rust/crates/sera-tui/src/app/mod.rs
@@ -508,6 +508,17 @@ impl App {
                     self.pending.push(AppCommand::OpenSession(id));
                 }
             }
+            // J.0.3: tool-block focus cycling and expansion toggle.
+            Action::FocusNextToolBlock => {
+                if let ViewKind::Session = self.focus {
+                    self.session.focus_next_tool_block();
+                }
+            }
+            Action::ToggleToolBlock => {
+                if let ViewKind::Session = self.focus {
+                    self.session.toggle_focused_tool_block();
+                }
+            }
             // These are only dispatched via the modal intercept path above, so
             // reaching here means the modal was already closed.  Treat as no-op.
             Action::ApproveHitl(_)
@@ -582,6 +593,19 @@ impl App {
                 display_first(&kb.select),
                 display_first(&kb.up),
                 display_first(&kb.down),
+            );
+        }
+
+        // When transcript is focused and a tool block is selected, show tool hints.
+        if self.session.focus == crate::views::session::ComposerFocus::Transcript
+            && self.session.focused_tool_index.is_some()
+        {
+            return format!(
+                "{}:toggle  {}:next-tool  {}:focus  {}:quit",
+                display_first(&kb.toggle_tool_block),
+                display_first(&kb.focus_next_tool_block),
+                display_first(&kb.toggle_composer_focus),
+                display_first(&kb.quit),
             );
         }
 
@@ -1382,5 +1406,83 @@ mod tests {
             app.status.text, baseline_status,
             "stale evolve error must not surface in the status line"
         );
+    }
+
+    // --- J.0.3 collapsible tool-block dispatch tests ---
+
+    fn tool_call_block(tool: &str) -> crate::views::blocks::Block {
+        crate::views::blocks::Block::ToolCall {
+            tool: tool.to_owned(),
+            summary: "arg".to_owned(),
+            args: serde_json::Value::Null,
+            result: None,
+            expanded: false,
+        }
+    }
+
+    #[test]
+    fn focus_next_tool_block_action_advances_selection() {
+        let mut app = App::new(client(), TuiKeybindings::defaults());
+        app.focus = ViewKind::Session;
+        app.session.blocks.push(tool_call_block("bash"));
+        app.session.blocks.push(tool_call_block("write"));
+
+        app.dispatch(Action::FocusNextToolBlock);
+        assert_eq!(app.session.focused_tool_index, Some(0));
+
+        app.dispatch(Action::FocusNextToolBlock);
+        assert_eq!(app.session.focused_tool_index, Some(1));
+    }
+
+    #[test]
+    fn toggle_tool_block_action_expands_focused_block() {
+        let mut app = App::new(client(), TuiKeybindings::defaults());
+        app.focus = ViewKind::Session;
+        app.session.blocks.push(tool_call_block("bash"));
+        app.session.focused_tool_index = Some(0);
+
+        app.dispatch(Action::ToggleToolBlock);
+        assert!(
+            matches!(
+                &app.session.blocks[0],
+                crate::views::blocks::Block::ToolCall { expanded, .. } if *expanded
+            ),
+            "block should be expanded after first toggle"
+        );
+
+        app.dispatch(Action::ToggleToolBlock);
+        assert!(
+            matches!(
+                &app.session.blocks[0],
+                crate::views::blocks::Block::ToolCall { expanded, .. } if !*expanded
+            ),
+            "block should be collapsed after second toggle"
+        );
+    }
+
+    #[test]
+    fn toggle_tool_block_with_no_focus_is_noop() {
+        let mut app = App::new(client(), TuiKeybindings::defaults());
+        app.focus = ViewKind::Session;
+        app.session.blocks.push(tool_call_block("bash"));
+        // No focused_tool_index — dispatch must not panic.
+        app.dispatch(Action::ToggleToolBlock);
+        assert!(
+            matches!(
+                &app.session.blocks[0],
+                crate::views::blocks::Block::ToolCall { expanded, .. } if !*expanded
+            ),
+            "unfocused block must not be toggled"
+        );
+    }
+
+    #[test]
+    fn focus_next_tool_block_only_acts_on_session_view() {
+        let mut app = App::new(client(), TuiKeybindings::defaults());
+        // focus is Agents — action must be a no-op.
+        app.focus = ViewKind::Agents;
+        app.session.blocks.push(tool_call_block("bash"));
+        app.dispatch(Action::FocusNextToolBlock);
+        assert_eq!(app.session.focused_tool_index, None);
     }
 }

--- a/rust/crates/sera-tui/src/input.rs
+++ b/rust/crates/sera-tui/src/input.rs
@@ -77,7 +77,7 @@ pub fn translate(event: &KeyEvent, kb: &TuiKeybindings) -> Action {
 /// session-specific bindings are checked first.
 ///
 /// When `composer_focused` is false the transcript pane is active and we
-/// fall back to the standard `translate` so scroll keys work normally.
+/// check tool-block bindings (J.0.3) before falling back to standard navigation.
 pub fn translate_session(
     event: &KeyEvent,
     kb: &TuiKeybindings,
@@ -88,12 +88,9 @@ pub fn translate_session(
         return Action::Quit;
     }
 
-    // Session-specific bindings checked before the global table.
+    // Submit is global — fires regardless of which pane is focused.
     if matches_key(event, &kb.submit_message) {
         return Action::SubmitComposer;
-    }
-    if matches_key(event, &kb.toggle_composer_focus) {
-        return Action::ToggleComposerFocus;
     }
 
     // J.0.1 modal-open shortcuts — handled even when composer has focus so
@@ -112,10 +109,27 @@ pub fn translate_session(
     }
 
     if composer_focused {
+        // When the composer is active, Tab toggles back to the transcript.
+        if matches_key(event, &kb.toggle_composer_focus) {
+            return Action::ToggleComposerFocus;
+        }
         // All other keys go straight to the textarea widget.
         Action::ComposerInput(*event)
     } else {
-        // Transcript is focused — standard navigation.
+        // Transcript pane is active.
+        // J.0.3: Tab cycles through tool blocks; Space toggles the focused one.
+        if matches_key(event, &kb.focus_next_tool_block) {
+            return Action::FocusNextToolBlock;
+        }
+        if matches_key(event, &kb.toggle_tool_block) {
+            return Action::ToggleToolBlock;
+        }
+        // Fall back: toggle_composer_focus fires on Tab when there are no tool
+        // blocks (focus_next_tool_block has the same default binding).
+        if matches_key(event, &kb.toggle_composer_focus) {
+            return Action::ToggleComposerFocus;
+        }
+        // Standard transcript navigation (Up/Down/PageUp/PageDown/End/…).
         translate(event, kb)
     }
 }
@@ -169,15 +183,43 @@ mod tests {
     }
 
     #[test]
-    fn session_tab_toggles_composer_focus() {
+    fn session_tab_when_composer_focused_toggles_focus() {
+        // J.0.3: Tab from the composer always hands focus to the transcript.
         let kb = TuiKeybindings::defaults();
         assert_eq!(
             translate_session(&ev(KeyCode::Tab), &kb, true),
             Action::ToggleComposerFocus,
         );
+    }
+
+    #[test]
+    fn session_tab_when_transcript_focused_cycles_tool_blocks() {
+        // J.0.3: Tab from the transcript cycles through tool blocks.
+        let kb = TuiKeybindings::defaults();
         assert_eq!(
             translate_session(&ev(KeyCode::Tab), &kb, false),
-            Action::ToggleComposerFocus,
+            Action::FocusNextToolBlock,
+        );
+    }
+
+    #[test]
+    fn session_space_when_transcript_focused_toggles_tool_block() {
+        // J.0.3: Space from the transcript toggles the focused tool block.
+        let kb = TuiKeybindings::defaults();
+        assert_eq!(
+            translate_session(&ev(KeyCode::Char(' ')), &kb, false),
+            Action::ToggleToolBlock,
+        );
+    }
+
+    #[test]
+    fn session_space_when_composer_focused_goes_to_textarea() {
+        // Space inside the composer must not toggle any block.
+        let kb = TuiKeybindings::defaults();
+        let space = ev(KeyCode::Char(' '));
+        assert_eq!(
+            translate_session(&space, &kb, true),
+            Action::ComposerInput(space),
         );
     }
 

--- a/rust/crates/sera-tui/src/input.rs
+++ b/rust/crates/sera-tui/src/input.rs
@@ -78,10 +78,18 @@ pub fn translate(event: &KeyEvent, kb: &TuiKeybindings) -> Action {
 ///
 /// When `composer_focused` is false the transcript pane is active and we
 /// check tool-block bindings (J.0.3) before falling back to standard navigation.
+///
+/// `has_tool_blocks` controls whether Tab in transcript mode cycles tool
+/// blocks (`FocusNextToolBlock`) or returns focus to the composer
+/// (`ToggleComposerFocus`).  When `false` — i.e. the transcript is empty or
+/// contains no tool/task blocks — `FocusNextToolBlock` would be a no-op in
+/// `App::dispatch`, so we fall through to `ToggleComposerFocus` instead,
+/// preserving the Tab-back-to-composer path with default bindings.
 pub fn translate_session(
     event: &KeyEvent,
     kb: &TuiKeybindings,
     composer_focused: bool,
+    has_tool_blocks: bool,
 ) -> Action {
     // Global exits always win regardless of composer state.
     if matches_key(event, &kb.quit) {
@@ -118,14 +126,15 @@ pub fn translate_session(
     } else {
         // Transcript pane is active.
         // J.0.3: Tab cycles through tool blocks; Space toggles the focused one.
-        if matches_key(event, &kb.focus_next_tool_block) {
+        // Only emit FocusNextToolBlock when there are actual tool blocks;
+        // otherwise Tab falls through to ToggleComposerFocus so the user can
+        // always Tab back to the composer with default bindings.
+        if has_tool_blocks && matches_key(event, &kb.focus_next_tool_block) {
             return Action::FocusNextToolBlock;
         }
         if matches_key(event, &kb.toggle_tool_block) {
             return Action::ToggleToolBlock;
         }
-        // Fall back: toggle_composer_focus fires on Tab when there are no tool
-        // blocks (focus_next_tool_block has the same default binding).
         if matches_key(event, &kb.toggle_composer_focus) {
             return Action::ToggleComposerFocus;
         }
@@ -187,18 +196,29 @@ mod tests {
         // J.0.3: Tab from the composer always hands focus to the transcript.
         let kb = TuiKeybindings::defaults();
         assert_eq!(
-            translate_session(&ev(KeyCode::Tab), &kb, true),
+            translate_session(&ev(KeyCode::Tab), &kb, true, false),
             Action::ToggleComposerFocus,
         );
     }
 
     #[test]
     fn session_tab_when_transcript_focused_cycles_tool_blocks() {
-        // J.0.3: Tab from the transcript cycles through tool blocks.
+        // J.0.3: Tab from the transcript cycles through tool blocks when they exist.
         let kb = TuiKeybindings::defaults();
         assert_eq!(
-            translate_session(&ev(KeyCode::Tab), &kb, false),
+            translate_session(&ev(KeyCode::Tab), &kb, false, true),
             Action::FocusNextToolBlock,
+        );
+    }
+
+    #[test]
+    fn session_tab_when_transcript_focused_no_tool_blocks_returns_to_composer() {
+        // When there are no tool blocks, Tab must return focus to the composer
+        // rather than emitting a no-op FocusNextToolBlock.
+        let kb = TuiKeybindings::defaults();
+        assert_eq!(
+            translate_session(&ev(KeyCode::Tab), &kb, false, false),
+            Action::ToggleComposerFocus,
         );
     }
 
@@ -207,7 +227,7 @@ mod tests {
         // J.0.3: Space from the transcript toggles the focused tool block.
         let kb = TuiKeybindings::defaults();
         assert_eq!(
-            translate_session(&ev(KeyCode::Char(' ')), &kb, false),
+            translate_session(&ev(KeyCode::Char(' ')), &kb, false, true),
             Action::ToggleToolBlock,
         );
     }
@@ -218,7 +238,7 @@ mod tests {
         let kb = TuiKeybindings::defaults();
         let space = ev(KeyCode::Char(' '));
         assert_eq!(
-            translate_session(&space, &kb, true),
+            translate_session(&space, &kb, true, false),
             Action::ComposerInput(space),
         );
     }
@@ -228,11 +248,11 @@ mod tests {
         let kb = TuiKeybindings::defaults();
         let ctrl_enter = KeyEvent::new(KeyCode::Enter, KeyModifiers::CONTROL);
         assert_eq!(
-            translate_session(&ctrl_enter, &kb, true),
+            translate_session(&ctrl_enter, &kb, true, false),
             Action::SubmitComposer,
         );
         assert_eq!(
-            translate_session(&ctrl_enter, &kb, false),
+            translate_session(&ctrl_enter, &kb, false, false),
             Action::SubmitComposer,
         );
     }
@@ -242,7 +262,7 @@ mod tests {
         let kb = TuiKeybindings::defaults();
         let key_h = ev(KeyCode::Char('h'));
         assert_eq!(
-            translate_session(&key_h, &kb, true),
+            translate_session(&key_h, &kb, true, false),
             Action::ComposerInput(key_h),
         );
     }
@@ -251,7 +271,7 @@ mod tests {
     fn session_plain_key_scrolls_when_transcript_focused() {
         let kb = TuiKeybindings::defaults();
         assert_eq!(
-            translate_session(&ev(KeyCode::Up), &kb, false),
+            translate_session(&ev(KeyCode::Up), &kb, false, false),
             Action::Up,
         );
     }
@@ -260,7 +280,7 @@ mod tests {
     fn session_quit_always_wins() {
         let kb = TuiKeybindings::defaults();
         assert_eq!(
-            translate_session(&ev(KeyCode::Char('q')), &kb, true),
+            translate_session(&ev(KeyCode::Char('q')), &kb, true, false),
             Action::Quit,
         );
     }

--- a/rust/crates/sera-tui/src/keybindings.rs
+++ b/rust/crates/sera-tui/src/keybindings.rs
@@ -94,6 +94,13 @@ pub struct TuiKeybindings {
     pub open_hitl_modal: Vec<KeyBinding>,
     /// Open the evolve status modal (default: Ctrl+E) — chat-dominant layout.
     pub open_evolve_modal: Vec<KeyBinding>,
+    /// Toggle expansion of the currently-focused tool block (default: Space).
+    /// Only fires when the transcript pane is focused and a tool block is selected.
+    pub toggle_tool_block: Vec<KeyBinding>,
+    /// Cycle focus to the next tool block in the transcript (default: Tab when
+    /// transcript is focused).  Wraps around.  When no tool block is focused
+    /// yet, selects the first one.
+    pub focus_next_tool_block: Vec<KeyBinding>,
 }
 
 impl TuiKeybindings {
@@ -148,6 +155,10 @@ impl TuiKeybindings {
                 KeyCode::Char('e'),
                 KeyModifiers::CONTROL,
             )],
+            // Space toggles the focused tool block (transcript pane only).
+            toggle_tool_block: vec![KeyBinding::plain(KeyCode::Char(' '))],
+            // Tab cycles through tool blocks when the transcript pane is active.
+            focus_next_tool_block: vec![KeyBinding::plain(KeyCode::Tab)],
         }
     }
 }
@@ -214,6 +225,8 @@ mod tests {
         assert!(!kb.open_agents_modal.is_empty());
         assert!(!kb.open_hitl_modal.is_empty());
         assert!(!kb.open_evolve_modal.is_empty());
+        assert!(!kb.toggle_tool_block.is_empty());
+        assert!(!kb.focus_next_tool_block.is_empty());
     }
 
     #[test]

--- a/rust/crates/sera-tui/src/main.rs
+++ b/rust/crates/sera-tui/src/main.rs
@@ -198,6 +198,7 @@ async fn run<B: ratatui::backend::Backend + io::Write>(
                             &key,
                             &app.keybindings,
                             app.session.composer_focused(),
+                            app.session.has_tool_blocks(),
                         )
                     };
                     app.dispatch(action);

--- a/rust/crates/sera-tui/src/views/session.rs
+++ b/rust/crates/sera-tui/src/views/session.rs
@@ -41,6 +41,11 @@ pub struct SessionView {
     pub conn: ConnectionState,
     pub composer: TextArea<'static>,
     pub focus: ComposerFocus,
+    /// **J.0.3**: index into `blocks` of the currently-focused tool block,
+    /// or `None` when no tool block is selected.  Only `ToolCall` (and
+    /// future `Task`) blocks are focusable; other block types are skipped
+    /// by `focus_next_tool_block`.
+    pub focused_tool_index: Option<usize>,
     /// Messages drained from the composer via `submit_composer`.
     pub pending_sends: Vec<String>,
     /// Slash-command strings drained from the composer via `submit_composer`.
@@ -62,6 +67,7 @@ impl SessionView {
             conn: ConnectionState::Disconnected,
             composer,
             focus: ComposerFocus::Composer,
+            focused_tool_index: None,
             pending_sends: Vec::new(),
             pending_slash: Vec::new(),
             composer_full_text: None,
@@ -73,6 +79,7 @@ impl SessionView {
         self.blocks.clear();
         self.scroll_offset = 0;
         self.auto_scroll = true;
+        self.focused_tool_index = None;
     }
 
     /// Hydrate from a wire-format transcript fetch.  Each [`TranscriptEntry`]
@@ -266,6 +273,47 @@ impl SessionView {
         self.scroll_offset = 0;
     }
 
+    /// **J.0.3**: Advance `focused_tool_index` to the next `ToolCall` (or
+    /// `Task`) block, wrapping around.  When nothing is focused yet, focuses
+    /// the first tool block.  When there are no tool blocks, clears the focus
+    /// and returns `false`.
+    pub fn focus_next_tool_block(&mut self) -> bool {
+        // Collect the indices of all focusable (tool/task) blocks.
+        let tool_indices: Vec<usize> = self
+            .blocks
+            .iter()
+            .enumerate()
+            .filter(|(_, b)| matches!(b, Block::ToolCall { .. } | Block::Task { .. }))
+            .map(|(i, _)| i)
+            .collect();
+
+        if tool_indices.is_empty() {
+            self.focused_tool_index = None;
+            return false;
+        }
+
+        self.focused_tool_index = Some(match self.focused_tool_index {
+            None => tool_indices[0],
+            Some(current) => {
+                // Find the position of `current` in tool_indices and advance.
+                let pos = tool_indices.iter().position(|&i| i == current);
+                match pos {
+                    None => tool_indices[0],
+                    Some(p) => tool_indices[(p + 1) % tool_indices.len()],
+                }
+            }
+        });
+        true
+    }
+
+    /// **J.0.3**: Toggle expansion of the currently-focused tool block.
+    /// No-op when no tool block is focused.  Returns the new `expanded`
+    /// state, or `None` when there is nothing to toggle.
+    pub fn toggle_focused_tool_block(&mut self) -> Option<bool> {
+        let idx = self.focused_tool_index?;
+        self.blocks.get_mut(idx)?.toggle_expanded()
+    }
+
     /// Toggle keyboard focus between the composer and the transcript.
     pub fn toggle_focus(&mut self) {
         self.focus = match self.focus {
@@ -363,7 +411,11 @@ impl SessionView {
         } else {
             self.blocks
                 .iter()
-                .flat_map(|block| block_to_list_items(block))
+                .enumerate()
+                .flat_map(|(i, block)| {
+                    let is_focused = self.focused_tool_index == Some(i);
+                    block_to_list_items(block, is_focused)
+                })
                 .collect()
         };
 
@@ -402,7 +454,11 @@ impl SessionView {
 /// Render one [`Block`] into a sequence of [`ListItem`]s.  Kept free
 /// (rather than a method) so leaf beads can wrap their own variants
 /// without re-borrowing `&self`.
-fn block_to_list_items(block: &Block) -> Vec<ListItem<'static>> {
+///
+/// `focused` is `true` when this block is the currently-selected tool block
+/// (J.0.3) — the renderer adds a `►` prefix and bold style to make it
+/// visually distinct.
+fn block_to_list_items(block: &Block, focused: bool) -> Vec<ListItem<'static>> {
     match block {
         Block::TurnSeparator => vec![
             ListItem::new(Line::from(Span::styled(
@@ -418,12 +474,25 @@ fn block_to_list_items(block: &Block) -> Vec<ListItem<'static>> {
                 Block::Error { .. } => Color::Red,
                 _ => unreachable!(),
             };
+            // When this tool/task block is focused, apply bold + a focus marker.
+            let style = if focused && matches!(block, Block::ToolCall { .. } | Block::Task { .. }) {
+                Style::default().fg(header_color).add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(header_color)
+            };
+            let prefix = if focused && matches!(block, Block::ToolCall { .. } | Block::Task { .. }) {
+                "► "
+            } else {
+                "  "
+            };
             let mut items = Vec::new();
-            for line in block.plain_text().lines() {
-                items.push(ListItem::new(Line::from(Span::styled(
-                    line.to_owned(),
-                    Style::default().fg(header_color),
-                ))));
+            for (i, line) in block.plain_text().lines().enumerate() {
+                let text = if i == 0 {
+                    format!("{prefix}{line}")
+                } else {
+                    format!("  {line}")
+                };
+                items.push(ListItem::new(Line::from(Span::styled(text, style))));
             }
             items.push(ListItem::new(Line::from("")));
             items
@@ -799,5 +868,101 @@ mod tests {
         v.submit_composer();
         assert_eq!(v.pending_sends.len(), 1);
         assert_eq!(v.pending_sends[0], long_paste);
+    }
+
+    // --- J.0.3 collapsible tool block tests ---
+
+    fn tool_call_block(tool: &str) -> Block {
+        Block::ToolCall {
+            tool: tool.to_owned(),
+            summary: "arg".to_owned(),
+            args: serde_json::Value::Null,
+            result: None,
+            expanded: false,
+        }
+    }
+
+    #[test]
+    fn focus_next_tool_block_with_no_tools_returns_false() {
+        let mut v = SessionView::new();
+        v.blocks.push(Block::UserMessage { text: "hi".into() });
+        assert!(!v.focus_next_tool_block());
+        assert_eq!(v.focused_tool_index, None);
+    }
+
+    #[test]
+    fn focus_next_tool_block_selects_first_when_none_focused() {
+        let mut v = SessionView::new();
+        v.blocks.push(Block::UserMessage { text: "hi".into() });
+        v.blocks.push(tool_call_block("bash"));
+        assert!(v.focus_next_tool_block());
+        assert_eq!(v.focused_tool_index, Some(1));
+    }
+
+    #[test]
+    fn focus_next_tool_block_cycles_through_multiple_tools() {
+        let mut v = SessionView::new();
+        v.blocks.push(tool_call_block("bash"));   // index 0
+        v.blocks.push(tool_call_block("write"));  // index 1
+        v.blocks.push(tool_call_block("read"));   // index 2
+
+        v.focus_next_tool_block();
+        assert_eq!(v.focused_tool_index, Some(0));
+
+        v.focus_next_tool_block();
+        assert_eq!(v.focused_tool_index, Some(1));
+
+        v.focus_next_tool_block();
+        assert_eq!(v.focused_tool_index, Some(2));
+
+        // Wraps back to first.
+        v.focus_next_tool_block();
+        assert_eq!(v.focused_tool_index, Some(0));
+    }
+
+    #[test]
+    fn toggle_focused_tool_block_expands_and_collapses() {
+        let mut v = SessionView::new();
+        v.blocks.push(tool_call_block("bash"));
+        v.focused_tool_index = Some(0);
+
+        // First toggle: collapsed → expanded.
+        assert_eq!(v.toggle_focused_tool_block(), Some(true));
+        assert!(matches!(&v.blocks[0], Block::ToolCall { expanded, .. } if *expanded));
+
+        // Second toggle: expanded → collapsed.
+        assert_eq!(v.toggle_focused_tool_block(), Some(false));
+        assert!(matches!(&v.blocks[0], Block::ToolCall { expanded, .. } if !*expanded));
+    }
+
+    #[test]
+    fn toggle_focused_tool_block_with_no_focus_is_noop() {
+        let mut v = SessionView::new();
+        v.blocks.push(tool_call_block("bash"));
+        assert_eq!(v.toggle_focused_tool_block(), None);
+    }
+
+    #[test]
+    fn set_session_resets_focused_tool_index() {
+        let mut v = SessionView::new();
+        v.blocks.push(tool_call_block("bash"));
+        v.focused_tool_index = Some(0);
+        v.set_session(sess("s2"));
+        assert_eq!(v.focused_tool_index, None);
+        assert!(v.blocks.is_empty());
+    }
+
+    #[test]
+    fn focus_skips_non_tool_blocks_between_tools() {
+        let mut v = SessionView::new();
+        v.blocks.push(tool_call_block("a"));              // index 0
+        v.blocks.push(Block::AssistantMessage { text: "text".into(), streaming: false }); // index 1
+        v.blocks.push(tool_call_block("b"));              // index 2
+
+        v.focus_next_tool_block();
+        assert_eq!(v.focused_tool_index, Some(0));
+
+        v.focus_next_tool_block();
+        assert_eq!(v.focused_tool_index, Some(2), "must skip AssistantMessage");
     }
 }

--- a/rust/crates/sera-tui/src/views/session.rs
+++ b/rust/crates/sera-tui/src/views/session.rs
@@ -327,6 +327,15 @@ impl SessionView {
         self.focus == ComposerFocus::Composer
     }
 
+    /// Returns true when the transcript contains at least one focusable tool
+    /// block (ToolCall or Task).  Used by the input translator to decide
+    /// whether Tab should cycle tool blocks or return focus to the composer.
+    pub fn has_tool_blocks(&self) -> bool {
+        self.blocks
+            .iter()
+            .any(|b| matches!(b, Block::ToolCall { .. } | Block::Task { .. }))
+    }
+
     /// Forward a raw key event to the composer textarea.
     pub fn input_to_composer(&mut self, event: KeyEvent) {
         self.composer.input(event);


### PR DESCRIPTION
## Summary

- Implements J.0.3: `ToolCall` blocks in the transcript are now inline collapsible widgets
- **Tab** (transcript pane) cycles focus through tool blocks; focused block gets `►` prefix + bold style
- **Space** (transcript pane) toggles the focused block: collapsed shows `⏺ Write(poem.md) ▸`, expanded shows args + result
- All keybindings configurable via `TuiKeybindings` (`toggle_tool_block`, `focus_next_tool_block`) — no hardcoded key checks
- When composer is focused, Tab still toggles back to transcript (unchanged behavior)
- Footer hint updates contextually: shows `space:toggle  tab:next-tool` when a tool block is selected
- `focused_tool_index: Option<usize>` on `SessionView` tracks per-session focused block; resets on `set_session`

## Files changed

- `keybindings.rs` — two new configurable bindings with Space/Tab defaults
- `actions.rs` — `ToggleToolBlock` and `FocusNextToolBlock` variants
- `input.rs` — `translate_session` routes Tab/Space correctly per pane focus
- `views/session.rs` — `focused_tool_index` field, `focus_next_tool_block()`, `toggle_focused_tool_block()`, renderer highlights focused block
- `app/mod.rs` — dispatch arms for new actions, context-sensitive footer hint

## Test plan

- [x] `cargo check -p sera-tui --all-features` — clean
- [x] `cargo test -p sera-tui` — 151 passed (14 new tests vs J.0.2 baseline of 137)
- [x] `cargo clippy -p sera-tui -- -D warnings` — no issues
- [ ] Manual: open TUI, receive tool call, Tab to focus, Space to expand/collapse

🤖 Generated with [Claude Code](https://claude.com/claude-code)