### PR TITLE
feat(web): add operator task panel

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -288,3 +288,38 @@ export interface HooksList {
 }
 
 export const getHooks = () => apiFetch<HooksList>('/hooks');
+
+// ── Operator tasks (sera-6zcb dogfood loop) ────────────────────────────────
+
+export interface OperatorTaskRequest {
+  task: string;
+  agent?: string;
+  helper?: string;
+}
+
+export interface SpawnedHelperStatus {
+  agent?: string | null;
+  task_id?: string | null;
+  status?: string | null;
+  count?: number | null;
+  total?: number | null;
+}
+
+export interface OperatorTaskStatusCard {
+  accepted_task?: string | null;
+  active_agent?: string | null;
+  spawned_helper?: SpawnedHelperStatus | null;
+  handoff_tool?: string | null;
+  latest_event?: string | null;
+  status?: string | null;
+  blocked?: boolean | null;
+  result?: string | null;
+  audit_id?: string | null;
+  session_key?: string | null;
+}
+
+export const runOperatorTask = (body: OperatorTaskRequest) =>
+  apiFetch<OperatorTaskStatusCard>('/operator/tasks', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });

--- a/web/src/views/ChatView.test.ts
+++ b/web/src/views/ChatView.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { parseChatSseEvent } from '@/lib/api';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ApiError, parseChatSseEvent, runOperatorTask, setToken } from '@/lib/api';
 
 describe('parseChatSseEvent', () => {
   it('parses a message delta event', () => {
@@ -100,5 +100,89 @@ describe('parseChatSseEvent', () => {
 
     expect(accumulated).toBe('Hello world!');
     expect(done).toBe(true);
+  });
+});
+
+describe('runOperatorTask', () => {
+  beforeEach(() => {
+    setToken('test-key');
+  });
+  afterEach(() => {
+    setToken(null);
+    vi.restoreAllMocks();
+  });
+
+  it('POSTs to /api/operator/tasks with bearer auth and returns the status card', async () => {
+    const card = {
+      accepted_task: 'do thing',
+      active_agent: 'sera',
+      spawned_helper: { agent: 'serahelper', task_id: 'sera:abc/h1', status: 'idle', count: 1, total: 1 },
+      handoff_tool: 'handoff_to_serahelper',
+      latest_event: 'intercom:operator.task delivered=true',
+      status: 'complete',
+      blocked: false,
+      result: 'ok',
+      audit_id: 'aud_1',
+      session_key: 'sera:abc',
+    };
+
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify(card), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await runOperatorTask({
+      task: 'do thing',
+      agent: 'sera',
+      helper: 'serahelper',
+    });
+
+    expect(result).toEqual(card);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe('/api/operator/tasks');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body as string)).toEqual({
+      task: 'do thing',
+      agent: 'sera',
+      helper: 'serahelper',
+    });
+    const headers = new Headers(init.headers);
+    expect(headers.get('Authorization')).toBe('Bearer test-key');
+    expect(headers.get('Content-Type')).toBe('application/json');
+  });
+
+  it('throws ApiError with status 401 on auth failure', async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ error: 'unauthorized' }), {
+        status: 401,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(runOperatorTask({ task: 'hi' })).rejects.toMatchObject({
+      name: 'ApiError',
+      status: 401,
+    });
+    await expect(runOperatorTask({ task: 'hi' })).rejects.toBeInstanceOf(ApiError);
+  });
+
+  it('tolerates a permissive response shape with missing optional fields', async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ status: 'complete', result: 'ok' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await runOperatorTask({ task: 'hi' });
+    expect(result.status).toBe('complete');
+    expect(result.result).toBe('ok');
+    expect(result.spawned_helper).toBeUndefined();
   });
 });

--- a/web/src/views/ChatView.tsx
+++ b/web/src/views/ChatView.tsx
@@ -1,7 +1,13 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
 import { Send } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { chatStream, ApiError, type ChatStreamEvent } from '@/lib/api';
