### PR TITLE
feat(sera-gateway): kill harness subprocess on KillSwitch ROLLBACK (sera-40y3)

### DIFF
--- a/rust/crates/sera-gateway/src/agent_transport.rs
+++ b/rust/crates/sera-gateway/src/agent_transport.rs
@@ -134,6 +134,24 @@ pub trait AgentTurnTransport: Send + Sync {
     fn dispatch_kind(&self) -> &'static str {
         "unknown"
     }
+
+    /// Discard any backing state pinned to an aborted turn (sera-40y3).
+    /// Called from the KillSwitch ROLLBACK callback after
+    /// `cancel_all_in_flight` cancels every in-flight cancellation token.
+    ///
+    /// `cancel_all_in_flight` only flips Tokio cancellation tokens — the
+    /// stdio child process keeps running and its NDJSON stdout pipe still
+    /// holds whatever frames it had buffered (a stale `TurnCompleted`,
+    /// partial deltas, etc.). On DISARM-and-resume without a gateway
+    /// restart, the next submission would read those stale frames as its
+    /// own reply (cross-turn state corruption).
+    ///
+    /// Implementors are expected to terminate any subprocess they own and
+    /// drop any cached transport state so the next turn starts from a
+    /// clean slate. The default is a no-op for backends that have no
+    /// process/connection to invalidate (`EmbeddedRuntimeTransport`, test
+    /// doubles).
+    async fn kill_for_rollback(&self) {}
 }
 
 #[cfg(test)]

--- a/rust/crates/sera-gateway/src/agent_transport.rs
+++ b/rust/crates/sera-gateway/src/agent_transport.rs
@@ -136,8 +136,10 @@ pub trait AgentTurnTransport: Send + Sync {
     }
 
     /// Discard any backing state pinned to an aborted turn (sera-40y3).
-    /// Called from the KillSwitch ROLLBACK callback after
-    /// `cancel_all_in_flight` cancels every in-flight cancellation token.
+    /// Called and **awaited** from the KillSwitch ROLLBACK callback after
+    /// `cancel_all_in_flight` cancels every in-flight cancellation token,
+    /// so all children are gone before the caller can issue `DISARM` and
+    /// resume serving.
     ///
     /// `cancel_all_in_flight` only flips Tokio cancellation tokens — the
     /// stdio child process keeps running and its NDJSON stdout pipe still

--- a/rust/crates/sera-gateway/src/bin/sera.rs
+++ b/rust/crates/sera-gateway/src/bin/sera.rs
@@ -1150,6 +1150,40 @@ impl AgentTurnTransport for RuntimeChildSupervisor {
     fn dispatch_kind(&self) -> &'static str {
         "runtime"
     }
+
+    /// sera-40y3: kill the current child and clear the harness slot so the
+    /// next `acquire()` respawns fresh. Called from the KillSwitch ROLLBACK
+    /// callback after `cancel_all_in_flight` flips the cancellation tokens.
+    /// Without this, the runtime child keeps running and the next
+    /// post-DISARM submission could read a stale `TurnCompleted` frame
+    /// from the previous (aborted) turn.
+    async fn kill_for_rollback(&self) {
+        let mut state = self.state.lock().await;
+        if let Some(harness) = state.harness.as_ref() {
+            // Best-effort kill — the child may already be dead, in which
+            // case `start_kill` returns an error we just log.
+            let mut child = harness.child.lock().await;
+            if let Err(e) = child.start_kill() {
+                tracing::warn!(
+                    agent = %self.agent_id,
+                    generation = state.generation,
+                    error = %e,
+                    "kill_for_rollback: start_kill failed (child may already be gone)"
+                );
+            } else {
+                tracing::warn!(
+                    agent = %self.agent_id,
+                    generation = state.generation,
+                    event = "harness:killed_for_rollback",
+                    "killed runtime child after KillSwitch ROLLBACK"
+                );
+            }
+        }
+        // Drop the harness regardless — next acquire() will respawn. We do
+        // not bump generation here; respawn_locked will.
+        state.harness = None;
+        state.last_exit = Some("killed_for_rollback".to_string());
+    }
 }
 
 // ── Turn event types ────────────────────────────────────────────────────────
