### PR TITLE
feat(sera-runtime): ToolScope dispatcher gate (sera-u4gj PR3)

### DIFF
--- a/rust/crates/sera-runtime/src/tools/dispatcher.rs
+++ b/rust/crates/sera-runtime/src/tools/dispatcher.rs
@@ -17,6 +17,18 @@
 //! denial returns [`ToolError::PolicyDenied`]; the underlying tool handler is
 //! never invoked, so a denied tool truly does not start.
 //!
+//! # Principal-policy ToolScope gate (sera-u4gj)
+//!
+//! When a [`PrincipalPolicy`] is attached via
+//! [`RegistryDispatcher::with_principal_policy`], every dispatch checks the
+//! dispatched tool's [`sera_types::tool::ToolMetadata::scope`] against
+//! `policy.allowed_tool_scopes` **before** the CapabilityRegistry gate, the
+//! escalation gate, any pre-tool hook, or `TraitToolRegistry::execute`. A
+//! denial returns [`ToolError::PolicyDenied`] with the `[sera-policy] …`
+//! prefix used by the gateway audit filter. Unknown tool names fall through
+//! to the existing `NotFound` path — typoed names are reported as
+//! tool-not-found, not as policy violations.
+//!
 //! # Tool hooks and permission escalation (sera-ddz / GH#544, GH#545)
 //!
 //! `RegistryDispatcher` holds **additive** optional layers:
@@ -35,6 +47,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use sera_auth::policy::PrincipalPolicy;
 use sera_config::CapabilityRegistry;
 use sera_types::tool::{ToolContext, ToolInput, ToolOutput};
 
@@ -67,6 +80,14 @@ pub struct RegistryDispatcher {
     /// tool runs; a denial returns [`ToolError::PolicyDenied`] so the tool
     /// handler is never invoked.
     capability: Option<(Arc<CapabilityRegistry>, String)>,
+    /// Optional principal-policy ToolScope gate (sera-u4gj). When `Some`,
+    /// every dispatch checks the dispatched tool's
+    /// [`sera_types::tool::ToolMetadata::scope`] against
+    /// `policy.allowed_tool_scopes` **before** the CapabilityRegistry gate,
+    /// any escalation/hook layer, or `TraitToolRegistry::execute`. Unknown
+    /// tool names are not gated here — they fall through to the existing
+    /// `NotFound` path.
+    principal_policy: Option<Arc<PrincipalPolicy>>,
 }
 
 impl RegistryDispatcher {
@@ -79,6 +100,7 @@ impl RegistryDispatcher {
             caller_mode: PermissionMode::Standard,
             default_tool_mode: PermissionMode::Standard,
             capability: None,
+            principal_policy: None,
         }
     }
 
@@ -101,6 +123,19 @@ impl RegistryDispatcher {
         agent_id: impl Into<String>,
     ) -> Self {
         self.capability = Some((registry, agent_id.into()));
+        self
+    }
+
+    /// Attach a [`PrincipalPolicy`] for the agent run this dispatcher is
+    /// servicing (sera-u4gj). When set, every `dispatch` call checks the
+    /// dispatched tool's [`sera_types::tool::ToolMetadata::scope`] against
+    /// `policy.allowed_tool_scopes` **before** the CapabilityRegistry gate,
+    /// the escalation gate, hooks, or `TraitToolRegistry::execute`. Unknown
+    /// tool names are not gated — they fall through to the existing
+    /// `NotFound` path so typos surface as tool-not-found, not as policy
+    /// violations.
+    pub fn with_principal_policy(mut self, policy: Arc<PrincipalPolicy>) -> Self {
+        self.principal_policy = Some(policy);
         self
     }
 
@@ -182,6 +217,26 @@ impl ToolDispatcher for RegistryDispatcher {
             arguments,
             call_id: tool_call_id.to_string(),
         };
