### PR TITLE
feat(sera-tui): J.2.3 subagent live-streaming into child thread (sera-mfj3)

### DIFF
--- a/rust/crates/sera-tui/src/app/actions.rs
+++ b/rust/crates/sera-tui/src/app/actions.rs
@@ -156,6 +156,17 @@ pub enum Action {
     /// Escalate the focused inline Approval block in the transcript (J.1.4).
     #[allow(dead_code)]
     EscalateInlineBlock(String),
+    /// Drill into the `child_thread` of the currently focused Task block
+    /// (J.2.2 / sera-9vkz).  Pushes the child thread onto `App::thread_stack`.
+    /// Currently dispatched via the `Select` arm in `App::dispatch` when the
+    /// transcript pane is focused; reserved here for an explicit binding.
+    #[allow(dead_code)]
+    DrillIn,
+    /// Pop the top of `App::thread_stack` (J.2.2 / sera-9vkz).  Currently
+    /// dispatched via the `Back` arm in `App::dispatch`; reserved here for
+    /// an explicit binding.
+    #[allow(dead_code)]
+    DrillOut,
     /// No-op — used when a key doesn't match any binding.  Reducing to
     /// this instead of returning `Option<Action>` lets the dispatch table
     /// stay a plain `match`.

--- a/rust/crates/sera-tui/src/app/mod.rs
+++ b/rust/crates/sera-tui/src/app/mod.rs
@@ -800,7 +800,36 @@ impl App {
                     // pricing will be threaded in via a separate bead.
                     self.usage_cost_usd = 0.0;
                 }
-                self.session.apply_event(ev);
+                // J.2.3 (sera-mfj3): when a child event is routed into a
+                // Task block's child_thread, sync the updated ThreadView into
+                // the thread_stack so the drilled-in view is live.
+                if let Some(ref task_id) = ev.parent_task_id.clone() {
+                    self.session.apply_event(ev);
+                    // Find the matching Task block and propagate its updated
+                    // child_thread to the topmost thread_stack entry whose
+                    // blocks originated from that task.  We match by task_id
+                    // stored on the block — the stack entry was cloned from it
+                    // at drill_in time.
+                    if let Some(stack_thread) = self.thread_stack.last_mut() {
+                        if let Some(child) = self.session.blocks.iter().find_map(|b| {
+                            if let crate::views::blocks::Block::Task {
+                                task_id: tid,
+                                child_thread,
+                                ..
+                            } = b
+                                && tid == task_id
+                            {
+                                Some(child_thread.clone())
+                            } else {
+                                None
+                            }
+                        }) {
+                            *stack_thread = child;
+                        }
+                    }
+                } else {
+                    self.session.apply_event(ev);
+                }
             }
             SseUpdate::State(s) => {
                 // Only clear turn_streaming when the stream transitions out
@@ -2173,5 +2202,124 @@ mod tests {
             "expected Approve(h1), got: {:?}",
             app.pending.last()
         );
+    }
+
+    // --- J.2.3 (sera-mfj3) subagent live-streaming tests ---
+
+    #[test]
+    fn subagent_start_creates_task_block() {
+        let mut app = App::new(client(), TuiKeybindings::defaults());
+        app.apply_sse(SseUpdate::Event(StreamEvent {
+            event_type: "subagent_start".into(),
+            session_id: "task-abc".into(),
+            role: String::new(),
+            delta: "searching docs".into(),
+            tool: "researcher".into(),
+            parent_task_id: None,
+            prompt_tokens: 0,
+            completion_tokens: 0,
+            total_tokens: 0,
+        }));
+        assert_eq!(app.session.blocks.len(), 1);
+        match &app.session.blocks[0] {
+            crate::views::blocks::Block::Task {
+                task_id,
+                agent,
+                summary,
+                ..
+            } => {
+                assert_eq!(task_id, "task-abc");
+                assert_eq!(agent, "researcher");
+                assert_eq!(summary, "searching docs");
+            }
+            other => panic!("expected Task block, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn subagent_text_events_route_into_child_thread() {
+        let mut app = App::new(client(), TuiKeybindings::defaults());
+        // First create the task block via subagent_start.
+        app.apply_sse(SseUpdate::Event(StreamEvent {
+            event_type: "subagent_start".into(),
+            session_id: "task-1".into(),
+            role: String::new(),
+            delta: "summary".into(),
+            tool: "planner".into(),
+            parent_task_id: None,
+            prompt_tokens: 0,
+            completion_tokens: 0,
+            total_tokens: 0,
+        }));
+        // Then stream text into it via parent_task_id.
+        app.apply_sse(SseUpdate::Event(StreamEvent {
+            event_type: "message".into(),
+            session_id: String::new(),
+            role: "assistant".into(),
+            delta: "child text".into(),
+            tool: String::new(),
+            parent_task_id: Some("task-1".into()),
+            prompt_tokens: 0,
+            completion_tokens: 0,
+            total_tokens: 0,
+        }));
+        // Top-level transcript should still have only the Task block.
+        assert_eq!(app.session.blocks.len(), 1);
+        // The child_thread should have the streamed text.
+        match &app.session.blocks[0] {
+            crate::views::blocks::Block::Task { child_thread, .. } => {
+                assert_eq!(child_thread.blocks.len(), 1);
+                match &child_thread.blocks[0] {
+                    crate::views::blocks::Block::AssistantMessage { text, .. } => {
+                        assert_eq!(text, "child text");
+                    }
+                    other => panic!("expected AssistantMessage, got {other:?}"),
+                }
+            }
+            other => panic!("expected Task block, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn drilled_in_thread_stack_synced_on_child_event() {
+        let mut app = App::new(client(), TuiKeybindings::defaults());
+        // Create the task block.
+        app.apply_sse(SseUpdate::Event(StreamEvent {
+            event_type: "subagent_start".into(),
+            session_id: "task-2".into(),
+            role: String::new(),
+            delta: "plan".into(),
+            tool: "executor".into(),
+            parent_task_id: None,
+            prompt_tokens: 0,
+            completion_tokens: 0,
+            total_tokens: 0,
+        }));
+        // Drill in (simulates user pressing Enter on the task block).
+        app.focus = ViewKind::Session;
+        app.dispatch(Action::DrillIn);
+        assert_eq!(app.thread_stack.len(), 1);
+        assert!(app.thread_stack[0].blocks.is_empty());
+        // Stream a child event — stack entry should be updated.
+        app.apply_sse(SseUpdate::Event(StreamEvent {
+            event_type: "message".into(),
+            session_id: String::new(),
+            role: "assistant".into(),
+            delta: "live output".into(),
+            tool: String::new(),
+            parent_task_id: Some("task-2".into()),
+            prompt_tokens: 0,
+            completion_tokens: 0,
+            total_tokens: 0,
+        }));
+        // The top of thread_stack must now contain the streamed block.
+        assert_eq!(app.thread_stack.len(), 1);
+        assert_eq!(app.thread_stack[0].blocks.len(), 1);
+        match &app.thread_stack[0].blocks[0] {
+            crate::views::blocks::Block::AssistantMessage { text, .. } => {
+                assert_eq!(text, "live output");
+            }
+            other => panic!("expected AssistantMessage in stack, got {other:?}"),
+        }
     }
 }

--- a/rust/crates/sera-tui/src/app/mod.rs
+++ b/rust/crates/sera-tui/src/app/mod.rs
@@ -252,6 +252,18 @@ pub struct App {
     /// bead will introduce a real pricing table; until then this stays 0.0
     /// for local backends.
     pub usage_cost_usd: f64,
+
+    /// **J.2.2 (sera-9vkz)** drill-in stack.  Each entry is a child
+    /// `ThreadView` cloned from a `Block::Task` when the operator pressed
+    /// Enter on it.  Empty = the root session transcript is active.
+    /// `DrillOut` pops one level; `Back` falls through to this before
+    /// resetting `focus`.  J.2.3 (sera-mfj3) wires live SSE streaming
+    /// into the topmost stack entry's `blocks`.
+    pub thread_stack: Vec<crate::views::blocks::ThreadView>,
+    /// Optional human-readable label for each stack entry, used by the
+    /// status bar breadcrumb (`└ Task(agent)`).  Same length as
+    /// `thread_stack` — index `i` labels the thread at depth `i+1`.
+    pub thread_stack_labels: Vec<String>,
 }
 
 impl App {
@@ -288,6 +300,61 @@ impl App {
             usage_prompt_tokens: 0,
             usage_completion_tokens: 0,
             usage_cost_usd: 0.0,
+            thread_stack: Vec::new(),
+            thread_stack_labels: Vec::new(),
+        }
+    }
+
+    /// **J.2.2 (sera-9vkz)** breadcrumb describing the current drill-in
+    /// depth.  Empty string when the root transcript is active.  Used by
+    /// the status bar to hint at the current child-thread context, e.g.
+    /// `└ Task(planner) › Task(executor)`.
+    pub fn drill_breadcrumb(&self) -> String {
+        if self.thread_stack_labels.is_empty() {
+            String::new()
+        } else {
+            format!("└ {}", self.thread_stack_labels.join(" › "))
+        }
+    }
+
+    /// **J.2.2 (sera-9vkz)** push the `child_thread` of the first
+    /// `Block::Task` in the active thread (root or topmost stacked) onto
+    /// `thread_stack`.  Returns `true` when a Task block was found and
+    /// pushed; `false` otherwise (no-op).
+    fn drill_in(&mut self) -> bool {
+        // Locate a Task block in the currently-active block list.
+        let active_blocks: &[crate::views::blocks::Block] = match self.thread_stack.last() {
+            Some(thread) => &thread.blocks,
+            None => &self.session.blocks,
+        };
+        let task = active_blocks.iter().find_map(|b| {
+            if let crate::views::blocks::Block::Task {
+                agent, child_thread, ..
+            } = b
+            {
+                Some((agent.clone(), child_thread.clone()))
+            } else {
+                None
+            }
+        });
+        if let Some((agent, child)) = task {
+            self.thread_stack.push(child);
+            self.thread_stack_labels.push(format!("Task({agent})"));
+            true
+        } else {
+            false
+        }
+    }
+
+    /// **J.2.2 (sera-9vkz)** pop the topmost entry from `thread_stack`.
+    /// Returns `true` when a level was popped; `false` when the stack was
+    /// already empty.
+    fn drill_out(&mut self) -> bool {
+        if self.thread_stack.pop().is_some() {
+            self.thread_stack_labels.pop();
+            true
+        } else {
+            false
         }
     }
 
@@ -474,6 +541,13 @@ impl App {
                     self.active_agent_id = Some(id.clone());
                     self.focus = ViewKind::Session;
                     self.pending.push(AppCommand::LoadSessionFor(id));
+                } else if self.focus == ViewKind::Session
+                    && self.session.focus == crate::views::session::ComposerFocus::Transcript
+                {
+                    // J.2.2 (sera-9vkz): Enter while the transcript pane is
+                    // focused drills into the first Task block in the active
+                    // thread.  No-op when no Task block is present.
+                    self.drill_in();
                 }
             }
             Action::SelectAgent(id) => {
@@ -482,10 +556,25 @@ impl App {
                 self.pending.push(AppCommand::LoadSessionFor(id));
             }
             Action::Back => {
-                if self.focus != ViewKind::Agents {
+                // J.2.2 (sera-9vkz): when drilled into a child thread, Back
+                // pops one level instead of bouncing back to the agent list.
+                if self.drill_out() {
+                    // Stack popped — stay on Session view.
+                } else if self.focus != ViewKind::Agents {
                     self.focus = ViewKind::Agents;
                     self.pending.push(AppCommand::RefreshCurrent);
                 }
+            }
+            Action::DrillIn => {
+                // Only meaningful while the Session view is active.  Looks
+                // for a Task block in the currently-active thread and
+                // pushes its `child_thread` onto the drill-in stack.
+                if self.focus == ViewKind::Session {
+                    self.drill_in();
+                }
+            }
+            Action::DrillOut => {
+                self.drill_out();
             }
             Action::Approve => {
                 if let ViewKind::Hitl = self.focus
@@ -1956,6 +2045,113 @@ mod tests {
             "expected EscalateInlineBlock(req-3), got: {:?}",
             app.pending.last()
         );
+    }
+
+    // --- J.2.2 (sera-9vkz) drill-in stack tests ---
+
+    fn task_block(task_id: &str, agent: &str) -> crate::views::blocks::Block {
+        crate::views::blocks::Block::Task {
+            task_id: task_id.into(),
+            agent: agent.into(),
+            summary: "doing things".into(),
+            child_thread: crate::views::blocks::ThreadView::default(),
+            expanded: false,
+        }
+    }
+
+    #[test]
+    fn drill_in_pushes_child_thread_onto_stack() {
+        let mut app = App::new(client(), TuiKeybindings::defaults());
+        app.focus = ViewKind::Session;
+        app.session.focus = crate::views::session::ComposerFocus::Transcript;
+        app.session.blocks.push(task_block("t-1", "planner"));
+        assert!(app.thread_stack.is_empty());
+        app.dispatch(Action::Select);
+        assert_eq!(app.thread_stack.len(), 1);
+        assert_eq!(app.thread_stack_labels, vec!["Task(planner)".to_owned()]);
+    }
+
+    #[test]
+    fn drill_in_noop_when_no_task_block_present() {
+        let mut app = App::new(client(), TuiKeybindings::defaults());
+        app.focus = ViewKind::Session;
+        app.session.focus = crate::views::session::ComposerFocus::Transcript;
+        // No task block in transcript.
+        app.dispatch(Action::Select);
+        assert!(app.thread_stack.is_empty());
+        assert!(app.thread_stack_labels.is_empty());
+    }
+
+    #[test]
+    fn back_pops_thread_stack_before_resetting_focus() {
+        let mut app = App::new(client(), TuiKeybindings::defaults());
+        app.focus = ViewKind::Session;
+        app.session.focus = crate::views::session::ComposerFocus::Transcript;
+        app.session.blocks.push(task_block("t-1", "planner"));
+        app.dispatch(Action::Select); // drill in
+        assert_eq!(app.thread_stack.len(), 1);
+        app.dispatch(Action::Back); // first Back pops the stack
+        assert!(app.thread_stack.is_empty());
+        // Focus stays on Session (we only popped a level, didn't bounce out).
+        assert_eq!(app.focus, ViewKind::Session);
+        // A second Back with empty stack falls through to the focus reset.
+        app.dispatch(Action::Back);
+        assert_eq!(app.focus, ViewKind::Agents);
+    }
+
+    #[test]
+    fn drill_out_action_pops_stack() {
+        let mut app = App::new(client(), TuiKeybindings::defaults());
+        app.focus = ViewKind::Session;
+        app.session.focus = crate::views::session::ComposerFocus::Transcript;
+        app.session.blocks.push(task_block("t-1", "executor"));
+        app.dispatch(Action::Select);
+        assert_eq!(app.thread_stack.len(), 1);
+        app.dispatch(Action::DrillOut);
+        assert!(app.thread_stack.is_empty());
+    }
+
+    #[test]
+    fn drill_in_action_pushes_when_explicit() {
+        let mut app = App::new(client(), TuiKeybindings::defaults());
+        app.focus = ViewKind::Session;
+        // Transcript focus is the contract for Select-drill, but the
+        // explicit DrillIn action is gated only on focus == Session.
+        app.session.blocks.push(task_block("t-2", "writer"));
+        app.dispatch(Action::DrillIn);
+        assert_eq!(app.thread_stack.len(), 1);
+        assert_eq!(app.thread_stack_labels, vec!["Task(writer)".to_owned()]);
+    }
+
+    #[test]
+    fn drill_breadcrumb_renders_path() {
+        let mut app = App::new(client(), TuiKeybindings::defaults());
+        assert_eq!(app.drill_breadcrumb(), "");
+        app.thread_stack
+            .push(crate::views::blocks::ThreadView::default());
+        app.thread_stack_labels.push("Task(planner)".into());
+        assert_eq!(app.drill_breadcrumb(), "└ Task(planner)");
+        app.thread_stack
+            .push(crate::views::blocks::ThreadView::default());
+        app.thread_stack_labels.push("Task(executor)".into());
+        assert_eq!(
+            app.drill_breadcrumb(),
+            "└ Task(planner) › Task(executor)"
+        );
+    }
+
+    #[test]
+    fn select_on_session_with_composer_focus_does_not_drill() {
+        let mut app = App::new(client(), TuiKeybindings::defaults());
+        app.focus = ViewKind::Session;
+        // Composer focus is the default — drill-in via Select must not fire.
+        assert_eq!(
+            app.session.focus,
+            crate::views::session::ComposerFocus::Composer,
+        );
+        app.session.blocks.push(task_block("t-3", "planner"));
+        app.dispatch(Action::Select);
+        assert!(app.thread_stack.is_empty());
     }
 
     #[test]

--- a/rust/crates/sera-tui/src/keybindings.rs
+++ b/rust/crates/sera-tui/src/keybindings.rs
@@ -108,6 +108,18 @@ pub struct TuiKeybindings {
     pub popup_select: Vec<KeyBinding>,
     /// Dismiss the autocomplete popup without inserting (default: Esc).
     pub popup_dismiss: Vec<KeyBinding>,
+    /// Drill into the focused Task block's child thread (default: Enter)
+    /// when the transcript pane is focused (J.2.2 / sera-9vkz).  Currently
+    /// dispatched implicitly via `select` while transcript is focused; the
+    /// dedicated binding is reserved for the explicit input layer wiring
+    /// that lands with sera-mfj3.
+    #[allow(dead_code)]
+    pub drill_in: Vec<KeyBinding>,
+    /// Pop one level out of the drill-in stack (default: Esc) — only fires
+    /// when the stack is non-empty (J.2.2 / sera-9vkz).  Currently
+    /// dispatched implicitly via `back`; reserved for explicit wiring.
+    #[allow(dead_code)]
+    pub drill_out: Vec<KeyBinding>,
 }
 
 impl TuiKeybindings {
@@ -171,6 +183,8 @@ impl TuiKeybindings {
                 KeyBinding::plain(KeyCode::Tab),
             ],
             popup_dismiss: vec![KeyBinding::plain(KeyCode::Esc)],
+            drill_in: vec![KeyBinding::plain(KeyCode::Enter)],
+            drill_out: vec![KeyBinding::plain(KeyCode::Esc)],
         }
     }
 }
@@ -243,6 +257,8 @@ mod tests {
         assert!(!kb.popup_down.is_empty());
         assert!(!kb.popup_select.is_empty());
         assert!(!kb.popup_dismiss.is_empty());
+        assert!(!kb.drill_in.is_empty());
+        assert!(!kb.drill_out.is_empty());
     }
 
     #[test]

--- a/rust/crates/sera-tui/src/ui.rs
+++ b/rust/crates/sera-tui/src/ui.rs
@@ -44,6 +44,7 @@ pub fn render(frame: &mut Frame, app: &mut App) {
     // Status bar: agent name + session short-id + connection state.
     let agent = app.active_agent_id.as_deref();
     let session_id = app.session.session.as_ref().map(|s| s.id.as_str());
+    let drill_breadcrumb = app.drill_breadcrumb();
     StatusBar {
         agent,
         session_id,
@@ -51,6 +52,7 @@ pub fn render(frame: &mut Frame, app: &mut App) {
         prompt_tokens: app.usage_prompt_tokens,
         completion_tokens: app.usage_completion_tokens,
         cost_usd: app.usage_cost_usd,
+        drill_breadcrumb: drill_breadcrumb.as_str(),
     }
     .render(frame, chunks[0]);
 

--- a/rust/crates/sera-tui/src/views/session.rs
+++ b/rust/crates/sera-tui/src/views/session.rs
@@ -117,7 +117,20 @@ impl SessionView {
     ///   the most recent unresolved `ToolCall`; does **not** push a new block.
     /// * `tool_end` — attach a [`ToolResult`] to the most recent matching
     ///   `ToolCall` block.
+    ///
+    /// **J.2.3 (sera-mfj3)**: when `ev.parent_task_id` is `Some(id)`, the
+    /// event is routed into the `child_thread` of the matching `Block::Task`
+    /// instead of the top-level `blocks` list.  Returns `true` when the task
+    /// was found and the event applied; `false` when the task id has no
+    /// matching block (event is silently dropped so the main transcript is
+    /// not polluted).
     pub fn apply_event(&mut self, ev: StreamEvent) -> bool {
+        // J.2.3: child-thread routing — events tagged with parent_task_id
+        // are streamed into the matching Task block's child_thread.
+        if let Some(ref task_id) = ev.parent_task_id.clone() {
+            return self.apply_child_event(task_id, ev);
+        }
+
         let et = ev.event_type.to_ascii_lowercase();
 
         // J.2.1: subagent_start SSE frame → push a collapsed Task block.
@@ -342,6 +355,76 @@ impl SessionView {
             child_thread: ThreadView::default(),
             expanded: false,
         });
+    }
+
+    /// **J.2.3 (sera-mfj3)** route a child SSE event into the `child_thread`
+    /// of the `Block::Task` whose `task_id` matches `id`.  Applies the same
+    /// rendering logic as `apply_event` but writes into the child block list.
+    /// Returns `true` when the task was found and updated; `false` otherwise.
+    pub fn apply_child_event(&mut self, id: &str, ev: StreamEvent) -> bool {
+        let task = self.blocks.iter_mut().find_map(|b| {
+            if let Block::Task {
+                task_id,
+                child_thread,
+                ..
+            } = b
+                && task_id == id
+            {
+                Some(child_thread)
+            } else {
+                None
+            }
+        });
+        let Some(thread) = task else {
+            return false;
+        };
+        let et = ev.event_type.to_ascii_lowercase();
+        if et == "tool_start" {
+            let args = if ev.delta.trim_start().starts_with('{') {
+                serde_json::from_str(&ev.delta).unwrap_or(serde_json::Value::Null)
+            } else {
+                serde_json::Value::Null
+            };
+            thread.blocks.push(Block::ToolCall {
+                tool: ev.tool.clone(),
+                summary: ev.delta.clone(),
+                args,
+                result: None,
+                expanded: false,
+            });
+            return true;
+        }
+        if et == "tool_end" {
+            for block in thread.blocks.iter_mut().rev() {
+                if let Block::ToolCall {
+                    tool: t,
+                    result,
+                    ..
+                } = block
+                    && result.is_none()
+                    && (ev.tool.is_empty() || t == &ev.tool)
+                {
+                    *result = Some(ToolResult {
+                        ok: true,
+                        output: ev.delta.clone(),
+                    });
+                    return true;
+                }
+            }
+            return true;
+        }
+        if et == "error" {
+            thread.blocks.push(Block::Error {
+                message: ev.delta.clone(),
+                retryable: false,
+            });
+            return true;
+        }
+        if !ev.delta.is_empty() {
+            Block::extend_assistant_text(&mut thread.blocks, &ev.delta);
+            return true;
+        }
+        false
     }
 
     pub fn set_connection(&mut self, state: ConnectionState) {

--- a/rust/crates/sera-tui/src/views/status_bar.rs
+++ b/rust/crates/sera-tui/src/views/status_bar.rs
@@ -28,6 +28,10 @@ pub struct StatusBar<'a> {
     pub completion_tokens: u64,
     /// Cumulative cost in USD. `0.0` for local models.
     pub cost_usd: f64,
+    /// **J.2.2 (sera-9vkz)** drill-in breadcrumb (e.g. `└ Task(planner)`).
+    /// Empty string means the root transcript is active; rendered as a
+    /// trailing segment in the status line when non-empty.
+    pub drill_breadcrumb: &'a str,
 }
 
 impl StatusBar<'_> {
@@ -54,7 +58,7 @@ impl StatusBar<'_> {
             "cost=$0".to_owned()
         };
 
-        let spans = vec![
+        let mut spans = vec![
             Span::raw(" agent="),
             Span::styled(
                 agent_label.to_owned(),
@@ -70,6 +74,17 @@ impl StatusBar<'_> {
             Span::styled(cost_label, Style::default().fg(Color::White)),
             Span::raw(" "),
         ];
+        // J.2.2 (sera-9vkz): append the drill-in breadcrumb when the
+        // operator has drilled into a child thread.  Hidden at the root
+        // transcript so the status line stays compact.
+        if !self.drill_breadcrumb.is_empty() {
+            spans.push(Span::raw("· "));
+            spans.push(Span::styled(
+                self.drill_breadcrumb.to_owned(),
+                Style::default().fg(Color::Magenta),
+            ));
+            spans.push(Span::raw(" "));
+        }
 
         let bar = Paragraph::new(Line::from(spans))
             .style(Style::default().fg(Color::DarkGray));
@@ -112,6 +127,7 @@ mod tests {
             prompt_tokens: 0,
             completion_tokens: 0,
             cost_usd: 0.0,
+            drill_breadcrumb: "",
         }
     }
 
@@ -139,6 +155,7 @@ mod tests {
             prompt_tokens: 42,
             completion_tokens: 17,
             cost_usd: 0.0,
+            drill_breadcrumb: "",
         };
         let out = render_to_string(bar, 160);
         assert!(out.contains("tokens=59"), "expected 'tokens=59' in: {out}");
@@ -166,5 +183,37 @@ mod tests {
         let bar = bar_with(Some("test"), None, ConnectionState::Connected);
         let out = render_to_string(bar, 120);
         assert!(out.contains("session=-"), "expected 'session=-' in: {out}");
+    }
+
+    // --- J.2.2 (sera-9vkz) drill-in breadcrumb tests ---
+
+    #[test]
+    fn renders_drill_breadcrumb_when_non_empty() {
+        let bar = StatusBar {
+            agent: Some("sera"),
+            session_id: Some("s1"),
+            conn: ConnectionState::Connected,
+            prompt_tokens: 0,
+            completion_tokens: 0,
+            cost_usd: 0.0,
+            drill_breadcrumb: "└ Task(planner)",
+        };
+        let out = render_to_string(bar, 120);
+        assert!(out.contains("Task(planner)"), "expected breadcrumb in: {out}");
+    }
+
+    #[test]
+    fn omits_drill_breadcrumb_when_empty() {
+        let bar = StatusBar {
+            agent: Some("sera"),
+            session_id: Some("s1"),
+            conn: ConnectionState::Connected,
+            prompt_tokens: 0,
+            completion_tokens: 0,
+            cost_usd: 0.0,
+            drill_breadcrumb: "",
+        };
+        let out = render_to_string(bar, 120);
+        assert!(!out.contains("Task("), "did not expect breadcrumb in: {out}");
     }
 }


### PR DESCRIPTION
## Summary

- Route SSE events tagged with `parent_task_id` into the matching `Block::Task::child_thread` instead of the top-level transcript
- Add `SessionView::apply_child_event` to handle text/tool/error events inside a child thread using the same rendering logic as the parent
- Sync the `thread_stack` entry in `App::apply_sse` so the drilled-in view is live-updated as child events stream in
- `DrillIn`/`DrillOut` actions (wired by sera-9vkz) work as-is — Enter pushes the child thread, Esc pops it

## Stack

Stacks on top of PR for `sera-9vkz-drill-in-stack` (J.2.2 drill-in stack).

## Test plan

- [x] `subagent_start_creates_task_block` — `subagent_start` SSE frame pushes a `Block::Task` with correct `task_id`, `agent`, and `summary`
- [x] `subagent_text_events_route_into_child_thread` — events with `parent_task_id` go into `child_thread.blocks`, not top-level
- [x] `drilled_in_thread_stack_synced_on_child_event` — `thread_stack` entry is updated live when child events arrive while drilled in
- [x] All 217 existing tests continue to pass (`cargo test -p sera-tui`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)