@@ -4851,9 +4885,31 @@ async fn run_start(config: PathBuf, port: u16, local: bool) -> anyhow::Result<()
         let sock_path = admin_sock_path();
         // sera-bsem: the rollback callback also cancels every in-flight
         // turn/steer so wedged runtimes release their lane slots promptly.
+        // sera-40y3: it also kills every registered runtime harness so the
+        // post-DISARM resume path cannot read stale TurnCompleted frames
+        // from the previous (aborted) turn — see AgentTurnTransport::
+        // kill_for_rollback.
         let rollback_state = Arc::clone(&state);
         spawn_admin_socket(ks, sock_path, move || {
             let cancelled = rollback_state.cancel_all_in_flight();
+            // Spawn the harness kills onto the runtime — the on_rollback
+            // hook is a synchronous Fn() and `kill_for_rollback` is async.
+            let harness_state = Arc::clone(&rollback_state);
+            tokio::spawn(async move {
+                let count = harness_state.harnesses.len();
+                for (agent, harness) in harness_state.harnesses.iter() {
+                    tracing::warn!(
+                        agent = %agent,
+                        "killing runtime harness after KillSwitch ROLLBACK"
+                    );
+                    harness.kill_for_rollback().await;
+                }
+                tracing::warn!(
+                    event = "KILL_SWITCH_HARNESSES_KILLED",
+                    harnesses_killed = count,
+                    "killed every registered runtime harness on ROLLBACK"
+                );
+            });
             tracing::warn!(
                 event = "KILL_SWITCH_ACTIVATED",
                 cancelled_turns = cancelled,
@@ -8744,6 +8800,50 @@ spec:
                 "expected a shutting-down error, got: {err}"
             ),
         }
+    }
+
+    /// sera-40y3: `kill_for_rollback` kills the live child and clears the
+    /// harness slot so the next `acquire` respawns. Without this, the
+    /// runtime child keeps running and its NDJSON stdout still buffers
+    /// the aborted turn's `TurnCompleted` frame — the next post-DISARM
+    /// submission would read it as its own reply.
+    #[tokio::test]
+    async fn supervisor_kill_for_rollback_forces_respawn() {
+        let supervisor = RuntimeChildSupervisor::start_with_factory("agent", || async {
+            StdioHarness::spawn_mock().await
+        })
+        .await
+        .expect("initial spawn");
+
+        let gen0 = supervisor.current_generation().await;
+        // Warm the harness so a real child is live.
+        let _ = supervisor.acquire().await.expect("acquire before rollback");
+        assert_eq!(supervisor.current_generation().await, gen0);
+
+        // Operator fires ROLLBACK — kill the harness.
+        supervisor.kill_for_rollback().await;
+
+        // Next acquire must respawn (gen incremented) and produce a
+        // healthy harness — proves the stale child was disposed of.
+        let h1 = supervisor
+            .acquire()
+            .await
+            .expect("acquire after kill_for_rollback must respawn");
+        let gen1 = supervisor.current_generation().await;
+        assert!(
+            gen1 > gen0,
+            "kill_for_rollback must force a fresh generation \
+             (gen0={gen0} gen1={gen1})"
+        );
+        let events = h1
+            .send_turn(Vec::new(), "40y3-post-rollback")
+            .await
+            .expect("respawned harness answers normally");
+        assert_eq!(
+            events.response, "mock response",
+            "post-rollback harness must come from a fresh child, not a \
+             stale buffer"
+        );
     }
 
     /// End-to-end through `execute_turn`: a cold-crashed initial child must

--- a/rust/crates/sera-gateway/src/bin/sera.rs
+++ b/rust/crates/sera-gateway/src/bin/sera.rs
@@ -4885,19 +4885,21 @@ async fn run_start(config: PathBuf, port: u16, local: bool) -> anyhow::Result<()
         let sock_path = admin_sock_path();
         // sera-bsem: the rollback callback also cancels every in-flight
         // turn/steer so wedged runtimes release their lane slots promptly.
