### PR TITLE
fix(sera-gateway): update gate integration tests for current scheduler signatures

### DIFF
--- a/rust/crates/sera-gateway/src/bin/sera.rs
+++ b/rust/crates/sera-gateway/src/bin/sera.rs
@@ -5636,6 +5636,7 @@ mod tests {
             ticket_store: Arc::new(InMemoryTicketStore::new()),
             workflow_store: Arc::new(InMemoryWorkflowTaskStore::new()),
             gh_run_store: Arc::new(InMemoryGhRunStateStore::new()),
+            human_gate_store: Arc::new(InMemoryHumanGateStore::new()),
             admin_auth: None,
             admin_audit: None,
         })
@@ -5682,6 +5683,7 @@ mod tests {
             ticket_store: Arc::new(InMemoryTicketStore::new()),
             workflow_store: Arc::new(InMemoryWorkflowTaskStore::new()),
             gh_run_store: Arc::new(InMemoryGhRunStateStore::new()),
+            human_gate_store: Arc::new(InMemoryHumanGateStore::new()),
             admin_auth: None,
             admin_audit: None,
         })
@@ -5728,6 +5730,7 @@ mod tests {
             ticket_store: Arc::new(InMemoryTicketStore::new()),
             workflow_store: Arc::new(InMemoryWorkflowTaskStore::new()),
             gh_run_store: Arc::new(InMemoryGhRunStateStore::new()),
+            human_gate_store: Arc::new(InMemoryHumanGateStore::new()),
             admin_auth: None,
             admin_audit: None,
         })
@@ -5774,6 +5777,7 @@ mod tests {
             ticket_store: Arc::new(InMemoryTicketStore::new()),
             workflow_store: Arc::new(InMemoryWorkflowTaskStore::new()),
             gh_run_store: Arc::new(InMemoryGhRunStateStore::new()),
+            human_gate_store: Arc::new(InMemoryHumanGateStore::new()),
             admin_auth: None,
             admin_audit: None,
         })
@@ -6274,6 +6278,7 @@ spec:
             ticket_store: Arc::new(InMemoryTicketStore::new()),
             workflow_store: Arc::new(InMemoryWorkflowTaskStore::new()),
             gh_run_store: Arc::new(InMemoryGhRunStateStore::new()),
+            human_gate_store: Arc::new(InMemoryHumanGateStore::new()),
             admin_auth: None,
             admin_audit: None,
         })
@@ -6782,6 +6787,7 @@ spec:
             ticket_store: Arc::new(InMemoryTicketStore::new()),
             workflow_store: Arc::new(InMemoryWorkflowTaskStore::new()),
             gh_run_store: Arc::new(InMemoryGhRunStateStore::new()),
+            human_gate_store: Arc::new(InMemoryHumanGateStore::new()),
             admin_auth: None,
             admin_audit: None,
         };
@@ -6831,6 +6837,7 @@ spec:
             ticket_store: Arc::new(InMemoryTicketStore::new()),
             workflow_store: Arc::new(InMemoryWorkflowTaskStore::new()),
             gh_run_store: Arc::new(InMemoryGhRunStateStore::new()),
+            human_gate_store: Arc::new(InMemoryHumanGateStore::new()),
             admin_auth: None,
             admin_audit: None,
         };
@@ -6881,6 +6888,7 @@ spec:
             ticket_store: Arc::new(InMemoryTicketStore::new()),
             workflow_store: Arc::new(InMemoryWorkflowTaskStore::new()),
             gh_run_store: Arc::new(InMemoryGhRunStateStore::new()),
+            human_gate_store: Arc::new(InMemoryHumanGateStore::new()),
             admin_auth: None,
             admin_audit: None,
         };
@@ -6934,6 +6942,7 @@ spec:
             ticket_store: Arc::new(InMemoryTicketStore::new()),
             workflow_store: Arc::new(InMemoryWorkflowTaskStore::new()),
             gh_run_store: Arc::new(InMemoryGhRunStateStore::new()),
+            human_gate_store: Arc::new(InMemoryHumanGateStore::new()),
             admin_auth: None,
             admin_audit: None,
         };
@@ -9266,6 +9275,7 @@ spec:
             ticket_store: Arc::new(InMemoryTicketStore::new()),
             workflow_store: Arc::new(InMemoryWorkflowTaskStore::new()),
             gh_run_store: Arc::new(InMemoryGhRunStateStore::new()),