+
+        // ── Principal-policy ToolScope gate (sera-u4gj) ──────────────────
+        // PrincipalPolicy.allowed_tool_scopes must contain the dispatched
+        // tool's declared ToolScope BEFORE the CapabilityRegistry gate, the
+        // escalation gate, any pre-tool hook, or TraitToolRegistry::execute.
+        // Unknown tool names are NOT gated here — they fall through to the
+        // existing NotFound path so a typoed name is reported as
+        // tool-not-found rather than a policy violation (sera-zdky is the
+        // separate bead that may pre-filter tool names at the gateway).
+        if let Some(policy) = self.principal_policy.as_ref()
+            && let Some(tool) = self.registry.get(&input.name)
+        {
+            let scope = tool.metadata().scope;
+            if !policy.allowed_tool_scopes.contains(&scope) {
+                return Err(ToolError::PolicyDenied(format!(
+                    "[sera-policy] tool '{}' denied by principal policy: scope {:?} not in allowed_tool_scopes",
+                    input.name, scope
+                )));
+            }
+        }
 
         // ── Capability policy gate (sera-eo71) ───────────────────────────
         // Pre-dispatch check: a deny here returns before any hook fires and
@@ -866,5 +921,235 @@ mod tests {
             .await
             .expect("unbound agent passes the gate");
         assert_eq!(result["tool_call_id"], "call-cap-unbound-1");
+    }
+
+    // ── sera-u4gj: pre-dispatch ToolScope (PrincipalPolicy) gate ─────────
+
+    use sera_auth::policy::PrincipalPolicy;
+    use sera_types::principal::PrincipalKind;
+    use sera_types::tool::{
+        ExecutionTarget, FunctionParameters, RiskLevel, Tool, ToolMetadata, ToolSchema,
+        ToolScope,
+    };
+
+    /// Construct a `PrincipalPolicy` with exactly the supplied scope set.
+    /// Other fields use the default-deny shape from
+    /// [`PrincipalPolicy::empty`] — irrelevant to scope-gate tests.
+    fn policy_with_scopes(scopes: &[ToolScope]) -> Arc<PrincipalPolicy> {
+        let mut p = PrincipalPolicy::empty();
+        p.allowed_tool_scopes = scopes.iter().copied().collect();
+        Arc::new(p)
+    }
+
+    fn shell_exec_call(id: &str) -> serde_json::Value {
+        serde_json::json!({
+            "id": id,
+            "type": "function",
+            "function": {
+                "name": "shell-exec",
+                "arguments": "{\"command\":\"echo hi\"}"
+            }
+        })
+    }
+
+    #[tokio::test]
+    async fn dispatcher_scope_deny_blocks_handler_pre_dispatch() {
+        // Policy permits Read only; shell-exec is Execute. Denial must
+        // surface as PolicyDenied with the scope-shaped message before any
+        // shell process spawns.
+        let dispatcher = RegistryDispatcher::new(Arc::new(TraitToolRegistry::with_builtins()))
+            .with_principal_policy(policy_with_scopes(&[ToolScope::Read]));
+
+        let call = shell_exec_call("call-scope-deny-1");
+        let err = dispatcher
+            .dispatch(&call, &ToolContext::default())
+            .await
+            .unwrap_err();
+        match err {
+            ToolError::PolicyDenied(msg) => {
+                assert!(
+                    msg.starts_with("[sera-policy] tool 'shell-exec' denied by principal policy"),
+                    "unexpected message prefix: {msg}"
+                );
+                assert!(
+                    msg.contains("scope Execute not in allowed_tool_scopes"),
+                    "expected scope detail in message: {msg}"
+                );
+            }
+            other => panic!("expected PolicyDenied, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn dispatcher_scope_allow_runs_tool_normally() {
+        // Same policy permits Read; file-list is Read. The dispatcher must
+        // run the underlying tool and return the normal tool_call envelope.
+        let dispatcher = RegistryDispatcher::new(Arc::new(TraitToolRegistry::with_builtins()))
+            .with_principal_policy(policy_with_scopes(&[ToolScope::Read]));
+
+        let call = file_list_call("call-scope-allow-1");
+        let result = dispatcher
+            .dispatch(&call, &ToolContext::default())
+            .await
+            .expect("allowed scope dispatches normally");
+        assert_eq!(result["tool_call_id"], "call-scope-allow-1");
+        assert_eq!(result["role"], "tool");
+    }
+
+    #[tokio::test]
+    async fn dispatcher_scope_unknown_tool_falls_through_to_not_found() {
+        // Policy is attached but the tool name is unknown to the registry.
+        // The scope gate must NOT convert this into a policy denial — the
+        // existing NotFound path handles typos. (sera-zdky covers any
+        // gateway-side tool-list pre-filtering.)
+        let dispatcher = RegistryDispatcher::new(Arc::new(TraitToolRegistry::with_builtins()))
+            .with_principal_policy(policy_with_scopes(&[ToolScope::Read]));
+
+        let call = serde_json::json!({
+            "id": "call-scope-unknown-1",
+            "type": "function",
+            "function": {
+                "name": "does-not-exist",
+                "arguments": "{}"
+            }
+        });
+        let err = dispatcher
+            .dispatch(&call, &ToolContext::default())
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, ToolError::NotFound(_)),
+            "unknown tool name must fall through to NotFound, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatcher_scope_no_policy_attached_is_permissive() {
+        // Backwards-compat guard: a dispatcher built without
+        // `with_principal_policy` must behave identically to today.
+        let dispatcher = RegistryDispatcher::new(Arc::new(TraitToolRegistry::with_builtins()));
+
+        let call = file_list_call("call-scope-no-policy-1");
+        let result = dispatcher
+            .dispatch(&call, &ToolContext::default())
+            .await
+            .expect("no policy attached → permissive");
+        assert_eq!(result["tool_call_id"], "call-scope-no-policy-1");
+    }
+
+    #[tokio::test]
+    async fn dispatcher_scope_runs_before_capability_registry() {
+        // Both gates are armed: the scope policy denies Read (file-list is
+        // Read), AND the capability registry would also deny because
+        // file-list is not in its allow set. The error message must be the
+        // scope-shaped one — proving the scope gate runs first. This is the
+        // non-obvious test that catches future reorderings.
+        let cap_registry = capability_registry_with("alice", "deny-all", &[]);
+        let dispatcher = RegistryDispatcher::new(Arc::new(TraitToolRegistry::with_builtins()))
+            .with_capability_registry(cap_registry, "alice")
+            .with_principal_policy(policy_with_scopes(&[ToolScope::Execute]));
+
+        let call = file_list_call("call-scope-order-1");
+        let err = dispatcher
+            .dispatch(&call, &ToolContext::default())
+            .await
+            .unwrap_err();
+        match err {
+            ToolError::PolicyDenied(msg) => {
+                assert!(
+                    msg.contains("denied by principal policy"),
+                    "scope gate must fire first; got capability message: {msg}"
+                );
+                assert!(
+                    !msg.contains("denied by capability policy"),
+                    "scope gate must short-circuit before the capability gate: {msg}"
+                );
+                assert!(
+                    msg.contains("scope Read"),
+                    "denial must name the offending scope: {msg}"
+                );
+            }
+            other => panic!("expected PolicyDenied, got {other:?}"),
+        }
+    }
+
+    /// Synthetic Tool whose declared scope is [`ToolScope::Admin`]. Used by
+    /// `dispatcher_admin_scope_rejected_for_agent_kind_default` to exercise
+    /// the `PrincipalKind::Agent` default policy (which excludes Admin).
+    /// Built-in tools never carry the Admin scope today, so we register
+    /// this one ad-hoc for the test only.
+    struct AdminScopedTool;
+
+    #[async_trait]
+    impl Tool for AdminScopedTool {
+        fn metadata(&self) -> ToolMetadata {
+            ToolMetadata {
+                name: "test-admin-tool".to_string(),
+                description: "test-only Admin-scope tool for sera-u4gj".to_string(),
+                version: "1.0.0".to_string(),
+                author: None,
+                risk_level: RiskLevel::Admin,
+                execution_target: ExecutionTarget::InProcess,
+                tags: vec![],
+                scope: ToolScope::Admin,
+            }
+        }
+
+        fn schema(&self) -> ToolSchema {
+            ToolSchema {
+                parameters: FunctionParameters {
+                    schema_type: "object".to_string(),
+                    properties: Default::default(),
+                    required: vec![],
+                },
+            }
+        }
+
+        async fn execute(
+            &self,
+            _input: ToolInput,
+            _ctx: ToolContext,
+        ) -> Result<ToolOutput, ToolError> {
+            // Reaching this point would mean the scope gate failed open.
+            Ok(ToolOutput::success("admin-tool ran (gate failure)"))
+        }
+    }
+
+    #[tokio::test]
+    async fn dispatcher_admin_scope_rejected_for_agent_kind_default() {
+        // The Agent kind's default policy never carries Admin (the
+        // ExternalAgent / Service kinds are default-deny entirely; the
+        // Agent kind explicitly excludes Admin). A tool with scope=Admin
+        // must therefore be denied at the dispatcher.
+        let mut registry = TraitToolRegistry::with_builtins();
+        registry.register(Box::new(AdminScopedTool));
+        let dispatcher = RegistryDispatcher::new(Arc::new(registry))
+            .with_principal_policy(Arc::new(PrincipalPolicy::for_kind(PrincipalKind::Agent)));
+
+        let call = serde_json::json!({
+            "id": "call-scope-admin-1",
+            "type": "function",
+            "function": {
+                "name": "test-admin-tool",
+                "arguments": "{}"
+            }
+        });
+        let err = dispatcher
+            .dispatch(&call, &ToolContext::default())
+            .await
+            .unwrap_err();
+        match err {
+            ToolError::PolicyDenied(msg) => {
+                assert!(
+                    msg.contains("test-admin-tool"),
+                    "denial must name the offending tool: {msg}"
+                );
+                assert!(
+                    msg.contains("scope Admin"),
+                    "denial must name the Admin scope: {msg}"
+                );
+            }
+            other => panic!("expected PolicyDenied, got {other:?}"),
+        }
     }
 }

