### PR TITLE
fix(ci): disable docs auto-deploy trigger until Zensical migration (sera-0ys9)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,11 +1,9 @@
 name: Deploy Documentation
 
+# Disabled: mkdocs.yml was moved under legacy/ and the target site
+# (tkcen.github.io/sera/) is stale. This workflow will be replaced when
+# the Zensical migration (sera-yw99) lands. Until then only allow manual runs.
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'docs/**'
-      - 'mkdocs.yml'
   workflow_dispatch:
 
 permissions:
@@ -31,7 +29,7 @@ jobs:
         run: pip install mkdocs-material
 
       - name: Build site
-        run: mkdocs build
+        run: mkdocs build --config-file legacy/mkdocs.yml
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v5


### PR DESCRIPTION
## Summary

- Removes the `push`/`paths` trigger from `.github/workflows/docs.yml` — `mkdocs.yml` no longer exists at the repo root (moved to `legacy/`) so every `docs/**` push was failing the deploy job
- Keeps `workflow_dispatch` so the workflow can still be triggered manually
- Points the `mkdocs build` command at `legacy/mkdocs.yml` so a manual run would actually succeed

## Context

Pre-existing breakage surfaced during the docs-zensical lane (sera-yw99). The legacy docs site (`tkcen.github.io/sera/`) is stale. This workflow will be replaced entirely when the Zensical migration lands.

Fixes: sera-0ys9

## Test plan

- [ ] Confirm no CI job triggers on `docs/**` push after merge
- [ ] Confirm `workflow_dispatch` still appears in Actions UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)