### PR TITLE
feat(sera-gateway): Mail workflow gate + InMemoryMailLookup wiring (sera-0zch)

### DIFF
--- a/rust/crates/sera-gateway/src/bin/sera.rs
+++ b/rust/crates/sera-gateway/src/bin/sera.rs
@@ -1219,9 +1219,11 @@ struct AppState {
     /// `POST /api/mail/inbound` webhook.
     mail_correlator: Arc<HeaderMailCorrelator>,
     /// Scheduler-side [`sera_workflow::MailLookup`] fed by the correlator.
-    /// Exported so workflow DI can consume it when the ready-queue wires
-    /// through here; the correlator pushes `ReplyReceived` events into it.
-    #[allow(dead_code)]
+    /// The scheduler consults this on every tick to resolve Mail-gate tasks;
+    /// the correlator pushes `ReplyReceived`/`Closed` events into it via
+    /// `POST /api/mail/inbound`. Also exposed via `WorkflowAppState::mail_lookup`
+    /// so the `POST /api/workflow/mail/deliver` test endpoint can inject events
+    /// directly without real SMTP/IMAP infrastructure.
     mail_lookup: Arc<InMemoryMailLookup>,
     // ── Phase-3 SPEC-interop ─────────────────────────────────────────────────
     /// Known A2A peers and the inbound router (SPEC-interop §4).
@@ -1543,6 +1545,9 @@ impl WorkflowAppState for AppState {
     }
     fn workflow_store(&self) -> Arc<dyn WorkflowTaskStore> {
         Arc::clone(&self.workflow_store)
+    }
+    fn mail_lookup(&self) -> Arc<InMemoryMailLookup> {
+        Arc::clone(&self.mail_lookup)
     }
 }
 
@@ -4835,13 +4840,14 @@ async fn run_start(config: PathBuf, port: u16, local: bool) -> anyhow::Result<()
         event_loop(event_state, discord_rx).await;
     });
 
-    // 4a. Spawn workflow scheduler (sera-kgi8, Wave E Phase 1). Ticks every
+    // 4a. Spawn workflow scheduler (sera-kgi8 + sera-0zch). Ticks every
     // TICK_INTERVAL, asks sera-workflow which pending tasks are ready, and
-    // marks them resolved on the store. Only Timer gates are wired
-    // end-to-end in Phase 1 — other AwaitType variants stay pending until
-    // their dedicated beads add real lookups.
+    // marks them resolved on the store. Timer and Mail gates are wired
+    // end-to-end; other AwaitType variants stay pending until their dedicated
+    // beads add real lookups.
     spawn_scheduler(
         Arc::clone(&state.workflow_store),
+        Arc::clone(&state.mail_lookup),
         Arc::clone(&shutting_down),
     );
 
@@ -5239,7 +5245,7 @@ fn build_router(state: Arc<AppState>) -> Router {
             "/api/hitl/requests/{id}/escalate",
             post(route_hitl::escalate_ticket::<AppState>),
         )
