### PR TITLE
fix: block operator tasks on runtime failures

### DIFF
--- a/ops/e2e/operator_task_smoke.py
+++ b/ops/e2e/operator_task_smoke.py
@@ -32,8 +32,7 @@ def is_interrupted_runtime_result(value: Any) -> bool:
 def is_llm_error_result(value: Any) -> bool:
     if not isinstance(value, str):
         return False
-    lowered = value.lower()
-    return "[llm error:" in lowered or "llm call failed" in lowered
+    return value.lstrip().lower().startswith("[llm error:")
 
 
 def container_api_key(container: str) -> str:

--- a/ops/e2e/operator_task_smoke.py
+++ b/ops/e2e/operator_task_smoke.py
@@ -29,6 +29,13 @@ def is_interrupted_runtime_result(value: Any) -> bool:
     return "[interrupted:" in lowered or ("interrupted" in lowered and "doom loop:" in lowered)
 
 
+def is_llm_error_result(value: Any) -> bool:
+    if not isinstance(value, str):
+        return False
+    lowered = value.lower()
+    return "[llm error:" in lowered or "llm call failed" in lowered
+
+
 def container_api_key(container: str) -> str:
     raw = subprocess.check_output(["docker", "inspect", container], text=True)
     data = json.loads(raw)[0]
@@ -164,6 +171,7 @@ def build_summary(results: dict[str, Any], out: str) -> dict[str, Any]:
         "failure_class": card.get("failure_class") if isinstance(card, dict) else None,
         "next_action": card.get("next_action") if isinstance(card, dict) else None,
         "interrupted_result": is_interrupted_runtime_result(card.get("result") if isinstance(card, dict) else None),
+        "llm_error_result": is_llm_error_result(card.get("result") if isinstance(card, dict) else None),
         "session_key_present": bool(card.get("session_key")) if isinstance(card, dict) else False,
         "handoff_tool": card.get("handoff_tool") if isinstance(card, dict) else None,
         "helper_agent": (card.get("spawned_helper") or {}).get("agent") if isinstance(card.get("spawned_helper") if isinstance(card, dict) else None, dict) else None,
@@ -186,6 +194,8 @@ def validation_errors(results: dict[str, Any]) -> list[str]:
     result = card.get("result") if isinstance(card, dict) else None
     sse_lines = results.get("sse_lines") or []
     sse_data_seen = any(isinstance(line, str) and line.startswith("data:") and "operator.task" in line for line in sse_lines)
+    interrupted_result = is_interrupted_runtime_result(result)
+    llm_error_result = is_llm_error_result(result)
 
     checks = [
         ((results.get("health") or {}).get("status") == 200, "health status must be 200"),
@@ -197,13 +207,17 @@ def validation_errors(results: dict[str, Any]) -> list[str]:
         ((results.get("subagents") or {}).get("status") == 200, "subagents status must be 200"),
         (subagent_count >= 1, "subagents response must include at least one subagent"),
         (sse_data_seen, "SSE subscription must receive an operator.task data event"),
-        (not is_interrupted_runtime_result(result), "operator task result must not be interrupted/doom-loop"),
+        (not interrupted_result, "operator task result must not be interrupted/doom-loop"),
+        (not llm_error_result or card.get("status") == "blocked", "LLM/provider errors must be status=blocked"),
+        (not llm_error_result or card.get("blocked") is True, "LLM/provider errors must set blocked=true"),
+        (not llm_error_result or bool(card.get("failure_class")), "LLM/provider errors must expose failure_class"),
+        (not llm_error_result or bool(card.get("next_action")), "LLM/provider errors must expose next_action"),
     ]
     for ok, message in checks:
         if not ok:
             errors.append(message)
 
-    if isinstance(card, dict) and is_interrupted_runtime_result(result):
+    if isinstance(card, dict) and interrupted_result:
         if card.get("status") == "complete" or card.get("blocked") is False:
             errors.append("interrupted operator task must not be status=complete or blocked=false")
         if not card.get("failure_class"):

--- a/ops/e2e/test_operator_task_smoke.py
+++ b/ops/e2e/test_operator_task_smoke.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+"""Regression tests for operator_task_smoke result predicates."""
+
+import importlib.util
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).with_name("operator_task_smoke.py")
+spec = importlib.util.spec_from_file_location("operator_task_smoke", MODULE_PATH)
+operator_task_smoke = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+spec.loader.exec_module(operator_task_smoke)
+
+
+def test_free_form_llm_call_failed_text_is_not_llm_error() -> None:
+    text = "Smoke complete: yesterday's logs said llm call failed, but today passed."
+
+    assert operator_task_smoke.is_llm_error_result(text) is False
+
+
+def test_explicit_llm_error_sentinel_is_llm_error() -> None:
+    text = "[LLM error: LLM call failed: request error: HTTP 400]"
+
+    assert operator_task_smoke.is_llm_error_result(text) is True

