### PR TITLE
feat(sera-tui): J.2.2 drill-in stack — Enter push, Esc pop (sera-9vkz)

### DIFF
--- a/rust/crates/sera-tui/src/app/actions.rs
+++ b/rust/crates/sera-tui/src/app/actions.rs
@@ -156,6 +156,17 @@ pub enum Action {
     /// Escalate the focused inline Approval block in the transcript (J.1.4).
     #[allow(dead_code)]
     EscalateInlineBlock(String),
+    /// Drill into the `child_thread` of the currently focused Task block
+    /// (J.2.2 / sera-9vkz).  Pushes the child thread onto `App::thread_stack`.
+    /// Currently dispatched via the `Select` arm in `App::dispatch` when the
+    /// transcript pane is focused; reserved here for an explicit binding.
+    #[allow(dead_code)]
+    DrillIn,
+    /// Pop the top of `App::thread_stack` (J.2.2 / sera-9vkz).  Currently
+    /// dispatched via the `Back` arm in `App::dispatch`; reserved here for
+    /// an explicit binding.
+    #[allow(dead_code)]
+    DrillOut,
     /// No-op — used when a key doesn't match any binding.  Reducing to
     /// this instead of returning `Option<Action>` lets the dispatch table
     /// stay a plain `match`.

--- a/rust/crates/sera-tui/src/app/mod.rs
+++ b/rust/crates/sera-tui/src/app/mod.rs
@@ -252,6 +252,18 @@ pub struct App {
     /// bead will introduce a real pricing table; until then this stays 0.0
     /// for local backends.
     pub usage_cost_usd: f64,
+
+    /// **J.2.2 (sera-9vkz)** drill-in stack.  Each entry is a child
+    /// `ThreadView` cloned from a `Block::Task` when the operator pressed
+    /// Enter on it.  Empty = the root session transcript is active.
+    /// `DrillOut` pops one level; `Back` falls through to this before
+    /// resetting `focus`.  J.2.3 (sera-mfj3) wires live SSE streaming
+    /// into the topmost stack entry's `blocks`.
+    pub thread_stack: Vec<crate::views::blocks::ThreadView>,
+    /// Optional human-readable label for each stack entry, used by the
+    /// status bar breadcrumb (`└ Task(agent)`).  Same length as
+    /// `thread_stack` — index `i` labels the thread at depth `i+1`.
+    pub thread_stack_labels: Vec<String>,
 }
 
 impl App {
@@ -288,6 +300,61 @@ impl App {
             usage_prompt_tokens: 0,
             usage_completion_tokens: 0,
             usage_cost_usd: 0.0,
+            thread_stack: Vec::new(),
+            thread_stack_labels: Vec::new(),
+        }
+    }
+
+    /// **J.2.2 (sera-9vkz)** breadcrumb describing the current drill-in
+    /// depth.  Empty string when the root transcript is active.  Used by
+    /// the status bar to hint at the current child-thread context, e.g.
+    /// `└ Task(planner) › Task(executor)`.
+    pub fn drill_breadcrumb(&self) -> String {
+        if self.thread_stack_labels.is_empty() {
+            String::new()
+        } else {
+            format!("└ {}", self.thread_stack_labels.join(" › "))
+        }
+    }
+
+    /// **J.2.2 (sera-9vkz)** push the `child_thread` of the first
+    /// `Block::Task` in the active thread (root or topmost stacked) onto
+    /// `thread_stack`.  Returns `true` when a Task block was found and
+    /// pushed; `false` otherwise (no-op).
+    fn drill_in(&mut self) -> bool {
+        // Locate a Task block in the currently-active block list.
+        let active_blocks: &[crate::views::blocks::Block] = match self.thread_stack.last() {
+            Some(thread) => &thread.blocks,
+            None => &self.session.blocks,
+        };
+        let task = active_blocks.iter().find_map(|b| {
+            if let crate::views::blocks::Block::Task {
+                agent, child_thread, ..
+            } = b
+            {
+                Some((agent.clone(), child_thread.clone()))
+            } else {
+                None
+            }
+        });
+        if let Some((agent, child)) = task {
+            self.thread_stack.push(child);
+            self.thread_stack_labels.push(format!("Task({agent})"));
+            true
+        } else {
+            false
+        }
+    }
+
+    /// **J.2.2 (sera-9vkz)** pop the topmost entry from `thread_stack`.
+    /// Returns `true` when a level was popped; `false` when the stack was
+    /// already empty.
+    fn drill_out(&mut self) -> bool {
+        if self.thread_stack.pop().is_some() {
+            self.thread_stack_labels.pop();
+            true
+        } else {
+            false
         }
     }
 
@@ -474,6 +541,13 @@ impl App {
                     self.active_agent_id = Some(id.clone());
                     self.focus = ViewKind::Session;
                     self.pending.push(AppCommand::LoadSessionFor(id));
+                } else if self.focus == ViewKind::Session
+                    && self.session.focus == crate::views::session::ComposerFocus::Transcript
+                {
+                    // J.2.2 (sera-9vkz): Enter while the transcript pane is
+                    // focused drills into the first Task block in the active
+                    // thread.  No-op when no Task block is present.
+                    self.drill_in();
                 }
             }
             Action::SelectAgent(id) => {
@@ -482,10 +556,25 @@ impl App {
                 self.pending.push(AppCommand::LoadSessionFor(id));
             }
             Action::Back => {
-                if self.focus != ViewKind::Agents {
+                // J.2.2 (sera-9vkz): when drilled into a child thread, Back
+                // pops one level instead of bouncing back to the agent list.
+                if self.drill_out() {
+                    // Stack popped — stay on Session view.
+                } else if self.focus != ViewKind::Agents {
                     self.focus = ViewKind::Agents;
                     self.pending.push(AppCommand::RefreshCurrent);
                 }
+            }
+            Action::DrillIn => {
+                // Only meaningful while the Session view is active.  Looks
+                // for a Task block in the currently-active thread and
+                // pushes its `child_thread` onto the drill-in stack.
+                if self.focus == ViewKind::Session {
+                    self.drill_in();
+                }
+            }
+            Action::DrillOut => {
+                self.drill_out();
             }
             Action::Approve => {
                 if let ViewKind::Hitl = self.focus
@@ -1956,6 +2045,113 @@ mod tests {
             "expected EscalateInlineBlock(req-3), got: {:?}",
             app.pending.last()
         );
+    }
+
+    // --- J.2.2 (sera-9vkz) drill-in stack tests ---
+
+    fn task_block(task_id: &str, agent: &str) -> crate::views::blocks::Block {
+        crate::views::blocks::Block::Task {
+            task_id: task_id.into(),
+            agent: agent.into(),
+            summary: "doing things".into(),
+            child_thread: crate::views::blocks::ThreadView::default(),
+            expanded: false,
+        }
+    }
+
+    #[test]
+    fn drill_in_pushes_child_thread_onto_stack() {
+        let mut app = App::new(client(), TuiKeybindings::defaults());
+        app.focus = ViewKind::Session;
+        app.session.focus = crate::views::session::ComposerFocus::Transcript;
+        app.session.blocks.push(task_block("t-1", "planner"));
+        assert!(app.thread_stack.is_empty());
+        app.dispatch(Action::Select);
+        assert_eq!(app.thread_stack.len(), 1);
+        assert_eq!(app.thread_stack_labels, vec!["Task(planner)".to_owned()]);
+    }
+
+    #[test]
+    fn drill_in_noop_when_no_task_block_present() {
+        let mut app = App::new(client(), TuiKeybindings::defaults());
+        app.focus = ViewKind::Session;
+        app.session.focus = crate::views::session::ComposerFocus::Transcript;
+        // No task block in transcript.
+        app.dispatch(Action::Select);
+        assert!(app.thread_stack.is_empty());
+        assert!(app.thread_stack_labels.is_empty());
+    }
+
+    #[test]
+    fn back_pops_thread_stack_before_resetting_focus() {
+        let mut app = App::new(client(), TuiKeybindings::defaults());
+        app.focus = ViewKind::Session;
+        app.session.focus = crate::views::session::ComposerFocus::Transcript;
+        app.session.blocks.push(task_block("t-1", "planner"));
+        app.dispatch(Action::Select); // drill in
+        assert_eq!(app.thread_stack.len(), 1);
+        app.dispatch(Action::Back); // first Back pops the stack
+        assert!(app.thread_stack.is_empty());
+        // Focus stays on Session (we only popped a level, didn't bounce out).
+        assert_eq!(app.focus, ViewKind::Session);
+        // A second Back with empty stack falls through to the focus reset.
+        app.dispatch(Action::Back);
+        assert_eq!(app.focus, ViewKind::Agents);
+    }
+
+    #[test]
+    fn drill_out_action_pops_stack() {
+        let mut app = App::new(client(), TuiKeybindings::defaults());
+        app.focus = ViewKind::Session;
+        app.session.focus = crate::views::session::ComposerFocus::Transcript;
+        app.session.blocks.push(task_block("t-1", "executor"));
+        app.dispatch(Action::Select);
+        assert_eq!(app.thread_stack.len(), 1);
+        app.dispatch(Action::DrillOut);
+        assert!(app.thread_stack.is_empty());
+    }
+
+    #[test]
+    fn drill_in_action_pushes_when_explicit() {
+        let mut app = App::new(client(), TuiKeybindings::defaults());
+        app.focus = ViewKind::Session;
+        // Transcript focus is the contract for Select-drill, but the
+        // explicit DrillIn action is gated only on focus == Session.
+        app.session.blocks.push(task_block("t-2", "writer"));
+        app.dispatch(Action::DrillIn);
+        assert_eq!(app.thread_stack.len(), 1);
+        assert_eq!(app.thread_stack_labels, vec!["Task(writer)".to_owned()]);
+    }
+
+    #[test]
+    fn drill_breadcrumb_renders_path() {
+        let mut app = App::new(client(), TuiKeybindings::defaults());
+        assert_eq!(app.drill_breadcrumb(), "");
+        app.thread_stack
+            .push(crate::views::blocks::ThreadView::default());
+        app.thread_stack_labels.push("Task(planner)".into());
+        assert_eq!(app.drill_breadcrumb(), "└ Task(planner)");
+        app.thread_stack
+            .push(crate::views::blocks::ThreadView::default());
+        app.thread_stack_labels.push("Task(executor)".into());
+        assert_eq!(
+            app.drill_breadcrumb(),
+            "└ Task(planner) › Task(executor)"
+        );
+    }
+
+    #[test]
+    fn select_on_session_with_composer_focus_does_not_drill() {
+        let mut app = App::new(client(), TuiKeybindings::defaults());
+        app.focus = ViewKind::Session;
+        // Composer focus is the default — drill-in via Select must not fire.
+        assert_eq!(
+            app.session.focus,
+            crate::views::session::ComposerFocus::Composer,
+        );
+        app.session.blocks.push(task_block("t-3", "planner"));
+        app.dispatch(Action::Select);
+        assert!(app.thread_stack.is_empty());
     }
 
     #[test]

--- a/rust/crates/sera-tui/src/keybindings.rs
+++ b/rust/crates/sera-tui/src/keybindings.rs
@@ -108,6 +108,18 @@ pub struct TuiKeybindings {
     pub popup_select: Vec<KeyBinding>,
     /// Dismiss the autocomplete popup without inserting (default: Esc).
     pub popup_dismiss: Vec<KeyBinding>,
+    /// Drill into the focused Task block's child thread (default: Enter)
+    /// when the transcript pane is focused (J.2.2 / sera-9vkz).  Currently
+    /// dispatched implicitly via `select` while transcript is focused; the
+    /// dedicated binding is reserved for the explicit input layer wiring
+    /// that lands with sera-mfj3.
+    #[allow(dead_code)]
+    pub drill_in: Vec<KeyBinding>,
+    /// Pop one level out of the drill-in stack (default: Esc) — only fires
+    /// when the stack is non-empty (J.2.2 / sera-9vkz).  Currently
+    /// dispatched implicitly via `back`; reserved for explicit wiring.
+    #[allow(dead_code)]
+    pub drill_out: Vec<KeyBinding>,
 }
 
 impl TuiKeybindings {
@@ -171,6 +183,8 @@ impl TuiKeybindings {
                 KeyBinding::plain(KeyCode::Tab),
             ],
             popup_dismiss: vec![KeyBinding::plain(KeyCode::Esc)],
+            drill_in: vec![KeyBinding::plain(KeyCode::Enter)],
+            drill_out: vec![KeyBinding::plain(KeyCode::Esc)],
         }
     }
 }