-        // ── sera-kgi8: workflow task scheduler (Wave E Phase 1) ──────────────
+        // ── sera-kgi8 / sera-0zch: workflow task scheduler ───────────────────
         .route(
             "/api/workflow/tasks",
             post(route_workflow::create_task::<AppState>)
@@ -5248,6 +5254,11 @@ fn build_router(state: Arc<AppState>) -> Router {
         .route(
             "/api/workflow/tasks/{id}",
             get(route_workflow::get_task::<AppState>),
+        )
+        // sera-0zch: in-memory mail delivery for test/dev — no real SMTP/IMAP.
+        .route(
+            "/api/workflow/mail/deliver",
+            post(route_workflow::deliver_mail::<AppState>),
         )
         // ── sera-7ivj: OpenAI-compatible inference proxy ─────────────────────
         .route(

--- a/rust/crates/sera-gateway/src/routes/workflow.rs
+++ b/rust/crates/sera-gateway/src/routes/workflow.rs
@@ -1,14 +1,14 @@
-//! Workflow task HTTP routes — Wave E Phase 1 (sera-kgi8).
+//! Workflow task HTTP routes — Wave E Phase 1 (sera-kgi8) + Mail gate (sera-0zch).
 //!
 //! Routes:
-//!   POST /api/workflow/tasks      — create a task (Timer gate only in Phase 1)
-//!   GET  /api/workflow/tasks      — list every known task
-//!   GET  /api/workflow/tasks/{id} — fetch a single task
+//!   POST /api/workflow/tasks           — create a task (Timer and Mail gates)
+//!   GET  /api/workflow/tasks           — list every known task
+//!   GET  /api/workflow/tasks/{id}      — fetch a single task
+//!   POST /api/workflow/mail/deliver    — deliver a mail event (in-memory; for tests)
 //!
-//! Non-Timer `await_type` values are accepted by the schema but return
-//! 501 Not Implemented — their wiring ships in follow-up beads (Human:
-//! sera-dgk1, GhPr: sera-comg, GhRun: sera-4fel, Change: sera-7ggi,
-//! Mail: sera-0zch).
+//! Timer and Mail are fully wired end-to-end. Other non-Timer `await_type`
+//! values still return 501 Not Implemented — their wiring ships in follow-up
+//! beads (Human: sera-dgk1, GhPr: sera-comg, GhRun: sera-4fel, Change: sera-7ggi).
 #![allow(dead_code)]
 
 use std::sync::Arc;
@@ -21,7 +21,8 @@ use axum::{
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use sera_workflow::task::WorkflowTaskInput;
+use sera_mail::InMemoryMailLookup;
+use sera_workflow::task::{MailEvent, MailThreadId, WorkflowTaskInput};
 use sera_workflow::{AwaitType, WorkflowTask, WorkflowTaskStatus, WorkflowTaskType};
 
 use sera_gateway::workflow_store::{
@@ -48,9 +49,9 @@ pub enum AwaitTypeTag {
 
 /// Create-task request body.
 ///
-/// Phase 1 Timer-only path: pass `await_type = "timer"` and a `deadline`.
-/// `title` / `description` are optional — defaults keep the synthetic
-/// "wait for deadline" task compact when the caller doesn't care.
+/// - `timer` gate: supply `deadline`.
+/// - `mail` gate: supply `thread_id` (opaque string identifying the email thread).
+/// - `title` / `description` are always optional.
 #[derive(Debug, Deserialize)]
 pub struct CreateTaskRequest {
     pub await_type: AwaitTypeTag,
@@ -59,6 +60,10 @@ pub struct CreateTaskRequest {
     /// Required for `timer` await_type; ignored otherwise.
     #[serde(default)]
     pub deadline: Option<DateTime<Utc>>,
+    /// Required for `mail` await_type; the opaque thread identifier (e.g. RFC
+    /// 2822 Message-ID) the scheduler will watch for a terminal [`MailEvent`].
+    #[serde(default)]
+    pub thread_id: Option<String>,
     #[serde(default)]
     pub title: Option<String>,
     #[serde(default)]
@@ -122,6 +127,10 @@ fn check_auth(api_key: &Option<String>, headers: &HeaderMap) -> Result<(), Statu
 pub trait WorkflowAppState: Send + Sync + 'static {
     fn api_key(&self) -> &Option<String>;
     fn workflow_store(&self) -> Arc<dyn WorkflowTaskStore>;
+    /// The in-memory mail lookup shared with the scheduler. Required for the
+    /// `POST /api/workflow/mail/deliver` endpoint to inject test events without
+    /// real SMTP/IMAP infrastructure.
+    fn mail_lookup(&self) -> Arc<InMemoryMailLookup>;
 }
 
 // ── Handlers ─────────────────────────────────────────────────────────────────
@@ -137,14 +146,18 @@ where
 {
     check_auth(state.api_key(), &headers)?;
 
-    // Phase 1: only Timer is wired end-to-end. Other variants are accepted
-    // at the tag level but short-circuit with 501 — their gate wiring lands
-    // in follow-up beads (Human: sera-dgk1, GhPr: sera-comg, GhRun:
-    // sera-4fel, Change: sera-7ggi, Mail: sera-0zch).
+    // Timer and Mail are wired end-to-end. Other variants are accepted at the
+    // tag level but short-circuit with 501 — their gate wiring lands in
+    // follow-up beads (Human: sera-dgk1, GhPr: sera-comg, GhRun: sera-4fel,
+    // Change: sera-7ggi).
     let await_type = match body.await_type {
         AwaitTypeTag::Timer => {
             let deadline = body.deadline.ok_or(StatusCode::BAD_REQUEST)?;
             AwaitType::Timer { not_before: deadline }
+        }
+        AwaitTypeTag::Mail => {
+            let thread_id = body.thread_id.ok_or(StatusCode::BAD_REQUEST)?;
+            AwaitType::Mail { thread_id: MailThreadId::new(thread_id) }
         }
         _ => return Err(StatusCode::NOT_IMPLEMENTED),
     };
@@ -215,6 +228,46 @@ where
     Ok(Json(record.into()))
 }
 
+// ── Mail deliver (in-memory, for tests) ──────────────────────────────────────
+
+/// Request body for `POST /api/workflow/mail/deliver`.
+#[derive(Debug, Deserialize)]
+pub struct MailDeliverRequest {
+    /// The thread id previously used when creating the Mail-gate task.
+    pub thread_id: String,
+    /// The event to inject: `"reply_received"` or `"closed"`.
+    pub event: MailEvent,
+}
+
+/// `POST /api/workflow/mail/deliver` — inject a mail event into the in-memory
+/// lookup so the scheduler resolves any pending Mail-gate task watching that
+/// thread.
+///
+/// This endpoint is deliberately in-memory only: no real SMTP/IMAP involved.
+/// Production delivery comes via `POST /api/mail/inbound` → correlator →
+/// lookup. This route exists purely for test harnesses that need to drive the
+/// full wait-then-resume cycle without running a mail server.
+pub async fn deliver_mail<S>(
+    State(state): State<Arc<S>>,
+    headers: HeaderMap,
+    Json(body): Json<MailDeliverRequest>,
+) -> Result<StatusCode, StatusCode>
+where
+    S: WorkflowAppState,
+{
+    check_auth(state.api_key(), &headers)?;
+
+    let thread_id = MailThreadId::new(body.thread_id);
+    // gate_id is opaque for in-memory delivery; use a fixed sentinel.
+    let gate_id = sera_mail::GateId::new("direct-deliver");
+    state
+        .mail_lookup()
+        .notify(gate_id, &thread_id, body.event)
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
 // ── Tests ────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -232,6 +285,7 @@ mod tests {
     struct TestState {
         api_key: Option<String>,
         store: Arc<InMemoryWorkflowTaskStore>,
+        mail: Arc<InMemoryMailLookup>,
     }
 
     impl TestState {
@@ -239,6 +293,7 @@ mod tests {
             Arc::new(Self {
                 api_key: key.map(|k| k.to_owned()),
                 store: Arc::new(InMemoryWorkflowTaskStore::new()),
+                mail: Arc::new(InMemoryMailLookup::new()),
             })
         }
     }
@@ -250,6 +305,9 @@ mod tests {
         fn workflow_store(&self) -> Arc<dyn WorkflowTaskStore> {
             Arc::clone(&self.store) as Arc<dyn WorkflowTaskStore>
         }
+        fn mail_lookup(&self) -> Arc<InMemoryMailLookup> {
+            Arc::clone(&self.mail)
+        }
     }
 
     fn test_router(state: Arc<TestState>) -> Router {
@@ -257,6 +315,10 @@ mod tests {
             .route("/api/workflow/tasks", post(create_task::<TestState>))
             .route("/api/workflow/tasks", get(list_tasks::<TestState>))
             .route("/api/workflow/tasks/{id}", get(get_task::<TestState>))
+            .route(
+                "/api/workflow/mail/deliver",
+                post(deliver_mail::<TestState>),
+            )
             .with_state(state)
     }
 
@@ -374,5 +436,105 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn create_mail_task_returns_created() {
+        let app = test_router(TestState::new(None));
+        let body = serde_json::json!({
+            "await_type": "mail",
+            "agent_id": "sera",
+            "resume_token": "tok-mail-1",
+            "thread_id": "<msg-001@example.com>",
+        });
+        let resp = app
+            .oneshot(
+                Request::post("/api/workflow/tasks")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let view: WorkflowTaskView = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(view.agent_id, "sera");
+        assert_eq!(view.resume_token, "tok-mail-1");
+        assert_eq!(view.status, SchedulerTaskStatus::Pending);
+        // await_type must be Mail with the supplied thread_id.
+        assert!(matches!(
+            view.await_type,
+            Some(AwaitType::Mail { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn create_mail_task_missing_thread_id_is_bad_request() {
+        let app = test_router(TestState::new(None));
+        let body = serde_json::json!({
+            "await_type": "mail",
+            "agent_id": "sera",
+            "resume_token": "tok-mail-2",
+        });
+        let resp = app
+            .oneshot(
+                Request::post("/api/workflow/tasks")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn deliver_mail_returns_no_content() {
+        let state = TestState::new(None);
+        let app = test_router(Arc::clone(&state));
+        // First create a mail task so there's something to observe.
+        let create_body = serde_json::json!({
+            "await_type": "mail",
+            "agent_id": "sera",
+            "resume_token": "tok-mail-3",
+            "thread_id": "<msg-003@example.com>",
+        });
+        let _ = app
+            .clone()
+            .oneshot(
+                Request::post("/api/workflow/tasks")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&create_body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        // Deliver a reply_received event.
+        let deliver_body = serde_json::json!({
+            "thread_id": "<msg-003@example.com>",
+            "event": "reply_received",
+        });
+        let resp = app
+            .oneshot(
+                Request::post("/api/workflow/mail/deliver")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&deliver_body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+
+        // The lookup should now reflect the terminal event.
+        use sera_workflow::MailLookup;
+        use sera_workflow::task::MailThreadId;
+        let event = state
+            .mail
+            .thread_event(&MailThreadId::new("<msg-003@example.com>"));
+        assert_eq!(event, Some(MailEvent::ReplyReceived));
     }
 }

--- a/rust/crates/sera-gateway/src/scheduler.rs
+++ b/rust/crates/sera-gateway/src/scheduler.rs
@@ -1,4 +1,4 @@
-//! Workflow scheduler — Wave E Phase 1 (sera-kgi8).
+//! Workflow scheduler — Wave E Phase 1 (sera-kgi8) + Mail gate (sera-0zch).
 //!
 //! Wakes every [`TICK_INTERVAL`] and asks [`WorkflowTaskStore::list_pending`]
 //! for the current set of pending tasks. Each pending task is passed through
@@ -6,11 +6,10 @@
 //! `chrono::Utc::now` snapshot; tasks whose gates have resolved are marked
 //! resolved on the store.
 //!
-//! Phase 1 only wires the Timer gate end-to-end — the default
-//! [`ReadyContext`] exposes no-op lookups for the remaining await types, so
-//! Human / GhRun / GhPr / Change / Mail tasks created via the HTTP surface
-//! stay pending until their dedicated beads (sera-dgk1, sera-comg, sera-4fel,
-//! sera-7ggi, sera-0zch) add real lookups.
+//! Timer and Mail gates are fully wired end-to-end. Other await types
+//! (Human: sera-dgk1, GhPr: sera-comg, GhRun: sera-4fel, Change: sera-7ggi)
+//! use no-op lookups and stay pending until their dedicated beads add real
+//! lookup sources.
 //!
 //! Event emission: Phase 1 logs a `tracing::info!` line per resolution. Wiring
 //! to the session SSE stream / event bus is deferred to a follow-up bead — the
@@ -22,6 +21,8 @@ use std::time::Duration;
 
 use chrono::Utc;
 
+use sera_mail::InMemoryMailLookup;
+use sera_workflow::MailLookup;
 use sera_workflow::ready::{ReadyContext, ready_tasks_with_context};
 
 use crate::workflow_store::WorkflowTaskStore;
@@ -34,10 +35,18 @@ pub const TICK_INTERVAL: Duration = Duration::from_secs(5);
 /// Single scheduler pass: snapshot pending tasks, ask sera-workflow which
 /// are ready, and mark ready tasks resolved on the store.
 ///
+/// `mail_lookup` is consulted for every [`sera_workflow::task::AwaitType::Mail`]
+/// gate. Pass the `Arc<InMemoryMailLookup>` wired to the correlator for
+/// production; tests may construct a fresh lookup and call
+/// [`InMemoryMailLookup::notify`] directly to drive the gate.
+///
 /// Returns the number of tasks that transitioned from Pending → Resolved.
 /// Exposed as `pub` (not just `pub(crate)`) so integration tests can drive
 /// a single tick deterministically without racing the real ticker.
-pub async fn tick(store: Arc<dyn WorkflowTaskStore>) -> usize {
+pub async fn tick(
+    store: Arc<dyn WorkflowTaskStore>,
+    mail_lookup: Arc<InMemoryMailLookup>,
+) -> usize {
     let pending = store.list_pending().await;
     if pending.is_empty() {
         return 0;
@@ -49,7 +58,10 @@ pub async fn tick(store: Arc<dyn WorkflowTaskStore>) -> usize {
         pending.iter().map(|r| r.task.clone()).collect();
 
     let now = Utc::now();
-    let ctx = ReadyContext::default_noop();
+    let ctx = ReadyContext {
+        mail: mail_lookup.as_ref() as &dyn MailLookup,
+        ..ReadyContext::default_noop()
+    };
     let ready = ready_tasks_with_context(&tasks, now, &ctx);
 
     let mut resolved = 0;
@@ -70,6 +82,10 @@ pub async fn tick(store: Arc<dyn WorkflowTaskStore>) -> usize {
 
 /// Spawn the scheduler background task.
 ///
+/// `mail_lookup` is passed to every [`tick`] call so Mail-gate tasks resolve
+/// as soon as the correlator pushes a terminal [`sera_workflow::task::MailEvent`]
+/// into the lookup.
+///
 /// Ticks every [`TICK_INTERVAL`]. The loop exits when `shutting_down` flips
 /// to `true` — observed between ticks so an in-flight `tick` call is never
 /// interrupted mid-way.
@@ -80,6 +96,7 @@ pub async fn tick(store: Arc<dyn WorkflowTaskStore>) -> usize {
 /// background loops.
 pub fn spawn_scheduler(
     store: Arc<dyn WorkflowTaskStore>,
+    mail_lookup: Arc<InMemoryMailLookup>,
     shutting_down: Arc<AtomicBool>,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
@@ -102,7 +119,7 @@ pub fn spawn_scheduler(
             if shutting_down.load(Ordering::SeqCst) {
                 break;
             }
-            let resolved = tick(Arc::clone(&store)).await;
+            let resolved = tick(Arc::clone(&store), Arc::clone(&mail_lookup)).await;
             if resolved > 0 {
                 tracing::debug!(
                     event = "workflow_scheduler_tick",

--- a/rust/crates/sera-gateway/tests/workflow_mail_gate.rs
+++ b/rust/crates/sera-gateway/tests/workflow_mail_gate.rs
@@ -1,0 +1,197 @@
+//! End-to-end integration test for the Mail gate (sera-0zch).
+//!
+//! Exercises the full wait-then-deliver-then-resolve cycle without real SMTP/IMAP:
+//!
+//!  1. Create a Mail-gate task via the HTTP route.
+//!  2. Drive a scheduler tick — task must remain Pending (no mail yet).
+//!  3. Inject a terminal [`MailEvent::ReplyReceived`] via
+//!     [`InMemoryMailLookup::notify`].
+//!  4. Drive another tick — task must transition to Resolved.
+//!
+//! Also exercises [`spawn_scheduler`] end-to-end: starts the background task,
+//! injects a mail event, waits up to 10s for the scheduler to resolve the task.
+
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+
+use sera_gateway::scheduler::{spawn_scheduler, tick};
+use sera_gateway::workflow_store::{
+    InMemoryWorkflowTaskStore, SchedulerTaskStatus, WorkflowTaskRecord, WorkflowTaskStore,
+};
+use sera_mail::{GateId, InMemoryMailLookup};
+use sera_workflow::task::{MailEvent, MailThreadId, WorkflowTaskInput};
+use sera_workflow::{AwaitType, WorkflowTask, WorkflowTaskStatus, WorkflowTaskType};
+
+use chrono::Utc;
+
+fn make_mail_task(thread_id: &str) -> WorkflowTask {
+    let now = Utc::now();
+    let mut task = WorkflowTask::new(WorkflowTaskInput {
+        title: "mail gate exemplar".into(),
+        description: "sera-0zch".into(),
+        acceptance_criteria: Vec::new(),
+        status: WorkflowTaskStatus::Open,
+        priority: 5,
+        task_type: WorkflowTaskType::Meta,
+        source_formula: None,
+        source_location: None,
+        created_at: now,
+    });
+    task.await_type = Some(AwaitType::Mail {
+        thread_id: MailThreadId::new(thread_id),
+    });
+    task
+}
+
+fn pending_record(task: WorkflowTask, token: &str) -> WorkflowTaskRecord {
+    WorkflowTaskRecord {
+        task,
+        agent_id: "sera".into(),
+        resume_token: token.into(),
+        status: SchedulerTaskStatus::Pending,
+        resolved_at: None,
+    }
+}
+
+// ── tick-level tests ─────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn mail_gate_blocks_before_reply() {
+    let store = Arc::new(InMemoryWorkflowTaskStore::new());
+    let lookup = Arc::new(InMemoryMailLookup::new());
+
+    let task = make_mail_task("<thread-1@example.com>");
+    let task_id = task.id.to_string();
+    store.insert(pending_record(task, "tok-1")).await;
+
+    // No mail delivered yet — tick must NOT resolve.
+    let resolved = tick(Arc::clone(&store) as Arc<dyn WorkflowTaskStore>, Arc::clone(&lookup)).await;
+    assert_eq!(resolved, 0, "mail gate without reply must not resolve");
+
+    let rec = store.get(&task_id).await.unwrap();
+    assert_eq!(rec.status, SchedulerTaskStatus::Pending);
+    assert!(rec.resolved_at.is_none());
+}
+
+#[tokio::test]
+async fn mail_gate_resolves_after_reply_received() {
+    let store = Arc::new(InMemoryWorkflowTaskStore::new());
+    let lookup = Arc::new(InMemoryMailLookup::new());
+
+    let thread_id = MailThreadId::new("<thread-2@example.com>");
+    let task = make_mail_task(thread_id.as_str());
+    let task_id = task.id.to_string();
+    store.insert(pending_record(task, "tok-2")).await;
+
+    // Inject a terminal event.
+    lookup
+        .notify(GateId::new("test-gate"), &thread_id, MailEvent::ReplyReceived)
+        .unwrap();
+
+    let resolved = tick(Arc::clone(&store) as Arc<dyn WorkflowTaskStore>, Arc::clone(&lookup)).await;
+    assert_eq!(resolved, 1, "mail gate with reply must resolve on next tick");
+
+    let rec = store.get(&task_id).await.expect("record must still exist");
+    assert_eq!(rec.status, SchedulerTaskStatus::Resolved);
+    assert!(rec.resolved_at.is_some());
+}
+
+#[tokio::test]
+async fn mail_gate_resolves_on_closed() {
+    let store = Arc::new(InMemoryWorkflowTaskStore::new());
+    let lookup = Arc::new(InMemoryMailLookup::new());
+
+    let thread_id = MailThreadId::new("<thread-3@example.com>");
+    let task = make_mail_task(thread_id.as_str());
+    let task_id = task.id.to_string();
+    store.insert(pending_record(task, "tok-3")).await;
+
+    // Administratively close the thread — gate must also resolve.
+    lookup
+        .notify(GateId::new("test-gate"), &thread_id, MailEvent::Closed)
+        .unwrap();
+
+    let resolved = tick(Arc::clone(&store) as Arc<dyn WorkflowTaskStore>, Arc::clone(&lookup)).await;
+    assert_eq!(resolved, 1, "mail gate with Closed event must resolve");
+
+    let rec = store.get(&task_id).await.unwrap();
+    assert_eq!(rec.status, SchedulerTaskStatus::Resolved);
+}
+
+#[tokio::test]
+async fn mail_gate_stays_pending_on_non_terminal_event() {
+    let store = Arc::new(InMemoryWorkflowTaskStore::new());
+    let lookup = Arc::new(InMemoryMailLookup::new());
+
+    let thread_id = MailThreadId::new("<thread-4@example.com>");
+    let task = make_mail_task(thread_id.as_str());
+    let task_id = task.id.to_string();
+    store.insert(pending_record(task, "tok-4")).await;
+
+    // Inject a non-terminal Pending event — should not resolve.
+    lookup
+        .notify(GateId::new("test-gate"), &thread_id, MailEvent::Pending)
+        .unwrap();
+
+    let resolved = tick(Arc::clone(&store) as Arc<dyn WorkflowTaskStore>, Arc::clone(&lookup)).await;
+    assert_eq!(resolved, 0, "non-terminal mail event must not resolve gate");
+
+    let rec = store.get(&task_id).await.unwrap();
+    assert_eq!(rec.status, SchedulerTaskStatus::Pending);
+}
+
+// ── spawn_scheduler end-to-end test ─────────────────────────────────────────
+
+#[tokio::test]
+async fn scheduler_background_task_resolves_pending_mail() {
+    // Exercises spawn_scheduler end-to-end: start the background task, inject
+    // a reply event, wait briefly, and confirm the scheduler marked it resolved.
+    // Bounded by a 10s timeout so a stalled scheduler fails fast.
+    let store = Arc::new(InMemoryWorkflowTaskStore::new());
+    let lookup = Arc::new(InMemoryMailLookup::new());
+    let shutting_down = Arc::new(AtomicBool::new(false));
+
+    let handle = spawn_scheduler(
+        Arc::clone(&store) as Arc<dyn WorkflowTaskStore>,
+        Arc::clone(&lookup),
+        Arc::clone(&shutting_down),
+    );
+
+    let thread_id = MailThreadId::new("<thread-bg@example.com>");
+    let task = make_mail_task(thread_id.as_str());
+    let task_id = task.id.to_string();
+    store
+        .insert(WorkflowTaskRecord {
+            task,
+            agent_id: "sera".into(),
+            resume_token: "tok-bg".into(),
+            status: SchedulerTaskStatus::Pending,
+            resolved_at: None,
+        })
+        .await;
+
+    // Deliver a reply so the scheduler can resolve on its next tick.
+    lookup
+        .notify(GateId::new("test-gate"), &thread_id, MailEvent::ReplyReceived)
+        .unwrap();
+
+    // Poll for resolution — scheduler ticks every TICK_INTERVAL (5s).
+    // Allow up to 10s so a single missed tick boundary does not flake.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    let resolved = loop {
+        if let Some(rec) = store.get(&task_id).await
+            && rec.status == SchedulerTaskStatus::Resolved
+        {
+            break true;
+        }
+        if std::time::Instant::now() >= deadline {
+            break false;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    };
+
+    shutting_down.store(true, std::sync::atomic::Ordering::SeqCst);
+    drop(handle);
+
+    assert!(resolved, "background scheduler must resolve pending mail gate");
+}

--- a/rust/crates/sera-gateway/tests/workflow_timer.rs
+++ b/rust/crates/sera-gateway/tests/workflow_timer.rs
@@ -19,6 +19,7 @@ use sera_gateway::scheduler::{spawn_scheduler, tick};
 use sera_gateway::workflow_store::{
     InMemoryWorkflowTaskStore, SchedulerTaskStatus, WorkflowTaskRecord, WorkflowTaskStore,
 };
+use sera_mail::InMemoryMailLookup;
 use sera_workflow::task::WorkflowTaskInput;
 use sera_workflow::{AwaitType, WorkflowTask, WorkflowTaskStatus, WorkflowTaskType};
 
@@ -58,7 +59,11 @@ async fn timer_gate_resolves_after_deadline() {
     };
     store.insert(record).await;
 
-    let resolved = tick(Arc::clone(&store) as Arc<dyn WorkflowTaskStore>).await;
+    let resolved = tick(
+        Arc::clone(&store) as Arc<dyn WorkflowTaskStore>,
+        Arc::new(InMemoryMailLookup::new()),
+    )
+    .await;
     assert_eq!(resolved, 1, "timer gate with past deadline must resolve on first tick");
 
     let rec = store.get(&task_id).await.expect("record is still in store");
@@ -83,7 +88,11 @@ async fn timer_gate_blocks_before_deadline() {
     };
     store.insert(record).await;
 
-    let resolved = tick(Arc::clone(&store) as Arc<dyn WorkflowTaskStore>).await;
+    let resolved = tick(
+        Arc::clone(&store) as Arc<dyn WorkflowTaskStore>,
+        Arc::new(InMemoryMailLookup::new()),
+    )
+    .await;
     assert_eq!(resolved, 0, "future-deadline timer must not resolve");
 
     let rec = store.get(&task_id).await.unwrap();
@@ -102,6 +111,7 @@ async fn scheduler_background_task_resolves_pending_timer() {
 
     let handle = spawn_scheduler(
         Arc::clone(&store) as Arc<dyn WorkflowTaskStore>,
+        Arc::new(InMemoryMailLookup::new()),
         Arc::clone(&shutting_down),
     );
 


### PR DESCRIPTION
## Summary

- **Wire `InMemoryMailLookup` into the scheduler**: `tick` and `spawn_scheduler` now accept `Arc<InMemoryMailLookup>` and build a `ReadyContext` with it, so Mail-gate tasks resolve as soon as the lookup holds a terminal `MailEvent` (`ReplyReceived` or `Closed`). Removes the `#[allow(dead_code)]` that was suppressing the unused-field warning.
- **Mail gate in `POST /api/workflow/tasks`**: The `create_task` handler now accepts `await_type = "mail"` with a required `thread_id` field. All other non-Timer types still return 501.
- **`POST /api/workflow/mail/deliver`**: New in-memory delivery endpoint. Injects a `MailEvent` directly into `InMemoryMailLookup` for test/dev use without real SMTP/IMAP. Production delivery path (`POST /api/mail/inbound` → `HeaderMailCorrelator` → lookup) is unchanged.
- **`WorkflowAppState::mail_lookup()`**: New trait method so the deliver handler can access the shared lookup through the generic state abstraction.
- **Integration tests**: `tests/workflow_mail_gate.rs` adds 5 tests (block-before-reply, resolve-on-reply, resolve-on-close, non-terminal stays pending, `spawn_scheduler` end-to-end). `tests/workflow_timer.rs` updated for the new `tick`/`spawn_scheduler` signature — 3 existing tests still pass.

## Test plan

- [x] `cargo check -p sera-gateway -p sera-workflow -p sera-mail --all-features` — clean
- [x] `cargo clippy -p sera-gateway -p sera-workflow -p sera-mail -- -D warnings` — no issues
- [x] `cargo test -p sera-gateway --test workflow_mail_gate` — 5/5 passed
- [x] `cargo test -p sera-gateway --test workflow_timer` — 3/3 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)