--- a/rust/crates/sera-gateway/src/bin/sera.rs
+++ b/rust/crates/sera-gateway/src/bin/sera.rs
@@ -2002,6 +2002,15 @@ fn classify_operator_task_turn(turn: &MvsTurnResult) -> OperatorTaskCloseout {
         };
     }
 
+    if is_llm_unavailable_runtime_result(&turn.reply) {
+        return OperatorTaskCloseout {
+            status: "blocked",
+            blocked: true,
+            failure_class: Some("llm_unavailable"),
+            next_action: Some("inspect_llm_provider"),
+        };
+    }
+
     OperatorTaskCloseout {
         status: "complete",
         blocked: false,
@@ -2014,6 +2023,11 @@ fn is_interrupted_runtime_result(reply: &str) -> bool {
     let lower = reply.to_ascii_lowercase();
     lower.contains("[interrupted:")
         || (lower.contains("interrupted") && lower.contains("doom loop:"))
+}
+
+fn is_llm_unavailable_runtime_result(reply: &str) -> bool {
+    let lower = reply.to_ascii_lowercase();
+    lower.contains("[llm error:") || lower.contains("llm call failed")
 }
 
 /// Custom JSON extractor that maps axum's `JsonRejection` (which produces 422
@@ -7493,6 +7507,29 @@ spec:
             json["result"],
             "[interrupted: doom loop: 3 consecutive act cycles]"
         );
+    }
+
+    #[test]
+    fn operator_task_llm_error_is_actionable_blocked_failure() {
+        let turn = MvsTurnResult {
+            reply: "[LLM error: LLM call failed: request error: HTTP 400: failed to load model]"
+                .to_string(),
+            tool_events: vec![],
+            usage: UsageInfo {
+                prompt_tokens: 0,
+                completion_tokens: 0,
+                total_tokens: 0,
+            },
+            cancelled: false,
+            failure: None,
+        };
+
+        let closeout = classify_operator_task_turn(&turn);
+
+        assert_eq!(closeout.status, "blocked");
+        assert!(closeout.blocked);
+        assert_eq!(closeout.failure_class, Some("llm_unavailable"));
+        assert_eq!(closeout.next_action, Some("inspect_llm_provider"));
     }
 
     #[tokio::test]

--- a/rust/crates/sera-gateway/src/bin/sera.rs
+++ b/rust/crates/sera-gateway/src/bin/sera.rs
@@ -1984,6 +1984,19 @@ fn classify_operator_task_turn(turn: &MvsTurnResult) -> OperatorTaskCloseout {
         };
     }
 
