### PR TITLE
fix(sera-gateway): env-var-touching tests need test isolation locks (sera-r51k)

### DIFF
--- a/rust/crates/sera-gateway/src/admin/auth.rs
+++ b/rust/crates/sera-gateway/src/admin/auth.rs
@@ -115,6 +115,14 @@ pub async fn require_admin_token(
 mod tests {
     use super::*;
 
+    /// Serialises all tests that read or write `SERA_ADMIN_TOKEN` so they
+    /// don't race each other when `cargo test` runs them in parallel.
+    fn admin_token_lock() -> std::sync::MutexGuard<'static, ()> {
+        use std::sync::{Mutex, OnceLock};
+        static ENV_MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
+        ENV_MUTEX.get_or_init(|| Mutex::new(())).lock().unwrap_or_else(|e| e.into_inner())
+    }
+
     #[test]
     fn matches_is_true_for_equal_tokens() {
         let auth = AdminAuth::new("token-abc");
@@ -141,8 +149,10 @@ mod tests {
 
     #[test]
     fn resolve_errors_when_unset_and_not_local() {
+        let _lock = admin_token_lock();
         let saved = std::env::var("SERA_ADMIN_TOKEN").ok();
-        // SAFETY: single-threaded test scope.
+        // SAFETY: callers hold admin_token_lock so no concurrent reader can
+        // observe a torn value.
         unsafe { std::env::remove_var("SERA_ADMIN_TOKEN") };
         let result = AdminAuth::resolve(false);
         if let Some(v) = saved {
@@ -153,7 +163,10 @@ mod tests {
 
     #[test]
     fn resolve_uses_env_var_when_set() {
+        let _lock = admin_token_lock();
         let saved = std::env::var("SERA_ADMIN_TOKEN").ok();
+        // SAFETY: callers hold admin_token_lock so no concurrent reader can
+        // observe a torn value.
         unsafe { std::env::set_var("SERA_ADMIN_TOKEN", "explicit-token") };
         let auth = AdminAuth::resolve(false).unwrap();
         match saved {

--- a/rust/crates/sera-gateway/src/bin/sera.rs
+++ b/rust/crates/sera-gateway/src/bin/sera.rs
@@ -5585,6 +5585,12 @@ mod tests {
     // serialises them past the cargo-test default of parallel execution.
     static DISPATCH_MODE_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
+    // Serialises tests that read or write `SERA_READINESS_PROBE_TIMEOUT_SECS`.
+    static READINESS_TIMEOUT_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    // Serialises tests that read or write `SERA_TURN_TIMEOUT_SECS`.
+    static TURN_TIMEOUT_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     /// RAII guard that sets/unsets `SERA_DISPATCH_MODE` and restores the
     /// prior value on drop. Use under `DISPATCH_MODE_ENV_LOCK` only.
     struct DispatchModeEnvGuard {
@@ -6189,9 +6195,11 @@ mod tests {
     /// does not stall the suite for the default 5s.
     #[tokio::test]
     async fn readiness_returns_503_when_harness_does_not_respond() {
+        let _lock = READINESS_TIMEOUT_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         // Tight bound — the hung harness will sit forever, so the probe must
         // give up quickly. Env var must be set BEFORE the handler runs.
-        // SAFETY: tests in this binary do not read this var concurrently.
+        // SAFETY: callers hold READINESS_TIMEOUT_ENV_LOCK so no concurrent
+        // reader can observe a torn value.
         unsafe {
             std::env::set_var("SERA_READINESS_PROBE_TIMEOUT_SECS", "1");
         }
@@ -7516,10 +7524,10 @@ spec:
     ///    frames leaked past the steer call.
     #[tokio::test]
     async fn execute_steer_drains_until_turn_completed() {
+        let _lock = TURN_TIMEOUT_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let prior = std::env::var("SERA_TURN_TIMEOUT_SECS").ok();
-        // SAFETY: test-only env mutation; `turn_timeout()` reads the var
-        // each call, so the value is observed inline. Restored before the
-        // test returns to keep parallel tests hermetic.
+        // SAFETY: callers hold TURN_TIMEOUT_ENV_LOCK so no concurrent reader
+        // can observe a torn value.
         unsafe { std::env::set_var("SERA_TURN_TIMEOUT_SECS", "1") };
 
         let supervisor = RuntimeChildSupervisor::start_with_factory("sera", || async {
@@ -7550,7 +7558,7 @@ spec:
             .await
             .expect("follow-up send_turn must succeed against a fresh harness state");
 
-        // SAFETY: restoring the pre-test value; same caveat as above.
+        // SAFETY: callers hold TURN_TIMEOUT_ENV_LOCK; restoring the pre-test value.
         unsafe {
             match prior {
                 Some(v) => std::env::set_var("SERA_TURN_TIMEOUT_SECS", v),
@@ -9281,15 +9289,16 @@ spec:
     /// `SERA_TURN_TIMEOUT_SECS` env var is absent or unparseable.
     #[test]
     fn turn_timeout_defaults_when_env_unset() {
+        let _lock = TURN_TIMEOUT_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         // Snapshot, clear, restore — keep this test hermetic so parallel
         // invocations do not observe each other's environment.
         let prior = std::env::var("SERA_TURN_TIMEOUT_SECS").ok();
-        // SAFETY: test-only env mutation; no threads observe the transient
-        // unset state because the value is read inside `turn_timeout` below.
+        // SAFETY: callers hold TURN_TIMEOUT_ENV_LOCK so no concurrent reader
+        // can observe a torn value.
         unsafe { std::env::remove_var("SERA_TURN_TIMEOUT_SECS") };
         assert_eq!(turn_timeout(), DEFAULT_TURN_TIMEOUT);
         if let Some(v) = prior {
-            // SAFETY: restoring the pre-test value; same caveat as above.
+            // SAFETY: callers hold TURN_TIMEOUT_ENV_LOCK; restoring the pre-test value.
             unsafe { std::env::set_var("SERA_TURN_TIMEOUT_SECS", v) };
         }
     }

--- a/rust/crates/sera-gateway/src/kill_switch.rs
+++ b/rust/crates/sera-gateway/src/kill_switch.rs
@@ -279,6 +279,15 @@ where
 mod tests {
     use super::*;
 
+    /// Serialises all tests that read or write `SERA_ADMIN_SOCK` or
+    /// `XDG_RUNTIME_DIR` so they don't race each other when `cargo test`
+    /// runs them in parallel.
+    fn admin_sock_env_lock() -> std::sync::MutexGuard<'static, ()> {
+        use std::sync::{Mutex, OnceLock};
+        static ENV_MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
+        ENV_MUTEX.get_or_init(|| Mutex::new(())).lock().unwrap_or_else(|e| e.into_inner())
+    }
+
     #[test]
     fn initial_state_is_disarmed() {
         let ks = KillSwitch::new();
@@ -372,7 +381,9 @@ mod tests {
     /// Socket path resolves to env var when set.
     #[test]
     fn sock_path_from_env() {
-        // SAFETY: test-only; single-threaded test context.
+        let _lock = admin_sock_env_lock();
+        // SAFETY: callers hold admin_sock_env_lock so no concurrent reader can
+        // observe a torn value.
         unsafe { std::env::set_var("SERA_ADMIN_SOCK", "/tmp/test-admin.sock") };
         assert_eq!(admin_sock_path(), "/tmp/test-admin.sock");
         unsafe { std::env::remove_var("SERA_ADMIN_SOCK") };
@@ -381,6 +392,9 @@ mod tests {
     /// Socket path falls back to default when env var not set and /var/lib/sera exists.
     #[test]
     fn sock_path_default_when_prod_dir_exists() {
+        let _lock = admin_sock_env_lock();
+        // SAFETY: callers hold admin_sock_env_lock so no concurrent reader can
+        // observe a torn value.
         unsafe { std::env::remove_var("SERA_ADMIN_SOCK") };
         // Only verify the constant value; existence of /var/lib/sera varies by host.
         assert_eq!(DEFAULT_ADMIN_SOCK, "/var/lib/sera/admin.sock");
@@ -390,6 +404,9 @@ mod tests {
     /// or the tmpdir cascade rather than returning the prod default.
     #[test]
     fn sock_path_cascade_when_prod_dir_absent() {
+        let _lock = admin_sock_env_lock();
+        // SAFETY: callers hold admin_sock_env_lock so no concurrent reader can
+        // observe a torn value.
         unsafe { std::env::remove_var("SERA_ADMIN_SOCK") };
 
         // Use a tempdir to simulate an existing XDG_RUNTIME_DIR.
@@ -422,6 +439,9 @@ mod tests {
     /// When neither prod dir nor XDG_RUNTIME_DIR is available, falls through to tmpdir.
     #[test]
     fn sock_path_cascade_to_tmpdir() {
+        let _lock = admin_sock_env_lock();
+        // SAFETY: callers hold admin_sock_env_lock so no concurrent reader can
+        // observe a torn value.
         unsafe { std::env::remove_var("SERA_ADMIN_SOCK") };
         unsafe { std::env::remove_var("XDG_RUNTIME_DIR") };
 


### PR DESCRIPTION
## Summary

Audited all `std::env::set_var`/`remove_var` call sites in `sera-gateway` test blocks and applied the same `static OnceLock<Mutex<()>>` isolation pattern that was introduced in `constitutional_config.rs` by #1181.

**Offenders found and fixed:**

- `admin/auth.rs` — `SERA_ADMIN_TOKEN`: new `admin_token_lock()` helper guards `resolve_errors_when_unset_and_not_local` and `resolve_uses_env_var_when_set`
- `kill_switch.rs` — `SERA_ADMIN_SOCK` + `XDG_RUNTIME_DIR`: new `admin_sock_env_lock()` guards all four `sock_path_*` tests (both vars interact in the cascade, so one lock covers both)
- `bin/sera.rs` — `SERA_READINESS_PROBE_TIMEOUT_SECS`: new `READINESS_TIMEOUT_ENV_LOCK` static guards `readiness_returns_503_when_harness_does_not_respond`
- `bin/sera.rs` — `SERA_TURN_TIMEOUT_SECS`: new `TURN_TIMEOUT_ENV_LOCK` static guards `execute_steer_drains_until_turn_completed` and `turn_timeout_defaults_when_env_unset`
- `bin/sera.rs` — `SERA_DISPATCH_MODE`: `DISPATCH_MODE_ENV_LOCK` was **already present** from a prior fix; untouched

No production code changed — test-module only.

## Test plan

- [x] `cargo test -p sera-gateway --lib -- --test-threads=1` → 164 passed
- [x] `cargo test -p sera-gateway --lib` (default parallel threads) → 164 passed

🤖 Generated with [Claude Code](https://claude.ai/claude-code)