### PR TITLE
fix(gateway): block interrupted operator task closeouts

### DIFF
--- a/ops/e2e/operator_task_smoke.py
+++ b/ops/e2e/operator_task_smoke.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Strict operator-task live smoke for the SERA gateway.
+
+This script is intentionally conservative: it can validate a captured smoke JSON
+without touching a live service, or run the same checks against a local gateway.
+It fails if readiness is not connected or if an operator-task result contains an
+interrupted/doom-loop sentinel that would make a false-green closeout.
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+from typing import Any
+
+DEFAULT_BASE = "http://127.0.0.1:3001"
+DEFAULT_OUT = "/tmp/sera-6zcb-live-smoke.json"
+DEFAULT_CONTAINER = "rust-sera-1"
+
+
+def is_interrupted_runtime_result(value: Any) -> bool:
+    if not isinstance(value, str):
+        return False
+    lowered = value.lower()
+    return "[interrupted:" in lowered or ("interrupted" in lowered and "doom loop:" in lowered)
+
+
+def container_api_key(container: str) -> str:
+    raw = subprocess.check_output(["docker", "inspect", container], text=True)
+    data = json.loads(raw)[0]
+    for env in data.get("Config", {}).get("Env", []):
+        if env.startswith("SERA_API_KEY="):
+            return env.split("=", 1)[1]
+    return ""
+
+
+def req(base: str, auth_headers: dict[str, str], method: str, path: str, body: Any = None, timeout: int = 30) -> dict[str, Any]:
+    data = None
+    headers = dict(auth_headers)
+    if body is not None:
+        data = json.dumps(body).encode()
+        headers["Content-Type"] = "application/json"
+    request = urllib.request.Request(base + path, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as resp:
+            raw = resp.read().decode("utf-8", "replace")
+            ctype = resp.headers.get("content-type", "")
+            parsed = None
+            if "json" in ctype or raw.startswith("{") or raw.startswith("["):
+                try:
+                    parsed = json.loads(raw)
+                except Exception:
+                    parsed = None
+            return {"ok": True, "status": resp.status, "raw": raw, "json": parsed}
+    except urllib.error.HTTPError as exc:
+        raw = exc.read().decode("utf-8", "replace")
+        parsed = None
+        try:
+            parsed = json.loads(raw)
+        except Exception:
+            pass
+        return {"ok": False, "status": exc.code, "raw": raw, "json": parsed}
+
+
+def sse_reader(base: str, auth_headers: dict[str, str], started: threading.Event, stop_event: threading.Event, lines_out: list[str]) -> None:
+    request = urllib.request.Request(
+        base + "/api/intercom/subscribe/operator.task",
+        headers=auth_headers,
+        method="GET",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=20) as resp:
+            started.set()
+            deadline = time.time() + 20
+            while time.time() < deadline and not stop_event.is_set():
+                line = resp.readline()
+                if not line:
+                    break
+                text = line.decode("utf-8", "replace").rstrip("\n")
+                if text:
+                    lines_out.append(text)
+                    if text.startswith("data:"):
+                        stop_event.set()
+                        break
+    except Exception as exc:
+        lines_out.append(f"SSE_ERROR:{type(exc).__name__}:{exc}")
+        started.set()
+
+
+def run_smoke(base: str, out: str, container: str, api_key: str | None) -> dict[str, Any]:
+    if api_key is None:
+        api_key = container_api_key(container)
+    auth_headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+    results: dict[str, Any] = {}
+
+    for _attempt in range(1, 31):
+        health = req(base, auth_headers, "GET", "/health", timeout=5)
+        results["health"] = health
+        if health.get("ok"):
+            break
+        time.sleep(2)
+
+    results["ready"] = req(base, auth_headers, "GET", "/api/health/ready", timeout=10)
+    results["agents"] = req(base, auth_headers, "GET", "/api/agents", timeout=20)
+
+    started = threading.Event()
+    stop = threading.Event()
+    sse_lines: list[str] = []
+    thread = threading.Thread(target=sse_reader, args=(base, auth_headers, started, stop, sse_lines), daemon=True)
+    thread.start()
+    started.wait(timeout=5)
+
+    results["topics_before_operator_task"] = req(base, auth_headers, "GET", "/api/intercom/topics", timeout=10)
+    body = {
+        "task": "Live smoke: report current SERA deployment health with one helper. Return one concise sentence.",
+        "agent": "sera",
+        "helper": "operator-helper",
+    }
+    results["operator_task"] = req(base, auth_headers, "POST", "/api/operator/tasks", body=body, timeout=180)
+    card = results["operator_task"].get("json") or {}
+    session_key = card.get("session_key") if isinstance(card, dict) else None
+    if session_key:
+        results["subagents"] = req(base, auth_headers, "GET", f"/api/sessions/{session_key}/subagents", timeout=20)
+    else:
+        results["subagents"] = {"ok": False, "status": None, "raw": "no session_key returned", "json": None}
+
+    time.sleep(2)
+    stop.set()
+    thread.join(timeout=2)
+    results["sse_lines"] = sse_lines[:20]
+    results["topics_after_operator_task"] = req(base, auth_headers, "GET", "/api/intercom/topics", timeout=10)
+
+    with open(out, "w", encoding="utf-8") as handle:
+        json.dump(results, handle, indent=2)
+    return results
+
+
+def ready_runtime_connected(ready_json: Any) -> bool:
+    return isinstance(ready_json, dict) and ready_json.get("runtime_connected") is True
+
+
+def build_summary(results: dict[str, Any], out: str) -> dict[str, Any]:
+    card = (results.get("operator_task") or {}).get("json") or {}
+    ready_json = (results.get("ready") or {}).get("json")
+    agents_json = (results.get("agents") or {}).get("json")
+    subagents_json = (results.get("subagents") or {}).get("json") or {}
+    sse_lines = results.get("sse_lines") or []
+    agent_count = len(agents_json) if isinstance(agents_json, list) else None
+    subagent_count = len(subagents_json.get("subagents", [])) if isinstance(subagents_json, dict) else None
+
+    return {
+        "health_status": (results.get("health") or {}).get("status"),
+        "ready_status": (results.get("ready") or {}).get("status"),
+        "runtime_connected": ready_json.get("runtime_connected") if isinstance(ready_json, dict) else None,
+        "agents_status": (results.get("agents") or {}).get("status"),
+        "agent_count": agent_count,
+        "operator_status": (results.get("operator_task") or {}).get("status"),
+        "operator_card_status": card.get("status") if isinstance(card, dict) else None,
+        "operator_blocked": card.get("blocked") if isinstance(card, dict) else None,
+        "failure_class": card.get("failure_class") if isinstance(card, dict) else None,
+        "next_action": card.get("next_action") if isinstance(card, dict) else None,
+        "interrupted_result": is_interrupted_runtime_result(card.get("result") if isinstance(card, dict) else None),
+        "session_key_present": bool(card.get("session_key")) if isinstance(card, dict) else False,
+        "handoff_tool": card.get("handoff_tool") if isinstance(card, dict) else None,
+        "helper_agent": (card.get("spawned_helper") or {}).get("agent") if isinstance(card.get("spawned_helper") if isinstance(card, dict) else None, dict) else None,
+        "subagents_status": (results.get("subagents") or {}).get("status"),
+        "subagent_count": subagent_count,
+        "sse_data_seen": any(isinstance(line, str) and line.startswith("data:") and "operator.task" in line for line in sse_lines),
+        "topics_before": (results.get("topics_before_operator_task") or {}).get("json"),
+        "full_output": out,
+    }
+
+
+def validation_errors(results: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    card = (results.get("operator_task") or {}).get("json") or {}
+    ready = results.get("ready") or {}
+    ready_json = ready.get("json")
+    subagents_json = (results.get("subagents") or {}).get("json") or {}
+    subagent_count = len(subagents_json.get("subagents", [])) if isinstance(subagents_json, dict) else 0
+    session_key = card.get("session_key") if isinstance(card, dict) else None
+    result = card.get("result") if isinstance(card, dict) else None
+
+    checks = [
+        ((results.get("health") or {}).get("status") == 200, "health status must be 200"),
+        (ready.get("status") == 200, "readiness status must be 200"),
+        (ready_runtime_connected(ready_json), "readiness must report runtime_connected=true"),
+        ((results.get("agents") or {}).get("status") == 200, "agents status must be 200"),
+        ((results.get("operator_task") or {}).get("status") == 200, "operator task POST must return 200"),
+        (bool(session_key), "operator task card must include session_key"),
+        ((results.get("subagents") or {}).get("status") == 200, "subagents status must be 200"),
+        (subagent_count >= 1, "subagents response must include at least one subagent"),
+        (not is_interrupted_runtime_result(result), "operator task result must not be interrupted/doom-loop"),
+    ]
+    for ok, message in checks:
+        if not ok:
+            errors.append(message)
+
+    if isinstance(card, dict) and is_interrupted_runtime_result(result):
+        if card.get("status") == "complete" or card.get("blocked") is False:
+            errors.append("interrupted operator task must not be status=complete or blocked=false")
+        if not card.get("failure_class"):
+            errors.append("interrupted operator task should expose failure_class")
+        if not card.get("next_action"):
+            errors.append("interrupted operator task should expose next_action")
+    return errors
+
+
+def load_results(path: str) -> dict[str, Any]:
+    with open(path, "r", encoding="utf-8") as handle:
+        data = json.load(handle)
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} does not contain a JSON object")
+    return data
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run or validate strict SERA operator-task smoke checks.")
+    parser.add_argument("--base", default=DEFAULT_BASE)
+    parser.add_argument("--out", default=DEFAULT_OUT)
+    parser.add_argument("--container", default=DEFAULT_CONTAINER)
+    parser.add_argument("--api-key", default=None, help="Bearer token; defaults to SERA_API_KEY from docker inspect.")
+    parser.add_argument("--validate-only", metavar="PATH", help="Validate an existing smoke JSON artifact without live side effects.")
+    args = parser.parse_args()
+
+    if args.validate_only:
+        results = load_results(args.validate_only)
+        out = args.validate_only
+    else:
+        results = run_smoke(args.base.rstrip("/"), args.out, args.container, args.api_key)
+        out = args.out
+
+    summary = build_summary(results, out)
+    errors = validation_errors(results)
+    if errors:
+        summary["validation_errors"] = errors
+    print(json.dumps(summary, indent=2))
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ops/e2e/operator_task_smoke.py
+++ b/ops/e2e/operator_task_smoke.py
@@ -184,6 +184,8 @@ def validation_errors(results: dict[str, Any]) -> list[str]:
     subagent_count = len(subagents_json.get("subagents", [])) if isinstance(subagents_json, dict) else 0
     session_key = card.get("session_key") if isinstance(card, dict) else None
     result = card.get("result") if isinstance(card, dict) else None
+    sse_lines = results.get("sse_lines") or []
+    sse_data_seen = any(isinstance(line, str) and line.startswith("data:") and "operator.task" in line for line in sse_lines)
 
     checks = [
         ((results.get("health") or {}).get("status") == 200, "health status must be 200"),
@@ -194,6 +196,7 @@ def validation_errors(results: dict[str, Any]) -> list[str]:
         (bool(session_key), "operator task card must include session_key"),
         ((results.get("subagents") or {}).get("status") == 200, "subagents status must be 200"),
         (subagent_count >= 1, "subagents response must include at least one subagent"),
+        (sse_data_seen, "SSE subscription must receive an operator.task data event"),
         (not is_interrupted_runtime_result(result), "operator task result must not be interrupted/doom-loop"),
     ]
     for ok, message in checks:

--- a/rust/crates/sera-gateway/src/bin/sera.rs
+++ b/rust/crates/sera-gateway/src/bin/sera.rs
@@ -727,6 +727,21 @@ impl StdioHarness {
         Self::spawn_with_script(script).await
     }
 
+    /// Spawn a mock runtime that emits the live false-green sentinel seen in
+    /// `/tmp/sera-6zcb-live-smoke.json`: a terminal turn with an interrupted
+    /// doom-loop result string rather than a transport error.
+    async fn spawn_mock_interrupted_doom_loop() -> anyhow::Result<Self> {
+        let script = concat!(
+            r#"while IFS= read -r line; do "#,
+            r#"echo '{"id":"00000000-0000-0000-0000-000000000001","submission_id":"00000000-0000-0000-0000-000000000000","msg":{"type":"turn_started","turn_id":"00000000-0000-0000-0000-000000000002"},"timestamp":"2024-01-01T00:00:00Z"}'; "#,
+            r#"echo '{"id":"00000000-0000-0000-0000-000000000003","submission_id":"00000000-0000-0000-0000-000000000000","msg":{"type":"streaming_delta","delta":"[interrupted: doom loop: 3 consecutive act cycles]"},"timestamp":"2024-01-01T00:00:00Z"}'; "#,
+            r#"echo '{"id":"00000000-0000-0000-0000-000000000004","submission_id":"00000000-0000-0000-0000-000000000000","msg":{"type":"turn_completed","turn_id":"00000000-0000-0000-0000-000000000002"},"timestamp":"2024-01-01T00:00:00Z"}'; "#,
+            r#"done"#,
+        );
+
+        Self::spawn_with_script(script).await
+    }
+
     /// Spawn a mock runtime that consumes submissions but never emits events.
     /// Used to exercise the turn timeout path — a live child with an open
     /// stdout that simply never produces output.
@@ -1944,8 +1959,61 @@ struct OperatorTaskStatusCard {
     status: String,
     blocked: bool,
     result: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    failure_class: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    next_action: Option<String>,
     audit_id: String,
     session_key: String,
+}
+
+struct OperatorTaskCloseout {
+    status: &'static str,
+    blocked: bool,
+    failure_class: Option<&'static str>,
+    next_action: Option<&'static str>,
+}
+
+fn classify_operator_task_turn(turn: &MvsTurnResult) -> OperatorTaskCloseout {
+    if turn.cancelled {
+        return OperatorTaskCloseout {
+            status: "blocked",
+            blocked: true,
+            failure_class: Some("runtime_cancelled"),
+            next_action: Some("retry_or_inspect_runtime"),
+        };
+    }
+
+    if turn.failure.is_some() {
+        return OperatorTaskCloseout {
+            status: "blocked",
+            blocked: true,
+            failure_class: Some("runtime_failure"),
+            next_action: Some("inspect_runtime"),
+        };
+    }
+
+    if is_interrupted_runtime_result(&turn.reply) {
+        return OperatorTaskCloseout {
+            status: "blocked",
+            blocked: true,
+            failure_class: Some("runtime_interrupted"),
+            next_action: Some("retry_or_inspect_runtime"),
+        };
+    }
+
+    OperatorTaskCloseout {
+        status: "complete",
+        blocked: false,
+        failure_class: None,
+        next_action: None,
+    }
+}
+
+fn is_interrupted_runtime_result(reply: &str) -> bool {
+    let lower = reply.to_ascii_lowercase();
+    lower.contains("[interrupted:")
+        || (lower.contains("interrupted") && lower.contains("doom loop:"))
 }
 
 /// Custom JSON extractor that maps axum's `JsonRejection` (which produces 422
@@ -3376,12 +3444,7 @@ async fn operator_task_handler(
         .filter(|id| id.starts_with(&format!("{session_key}/")))
         .count();
     let latest_event = format!("intercom:operator.task delivered={delivered}");
-    let status = if turn.cancelled || turn.failure.is_some() {
-        "blocked"
-    } else {
-        "complete"
-    }
-    .to_string();
+    let closeout = classify_operator_task_turn(&turn);
 
     Ok(Json(OperatorTaskStatusCard {
         accepted_task: task,
@@ -3395,9 +3458,11 @@ async fn operator_task_handler(
         },
         handoff_tool: format!("handoff_to_{helper}"),
         latest_event,
-        status: status.clone(),
-        blocked: status == "blocked",
+        status: closeout.status.to_string(),
+        blocked: closeout.blocked,
         result: turn.reply,
+        failure_class: closeout.failure_class.map(str::to_string),
+        next_action: closeout.next_action.map(str::to_string),
         audit_id,
         session_key,
     }))
@@ -7376,6 +7441,57 @@ spec:
         assert!(
             spec.subagents_allowed.iter().any(|agent| agent == "smoke-helper"),
             "operator helper should be persisted to the parent agent allow-list"
+        );
+    }
+
+    #[tokio::test]
+    async fn operator_task_interrupted_doom_loop_is_not_false_complete() {
+        let mut state = test_state_async().await;
+        let interrupted_sup: Arc<dyn AgentTurnTransport> =
+            RuntimeChildSupervisor::start_with_factory("sera", || async {
+                StdioHarness::spawn_mock_interrupted_doom_loop().await
+            })
+            .await
+            .unwrap();
+        Arc::get_mut(&mut state)
+            .expect("unique state ref")
+            .harnesses
+            .insert("sera".to_string(), interrupted_sup);
+        let app = build_router(Arc::clone(&state));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/operator/tasks")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "task": "Summarize the deployment state",
+                            "agent": "sera",
+                            "helper": "smoke-helper"
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 8192)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        assert_ne!(json["status"], "complete");
+        assert_eq!(json["status"], "blocked");
+        assert_eq!(json["blocked"], true);
+        assert_eq!(json["failure_class"], "runtime_interrupted");
+        assert_eq!(json["next_action"], "retry_or_inspect_runtime");
+        assert_eq!(
+            json["result"],
+            "[interrupted: doom loop: 3 consecutive act cycles]"
         );
     }
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -314,6 +314,8 @@ export interface OperatorTaskStatusCard {
   status?: string | null;
   blocked?: boolean | null;
   result?: string | null;
+  failure_class?: string | null;
+  next_action?: string | null;
   audit_id?: string | null;
   session_key?: string | null;
 }

