### PR TITLE
fix(sera-tui): collapse nested if into let-chain (clippy)

### DIFF
--- a/rust/crates/sera-tui/src/app/mod.rs
+++ b/rust/crates/sera-tui/src/app/mod.rs
@@ -810,8 +810,8 @@ impl App {
                     // blocks originated from that task.  We match by task_id
                     // stored on the block — the stack entry was cloned from it
                     // at drill_in time.
-                    if let Some(stack_thread) = self.thread_stack.last_mut() {
-                        if let Some(child) = self.session.blocks.iter().find_map(|b| {
+                    if let Some(stack_thread) = self.thread_stack.last_mut()
+                        && let Some(child) = self.session.blocks.iter().find_map(|b| {
                             if let crate::views::blocks::Block::Task {
                                 task_id: tid,
                                 child_thread,
@@ -823,9 +823,9 @@ impl App {
                             } else {
                                 None
                             }
-                        }) {
-                            *stack_thread = child;
-                        }
+                        })
+                    {
+                        *stack_thread = child;
                     }
                 } else {
                     self.session.apply_event(ev);


### PR DESCRIPTION
Edition 2024 `collapsible_if` lint regression introduced by #1188. One-line fix unblocking #1190/#1191/#1192.