--- a/rust/crates/sera-runtime/src/tools/dispatcher.rs
+++ b/rust/crates/sera-runtime/src/tools/dispatcher.rs
@@ -130,13 +130,28 @@ impl RegistryDispatcher {
     /// servicing (sera-u4gj). When set, every `dispatch` call checks the
     /// dispatched tool's [`sera_types::tool::ToolMetadata::scope`] against
     /// `policy.allowed_tool_scopes` **before** the CapabilityRegistry gate,
-    /// the escalation gate, hooks, or `TraitToolRegistry::execute`. Unknown
-    /// tool names are not gated — they fall through to the existing
-    /// `NotFound` path so typos surface as tool-not-found, not as policy
-    /// violations.
+    /// the escalation gate, hooks, or `TraitToolRegistry::execute`; pre-hook
+    /// name rewrites are rechecked before execution. Unknown tool names are not
+    /// gated — they fall through to the existing `NotFound` path so typos
+    /// surface as tool-not-found, not as policy violations.
     pub fn with_principal_policy(mut self, policy: Arc<PrincipalPolicy>) -> Self {
         self.principal_policy = Some(policy);
         self
+    }
+
+    fn enforce_principal_policy_scope(&self, tool_name: &str) -> Result<(), ToolError> {
+        if let Some(policy) = self.principal_policy.as_ref()
+            && let Some(tool) = self.registry.get(tool_name)
+        {
+            let scope = tool.metadata().scope;
+            if !policy.allowed_tool_scopes.contains(&scope) {
+                return Err(ToolError::PolicyDenied(format!(
+                    "[sera-policy] tool '{}' denied by principal policy: scope {:?} not in allowed_tool_scopes",
+                    tool_name, scope
+                )));
+            }
+        }
+        Ok(())
     }
 
     /// Attach a [`EscalationAuthority`] and caller / required permission
@@ -226,17 +241,7 @@ impl ToolDispatcher for RegistryDispatcher {
         // existing NotFound path so a typoed name is reported as
         // tool-not-found rather than a policy violation (sera-zdky is the
         // separate bead that may pre-filter tool names at the gateway).
-        if let Some(policy) = self.principal_policy.as_ref()
-            && let Some(tool) = self.registry.get(&input.name)
-        {
-            let scope = tool.metadata().scope;
-            if !policy.allowed_tool_scopes.contains(&scope) {
-                return Err(ToolError::PolicyDenied(format!(
-                    "[sera-policy] tool '{}' denied by principal policy: scope {:?} not in allowed_tool_scopes",
-                    input.name, scope
-                )));
-            }
-        }
+        self.enforce_principal_policy_scope(&input.name)?;
 
         // ── Capability policy gate (sera-eo71) ───────────────────────────
         // Pre-dispatch check: a deny here returns before any hook fires and
@@ -330,6 +335,11 @@ impl ToolDispatcher for RegistryDispatcher {
                     ),
                 });
             }
