### PR TITLE
feat(sera-runtime): wire manifest subagents_allowed into ctx.handoffs (sera-q9i5)

### DIFF
--- a/rust/crates/sera-gateway/src/bin/sera.rs
+++ b/rust/crates/sera-gateway/src/bin/sera.rs
@@ -4848,6 +4848,16 @@ async fn run_start(config: PathBuf, port: u16, local: bool) -> anyhow::Result<()
         if let Ok(deny) = std::env::var("SERA_AGENT_TOOLS_DENY") {
             env.insert("SERA_AGENT_TOOLS_DENY".to_string(), deny);
         }
+        // sera-q9i5: forward the agent's `subagents_allowed` list as a
+        // comma-separated string so the runtime can populate ctx.handoffs
+        // and surface `handoff_to_<id>` tools to the LLM. Always set the
+        // var (empty = no handoffs) to prevent stale parent-process values
+        // from leaking into a freshly-restricted agent.
+        let subagents_csv = agent_spec.subagents_allowed.join(",");
+        env.insert(
+            "SERA_AGENT_SUBAGENTS_ALLOWED".to_string(),
+            subagents_csv,
+        );
 
         // sera-ve9x: branch on the effective dispatch mode. `runtime` (default)
         // spawns the existing supervised stdio child; `embedded` builds an
@@ -7713,6 +7723,7 @@ spec:
             policy_ref: None,
             enforcement_mode: None,
             approval_policy: None,
+            subagents_allowed: Vec::new(),
         };
         let skill_engine = SkillDispatchEngine::new();
         let semantic_store: Arc<dyn SemanticMemoryStore> = Arc::new(
@@ -9256,6 +9267,7 @@ spec:
             policy_ref: None,
             enforcement_mode: None,
             approval_policy: None,
+            subagents_allowed: Vec::new(),
         };
         let skill_engine = SkillDispatchEngine::new();
         let semantic_store: Arc<dyn SemanticMemoryStore> = Arc::new(
@@ -9330,6 +9342,7 @@ spec:
             policy_ref: None,
             enforcement_mode: None,
             approval_policy: None,
+            subagents_allowed: Vec::new(),
         };
         let skill_engine = SkillDispatchEngine::new();
         let semantic_store: Arc<dyn SemanticMemoryStore> = Arc::new(

--- a/rust/crates/sera-gateway/src/hitl_gateway.rs
+++ b/rust/crates/sera-gateway/src/hitl_gateway.rs
@@ -372,6 +372,7 @@ mod tests {
             policy_ref: None,
             enforcement_mode: None,
             approval_policy: None,
+            subagents_allowed: Vec::new(),
         };
         assert_eq!(resolve_hitl_mode(&spec), HitlMode::Autonomous);
     }
@@ -387,6 +388,7 @@ mod tests {
             policy_ref: None,
             enforcement_mode: Some("strict".into()),
             approval_policy: None,
+            subagents_allowed: Vec::new(),
         };
         assert_eq!(resolve_hitl_mode(&spec), HitlMode::Strict);
     }
@@ -402,6 +404,7 @@ mod tests {
             policy_ref: None,
             enforcement_mode: Some("bogus".into()),
             approval_policy: None,
+            subagents_allowed: Vec::new(),
         };
         assert_eq!(resolve_hitl_mode(&spec), HitlMode::Autonomous);
     }