@@ -243,6 +257,8 @@ mod tests {
         assert!(!kb.popup_down.is_empty());
         assert!(!kb.popup_select.is_empty());
         assert!(!kb.popup_dismiss.is_empty());
+        assert!(!kb.drill_in.is_empty());
+        assert!(!kb.drill_out.is_empty());
     }
 
     #[test]

--- a/rust/crates/sera-tui/src/ui.rs
+++ b/rust/crates/sera-tui/src/ui.rs
@@ -44,6 +44,7 @@ pub fn render(frame: &mut Frame, app: &mut App) {
     // Status bar: agent name + session short-id + connection state.
     let agent = app.active_agent_id.as_deref();
     let session_id = app.session.session.as_ref().map(|s| s.id.as_str());
+    let drill_breadcrumb = app.drill_breadcrumb();
     StatusBar {
         agent,
         session_id,
@@ -51,6 +52,7 @@ pub fn render(frame: &mut Frame, app: &mut App) {
         prompt_tokens: app.usage_prompt_tokens,
         completion_tokens: app.usage_completion_tokens,
         cost_usd: app.usage_cost_usd,
+        drill_breadcrumb: drill_breadcrumb.as_str(),
     }
     .render(frame, chunks[0]);
 

--- a/rust/crates/sera-tui/src/views/status_bar.rs
+++ b/rust/crates/sera-tui/src/views/status_bar.rs
@@ -28,6 +28,10 @@ pub struct StatusBar<'a> {
     pub completion_tokens: u64,
     /// Cumulative cost in USD. `0.0` for local models.
     pub cost_usd: f64,
+    /// **J.2.2 (sera-9vkz)** drill-in breadcrumb (e.g. `└ Task(planner)`).
+    /// Empty string means the root transcript is active; rendered as a
+    /// trailing segment in the status line when non-empty.
+    pub drill_breadcrumb: &'a str,
 }
 
 impl StatusBar<'_> {
@@ -54,7 +58,7 @@ impl StatusBar<'_> {
             "cost=$0".to_owned()
         };
 