+            // Re-run the principal-policy ToolScope gate after hook rewrites.
+            // A same/lower-risk rewrite can still cross scope boundaries
+            // (e.g. Execute → Network), so the pre-hook target must be checked
+            // before execution as well.
+            self.enforce_principal_policy_scope(&input.name)?;
         }
 
         // ── Execute ──────────────────────────────────────────────────────
@@ -1070,6 +1080,42 @@ mod tests {
                 );
             }
             other => panic!("expected PolicyDenied, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn dispatcher_scope_rechecks_after_pre_hook_rewrite() {
+        // Codex P1 regression guard: the initial call is shell-exec
+        // (ToolScope::Execute), which this policy allows. A pre-hook then
+        // rewrites the same Execute-risk call to http-request, whose scope is
+        // Network. The post-hook scope recheck must block the mutated target
+        // before execution, otherwise same-risk scope changes can bypass the
+        // principal policy.
+        let hooks = Arc::new(ToolHookRegistry::new());
+        hooks
+            .register(Arc::new(RewriteNameHook("shell-exec", "http-request")))
+            .await;
+        let dispatcher = RegistryDispatcher::new(Arc::new(TraitToolRegistry::with_builtins()))
+            .with_hooks(hooks)
+            .with_principal_policy(policy_with_scopes(&[ToolScope::Execute]));
+
+        let call = shell_exec_call("call-scope-rewrite-1");
+        let err = dispatcher
+            .dispatch(&call, &ToolContext::default())
+            .await
+            .unwrap_err();
+        match err {
+            ToolError::PolicyDenied(msg) => {
+                assert!(
+                    msg.contains("tool 'http-request' denied by principal policy"),
+                    "denial must name the rewritten tool: {msg}"
+                );
+                assert!(
+                    msg.contains("scope Network not in allowed_tool_scopes"),
+                    "denial must use the rewritten tool scope: {msg}"
+                );
+            }
+            other => panic!("expected PolicyDenied after hook rewrite, got {other:?}"),
         }
     }
 


