### PR TITLE
feat(sera-tui): inline HITL approval block (sera-7olp)

### DIFF
--- a/rust/crates/sera-tui/src/app/actions.rs
+++ b/rust/crates/sera-tui/src/app/actions.rs
@@ -145,6 +145,17 @@ pub enum Action {
     PopupSelect,
     /// Dismiss the autocomplete popup without inserting anything (J.0.5).
     PopupDismiss,
+    /// Approve the focused inline Approval block in the transcript (J.1.4).
+    /// Carries the HITL request_id extracted from the block.
+    /// Also dispatched by `/approve <id>` slash command.
+    #[allow(dead_code)]
+    ApproveInlineBlock(String),
+    /// Reject the focused inline Approval block in the transcript (J.1.4).
+    #[allow(dead_code)]
+    RejectInlineBlock(String),
+    /// Escalate the focused inline Approval block in the transcript (J.1.4).
+    #[allow(dead_code)]
+    EscalateInlineBlock(String),
     /// No-op — used when a key doesn't match any binding.  Reducing to
     /// this instead of returning `Option<Action>` lets the dispatch table
     /// stay a plain `match`.

--- a/rust/crates/sera-tui/src/app/mod.rs
+++ b/rust/crates/sera-tui/src/app/mod.rs
@@ -396,9 +396,11 @@ impl App {
 
         // J.1.4: when a pending inline Approval block exists in the transcript,
         // intercept approve/reject/escalate and route to the inline block action.
-        // This takes lower priority than the modal overlay (above) but higher
-        // priority than the HITL queue pane handler (in the main match below).
-        if let Some(id) = self.session.first_pending_approval_id().map(str::to_owned) {
+        // Only active when the Session view has focus so that approve/reject/
+        // escalate keypresses in the HITL queue view (or other views) are not
+        // silently redirected to the first pending inline block.
+        if self.focus == ViewKind::Session
+            && let Some(id) = self.session.first_pending_approval_id().map(str::to_owned) {
             match action {
                 Action::Approve => {
                     self.pending.push(AppCommand::ApproveInlineBlock(id));
@@ -1838,6 +1840,7 @@ mod tests {
     #[test]
     fn approve_inline_block_routes_to_approve_inline_command() {
         let mut app = App::new(client(), TuiKeybindings::defaults());
+        app.focus = ViewKind::Session;
         // Seed a pending approval block.
         app.session
             .push_approval("req-99".into(), "Write".into(), "reason".into());
@@ -1892,6 +1895,7 @@ mod tests {
     #[test]
     fn reject_inline_block_routes_to_reject_inline_command() {
         let mut app = App::new(client(), TuiKeybindings::defaults());
+        app.focus = ViewKind::Session;
         app.session
             .push_approval("req-7".into(), "Bash".into(), "cmd".into());
         app.dispatch(Action::Reject);
@@ -1908,6 +1912,7 @@ mod tests {
     #[test]
     fn escalate_inline_block_routes_to_escalate_inline_command() {
         let mut app = App::new(client(), TuiKeybindings::defaults());
+        app.focus = ViewKind::Session;
         app.session
             .push_approval("req-3".into(), "Read".into(), "sensitive file".into());
         app.dispatch(Action::Escalate);

--- a/rust/crates/sera-tui/src/app/mod.rs
+++ b/rust/crates/sera-tui/src/app/mod.rs
@@ -22,6 +22,7 @@ use crate::client::{
 };
 use crate::keybindings::TuiKeybindings;
 use crate::views::agent_list::AgentListView;
+use crate::views::blocks::ApprovalStatus;
 use crate::views::evolve_status::EvolveStatusView;
 use crate::views::hitl_queue::HitlQueueView;
 use crate::views::session::SessionView;
@@ -146,6 +147,13 @@ pub enum AppCommand {
     /// Re-attempt a `SendChat` that previously failed due to a disconnected
     /// gateway.  Bypasses the backoff timer and retries immediately.
     RetrySendChat { agent: String, message: String },
+    /// Approve an inline transcript Approval block (J.1.4).
+    /// On success the block status is updated to Approved.
+    ApproveInlineBlock(String),
+    /// Reject an inline transcript Approval block (J.1.4).
+    RejectInlineBlock(String),
+    /// Escalate an inline transcript Approval block (J.1.4).
+    EscalateInlineBlock(String),
 }
 
 /// Root application state.
@@ -386,6 +394,29 @@ impl App {
             return;
         }
 
+        // J.1.4: when a pending inline Approval block exists in the transcript,
+        // intercept approve/reject/escalate and route to the inline block action.
+        // This takes lower priority than the modal overlay (above) but higher
+        // priority than the HITL queue pane handler (in the main match below).
+        if let Some(id) = self.session.first_pending_approval_id().map(str::to_owned) {
+            match action {
+                Action::Approve => {
+                    self.pending.push(AppCommand::ApproveInlineBlock(id));
+                    return;
+                }
+                Action::Reject => {
+                    self.pending.push(AppCommand::RejectInlineBlock(id));
+                    return;
+                }
+                Action::Escalate => {
+                    self.pending.push(AppCommand::EscalateInlineBlock(id));
+                    return;
+                }
+                // All other actions fall through to the normal handler.
+                _ => {}
+            }
+        }
+
         match action {
             Action::Quit => self.should_quit = true,
             Action::NextView => {
@@ -622,6 +653,17 @@ impl App {
                     self.status = Status::warn("cancelling…");
                     self.pending.push(AppCommand::CancelTurn(session_id));
                 }
+            }
+            // J.1.4: inline transcript Approval block actions.
+            // Dispatch HTTP command; runtime will update block status on success.
+            Action::ApproveInlineBlock(id) => {
+                self.pending.push(AppCommand::ApproveInlineBlock(id));
+            }
+            Action::RejectInlineBlock(id) => {
+                self.pending.push(AppCommand::RejectInlineBlock(id));
+            }
+            Action::EscalateInlineBlock(id) => {
+                self.pending.push(AppCommand::EscalateInlineBlock(id));
             }
             Action::NoOp => {}
         }
@@ -961,6 +1003,48 @@ impl Runtime {
                 }
                 AppCommand::OpenSession(session_id) => {
                     self.load_session_by_id(app, session_id).await;
+                }
+                // J.1.4: inline transcript Approval block actions.
+                // Call the HITL HTTP endpoint; update the block status in the
+                // transcript on success so the operator sees the resolved state.
+                AppCommand::ApproveInlineBlock(id) => {
+                    match app.client.approve_hitl(&id).await {
+                        Ok(()) => {
+                            app.session
+                                .update_approval_status(&id, ApprovalStatus::Approved);
+                            app.status = Status::info(format!("approved {id}"));
+                            self.spawn_refresh_hitl(app);
+                        }
+                        Err(e) => {
+                            app.status = Status::error(format!("approve failed: {e}"));
+                        }
+                    }
+                }
+                AppCommand::RejectInlineBlock(id) => {
+                    match app.client.reject_hitl(&id).await {
+                        Ok(()) => {
+                            app.session
+                                .update_approval_status(&id, ApprovalStatus::Rejected);
+                            app.status = Status::info(format!("rejected {id}"));
+                            self.spawn_refresh_hitl(app);
+                        }
+                        Err(e) => {
+                            app.status = Status::error(format!("reject failed: {e}"));
+                        }
+                    }
+                }
+                AppCommand::EscalateInlineBlock(id) => {
+                    match app.client.escalate_hitl(&id).await {
+                        Ok(()) => {
+                            app.session
+                                .update_approval_status(&id, ApprovalStatus::Escalated);
+                            app.status = Status::info(format!("escalated {id}"));
+                            self.spawn_refresh_hitl(app);
+                        }
+                        Err(e) => {
+                            app.status = Status::error(format!("escalate failed: {e}"));
+                        }
+                    }
                 }
             }
         }
@@ -1749,6 +1833,28 @@ mod tests {
         );
     }
 
+    // --- J.1.4: inline HITL approval block dispatch tests ---
+
+    #[test]
+    fn approve_inline_block_routes_to_approve_inline_command() {
+        let mut app = App::new(client(), TuiKeybindings::defaults());
+        // Seed a pending approval block.
+        app.session
+            .push_approval("req-99".into(), "Write".into(), "reason".into());
+        assert_eq!(app.session.first_pending_approval_id(), Some("req-99"));
+
+        // Dispatching Approve with a pending block should push ApproveInlineBlock.
+        app.dispatch(Action::Approve);
+        assert!(
+            matches!(
+                app.pending.last(),
+                Some(AppCommand::ApproveInlineBlock(id)) if id == "req-99"
+            ),
+            "expected ApproveInlineBlock(req-99), got: {:?}",
+            app.pending.last()
+        );
+    }
+
     #[test]
     fn apply_sse_state_reconnecting_keeps_turn_streaming() {
         let mut app = App::new(client(), TuiKeybindings::defaults());
@@ -1781,5 +1887,58 @@ mod tests {
         app.dispatch(Action::RetryConnection);
         let secs = app.disconnect_banner.as_ref().unwrap().secs_until_retry();
         assert_eq!(secs, 0, "banner timer must be reset to now");
+    }
+
+    #[test]
+    fn reject_inline_block_routes_to_reject_inline_command() {
+        let mut app = App::new(client(), TuiKeybindings::defaults());
+        app.session
+            .push_approval("req-7".into(), "Bash".into(), "cmd".into());
+        app.dispatch(Action::Reject);
+        assert!(
+            matches!(
+                app.pending.last(),
+                Some(AppCommand::RejectInlineBlock(id)) if id == "req-7"
+            ),
+            "expected RejectInlineBlock(req-7), got: {:?}",
+            app.pending.last()
+        );
+    }
+
+    #[test]
+    fn escalate_inline_block_routes_to_escalate_inline_command() {
+        let mut app = App::new(client(), TuiKeybindings::defaults());
+        app.session
+            .push_approval("req-3".into(), "Read".into(), "sensitive file".into());
+        app.dispatch(Action::Escalate);
+        assert!(
+            matches!(
+                app.pending.last(),
+                Some(AppCommand::EscalateInlineBlock(id)) if id == "req-3"
+            ),
+            "expected EscalateInlineBlock(req-3), got: {:?}",
+            app.pending.last()
+        );
+    }
+
+    #[test]
+    fn approve_falls_through_to_hitl_queue_when_no_pending_approval_block() {
+        let mut app = App::new(client(), TuiKeybindings::defaults());
+        // No approval blocks in transcript — focus HITL view and add a request.
+        app.focus = ViewKind::Hitl;
+        app.hitl.set_requests(vec![HitlRequest {
+            id: "h1".into(),
+            agent_id: "a1".into(),
+            summary: "read".into(),
+            age: "".into(),
+            status: "pending".into(),
+        }]);
+        app.dispatch(Action::Approve);
+        // Should have routed to the HITL queue pane handler.
+        assert!(
+            matches!(app.pending.last(), Some(AppCommand::Approve(id)) if id == "h1"),
+            "expected Approve(h1), got: {:?}",
+            app.pending.last()
+        );
     }
 }

--- a/rust/crates/sera-tui/src/ui.rs
+++ b/rust/crates/sera-tui/src/ui.rs
@@ -52,7 +52,7 @@ pub fn render(frame: &mut Frame, app: &mut App) {
     .render(frame, chunks[0]);
 
     // Main canvas: Session chat (transcript + tool log).
-    app.session.render_chat(frame, chunks[1], true);
+    app.session.render_chat(frame, chunks[1], true, &app.keybindings);
 
     // Composer — always visible, regardless of modal state.
     app.session.render_composer_only(frame, chunks[2]);

--- a/rust/crates/sera-tui/src/views/blocks.rs
+++ b/rust/crates/sera-tui/src/views/blocks.rs
@@ -84,14 +84,11 @@ pub struct ToolResult {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ApprovalStatus {
     Pending,
-    /// Wired by J.1.4 (sera-7olp) when the operator presses `[a]pprove`.
-    #[allow(dead_code)]
+    /// Set when the operator presses the approve key on the inline block (J.1.4).
     Approved,
-    /// Wired by J.1.4 (sera-7olp) when the operator presses `[r]eject`.
-    #[allow(dead_code)]
+    /// Set when the operator presses the reject key on the inline block (J.1.4).
     Rejected,
-    /// Wired by J.1.4 (sera-7olp) when the operator presses `[e]scalate`.
-    #[allow(dead_code)]
+    /// Set when the operator presses the escalate key on the inline block (J.1.4).
     Escalated,
 }
 
@@ -184,10 +181,37 @@ impl Block {
                 reason,
                 status,
                 ..
-            } => format!("⚠ Approval required: {tool} — {reason} [{status:?}]"),
+            } => match status {
+                ApprovalStatus::Pending => {
+                    format!("⚠ Approval required: {tool} — {reason}  [a]pprove [r]eject [e]scalate")
+                }
+                ApprovalStatus::Approved => format!("✓ Approved: {tool}"),
+                ApprovalStatus::Rejected => format!("✗ Rejected: {tool}"),
+                ApprovalStatus::Escalated => format!("↑ Escalated: {tool}"),
+            },
             Block::Error { message, .. } => format!("⨯ {message}"),
             Block::TurnSeparator => String::new(),
         }
+    }
+
+    /// Find the first `Approval` block with `request_id == id` and set its
+    /// status.  Returns `true` if a matching block was found and updated.
+    /// Called by `SessionView::update_approval_status` after the HTTP action
+    /// completes so the inline block reflects the resolved state (J.1.4).
+    pub fn update_approval_status(blocks: &mut [Block], id: &str, status: ApprovalStatus) -> bool {
+        for block in blocks.iter_mut() {
+            if let Block::Approval {
+                request_id,
+                status: s,
+                ..
+            } = block
+                && request_id == id
+            {
+                *s = status;
+                return true;
+            }
+        }
+        false
     }
 
     /// Stable role label used by the J.0.2 transitional list renderer to

--- a/rust/crates/sera-tui/src/views/session.rs
+++ b/rust/crates/sera-tui/src/views/session.rs
@@ -118,6 +118,20 @@ impl SessionView {
     ///   `ToolCall` block.
     pub fn apply_event(&mut self, ev: StreamEvent) -> bool {
         let et = ev.event_type.to_ascii_lowercase();
+
+        // J.1.4: approval_required SSE frame → push an inline Approval block.
+        // The request_id comes in `session_id` (repurposed) or the `delta`
+        // field; tool name is in `tool`; reason/summary is in `delta`.
+        if et == "approval_required" {
+            let request_id = if !ev.session_id.is_empty() {
+                ev.session_id.clone()
+            } else {
+                ev.delta.clone()
+            };
+            self.push_approval(request_id, ev.tool.clone(), ev.delta.clone());
+            return true;
+        }
+
         let is_tool_event = et == "tool" || et == "tool_start" || et == "tool_end" || !ev.tool.is_empty();
         if is_tool_event {
             if et == "tool_end" {
@@ -259,8 +273,8 @@ impl SessionView {
         self.blocks.push(Block::Error { message, retryable });
     }
 
-    /// Push an inline approval block.  Wired by J.1.4 (sera-7olp).
-    #[allow(dead_code)] // J.1.4 will wire this
+    /// Push an inline approval block.  Called by `apply_event` on
+    /// `approval_required` SSE frames (J.1.4).
     pub fn push_approval(&mut self, request_id: String, tool: String, reason: String) {
         self.blocks.push(Block::Approval {
             request_id,
@@ -268,6 +282,30 @@ impl SessionView {
             reason,
             status: ApprovalStatus::Pending,
         });
+    }
+
+    /// Update the status of an inline approval block by request id.
+    /// Called by the app after the HTTP action completes (J.1.4).
+    pub fn update_approval_status(&mut self, request_id: &str, status: ApprovalStatus) {
+        Block::update_approval_status(&mut self.blocks, request_id, status);
+    }
+
+    /// Return the `request_id` of the first `Pending` inline Approval block,
+    /// if any.  Used by the app reducer to route approve/reject/escalate keys
+    /// to the inline block when one is waiting (J.1.4).
+    pub fn first_pending_approval_id(&self) -> Option<&str> {
+        self.blocks.iter().find_map(|b| {
+            if let Block::Approval {
+                request_id,
+                status: ApprovalStatus::Pending,
+                ..
+            } = b
+            {
+                Some(request_id.as_str())
+            } else {
+                None
+            }
+        })
     }
 
     /// Push a turn separator.  Renderers use this to draw a thin rule
@@ -493,11 +531,17 @@ fn block_to_list_items(block: &Block) -> Vec<ListItem<'static>> {
                 Style::default().fg(Color::DarkGray),
             ))),
         ],
-        Block::ToolCall { .. } | Block::Task { .. } | Block::Approval { .. } | Block::Error { .. } => {
+        // J.1.4: Approval blocks get rich inline rendering with action hints.
+        Block::Approval {
+            tool,
+            reason,
+            status,
+            ..
+        } => render_approval_block(tool, reason, *status),
+        Block::ToolCall { .. } | Block::Task { .. } | Block::Error { .. } => {
             let header_color = match block {
                 Block::ToolCall { .. } => Color::Yellow,
                 Block::Task { .. } => Color::Magenta,
-                Block::Approval { .. } => Color::Yellow,
                 Block::Error { .. } => Color::Red,
                 _ => unreachable!(),
             };
@@ -545,6 +589,78 @@ fn block_to_list_items(block: &Block) -> Vec<ListItem<'static>> {
             items.push(ListItem::new(Line::from("")));
             items
         }
+    }
+}
+
+/// Render an inline [`Block::Approval`] as styled list items.
+///
+/// Pending blocks show a warning header and a coloured action-hint line:
+/// ```text
+/// ⚠ Approval required: Write — write to /tmp/foo
+///   [a]pprove  [r]eject  [e]scalate
+/// ```
+/// Resolved blocks show a single status line with matching colour.
+fn render_approval_block(tool: &str, reason: &str, status: ApprovalStatus) -> Vec<ListItem<'static>> {
+    match status {
+        ApprovalStatus::Pending => {
+            let header = ListItem::new(Line::from(vec![
+                Span::styled(
+                    "⚠ Approval required: ".to_owned(),
+                    Style::default()
+                        .fg(Color::Yellow)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(
+                    tool.to_owned(),
+                    Style::default()
+                        .fg(Color::White)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(
+                    format!(" — {reason}"),
+                    Style::default().fg(Color::Yellow),
+                ),
+            ]));
+            let hint = ListItem::new(Line::from(vec![
+                Span::raw("  "),
+                Span::styled(
+                    "[a]pprove".to_owned(),
+                    Style::default().fg(Color::Green).add_modifier(Modifier::BOLD),
+                ),
+                Span::raw("  "),
+                Span::styled(
+                    "[r]eject".to_owned(),
+                    Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+                ),
+                Span::raw("  "),
+                Span::styled(
+                    "[e]scalate".to_owned(),
+                    Style::default().fg(Color::Magenta).add_modifier(Modifier::BOLD),
+                ),
+            ]));
+            vec![header, hint, ListItem::new(Line::from(""))]
+        }
+        ApprovalStatus::Approved => vec![
+            ListItem::new(Line::from(Span::styled(
+                format!("✓ Approved: {tool}"),
+                Style::default().fg(Color::Green),
+            ))),
+            ListItem::new(Line::from("")),
+        ],
+        ApprovalStatus::Rejected => vec![
+            ListItem::new(Line::from(Span::styled(
+                format!("✗ Rejected: {tool}"),
+                Style::default().fg(Color::Red),
+            ))),
+            ListItem::new(Line::from("")),
+        ],
+        ApprovalStatus::Escalated => vec![
+            ListItem::new(Line::from(Span::styled(
+                format!("↑ Escalated: {tool}"),
+                Style::default().fg(Color::Magenta),
+            ))),
+            ListItem::new(Line::from("")),
+        ],
     }
 }
 
@@ -945,5 +1061,83 @@ mod tests {
         v.submit_composer();
         assert_eq!(v.pending_sends.len(), 1);
         assert_eq!(v.pending_sends[0], long_paste);
+    }
+
+    // --- J.1.4: inline HITL approval block tests ---
+
+    #[test]
+    fn approval_required_sse_event_pushes_approval_block() {
+        let mut v = SessionView::new();
+        let updated = v.apply_event(StreamEvent {
+            event_type: "approval_required".into(),
+            session_id: "req-42".into(),
+            role: String::new(),
+            delta: "write /tmp/secret".into(),
+            tool: "Write".into(),
+        });
+        assert!(updated);
+        assert_eq!(v.blocks.len(), 1);
+        match &v.blocks[0] {
+            Block::Approval {
+                request_id,
+                tool,
+                reason,
+                status,
+            } => {
+                assert_eq!(request_id, "req-42");
+                assert_eq!(tool, "Write");
+                assert_eq!(reason, "write /tmp/secret");
+                assert_eq!(*status, ApprovalStatus::Pending);
+            }
+            other => panic!("expected Approval block, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn first_pending_approval_id_returns_pending_block_id() {
+        let mut v = SessionView::new();
+        v.push_approval("req-1".into(), "Bash".into(), "run cmd".into());
+        assert_eq!(v.first_pending_approval_id(), Some("req-1"));
+    }
+
+    #[test]
+    fn first_pending_approval_id_returns_none_when_resolved() {
+        let mut v = SessionView::new();
+        v.push_approval("req-1".into(), "Bash".into(), "run cmd".into());
+        v.update_approval_status("req-1", ApprovalStatus::Approved);
+        assert_eq!(v.first_pending_approval_id(), None);
+    }
+
+    #[test]
+    fn update_approval_status_changes_block_status() {
+        let mut v = SessionView::new();
+        v.push_approval("req-5".into(), "Write".into(), "reason".into());
+        assert_eq!(v.first_pending_approval_id(), Some("req-5"));
+        v.update_approval_status("req-5", ApprovalStatus::Rejected);
+        assert_eq!(v.first_pending_approval_id(), None);
+        match &v.blocks[0] {
+            Block::Approval { status, .. } => assert_eq!(*status, ApprovalStatus::Rejected),
+            other => panic!("expected Approval, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn approval_block_plain_text_pending_shows_action_hints() {
+        let mut v = SessionView::new();
+        v.push_approval("r1".into(), "Bash".into(), "run rm -rf".into());
+        let text = v.blocks[0].plain_text();
+        assert!(text.contains("[a]pprove"), "missing approve hint in: {text}");
+        assert!(text.contains("[r]eject"), "missing reject hint in: {text}");
+        assert!(text.contains("[e]scalate"), "missing escalate hint in: {text}");
+    }
+
+    #[test]
+    fn approval_block_plain_text_resolved_shows_status() {
+        let mut v = SessionView::new();
+        v.push_approval("r1".into(), "Bash".into(), "cmd".into());
+        v.update_approval_status("r1", ApprovalStatus::Approved);
+        let text = v.blocks[0].plain_text();
+        assert!(text.contains("Approved"), "expected Approved in: {text}");
+        assert!(!text.contains("[a]pprove"), "should not show hints when resolved: {text}");
     }
 }

--- a/rust/crates/sera-tui/src/views/session.rs
+++ b/rust/crates/sera-tui/src/views/session.rs
@@ -20,6 +20,7 @@ use super::agent_list::make_block;
 use super::blocks::{ApprovalStatus, Block, ToolResult};
 use crate::client::{ConnectionState, SessionSummary, StreamEvent, TranscriptEntry};
 use crate::highlight;
+use crate::keybindings::{display_first, TuiKeybindings};
 
 /// Which pane inside the Session view holds keyboard focus.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -465,8 +466,8 @@ impl SessionView {
     /// by the root layout; this method renders the block-based transcript
     /// only — the legacy bottom tool-log pane is gone (tool calls are
     /// inline blocks now).
-    pub fn render_chat(&self, frame: &mut Frame, area: Rect, focused: bool) {
-        self.render_transcript(frame, area, focused);
+    pub fn render_chat(&self, frame: &mut Frame, area: Rect, focused: bool, kb: &TuiKeybindings) {
+        self.render_transcript(frame, area, focused, kb);
     }
 
     /// **J.0.1**: render only the composer into `area`.
@@ -474,7 +475,7 @@ impl SessionView {
         self.render_composer(frame, area);
     }
 
-    fn render_transcript(&self, frame: &mut Frame, area: Rect, focused: bool) {
+    fn render_transcript(&self, frame: &mut Frame, area: Rect, focused: bool, kb: &TuiKeybindings) {
         let transcript_focused = focused && self.focus == ComposerFocus::Transcript;
         let items: Vec<ListItem<'_>> = if self.blocks.is_empty() {
             vec![ListItem::new(Line::from(Span::styled(
@@ -484,7 +485,7 @@ impl SessionView {
         } else {
             self.blocks
                 .iter()
-                .flat_map(|block| block_to_list_items(block))
+                .flat_map(|block| block_to_list_items(block, kb))
                 .collect()
         };
 
@@ -523,7 +524,7 @@ impl SessionView {
 /// Render one [`Block`] into a sequence of [`ListItem`]s.  Kept free
 /// (rather than a method) so leaf beads can wrap their own variants
 /// without re-borrowing `&self`.
-fn block_to_list_items(block: &Block) -> Vec<ListItem<'static>> {
+fn block_to_list_items(block: &Block, kb: &TuiKeybindings) -> Vec<ListItem<'static>> {
     match block {
         Block::TurnSeparator => vec![
             ListItem::new(Line::from(Span::styled(
@@ -537,7 +538,7 @@ fn block_to_list_items(block: &Block) -> Vec<ListItem<'static>> {
             reason,
             status,
             ..
-        } => render_approval_block(tool, reason, *status),
+        } => render_approval_block(tool, reason, *status, kb),
         Block::ToolCall { .. } | Block::Task { .. } | Block::Error { .. } => {
             let header_color = match block {
                 Block::ToolCall { .. } => Color::Yellow,
@@ -600,7 +601,7 @@ fn block_to_list_items(block: &Block) -> Vec<ListItem<'static>> {
 ///   [a]pprove  [r]eject  [e]scalate
 /// ```
 /// Resolved blocks show a single status line with matching colour.
-fn render_approval_block(tool: &str, reason: &str, status: ApprovalStatus) -> Vec<ListItem<'static>> {
+fn render_approval_block(tool: &str, reason: &str, status: ApprovalStatus, kb: &TuiKeybindings) -> Vec<ListItem<'static>> {
     match status {
         ApprovalStatus::Pending => {
             let header = ListItem::new(Line::from(vec![
@@ -624,17 +625,17 @@ fn render_approval_block(tool: &str, reason: &str, status: ApprovalStatus) -> Ve
             let hint = ListItem::new(Line::from(vec![
                 Span::raw("  "),
                 Span::styled(
-                    "[a]pprove".to_owned(),
+                    format!("[{}]pprove", display_first(&kb.approve)),
                     Style::default().fg(Color::Green).add_modifier(Modifier::BOLD),
                 ),
                 Span::raw("  "),
                 Span::styled(
-                    "[r]eject".to_owned(),
+                    format!("[{}]eject", display_first(&kb.reject)),
                     Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
                 ),
                 Span::raw("  "),
                 Span::styled(
-                    "[e]scalate".to_owned(),
+                    format!("[{}]scalate", display_first(&kb.escalate)),
                     Style::default().fg(Color::Magenta).add_modifier(Modifier::BOLD),
                 ),
             ]));


### PR DESCRIPTION
## Summary

- **Inline approval block rendering**: `Block::Approval` is now fully wired. When an `approval_required` SSE event arrives, `apply_event` pushes an `Approval` block into the session transcript. Pending blocks render with coloured `[a]pprove [r]eject [e]scalate` keybinding hints; resolved blocks show a single status line (✓ Approved / ✗ Rejected / ↑ Escalated).
- **Key dispatch**: `App::dispatch` intercepts `Action::Approve/Reject/Escalate` when a pending inline approval block exists (checked via `first_pending_approval_id`), routing to new `AppCommand::ApproveInlineBlock/RejectInlineBlock/EscalateInlineBlock`. This intercept sits below the overlay modal but above the HITL queue pane handler, so priority order is correct.
- **HTTP + status update**: `Runtime::execute` calls the existing `approve_hitl`/`reject_hitl`/`escalate_hitl` client methods and updates the block status in the session transcript on success.
- **Modal preserved**: The existing `show_hitl_modal` overlay (PR #1079 / sera-1x16) is untouched. It still appears for HITL queue refreshes. A follow-up bead should retire it once confirmed redundant; I haven't deleted it here per the bead protocol.

## Changes

| File | What changed |
|------|-------------|
| `views/blocks.rs` | Remove `#[allow(dead_code)]` from `ApprovalStatus` variants; add `Block::update_approval_status`; improve `plain_text()` for `Approval` to show contextual hints vs resolved status |
| `views/session.rs` | Handle `approval_required` SSE in `apply_event`; add `update_approval_status` and `first_pending_approval_id` helpers; rich `render_approval_block` function with styled ratatui spans; remove `#[allow(dead_code)]` from `push_approval` |
| `app/actions.rs` | Add `ApproveInlineBlock/RejectInlineBlock/EscalateInlineBlock` action variants |
| `app/mod.rs` | Add `ApproveInlineBlock/RejectInlineBlock/EscalateInlineBlock` `AppCommand` variants; inline block intercept in `dispatch`; runtime handlers that call HTTP and update block status; import `ApprovalStatus` |

## Test plan

- [x] `cargo test -p sera-tui` — 147 tests pass (10 new: SSE event handler, `first_pending_approval_id`, `update_approval_status`, `plain_text` hints/resolved, dispatch routing for all three actions, fallthrough when no pending block)
- [x] `cargo clippy -p sera-tui -- -D warnings` — no issues
- [ ] Manual: start gateway, open TUI, trigger an approval request, verify `[a]pprove [r]eject [e]scalate` renders in transcript and `a` resolves the block inline

## Notes

- Keybindings are configurable (default `a`/`x`/`e` from `TuiKeybindings::defaults`; the intercept uses `Action::Approve/Reject/Escalate` which map through the keybinding system)
- The `approval_required` SSE event uses `session_id` field as `request_id` (gateway convention); falls back to `delta` if `session_id` is empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)