-        let spans = vec![
+        let mut spans = vec![
             Span::raw(" agent="),
             Span::styled(
                 agent_label.to_owned(),
@@ -70,6 +74,17 @@ impl StatusBar<'_> {
             Span::styled(cost_label, Style::default().fg(Color::White)),
             Span::raw(" "),
         ];
+        // J.2.2 (sera-9vkz): append the drill-in breadcrumb when the
+        // operator has drilled into a child thread.  Hidden at the root
+        // transcript so the status line stays compact.
+        if !self.drill_breadcrumb.is_empty() {
+            spans.push(Span::raw("· "));
+            spans.push(Span::styled(
+                self.drill_breadcrumb.to_owned(),
+                Style::default().fg(Color::Magenta),
+            ));
+            spans.push(Span::raw(" "));
+        }
 
         let bar = Paragraph::new(Line::from(spans))
             .style(Style::default().fg(Color::DarkGray));
@@ -112,6 +127,7 @@ mod tests {
             prompt_tokens: 0,
             completion_tokens: 0,
             cost_usd: 0.0,
+            drill_breadcrumb: "",
         }
     }
 
@@ -139,6 +155,7 @@ mod tests {
             prompt_tokens: 42,
             completion_tokens: 17,
             cost_usd: 0.0,
+            drill_breadcrumb: "",
         };
         let out = render_to_string(bar, 160);
         assert!(out.contains("tokens=59"), "expected 'tokens=59' in: {out}");
@@ -166,5 +183,37 @@ mod tests {
         let bar = bar_with(Some("test"), None, ConnectionState::Connected);
         let out = render_to_string(bar, 120);
         assert!(out.contains("session=-"), "expected 'session=-' in: {out}");
+    }
+
+    // --- J.2.2 (sera-9vkz) drill-in breadcrumb tests ---
+
+    #[test]
+    fn renders_drill_breadcrumb_when_non_empty() {
+        let bar = StatusBar {
+            agent: Some("sera"),
+            session_id: Some("s1"),
+            conn: ConnectionState::Connected,
+            prompt_tokens: 0,
+            completion_tokens: 0,
+            cost_usd: 0.0,
+            drill_breadcrumb: "└ Task(planner)",
+        };
+        let out = render_to_string(bar, 120);
+        assert!(out.contains("Task(planner)"), "expected breadcrumb in: {out}");
+    }
+
+    #[test]
+    fn omits_drill_breadcrumb_when_empty() {
+        let bar = StatusBar {
+            agent: Some("sera"),
+            session_id: Some("s1"),
+            conn: ConnectionState::Connected,
+            prompt_tokens: 0,
+            completion_tokens: 0,
+            cost_usd: 0.0,
+            drill_breadcrumb: "",
+        };
+        let out = render_to_string(bar, 120);
+        assert!(!out.contains("Task("), "did not expect breadcrumb in: {out}");
     }
 }