-        // sera-40y3: it also kills every registered runtime harness so the
+        // sera-40y3: it also kills every registered runtime harness and
+        // awaits completion before replying to the admin socket so the
         // post-DISARM resume path cannot read stale TurnCompleted frames
         // from the previous (aborted) turn — see AgentTurnTransport::
         // kill_for_rollback.
         let rollback_state = Arc::clone(&state);
         spawn_admin_socket(ks, sock_path, move || {
-            let cancelled = rollback_state.cancel_all_in_flight();
-            // Spawn the harness kills onto the runtime — the on_rollback
-            // hook is a synchronous Fn() and `kill_for_rollback` is async.
-            let harness_state = Arc::clone(&rollback_state);
-            tokio::spawn(async move {
-                let count = harness_state.harnesses.len();
-                for (agent, harness) in harness_state.harnesses.iter() {
+            let state = Arc::clone(&rollback_state);
+            Box::pin(async move {
+                let cancelled = state.cancel_all_in_flight();
+                // Kill every registered harness inline so harness resets
+                // complete before the caller can issue DISARM and resume
+                // serving.
+                let count = state.harnesses.len();
+                for (agent, harness) in state.harnesses.iter() {
                     tracing::warn!(
                         agent = %agent,
                         "killing runtime harness after KillSwitch ROLLBACK"
@@ -4905,16 +4907,12 @@ async fn run_start(config: PathBuf, port: u16, local: bool) -> anyhow::Result<()
                     harness.kill_for_rollback().await;
                 }
                 tracing::warn!(
-                    event = "KILL_SWITCH_HARNESSES_KILLED",
+                    event = "KILL_SWITCH_ACTIVATED",
+                    cancelled_turns = cancelled,
                     harnesses_killed = count,
-                    "killed every registered runtime harness on ROLLBACK"
+                    "ROLLBACK received on admin socket — gateway halted"
                 );
-            });
-            tracing::warn!(
-                event = "KILL_SWITCH_ACTIVATED",
-                cancelled_turns = cancelled,
-                "ROLLBACK received on admin socket — gateway halted"
-            );
+            })
         });
     }
 

--- a/rust/crates/sera-gateway/src/kill_switch.rs
+++ b/rust/crates/sera-gateway/src/kill_switch.rs
@@ -13,10 +13,18 @@
 //!
 //! Source of truth: SPEC-gateway §7a.4 and SPEC-self-evolution §13.
 
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use serde::{Deserialize, Serialize};
+
+/// A boxed async future returned by the `on_rollback` callback passed to
+/// [`spawn_admin_socket`]. The admin socket task awaits this future before
+/// writing the `"OK\n"` response, so all harness kills complete before the
+/// caller can issue `DISARM` and resume serving.
+pub type RollbackFuture = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
 
 /// Default admin socket path (Unix).
 pub const DEFAULT_ADMIN_SOCK: &str = "/var/lib/sera/admin.sock";
@@ -184,14 +192,16 @@ pub enum KillSwitchError {
 /// dispatches via [`KillSwitch::handle_command`], writes the response, and
 /// closes. Authentication is by OS file ownership (`0600` permissions).
 ///
-/// `on_rollback` is called (synchronously within the task) after every
-/// successful `ROLLBACK` command — use it to emit DB audit events.
+/// `on_rollback` is called and **awaited** after every successful `ROLLBACK`
+/// command before the `"OK\n"` response is written back to the caller. This
+/// ensures that all harness kills complete (and serving cannot resume via
+/// `DISARM`) until the callback future resolves.
 ///
 /// This function is a no-op on non-Unix targets (see `#[cfg(unix)]`).
 #[cfg(unix)]
 pub fn spawn_admin_socket<F>(ks: Arc<KillSwitch>, socket_path: String, on_rollback: F)
 where
-    F: Fn() + Send + Sync + 'static,
+    F: Fn() -> RollbackFuture + Send + Sync + 'static,
 {
     use std::os::unix::fs::PermissionsExt;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -246,7 +256,10 @@ where
             let command = String::from_utf8_lossy(&buf[..n]);
             let (response, did_rollback) = ks.handle_command(&command);
             if did_rollback {
-                on_rollback();
+                // Await the callback before replying so all harness kills
+                // complete before the caller can issue DISARM and resume
+                // serving (sera-40y3).
+                on_rollback().await;
             }
             let _ = stream.write_all(response.as_bytes()).await;
         }
@@ -257,7 +270,7 @@ where
 #[cfg(not(unix))]
 pub fn spawn_admin_socket<F>(_ks: Arc<KillSwitch>, _socket_path: String, _on_rollback: F)
 where
-    F: Fn() + Send + Sync + 'static,
+    F: Fn() -> RollbackFuture + Send + Sync + 'static,
 {
     tracing::info!("Admin kill-switch socket not supported on this platform");
 }
@@ -445,6 +458,7 @@ mod socket_tests {
 
         spawn_admin_socket(Arc::clone(&ks), path.clone(), move || {
             flag.store(true, Ordering::SeqCst);
+            Box::pin(async {})
         });
 
         // Give the listener a moment to bind.
@@ -469,7 +483,7 @@ mod socket_tests {
         let ks = Arc::new(KillSwitch::new());
         let path = format!("/tmp/sera-test-status-{}.sock", std::process::id());
 
-        spawn_admin_socket(Arc::clone(&ks), path.clone(), || {});
+        spawn_admin_socket(Arc::clone(&ks), path.clone(), || Box::pin(async {}));
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
         let mut stream = UnixStream::connect(&path).unwrap();
@@ -486,7 +500,7 @@ mod socket_tests {
         let ks = Arc::new(KillSwitch::new());
         let path = format!("/tmp/sera-test-disarm-{}.sock", std::process::id());
 
-        spawn_admin_socket(Arc::clone(&ks), path.clone(), || {});
+        spawn_admin_socket(Arc::clone(&ks), path.clone(), || Box::pin(async {}));
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
         // Arm it.

--- a/rust/crates/sera-gateway/tests/killswitch_abort.rs
+++ b/rust/crates/sera-gateway/tests/killswitch_abort.rs
@@ -55,6 +55,7 @@ async fn rollback_cancels_registered_tokens_within_one_second() {
         for (_key, token) in map.drain() {
             token.cancel();
         }
+        Box::pin(async {})
     });
 
     // Give the listener a moment to bind.
@@ -132,6 +133,7 @@ async fn rollback_does_not_retroactively_cancel_late_registrations() {
         for (_key, token) in map.drain() {
             token.cancel();
         }
+        Box::pin(async {})
     });
     tokio::time::sleep(Duration::from_millis(50)).await;
 


### PR DESCRIPTION
## Summary

Companion to sera-bsem (#1069). `cancel_all_in_flight` flips Tokio cancellation tokens, but the runtime child process keeps running and its NDJSON stdout still buffers whatever frames it emitted (stale `TurnCompleted`, partial deltas). On DISARM-and-resume without a gateway restart, the next submission would read those stale frames as its own reply — cross-turn state corruption.

Implementation:

- New `AgentTurnTransport::kill_for_rollback` (default no-op) — async, called from the ROLLBACK callback after `cancel_all_in_flight`.
- `RuntimeChildSupervisor::kill_for_rollback` — `start_kill()` the live child and clear the `harness` slot so the next `acquire()` respawns fresh. Best-effort: log if the child is already gone.
- The on_rollback closure (still a sync `Fn()`) `tokio::spawn`s a task that iterates every registered harness and awaits `kill_for_rollback`.
- `EmbeddedRuntimeTransport`, `InProcessTransport`, `DummyTransport`, and any test doubles inherit the trait default — they have no subprocess to invalidate.

Closes sera-40y3.

## Test plan
- [x] `cargo check -p sera-gateway` (default and `--all-features`)
- [x] `cargo test -p sera-gateway --bin sera-gateway supervisor_kill_for_rollback` — 1 passed
- [x] `cargo clippy -p sera-gateway -- -D warnings` (clean)
- [x] New `supervisor_kill_for_rollback_forces_respawn` test verifies generation increments and the respawned harness answers from a fresh child.

🤖 Generated with [Claude Code](https://claude.com/claude-code)