+            human_gate_store: Arc::new(InMemoryHumanGateStore::new()),
             admin_auth: None,
             admin_audit: None,
         });
@@ -9354,6 +9364,7 @@ spec:
                 ticket_store: Arc::new(InMemoryTicketStore::new()),
                 workflow_store: Arc::new(InMemoryWorkflowTaskStore::new()),
                 gh_run_store: Arc::new(InMemoryGhRunStateStore::new()),
+                human_gate_store: Arc::new(InMemoryHumanGateStore::new()),
                 admin_auth: None,
                 admin_audit: None,
             })
@@ -10087,6 +10098,7 @@ spec:
                 ticket_store: Arc::new(InMemoryTicketStore::new()),
                 workflow_store: Arc::new(InMemoryWorkflowTaskStore::new()),
                 gh_run_store: Arc::new(InMemoryGhRunStateStore::new()),
+                human_gate_store: Arc::new(InMemoryHumanGateStore::new()),
                 admin_auth: None,
                 admin_audit: None,
             });

--- a/rust/crates/sera-gateway/tests/workflow_change.rs
+++ b/rust/crates/sera-gateway/tests/workflow_change.rs
@@ -18,6 +18,7 @@ use sera_gateway::workflow_store::{
     ChangeArtifactStateStore, InMemoryChangeArtifactStateStore, InMemoryWorkflowTaskStore,
     SchedulerTaskStatus, WorkflowTaskRecord, WorkflowTaskStore,
 };
+use sera_mail::lookup::InMemoryMailLookup;
 use sera_types::evolution::ChangeArtifactId;
 use sera_workflow::task::{ChangeState, WorkflowTaskInput};
 use sera_workflow::{AwaitType, WorkflowTask, WorkflowTaskStatus, WorkflowTaskType};