### PR DESCRIPTION
## Summary

Implements the J.2.2 drill-in stack on top of #1187 (sera-xcii) so the operator can navigate into a subagent Task block and back out:

- `App::thread_stack: Vec<ThreadView>` + `thread_stack_labels: Vec<String>` — empty means the root session transcript is active.
- `Action::Select` while the transcript pane is focused pushes the first Task block's `child_thread` onto the stack; `Action::Back` pops the stack first, then falls through to focus reset.
- New `Action::DrillIn` / `Action::DrillOut` variants and `drill_in` / `drill_out` keybinding slots (Enter / Esc) reserved for explicit input wiring in sera-mfj3.
- `StatusBar` gains a `drill_breadcrumb` field; `ui::render` passes `App::drill_breadcrumb()` so the status line shows e.g. `└ Task(planner) › Task(executor)`.

Out of scope (sera-mfj3): live SSE streaming into the topmost stack entry's `blocks`. The Task block widget itself is untouched.

## Test plan

- [x] `cargo check -p sera-tui --tests` — clean
- [x] `cargo test -p sera-tui` — 214 passed (7 new in `app/mod.rs`, 2 new in `views/status_bar.rs`)
- [ ] Manual: with a Task block in the transcript, Tab → Enter pushes; Esc pops; status bar shows breadcrumb at depth ≥ 1

Stacked on #1187 — merge that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)