+    if turn
+        .failure
+        .as_deref()
+        .is_some_and(is_llm_unavailable_structured_failure)
+    {
+        return OperatorTaskCloseout {
+            status: "blocked",
+            blocked: true,
+            failure_class: Some("llm_unavailable"),
+            next_action: Some("inspect_llm_provider"),
+        };
+    }
+
     if turn.failure.is_some() {
         return OperatorTaskCloseout {
             status: "blocked",
@@ -2026,8 +2039,11 @@ fn is_interrupted_runtime_result(reply: &str) -> bool {
 }
 
 fn is_llm_unavailable_runtime_result(reply: &str) -> bool {
-    let lower = reply.to_ascii_lowercase();
-    lower.contains("[llm error:") || lower.contains("llm call failed")
+    reply.trim_start().to_ascii_lowercase().starts_with("[llm error:")
+}
+
+fn is_llm_unavailable_structured_failure(failure: &str) -> bool {
+    failure.to_ascii_lowercase().contains("llm call failed")
 }
 
 /// Custom JSON extractor that maps axum's `JsonRejection` (which produces 422
@@ -7522,6 +7538,51 @@ spec:
             },
             cancelled: false,
             failure: None,
+        };
+
+        let closeout = classify_operator_task_turn(&turn);
+
+        assert_eq!(closeout.status, "blocked");
+        assert!(closeout.blocked);
+        assert_eq!(closeout.failure_class, Some("llm_unavailable"));
+        assert_eq!(closeout.next_action, Some("inspect_llm_provider"));
+    }
+
+    #[test]
+    fn operator_task_success_text_mentioning_llm_call_failed_stays_complete() {
+        let turn = MvsTurnResult {
+            reply: "Deployment review complete: historical logs mentioned `llm call failed`, but the current check is healthy."
+                .to_string(),
+            tool_events: vec![],
+            usage: UsageInfo {
+                prompt_tokens: 0,
+                completion_tokens: 0,
+                total_tokens: 0,
+            },
+            cancelled: false,
+            failure: None,
+        };
+
+        let closeout = classify_operator_task_turn(&turn);
+
+        assert_eq!(closeout.status, "complete");
+        assert!(!closeout.blocked);
+        assert_eq!(closeout.failure_class, None);
+        assert_eq!(closeout.next_action, None);
+    }
+
+    #[test]
+    fn operator_task_structured_llm_failure_is_actionable_blocked_failure() {
+        let turn = MvsTurnResult {
+            reply: "[sera] Runtime error: LLM call failed: provider down".to_string(),
+            tool_events: vec![],
+            usage: UsageInfo {
+                prompt_tokens: 0,
+                completion_tokens: 0,
+                total_tokens: 0,
+            },
+            cancelled: false,
+            failure: Some("LLM call failed: provider down".to_string()),
         };
 
         let closeout = classify_operator_task_turn(&turn);

--- a/rust/crates/sera-runtime/src/turn.rs
+++ b/rust/crates/sera-runtime/src/turn.rs
@@ -411,7 +411,15 @@ pub async fn act(
     think_result: &ThinkResult,
     tool_dispatcher: Option<&dyn ToolDispatcher>,
 ) -> ActResult {
-    // Doom loop check
+    // No tool calls — return empty results. Check this before doom-loop
+    // enforcement so a model that used several tool rounds and then emits a
+    // final answer is allowed to complete instead of being interrupted only
+    // because the previous act-cycle count reached the threshold.
+    if think_result.tool_calls.is_empty() {
+        return ActResult::ToolResults(vec![]);
+    }
+
+    // Doom loop check applies only when the model is trying another act cycle.
     if ctx.doom_loop_count >= DOOM_LOOP_THRESHOLD {
         return ActResult::Interruption {
             reason: format!(
@@ -512,11 +520,6 @@ pub async fn act(
                 ticket_id: ticket.id.clone(),
             };
         }
-    }
-
-    // No tool calls — return empty results
-    if think_result.tool_calls.is_empty() {
-        return ActResult::ToolResults(vec![]);
     }
 
     // Dispatch tool calls and capture the result
@@ -1145,6 +1148,42 @@ mod tests {
                 assert!(reason.contains("doom loop"));
             }
             other => panic!("expected doom_loop Interruption, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn act_allows_final_answer_after_threshold_tool_cycles() {
+        let mut ctx = make_turn_ctx(vec![]);
+        ctx.doom_loop_count = DOOM_LOOP_THRESHOLD;
+        let think_result = make_think_result("Deployment is healthy.");
+
+        let result = act(&mut ctx, &think_result, None).await;
+
+        assert!(
+            matches!(result, ActResult::ToolResults(ref results) if results.is_empty()),
+            "expected empty ToolResults so react can finish final output, got {:?}",
+            result
+        );
+    }
+
+    #[tokio::test]
+    async fn act_interrupts_when_threshold_reached_and_model_calls_another_tool() {
+        let mut ctx = make_turn_ctx(vec![]);
+        ctx.doom_loop_count = DOOM_LOOP_THRESHOLD;
+        let think_result = ThinkResult {
+            response: serde_json::json!({"role": "assistant", "content": "checking once more"}),
+            tool_calls: vec![make_tool_call("status_probe")],
+            tokens: TokenUsage::default(),
+            plan: None,
+        };
+
+        let result = act(&mut ctx, &think_result, None).await;
+
+        match result {
+            ActResult::Interruption { reason } => {
+                assert!(reason.contains("doom loop"), "unexpected reason: {reason}");
+            }
+            other => panic!("expected doom-loop Interruption, got {:?}", other),
         }
     }
 

--- a/rust/crates/sera-runtime/tests/runtime_acceptance.rs
+++ b/rust/crates/sera-runtime/tests/runtime_acceptance.rs
@@ -102,8 +102,12 @@ async fn doom_loop_triggers_interruption() {
     };
 
     let think_result = ThinkResult {
-        response: serde_json::json!({}),
-        tool_calls: vec![],
+        response: serde_json::json!({"role": "assistant", "content": "checking once more"}),
+        tool_calls: vec![serde_json::json!({
+            "id": "call_1",
+            "type": "function",
+            "function": { "name": "noop", "arguments": "{}" }
+        })],
         tokens: TokenUsage::default(),
         plan: None,
     };


### PR DESCRIPTION
## Summary
- allow final answers after the runtime doom-loop threshold while still interrupting another tool cycle
- classify operator-task LLM/provider failures as blocked with failure_class=llm_unavailable and next_action=inspect_llm_provider
- tighten operator-task smoke validation so LLM/provider failures cannot pass as complete

## Test Plan
- cargo check -p sera-runtime
- cargo check -p sera-gateway --bin sera-gateway
- cargo test -p sera-runtime
- cargo test -p sera-gateway --bin sera-gateway operator_task -- --nocapture
- cargo test -p sera-runtime doom_loop -- --nocapture
- python3 -m py_compile ops/e2e/operator_task_smoke.py
- python3 ops/e2e/operator_task_smoke.py --validate-only /tmp/sera-live-operator-doom-loop-smoke.json (expected failure against pre-fix artifact: catches LLM error reported as complete)

Closes sera-mn32