--- a/web/src/views/ChatView.tsx
+++ b/web/src/views/ChatView.tsx
@@ -283,6 +283,8 @@ export function ChatView() {
                     : null
                 }
               />
+              <Field label="Failure" value={opCard.failure_class} />
+              <Field label="Next" value={opCard.next_action} />
             </div>
             {opCard.latest_event && (
               <div>


### PR DESCRIPTION
## Summary
- classify interrupted/doom-loop operator task results as blocked instead of complete
- expose `failure_class` and `next_action` in the operator task card/API/UI
- tighten the operator-task smoke validator so readiness, subagent/SSE evidence, and non-interrupted results are semantic gates

## Why
A strict dogfood smoke found a false green: `/api/operator/tasks` returned `status=complete` and `blocked=false` while the runtime result was `[interrupted: doom loop: 3 consecutive act cycles]`. That makes the operator card untrustworthy.

## Test Plan
- [x] `cargo test -p sera-gateway --bin sera-gateway operator_task`
- [x] `cargo test -p sera-gateway --bin sera-gateway`
- [x] `cargo check -p sera-gateway`
- [x] `cargo test -p sera-gateway`
- [x] `python3 -m py_compile ops/e2e/operator_task_smoke.py`
- [x] `python3 ops/e2e/operator_task_smoke.py --validate-only /tmp/sera-6zcb-live-smoke.json` fails as expected on the captured false-green artifact
- [x] positive validate-only fixture `/tmp/sera-rkwu-positive-smoke-fixture.json` passes

## Local validation gaps
- `cargo fmt --check` could not run in the worker because `rustfmt` was unavailable in that toolchain.
- `bun run typecheck && bun run lint` could not run because bun/node_modules were unavailable in the worker environment.

Closes sera-rkwu.