@@ -417,6 +420,7 @@ mod tests {
             policy_ref: None,
             enforcement_mode: None,
             approval_policy: None,
+            subagents_allowed: Vec::new(),
         };
         assert!(matches!(
             resolve_approval_routing(&spec),
@@ -439,6 +443,7 @@ mod tests {
             policy_ref: None,
             enforcement_mode: None,
             approval_policy: Some(json),
+            subagents_allowed: Vec::new(),
         };
         let routing = resolve_approval_routing(&spec);
         match routing {

--- a/rust/crates/sera-runtime/src/config.rs
+++ b/rust/crates/sera-runtime/src/config.rs
@@ -70,6 +70,14 @@ pub struct RuntimeConfig {
     /// When `Some`, [`crate::llm_client::LlmClient`] applies the matching
     /// provider-native parameter before sending each request.
     pub thinking_level: Option<ThinkingLevel>,
+    /// Agent IDs this agent may hand off control to (sera-q9i5).
+    ///
+    /// Reads `SERA_AGENT_SUBAGENTS_ALLOWED` (comma-separated). Forwarded by
+    /// the gateway from the agent manifest's `subagents_allowed` list. The
+    /// runtime injects this into every `TurnContext.metadata` so
+    /// `default_runtime` builds `handoff_to_<id>` tool definitions for the
+    /// LLM. Empty (the default) means no handoff tools are exposed.
+    pub subagents_allowed: Vec<String>,
 }
 
 impl RuntimeConfig {
@@ -129,6 +137,16 @@ impl RuntimeConfig {
             thinking_level: std::env::var("SERA_THINKING_LEVEL")
                 .ok()
                 .and_then(|v| v.parse::<ThinkingLevel>().ok()),
+            subagents_allowed: std::env::var("SERA_AGENT_SUBAGENTS_ALLOWED")
+                .ok()
+                .map(|v| {
+                    v.split(',')
+                        .map(str::trim)
+                        .filter(|s| !s.is_empty())
+                        .map(str::to_owned)
+                        .collect()
+                })
+                .unwrap_or_default(),
         }
     }
 }

--- a/rust/crates/sera-runtime/src/llm_client.rs
+++ b/rust/crates/sera-runtime/src/llm_client.rs
@@ -2085,6 +2085,7 @@ mod tests {
             tool_authz_enabled: false,
             tool_authz_roles: None,
             thinking_level: level,
+            subagents_allowed: Vec::new(),
         }
     }
 

--- a/rust/crates/sera-runtime/src/stdio.rs
+++ b/rust/crates/sera-runtime/src/stdio.rs
@@ -134,7 +134,13 @@ async fn process_submission(
     )
     .await?;
 
-    let turn_ctx = submission_to_turn_context(&submission, &config.agent_id, turn_id, tool_defs);
+    let turn_ctx = submission_to_turn_context(
+        &submission,
+        &config.agent_id,
+        turn_id,
+        tool_defs,
+        &config.subagents_allowed,
+    );
     let outcome = runtime.execute_turn(turn_ctx).await;
 
     // Extract tokens_used for the terminal TurnCompleted frame. `Interruption`
@@ -415,11 +421,17 @@ async fn emit(stdout: &mut tokio::io::Stdout, event: Event) -> anyhow::Result<()
 ///
 /// `session_key` / `parent_session_key` are envelope-level fields (sera-zx5w);
 /// only the `items` list is pulled from the [`Op`] variant.
+///
+/// `subagents_allowed` (sera-q9i5) is injected into
+/// `metadata["subagents_allowed"]` so
+/// [`crate::default_runtime::DefaultRuntime`] builds `handoff_to_<id>` tool
+/// definitions for the LLM. Empty list means no handoff tools are exposed.
 fn submission_to_turn_context(
     submission: &Submission,
     agent_id: &str,
     turn_id: uuid::Uuid,
     tool_defs: &[sera_types::tool::ToolDefinition],
+    subagents_allowed: &[String],
 ) -> TurnContext {
     let messages = match &submission.op {
         Op::UserTurn { items, .. } => items.clone(),
@@ -436,13 +448,26 @@ fn submission_to_turn_context(
         .clone()
         .unwrap_or_else(|| format!("session:{agent_id}:{}", submission.id));
 
+    let mut metadata = HashMap::new();
+    if !subagents_allowed.is_empty() {
+        metadata.insert(
+            "subagents_allowed".to_string(),
+            serde_json::Value::Array(
+                subagents_allowed
+                    .iter()
+                    .map(|id| serde_json::Value::String(id.clone()))
+                    .collect(),
+            ),
+        );
+    }
+
     TurnContext {
         event_id: turn_id.to_string(),
         agent_id: agent_id.to_string(),
         session_key,
         messages,
         available_tools: tool_defs.to_vec(),
-        metadata: HashMap::new(),
+        metadata,
         // Envelope-level `change_artifact` is a string tag for audit persistence;
         // TurnContext carries a typed `ChangeArtifactId` that only sera-meta
         // populates. Leave as None until wired through.
@@ -496,6 +521,66 @@ mod tests {
         }"#;
         let sub: Submission = serde_json::from_str(json).unwrap();
         assert!(matches!(sub.op, Op::System(SystemOp::Shutdown)));
+    }
+
+    // sera-q9i5: verify that submission_to_turn_context injects
+    // subagents_allowed into TurnContext.metadata so default_runtime can
+    // build handoff_to_<id> tool definitions.
+    #[test]
+    fn submission_to_turn_context_injects_subagents_allowed_metadata() {
+        let sub = Submission {
+            id: uuid::Uuid::nil(),
+            op: Op::UserTurn {
+                items: vec![],
+                cwd: None,
+                approval_policy: None,
+                sandbox_policy: None,
+                model_override: None,
+                effort: None,
+                final_output_schema: None,
+            },
+            trace: Default::default(),
+            change_artifact: None,
+            session_key: Some("session:test-agent:abc".to_string()),
+            parent_session_key: None,
+            parent_task_id: None,
+        };
+        let allowed = vec!["researcher".to_string(), "coder".to_string()];
+        let ctx =
+            submission_to_turn_context(&sub, "test-agent", uuid::Uuid::nil(), &[], &allowed);
+        let value = ctx
+            .metadata
+            .get("subagents_allowed")
+            .expect("subagents_allowed should be in metadata");
+        let arr = value.as_array().expect("subagents_allowed should be an array");
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0].as_str(), Some("researcher"));
+        assert_eq!(arr[1].as_str(), Some("coder"));
+    }
+
+    // sera-q9i5: empty subagents_allowed must not insert the key, so
+    // default_runtime falls back to its no-handoff branch.
+    #[test]
+    fn submission_to_turn_context_omits_subagents_allowed_when_empty() {
+        let sub = Submission {
+            id: uuid::Uuid::nil(),
+            op: Op::UserTurn {
+                items: vec![],
+                cwd: None,
+                approval_policy: None,
+                sandbox_policy: None,
+                model_override: None,
+                effort: None,
+                final_output_schema: None,
+            },
+            trace: Default::default(),
+            change_artifact: None,
+            session_key: None,
+            parent_session_key: None,
+            parent_task_id: None,
+        };
+        let ctx = submission_to_turn_context(&sub, "test-agent", uuid::Uuid::nil(), &[], &[]);
+        assert!(ctx.metadata.get("subagents_allowed").is_none());
     }
 
     #[test]

--- a/rust/crates/sera-types/src/config_manifest.rs
+++ b/rust/crates/sera-types/src/config_manifest.rs
@@ -244,6 +244,15 @@ pub struct AgentSpec {
     /// `{ "mode": "autonomous" }`. Wave D (sera-z6ql).
     #[serde(default, alias = "approvalPolicy", skip_serializing_if = "Option::is_none")]
     pub approval_policy: Option<serde_json::Value>,
+    /// Agent IDs this agent may hand off control to (sera-q9i5).
+    ///
+    /// When non-empty, the gateway forwards this list as
+    /// `SERA_AGENT_SUBAGENTS_ALLOWED` to the runtime; the runtime injects
+    /// `metadata["subagents_allowed"]` into every `TurnContext` so
+    /// `default_runtime` builds `handoff_to_<id>` tool definitions for the
+    /// LLM. Empty/absent (the default) means no handoff tools are exposed.
+    #[serde(default, alias = "subagentsAllowed", skip_serializing_if = "Vec::is_empty")]
+    pub subagents_allowed: Vec<String>,
 }
 
 /// Persona configuration within an agent spec.


### PR DESCRIPTION
## Summary
- The `Handoff` tool was defined in `sera-runtime/src/handoff.rs` and consumed by `turn.rs`, but `ctx.handoffs` was always empty in production: nothing populated `TurnContext.metadata["subagents_allowed"]`, so `default_runtime` built no `handoff_to_<id>` tools and the LLM never saw them.
- This PR threads the agent manifest's `subagents_allowed` list through the gateway → runtime → `ctx.handoffs` path so the dormant handoff machinery becomes reachable.

## Changes
- `sera-types/config_manifest.rs`: add `subagents_allowed: Vec<String>` to `AgentSpec` (alias `subagentsAllowed`).
- `sera-gateway/bin/sera.rs`: forward the list as `SERA_AGENT_SUBAGENTS_ALLOWED` env var when starting the runtime supervisor.
- `sera-runtime/config.rs`: read the env var into `RuntimeConfig::subagents_allowed`.
- `sera-runtime/stdio.rs`: `submission_to_turn_context` now injects `metadata["subagents_allowed"]` so the existing `default_runtime` builder produces the handoff tool defs.
- Test fixtures updated to populate the new field; two new tests cover the populated and empty paths.

## Test plan
- [x] `cargo check -p sera-types -p sera-runtime -p sera-gateway`
- [x] `cargo test -p sera-runtime --lib stdio::` (6 passed including the new injection tests)
- [ ] Operator smoke test: provision two agents with `subagentsAllowed`, observe `handoff_to_<id>` tool in LLM schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)