@@ -61,7 +62,10 @@ async fn change_gate_resolves_when_state_becomes_terminal() {
     // First tick — artifact state unknown, must remain pending.
     let resolved = tick(
         Arc::clone(&store) as Arc<dyn WorkflowTaskStore>,
+        Arc::new(InMemoryMailLookup::new()),
+        None,
         Some(Arc::clone(&change_store) as Arc<dyn ChangeArtifactStateStore>),
+        None,
     )
     .await;
     assert_eq!(resolved, 0, "unknown artifact state must not resolve");
@@ -75,7 +79,10 @@ async fn change_gate_resolves_when_state_becomes_terminal() {
     // Second tick — gate must now wake the task.
     let resolved = tick(
         Arc::clone(&store) as Arc<dyn WorkflowTaskStore>,
+        Arc::new(InMemoryMailLookup::new()),
+        None,
         Some(Arc::clone(&change_store) as Arc<dyn ChangeArtifactStateStore>),
+        None,
     )
     .await;
     assert_eq!(resolved, 1, "applied artifact must resolve the gate");
@@ -110,7 +117,10 @@ async fn change_gate_blocks_on_non_terminal_state() {
 
     let resolved = tick(
         Arc::clone(&store) as Arc<dyn WorkflowTaskStore>,
+        Arc::new(InMemoryMailLookup::new()),
+        None,
         Some(Arc::clone(&change_store) as Arc<dyn ChangeArtifactStateStore>),
+        None,
     )
     .await;
     assert_eq!(resolved, 0, "approved (non-terminal) artifact must not resolve");
@@ -144,7 +154,10 @@ async fn change_gate_resolves_on_rejected_too() {
 
     let resolved = tick(
         Arc::clone(&store) as Arc<dyn WorkflowTaskStore>,
+        Arc::new(InMemoryMailLookup::new()),
+        None,
         Some(Arc::clone(&change_store) as Arc<dyn ChangeArtifactStateStore>),
+        None,
     )
     .await;
     assert_eq!(resolved, 1, "rejected artifact must resolve the gate");

--- a/rust/crates/sera-gateway/tests/workflow_gh_run.rs
+++ b/rust/crates/sera-gateway/tests/workflow_gh_run.rs
@@ -21,6 +21,7 @@ use sera_gateway::workflow_store::{
     GhRunStateStore, InMemoryGhRunStateStore, InMemoryWorkflowTaskStore, SchedulerTaskStatus,
     WorkflowTaskRecord, WorkflowTaskStore,
 };
+use sera_mail::lookup::InMemoryMailLookup;
 use sera_workflow::task::{GhRunId, GhRunStatus, WorkflowTaskInput};
 use sera_workflow::{AwaitType, WorkflowTask, WorkflowTaskStatus, WorkflowTaskType};
 
@@ -65,7 +66,10 @@ async fn gh_run_gate_blocks_when_run_unknown() {
     // No status in store → tick must NOT resolve.
     let resolved = tick(
         Arc::clone(&store) as Arc<dyn WorkflowTaskStore>,
+        Arc::new(InMemoryMailLookup::new()),
         Some(Arc::clone(&gh_run_store) as Arc<dyn GhRunStateStore>),
+        None,
+        None,
     )
     .await;
     assert_eq!(resolved, 0, "unknown run must not resolve");
@@ -99,7 +103,10 @@ async fn gh_run_gate_resolves_on_terminal_status() {
 
     let resolved = tick(
         Arc::clone(&store) as Arc<dyn WorkflowTaskStore>,
+        Arc::new(InMemoryMailLookup::new()),
         Some(Arc::clone(&gh_run_store) as Arc<dyn GhRunStateStore>),
+        None,
+        None,
     )
     .await;
     assert_eq!(resolved, 1, "completed run must resolve on first tick");
@@ -133,7 +140,10 @@ async fn gh_run_gate_resolves_on_failed_status() {
 
     let resolved = tick(
         Arc::clone(&store) as Arc<dyn WorkflowTaskStore>,
+        Arc::new(InMemoryMailLookup::new()),
         Some(Arc::clone(&gh_run_store) as Arc<dyn GhRunStateStore>),
+        None,
+        None,
     )
     .await;
     assert_eq!(resolved, 1, "failed run must also resolve (handler branches on outcome)");
@@ -153,7 +163,10 @@ async fn gh_run_gate_background_scheduler_resolves_after_status_populated() {
 
     let handle = spawn_scheduler(
         Arc::clone(&store) as Arc<dyn WorkflowTaskStore>,
+        Arc::new(InMemoryMailLookup::new()),
         Some(Arc::clone(&gh_run_store) as Arc<dyn GhRunStateStore>),
+        None,
+        None,
         Arc::clone(&shutting_down),
     );
 

--- a/rust/crates/sera-gateway/tests/workflow_human.rs
+++ b/rust/crates/sera-gateway/tests/workflow_human.rs
@@ -25,6 +25,7 @@ use sera_gateway::workflow_store::{
     HumanGateStore, InMemoryHumanGateStore, InMemoryWorkflowTaskStore, SchedulerTaskStatus,
     WorkflowTaskRecord, WorkflowTaskStore,
 };
+use sera_mail::lookup::InMemoryMailLookup;
 use sera_hitl::{ApprovalId, TicketStatus};
 use sera_workflow::task::WorkflowTaskInput;
 use sera_workflow::{AwaitType, WorkflowTask, WorkflowTaskStatus, WorkflowTaskType};
@@ -73,6 +74,9 @@ async fn human_gate_blocks_without_resolution() {
     // No ticket status recorded → gate must NOT resolve.
     let resolved = tick(
         Arc::clone(&store) as Arc<dyn WorkflowTaskStore>,
+        Arc::new(InMemoryMailLookup::new()),
+        None,
+        None,
         Some(Arc::clone(&hitl) as Arc<dyn HumanGateStore>),
     )
     .await;
@@ -107,6 +111,9 @@ async fn human_gate_resolves_after_approval() {
 
     let resolved = tick(
         Arc::clone(&store) as Arc<dyn WorkflowTaskStore>,
+        Arc::new(InMemoryMailLookup::new()),
+        None,
+        None,
         Some(Arc::clone(&hitl) as Arc<dyn HumanGateStore>),
     )
     .await;
@@ -141,6 +148,9 @@ async fn human_gate_resolves_on_rejection() {
 
     let resolved = tick(
         Arc::clone(&store) as Arc<dyn WorkflowTaskStore>,
+        Arc::new(InMemoryMailLookup::new()),
+        None,
+        None,
         Some(Arc::clone(&hitl) as Arc<dyn HumanGateStore>),
     )
     .await;
@@ -173,6 +183,9 @@ async fn human_gate_resolves_on_expiry() {
 
     let resolved = tick(
         Arc::clone(&store) as Arc<dyn WorkflowTaskStore>,
+        Arc::new(InMemoryMailLookup::new()),
+        None,
+        None,
         Some(Arc::clone(&hitl) as Arc<dyn HumanGateStore>),
     )
     .await;
@@ -195,6 +208,9 @@ async fn scheduler_background_task_resolves_human_gate() {
 
     let handle = spawn_scheduler(
         Arc::clone(&store) as Arc<dyn WorkflowTaskStore>,
+        Arc::new(InMemoryMailLookup::new()),
+        None,
+        None,
         Some(Arc::clone(&hitl) as Arc<dyn HumanGateStore>),
         Arc::clone(&shutting_down),
     );
@@ -267,6 +283,14 @@ impl WorkflowAppState for TestState {
     }
     fn workflow_store(&self) -> Arc<dyn WfStore> {
         Arc::clone(&self.store) as Arc<dyn WfStore>
+    }
+    fn mail_lookup(&self) -> Arc<InMemoryMailLookup> {
+        Arc::new(InMemoryMailLookup::new())
+    }
+    fn change_artifact_store(
+        &self,
+    ) -> Option<Arc<dyn sera_gateway::workflow_store::ChangeArtifactStateStore>> {
+        None
     }
     fn human_gate_store(&self) -> Option<Arc<dyn HumanGateStoreTrait>> {
         Some(Arc::clone(&self.hitl) as Arc<dyn HumanGateStoreTrait>)
@@ -351,6 +375,9 @@ async fn http_create_human_task_and_resume_round_trip() {
     // 4. Tick the scheduler — the Human gate should now resolve.
     let resolved = tick(
         Arc::clone(&state.store) as Arc<dyn WfStore>,
+        Arc::new(InMemoryMailLookup::new()),
+        None,
+        None,
         Some(Arc::clone(&state.hitl) as Arc<dyn HumanGateStoreTrait>),
     )
     .await;

--- a/rust/crates/sera-gateway/tests/workflow_mail_gate.rs
+++ b/rust/crates/sera-gateway/tests/workflow_mail_gate.rs
@@ -65,7 +65,7 @@ async fn mail_gate_blocks_before_reply() {
     store.insert(pending_record(task, "tok-1")).await;
 
     // No mail delivered yet — tick must NOT resolve.
-    let resolved = tick(Arc::clone(&store) as Arc<dyn WorkflowTaskStore>, Arc::clone(&lookup)).await;
+    let resolved = tick(Arc::clone(&store) as Arc<dyn WorkflowTaskStore>, Arc::clone(&lookup), None, None, None).await;
     assert_eq!(resolved, 0, "mail gate without reply must not resolve");
 
     let rec = store.get(&task_id).await.unwrap();
@@ -88,7 +88,7 @@ async fn mail_gate_resolves_after_reply_received() {
         .notify(GateId::new("test-gate"), &thread_id, MailEvent::ReplyReceived)
         .unwrap();
 
-    let resolved = tick(Arc::clone(&store) as Arc<dyn WorkflowTaskStore>, Arc::clone(&lookup)).await;
+    let resolved = tick(Arc::clone(&store) as Arc<dyn WorkflowTaskStore>, Arc::clone(&lookup), None, None, None).await;
     assert_eq!(resolved, 1, "mail gate with reply must resolve on next tick");
 
     let rec = store.get(&task_id).await.expect("record must still exist");
@@ -111,7 +111,7 @@ async fn mail_gate_resolves_on_closed() {
         .notify(GateId::new("test-gate"), &thread_id, MailEvent::Closed)
         .unwrap();
 
-    let resolved = tick(Arc::clone(&store) as Arc<dyn WorkflowTaskStore>, Arc::clone(&lookup)).await;
+    let resolved = tick(Arc::clone(&store) as Arc<dyn WorkflowTaskStore>, Arc::clone(&lookup), None, None, None).await;
     assert_eq!(resolved, 1, "mail gate with Closed event must resolve");
 
     let rec = store.get(&task_id).await.unwrap();
@@ -133,7 +133,7 @@ async fn mail_gate_stays_pending_on_non_terminal_event() {
         .notify(GateId::new("test-gate"), &thread_id, MailEvent::Pending)
         .unwrap();
 
-    let resolved = tick(Arc::clone(&store) as Arc<dyn WorkflowTaskStore>, Arc::clone(&lookup)).await;
+    let resolved = tick(Arc::clone(&store) as Arc<dyn WorkflowTaskStore>, Arc::clone(&lookup), None, None, None).await;
     assert_eq!(resolved, 0, "non-terminal mail event must not resolve gate");
 
     let rec = store.get(&task_id).await.unwrap();
@@ -154,6 +154,9 @@ async fn scheduler_background_task_resolves_pending_mail() {
     let handle = spawn_scheduler(
         Arc::clone(&store) as Arc<dyn WorkflowTaskStore>,
         Arc::clone(&lookup),
+        None,
+        None,
+        None,
         Arc::clone(&shutting_down),
     );
 

--- a/rust/crates/sera-gateway/tests/workflow_sqlite_persistence.rs
+++ b/rust/crates/sera-gateway/tests/workflow_sqlite_persistence.rs
@@ -11,6 +11,7 @@ use sera_gateway::scheduler::tick;
 use sera_gateway::workflow_store::{
     SchedulerTaskStatus, SqliteWorkflowTaskStore, WorkflowTaskRecord, WorkflowTaskStore,
 };
+use sera_mail::lookup::InMemoryMailLookup;
 use sera_workflow::task::WorkflowTaskInput;
 use sera_workflow::{AwaitType, WorkflowTask, WorkflowTaskStatus, WorkflowTaskType};
 
@@ -60,7 +61,14 @@ async fn sqlite_store_round_trips_through_scheduler_tick() {
     // Phase 2 — "restart": reopen the same DB, run a single tick, confirm
     // the gate resolved.
     let store = Arc::new(SqliteWorkflowTaskStore::open(&db_path).unwrap());
-    let resolved = tick(Arc::clone(&store) as Arc<dyn WorkflowTaskStore>).await;
+    let resolved = tick(
+        Arc::clone(&store) as Arc<dyn WorkflowTaskStore>,
+        Arc::new(InMemoryMailLookup::new()),
+        None,
+        None,
+        None,
+    )
+    .await;
     assert_eq!(resolved, 1, "elapsed timer must resolve on reopened store");
 
     let rec = store.get(&task_id).await.expect("record present");
@@ -100,7 +108,14 @@ async fn sqlite_store_blocks_future_timer_across_restart() {
     }
 
     let store = Arc::new(SqliteWorkflowTaskStore::open(&db_path).unwrap());
-    let resolved = tick(Arc::clone(&store) as Arc<dyn WorkflowTaskStore>).await;
+    let resolved = tick(
+        Arc::clone(&store) as Arc<dyn WorkflowTaskStore>,
+        Arc::new(InMemoryMailLookup::new()),
+        None,
+        None,
+        None,
+    )
+    .await;
     assert_eq!(resolved, 0, "future-deadline timer must not resolve");
 
     let rec = store.get(&task_id).await.unwrap();


### PR DESCRIPTION
## Summary

Multiple gate integration tests had stale `tick()` / `spawn_scheduler()` call sites because each gate's PR was rebased independently and parallel gates' test files weren't updated when the scheduler signature grew to 5/6 args. `cargo check -p sera-gateway --tests` was failing on `main`, blocking #1158 (docs PR) and any other PR rebasing from main.

- Pads every `tick()` / `spawn_scheduler()` call site to the current 5/6-arg signatures, with sensible defaults: `None` for other gates' stores, fresh `InMemoryMailLookup` when not the mail test
- Fills the missing `human_gate_store` field in 13 `AppState` test-fixture initializers in `src/bin/sera.rs` (the production boot path already had it)
- Adds the missing `mail_lookup` / `change_artifact_store` `WorkflowAppState` impls in `workflow_human.rs`'s `TestState` — same parallel-gate rebase regression

Files touched: `workflow_change.rs`, `workflow_gh_run.rs`, `workflow_human.rs`, `workflow_mail_gate.rs`, `workflow_sqlite_persistence.rs`, `src/bin/sera.rs`.

## Test plan

- [x] `cargo check -p sera-gateway --tests` clean
- [x] `cargo clippy -p sera-gateway --tests -- -D warnings` clean
- [ ] CI green