### PR DESCRIPTION
## Summary

- Adds the **ToolScope dispatcher gate** (PR-B from the sera-ifjl/u4gj rescope). `RegistryDispatcher` now checks `PrincipalPolicy.allowed_tool_scopes` against the dispatched tool's `ToolMetadata.scope` **before** the existing `CapabilityRegistry` gate, the escalation gate, any pre-tool hook, or `TraitToolRegistry::execute`.
- Opt-in via a new `with_principal_policy` builder mirroring `with_capability_registry`; existing call sites that don't attach a policy keep today's behaviour unchanged.
- Denial reuses the existing `[sera-policy] tool '…' denied …` prefix so the gateway audit filter (`enforce_tool_events`) classifies scope denials uniformly with capability denials. The error body names the offending `ToolScope` so the message is distinguishable from a tool-name denial without changing `ToolError::PolicyDenied`'s shape.

Bead: **sera-u4gj** — feat(sera-tools): introduce ToolScope vocabulary and dispatcher gate
Reference rescope: `artifacts/reports/research/omc-sera-ifjl-u4gj-safety-rescope-2026-05-07.md` (sections 1.1, 1.2, 1.4, 2.2, 3.3, 4, 5.1, 5.2, 6)

## What landed

- `rust/crates/sera-runtime/src/tools/dispatcher.rs`
  - New field: `principal_policy: Option<Arc<sera_auth::policy::PrincipalPolicy>>` on `RegistryDispatcher`.
  - New builder: `with_principal_policy(self, Arc<PrincipalPolicy>) -> Self`.
  - New gate inside `dispatch()` placed strictly before the `CapabilityRegistry` gate. Tool scope is read from `self.registry.get(&input.name).map(|t| t.metadata().scope)`. Unknown tool names fall through to the existing `NotFound` path (sera-zdky stays orthogonal).

## Tests added (all passing)

`cargo test -p sera-runtime --lib tools::dispatcher` — 26 passed (20 pre-existing + 6 new), 0 failures:

