### PR TITLE
cleanup(sera-gateway): align connector module with SPEC-gateway §8 (sera-9r56)

### DIFF
--- a/rust/crates/sera-gateway/src/connector/mod.rs
+++ b/rust/crates/sera-gateway/src/connector/mod.rs
@@ -1,27 +1,11 @@
 //! Connector registry — external channel adapters (Discord, Slack, etc.).
+//!
+//! The canonical connector surface is defined in `sera-types::connector`.
+//! This module re-exports it so gateway code can use a single import path.
+//!
+//! See SPEC-gateway §8 and `sera-types::connector` for the full design.
 
-use std::collections::HashMap;
-use std::sync::Arc;
-
-use async_trait::async_trait;
-use tokio::sync::RwLock;
-
-pub use sera_types::connector::ConnectorError;
-
-/// Connector trait — delivers and receives messages from external channels.
-#[async_trait]
-pub trait Connector: Send + Sync {
-    /// Deliver a message to the external channel.
-    async fn deliver(&self, channel_id: &str, message: &str) -> Result<(), ConnectorError>;
-
-    /// Human-readable name of this connector.
-    fn name(&self) -> &str;
-}
-
-/// Registry of active connectors.
-pub type ConnectorRegistry = Arc<RwLock<HashMap<String, Box<dyn Connector>>>>;
-
-/// Create a new empty connector registry.
-pub fn new_connector_registry() -> ConnectorRegistry {
-    Arc::new(RwLock::new(HashMap::new()))
-}
+pub use sera_types::connector::{
+    ChannelConnector, ChannelType, ConnectorError, ConnectorIdentity, ConnectorRegistry,
+    ConnectorStatus, OutboundMessage,
+};


### PR DESCRIPTION
## Summary

- Removes the dead `Connector` trait and `ConnectorRegistry` type-alias from `sera-gateway::connector` — neither was implemented by any type nor used anywhere in the codebase
- Replaces the module content with re-exports of the canonical `ChannelConnector`, `ConnectorRegistry`, and supporting types from `sera-types::connector`, which already matched SPEC-gateway §8 / PRD §13 naming
- Closes the naming drift introduced when sera-er6j added the types-crate trait without reconciling with gateway code

## Test plan

- [x] `cargo check --workspace --tests` — clean
- [x] `cargo test --workspace` — 4503 passed, 0 failed

Closes sera-9r56

🤖 Generated with [Claude Code](https://claude.com/claude-code)