### PR TITLE
test(sera-gateway): KillSwitch ROLLBACK abort regression (sera-bsem)

### DIFF
--- a/rust/crates/sera-gateway/src/bin/sera.rs
+++ b/rust/crates/sera-gateway/src/bin/sera.rs
@@ -7407,6 +7407,60 @@ spec:
         );
     }
 
+    /// sera-bsem regression: after `cancel_all_in_flight` cancels every
+    /// registered token, the cancel arm of `execute_turn` returns
+    /// `MvsTurnResult { cancelled: true, .. }`, which the calling chat handler
+    /// drives through the same `release_lane` cleanup as the success path.
+    /// Lock down the end of that loop: a previously-busy lane must accept new
+    /// admissions once the operator path completes, otherwise ROLLBACK plus
+    /// disarm leaves the lane wedged at `active_runs == 1` until process
+    /// restart (the original bug).
+    #[tokio::test]
+    async fn rollback_releases_lane_slot_for_subsequent_admissions() {
+        let state = test_state_async().await;
+        let session_key = occupy_sera_lane(&state).await;
+
+        // Mirror the production registration sequence: a chat handler stamps a
+        // CancellationToken into the registry alongside the lane reservation.
+        let token = state.register_cancellation_token(&session_key);
+
+        // Operator fires ROLLBACK → cancel_all_in_flight drains the registry
+        // and cancels every token (the existing
+        // `cancel_all_in_flight_cancels_every_registered_token` test pins this
+        // half down).
+        let cancelled = state.cancel_all_in_flight();
+        assert_eq!(cancelled, 1, "rollback must cancel exactly one token");
+        assert!(token.is_cancelled());
+
+        // The cancel arm of execute_turn fires before the chat handler's
+        // `release_lane`. Mirror that cleanup so the lane returns to baseline.
+        {
+            let mut lq = state.lane_queue.lock().await;
+            lq.complete_run(&session_key);
+        }
+
+        let active = state.lane_queue.lock().await.active_runs();
+        assert_eq!(
+            active, 0,
+            "rollback + cancel arm cleanup must release the lane slot; \
+             leaving it at 1 is the sera-bsem wedge that pins the next \
+             /api/chat at 429 until process restart"
+        );
+
+        // Subsequent submissions on the same session_key must be admitted.
+        let principal = PrincipalRef {
+            id: PrincipalId::new("http-chat"),
+            kind: PrincipalKind::Human,
+        };
+        let event = DomainEvent::api_message("sera", &session_key, principal, "after rollback");
+        let mut lq = state.lane_queue.lock().await;
+        assert_eq!(
+            lq.enqueue(event),
+            sera_db::lane_queue::EnqueueResult::Ready,
+            "post-rollback enqueue must be Ready, not Queued — lane was leaked"
+        );
+    }
+
     /// sera-mplr: `AppState::cancel_http_chat_session` marks the matching
     /// `http:{agent}:{session_id}` handle as client-cancelled and fires its
     /// token. The handle is **not** removed here — the chat handler's


### PR DESCRIPTION
## Summary

Lock down the lane-release half of the sera-bsem fix (PR #1069). The existing tests cover that ROLLBACK fires every registered cancellation token, but no end-to-end test asserted that the lane slot returns to baseline so subsequent `/api/chat` admissions can proceed.

This adds a unit-level regression in `sera-gateway` that mirrors the production sequence:
1. Claim a lane slot (`occupy_sera_lane`).
2. Register a cancellation token for the same session_key (chat handler does this on entry).
3. Fire `cancel_all_in_flight` — token cancels, drain reports 1.
4. Mirror the cancel arm's cleanup (`lane_queue.complete_run`).
5. Assert `active_runs == 0` AND that a fresh `enqueue` for the same session_key returns `Ready`, not `Queued` — i.e., the lane is free.

The bug locked here was: pre-PR-1069, ROLLBACK only flipped a flag; the lane stayed pinned at `active_runs == 1` until process restart, so every subsequent submission for the wedged session returned 429.

Closes sera-bsem (verifying-only — main fix already shipped in #1069).

## Test plan
- [x] `cargo check -p sera-gateway --all-features` (clean)
- [x] `cargo test -p sera-gateway --bin sera-gateway rollback_releases_lane_slot` — 1 passed
- [x] `cargo clippy -p sera-gateway -- -D warnings` (clean)
- [x] Pre-existing E2E tests (`production_e2e::*`) failing because they require `sera-runtime` binary built — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)