- `dispatcher_scope_deny_blocks_handler_pre_dispatch` — Read-only policy denies `shell-exec` (Execute) with the scope-shaped message.
- `dispatcher_scope_allow_runs_tool_normally` — Read-only policy permits `file-list` (Read).
- `dispatcher_scope_unknown_tool_falls_through_to_not_found` — unknown tool name returns `NotFound`, not `PolicyDenied`. Pins the leaf-safety property.
- `dispatcher_scope_no_policy_attached_is_permissive` — backwards-compat guard: dispatcher built without `with_principal_policy` matches today's behaviour.
- `dispatcher_scope_runs_before_capability_registry` — both gates armed; scope message wins, proving order. Catches future reorderings.
- `dispatcher_admin_scope_rejected_for_agent_kind_default` — `PrincipalPolicy::for_kind(PrincipalKind::Agent)` rejects an Admin-scoped tool registered ad-hoc for the test.

## Verification

- `cargo check -p sera-runtime` — clean.
- `cargo test -p sera-runtime --lib tools::dispatcher` — 26 passed, 0 failed, 559 filtered out.
- `cargo fmt --check -p sera-runtime` — clean.
- `cargo clippy -p sera-runtime --tests -- -D warnings` — one **pre-existing** lint at `crates/sera-runtime/src/stdio.rs:583` (introduced by commit 785ec7c2 on 2026-05-02; unrelated to this change). Per the SERA "Surgical Changes" rule it is left untouched and tracked as drift.

## Deferred to PR-C (sera-u4gj PR4)

The rescope report (§3.3) prescribed gateway threading inside PR-B if practical. After scoping the seam I deferred it intentionally — the gate itself is shipped here, the gateway threading needs a larger interface change that does not belong in a "scope-gate-only" PR:

1. **Gateway PolicyResolver wiring** (`sera-gateway/src/bin/sera.rs`):
   - Instantiate `PolicyResolver::in_memory()` (or from `PrincipalPoliciesConfig`) in `run_start`.
   - Stash on `AppState` next to `capability_registry`.
   - In `chat_handler` (admission), call `resolver.resolve(&principal).await` per turn.
2. **Seam blocker for per-turn threading** — the production dispatcher is built **once per agent at boot** inside `build_embedded_transport` (`sera.rs:171–~285`), but `PrincipalPolicy` is resolved **per turn** at chat_handler admission (`sera.rs:2224`). Threading the per-turn policy to the boot-built dispatcher requires one of:
   - Extending `AgentTurnTransport::send_turn` (and the `EmbeddedRuntimeTransport` / NDJSON envelope) with a `Arc<PrincipalPolicy>` parameter — a cross-crate interface change.
   - Adding `principal_policy` to `ToolContext` — explicitly forbidden by the rescope (Risk §6) and this PR's scope.
   - Putting an `Arc<RwLock<…>>` cell on the dispatcher and mutating it per turn — race risk under concurrent turns within an agent run.
   None of these is "surgical" enough for PR-B; PR-C will pick the cleanest option and pair it with `narrow_for_subagent` invocation in `AgentToolRegistry`.
3. **Other PR-C work** (unchanged from rescope): persona presets (`read-only-reviewer`, `code-editor`, `test-runner`, `full-autonomy`), admin-tool registration hardening, sub-agent dispatch narrowing.
4. **`enforce_tool_events` audit parity** for out-of-process runtimes — not yet recognising scope-denial messages distinctly from capability denials. Body shape is already `[sera-policy]`-prefixed so today's filter still classifies them; the tightening is a PR-C item.

## Out of scope (explicitly left alone)

- `ToolContext` shape (kept untouched per rescope Risk §6).
- `ToolError::PolicyDenied` shape (still a `String` payload).
- The existing `NotFound` path (sera-zdky is a separate bead).
- Persona presets, sub-agent narrowing, admin-tool hardening (PR-C).
- sera-ifjl integration test / bead reconciliation (PR-A, separate lane).

## Test plan

- [x] `cargo test -p sera-runtime --lib tools::dispatcher` — all 6 new tests + 20 pre-existing tests pass.
- [x] `cargo check -p sera-runtime` — clean.
- [x] `cargo fmt --check -p sera-runtime` — clean.
- [x] Confirm `dispatcher_scope_runs_before_capability_registry` passes — guards future reorderings.
- [x] Confirm unknown-tool path remains `NotFound` (sera-zdky orthogonality).

🤖 Generated with [Claude Code](https://claude.com/claude-code)