+import {
+  chatStream,
+  runOperatorTask,
+  ApiError,
+  type ChatStreamEvent,
+  type OperatorTaskStatusCard,
+} from '@/lib/api';
 import { useAuth } from '@/contexts/auth-context';
 
 interface Message {
@@ -16,6 +22,12 @@ export function ChatView() {
   const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState('');
   const [thinking, setThinking] = useState(false);
+  const [opTask, setOpTask] = useState('');
+  const [opAgent, setOpAgent] = useState('sera');
+  const [opHelper, setOpHelper] = useState('serahelper');
+  const [opRunning, setOpRunning] = useState(false);
+  const [opCard, setOpCard] = useState<OperatorTaskStatusCard | null>(null);
+  const [opError, setOpError] = useState<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
   const mountedRef = useRef(true);
@@ -121,6 +133,31 @@ export function ChatView() {
     [sendMessage],
   );
 
+  const runTask = useCallback(async () => {
+    const task = opTask.trim();
+    if (!task || opRunning) return;
+    setOpRunning(true);
+    setOpError(null);
+    try {
+      const card = await runOperatorTask({
+        task,
+        agent: opAgent.trim() || undefined,
+        helper: opHelper.trim() || undefined,
+      });
+      if (!mountedRef.current) return;
+      setOpCard(card);
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 401) {
+        signOut();
+        return;
+      }
+      const msg = err instanceof Error ? err.message : 'Unknown error';
+      if (mountedRef.current) setOpError(msg);
+    } finally {
+      if (mountedRef.current) setOpRunning(false);
+    }
+  }, [opTask, opAgent, opHelper, opRunning, signOut]);
+
   return (
     <div className="flex h-full flex-col">
       {/* Transcript */}
@@ -160,8 +197,115 @@ export function ChatView() {
         <div ref={bottomRef} />
       </div>
 
+      {/* Operator task panel (sera-6zcb dogfood loop) */}
+      <div
+        className="border-t border-zinc-800 bg-zinc-950 p-3 space-y-2"
+        data-testid="operator-task-panel"
+      >
+        <div className="flex items-center justify-between">
+          <h2 className="text-xs font-semibold uppercase tracking-wide text-zinc-400">
+            Operator task
+          </h2>
+          {opCard?.status && (
+            <span
+              className={cn(
+                'rounded px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide',
+                opCard.blocked
+                  ? 'bg-red-950/60 text-red-300 border border-red-800'
+                  : 'bg-emerald-950/60 text-emerald-300 border border-emerald-800',
+              )}
+            >
+              {opCard.status}
+            </span>
+          )}
+        </div>
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-[1fr_auto_auto_auto]">
+          <input
+            type="text"
+            className="rounded-lg border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm text-zinc-100 placeholder-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500"
+            placeholder="Operator task… (e.g. summarize last release)"
+            value={opTask}
+            onChange={(e) => setOpTask(e.target.value)}
+            disabled={opRunning}
+            aria-label="Operator task"
+          />
+          <input
+            type="text"
+            className="rounded-lg border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm text-zinc-100 placeholder-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500 sm:w-32"
+            placeholder="agent"
+            value={opAgent}
+            onChange={(e) => setOpAgent(e.target.value)}
+            disabled={opRunning}
+            aria-label="Active agent"
+          />
+          <input
+            type="text"
+            className="rounded-lg border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm text-zinc-100 placeholder-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500 sm:w-36"
+            placeholder="helper"
+            value={opHelper}
+            onChange={(e) => setOpHelper(e.target.value)}
+            disabled={opRunning}
+            aria-label="Helper agent"
+          />
+          <button
+            type="button"
+            onClick={() => void runTask()}
+            disabled={!opTask.trim() || opRunning}
+            className={cn(
+              'rounded-lg px-3 py-2 text-sm font-medium transition-colors',
+              opTask.trim() && !opRunning
+                ? 'bg-zinc-700 text-zinc-100 hover:bg-zinc-600'
+                : 'bg-zinc-800 text-zinc-600 cursor-not-allowed',
+            )}
+          >
+            {opRunning ? 'Running…' : 'Run'}
+          </button>
+        </div>
+        {opError && (
+          <div className="rounded border border-red-800 bg-red-950/40 px-2 py-1 text-xs text-red-300">
+            Error: {opError}
+          </div>
+        )}
+        {opCard && (
+          <div
+            className="rounded border border-zinc-800 bg-zinc-900/60 p-2 text-xs text-zinc-300 space-y-1"
+            data-testid="operator-task-card"
+          >
+            <div className="grid grid-cols-2 gap-x-3 gap-y-0.5 sm:grid-cols-4">
+              <Field label="Agent" value={opCard.active_agent} />
+              <Field label="Helper" value={opCard.spawned_helper?.agent} />
+              <Field label="Tool" value={opCard.handoff_tool} />
+              <Field
+                label="Helpers"
+                value={
+                  opCard.spawned_helper
+                    ? `${opCard.spawned_helper.count ?? 0}/${opCard.spawned_helper.total ?? 0}`
+                    : null
+                }
+              />
+            </div>
+            {opCard.latest_event && (
+              <div>
+                <span className="text-zinc-500">Latest event: </span>
+                <span className="font-mono text-zinc-300">{opCard.latest_event}</span>
+              </div>
+            )}
+            {opCard.result && (
+              <div>
+                <span className="text-zinc-500">Result: </span>
+                <span className="whitespace-pre-wrap text-zinc-200">{opCard.result}</span>
+              </div>
+            )}
+            <div className="flex flex-wrap gap-x-3 text-[11px] text-zinc-500">
+              {opCard.session_key && <span>session={opCard.session_key}</span>}
+              {opCard.audit_id && <span>audit={opCard.audit_id}</span>}
+            </div>
+          </div>
+        )}
+      </div>
+
       {/* Composer */}
-      <div className="border-t border-zinc-800 bg-zinc-950 p-3">
+      <div className="border-t border-zinc-800 bg-zinc-950 p-3" data-testid="chat-composer">
         <div className="flex items-end gap-2">
           <textarea
             className="flex-1 resize-none rounded-lg border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm text-zinc-100 placeholder-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500"
@@ -188,6 +332,16 @@ export function ChatView() {
           </button>
         </div>
       </div>
+    </div>
+  );
+}
+
+function Field({ label, value }: { label: string; value: string | null | undefined }) {
+  if (!value) return null;
+  return (
+    <div className="truncate">
+      <span className="text-zinc-500">{label}: </span>
+      <span className="text-zinc-200">{value}</span>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Wires the new `POST /api/operator/tasks` dogfood loop (sera-6zcb) into the operator console.
- Adds a compact panel inside `ChatView` above the composer: task input, agent override (`sera`), helper override (`serahelper`), Run button, status pill, and a status card showing active agent, helper, handoff tool, latest event, result, `session_key`, and `audit_id`.
- Adds a typed `runOperatorTask` helper in `web/src/lib/api.ts` with a permissive response shape so optional/null gateway fields don't break the UI.
- 401 reuses the existing chat sign-out path; non-401 errors render in-place without crashing.

## Test plan

- [x] `bun run typecheck` (web/) — clean
- [x] `bun run test -- ChatView` (web/) — 12/12 pass, including 3 new tests for `runOperatorTask` (request shape + auth header, 401 → ApiError, permissive response)
- [x] `bun run build` (web/) — clean production bundle
- [ ] Manual smoke against a running gateway with `serahelper`/`sera` agents (deferred — requires live runtime)

🤖 Generated with [Claude Code](https://claude.com/claude-code)