### PR TITLE
qa(docker-compose.rust.yaml): publish sera-gateway on host :3002, dual-stack (sera-jefd)

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ A React 19 + Vite + Tailwind v4 SPA against the rust gateway. Five pages: dashbo
 docker compose -f docker-compose.rust.yaml up --build
 ```
 
-Starts Postgres (with pgvector), Centrifugo, `sera-gateway` on :3001, and the web operator console on <http://localhost:5173>. The gateway auto-detects `DATABASE_URL` and switches from SQLite to Postgres for all stores; pgvector replaces the SQLite hybrid store for Tier-1 semantic memory; Centrifugo enables multi-pod thought streaming.
+Starts Postgres (with pgvector), Centrifugo, `sera-gateway` on :3002 (host port; container listens on :3001), and the web operator console on <http://localhost:5173>. The gateway auto-detects `DATABASE_URL` and switches from SQLite to Postgres for all stores; pgvector replaces the SQLite hybrid store for Tier-1 semantic memory; Centrifugo enables multi-pod thought streaming.
 
 ## Memory tiers
 

--- a/docker-compose.rust.yaml
+++ b/docker-compose.rust.yaml
@@ -12,8 +12,14 @@
 # Host port assignments (chosen to avoid collisions on dev machine):
 #   5434  → postgres:5432       (5432 = hindsight-db internal, 5433 = radio-player)
 #   8001  → centrifugo:8000     (8000 = portainer internal, 8100 = radio-player centrifugo)
-#   3001  → sera-gateway:3001
+#   3002  → sera-gateway:3001   (3001 = the local rust/docker-compose.sera.yml stack)
 #   5173  → sera-web:80         (matches the dev `bun run dev` port)
+#
+# sera-jefd: published on both 0.0.0.0 and [::] so Windows 11 / WSL2 mirrored
+# networking can reach the container — the IPv4-only publish in rust/docker-
+# compose.sera.yml's sibling note still applies here. Host port is 3002 so
+# both stacks (`docker-compose.rust.yaml` and `rust/docker-compose.sera.yml`)
+# can run side-by-side without colliding on :3001.
 #
 # Provider endpoints default to host.docker.internal so a locally-running
 # Ollama or LM Studio on the host is reachable from inside the container.
@@ -82,8 +88,13 @@ services:
       RUST_LOG: ${RUST_LOG:-info}
     volumes:
       - sera_logs:/app/logs
+    # sera-jefd: host port 3002 → container 3001 to avoid colliding with the
+    # rust/docker-compose.sera.yml stack already publishing :3001. Dual-stack
+    # publish so localhost resolves on both v4 and v6 (Windows 11 / WSL2
+    # mirrored mode resolves localhost as ::1 first).
     ports:
-      - "3001:3001"
+      - "0.0.0.0:3002:3001"
+      - "[::]:3002:3001"
     networks:
       - sera_net
     healthcheck:

--- a/rust/crates/sera-eval/src/bin/sera-eval-first-run.rs
+++ b/rust/crates/sera-eval/src/bin/sera-eval-first-run.rs
@@ -53,7 +53,10 @@ use sera_eval::{EvalStore, HarnessConfig};
 
 const MODEL: &str = "qwen/qwen3.6-35b-a3b";
 const LM_STUDIO_BASE: &str = "http://127.0.0.1:1234/v1";
-const SERA_ENDPOINT_DEFAULT: &str = "http://127.0.0.1:3001";
+// docker-compose.rust.yaml publishes sera-gateway on host :3002 to avoid
+// colliding with rust/docker-compose.sera.yml which uses :3001.
+// Override via SERA_ENDPOINT env var for other setups.
+const SERA_ENDPOINT_DEFAULT: &str = "http://127.0.0.1:3002";
 const SERA_CONTAINER_DEFAULT: &str = "rust-sera-1";
 const SERA_API_KEY_DEFAULT: &str =
     "605d685d121d2f50daf1b1e3be84b3161ff80d16e56d60df4e5be35f9ebca639";
@@ -838,7 +841,9 @@ fn render_report(
     md.push_str("\n## How to reproduce\n\n");
     md.push_str(
         "```bash\n\
-         # from repo root; SERA gateway must be running at :3001 and LM Studio at :1234\n\
+         # from repo root; SERA gateway must be running at :3002 (docker-compose.rust.yaml)\n\
+         # or set SERA_ENDPOINT=http://127.0.0.1:3001 for the rust/docker-compose.sera.yml stack\n\
+         # LM Studio must be running at :1234\n\
          cd rust && cargo run -p sera-eval --bin sera-eval-first-run\n\
          ```\n\n",
     );


### PR DESCRIPTION
## Summary

The enterprise compose (`docker-compose.rust.yaml`) bound the host's :3001, conflicting with the local `rust/docker-compose.sera.yml` stack that also publishes :3001. Booting one while the other was running failed at port-bind.

Changes:
- Host port for `sera-gateway` moves from `3001:3001` to `3002:3001` so both stacks can run side-by-side.
- Publish on both `0.0.0.0` and `[::]` so Windows 11 / WSL2 mirrored networking can reach the container — matches the existing pattern in `rust/docker-compose.sera.yml` and the dual-stack note in `rust/CLAUDE.md` Learnings.
- Header port table updated.

Closes sera-jefd.

## Test plan
- [x] `docker compose -f docker-compose.rust.yaml config --quiet` (YAML valid)
- [ ] Manual smoke (operator): both stacks bootable simultaneously without port-bind error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)