### PR TITLE
fix(runtime): sanitize empty assistant provider errors

### DIFF
--- a/rust/crates/sera-gateway/src/bin/sera.rs
+++ b/rust/crates/sera-gateway/src/bin/sera.rs
@@ -2039,7 +2039,8 @@ fn is_interrupted_runtime_result(reply: &str) -> bool {
 }
 
 fn is_llm_unavailable_runtime_result(reply: &str) -> bool {
-    reply.trim_start().to_ascii_lowercase().starts_with("[llm error:")
+    let normalized = reply.trim_start().to_ascii_lowercase();
+    normalized.starts_with("[llm error:") || normalized.starts_with("[llm unavailable:")
 }
 
 fn is_llm_unavailable_structured_failure(failure: &str) -> bool {
@@ -7530,6 +7531,28 @@ spec:
         let turn = MvsTurnResult {
             reply: "[LLM error: LLM call failed: request error: HTTP 400: failed to load model]"
                 .to_string(),
+            tool_events: vec![],
+            usage: UsageInfo {
+                prompt_tokens: 0,
+                completion_tokens: 0,
+                total_tokens: 0,
+            },
+            cancelled: false,
+            failure: None,
+        };
+
+        let closeout = classify_operator_task_turn(&turn);
+
+        assert_eq!(closeout.status, "blocked");
+        assert!(closeout.blocked);
+        assert_eq!(closeout.failure_class, Some("llm_unavailable"));
+        assert_eq!(closeout.next_action, Some("inspect_llm_provider"));
+    }
+
+    #[test]
+    fn operator_task_sanitized_empty_model_response_is_actionable_blocked_failure() {
+        let turn = MvsTurnResult {
+            reply: "[LLM unavailable: model returned an empty response; retry the turn.]".to_string(),
             tool_events: vec![],
             usage: UsageInfo {
                 prompt_tokens: 0,

--- a/rust/crates/sera-runtime/src/turn.rs
+++ b/rust/crates/sera-runtime/src/turn.rs
@@ -73,6 +73,21 @@ pub enum ThinkError {
     UnsupportedToolUseBehavior(String),
 }
 
+impl ThinkError {
+    /// True when a provider/model emitted an empty assistant message with no tool calls.
+    ///
+    /// This is a provider edge case, not useful user-facing detail. Callers
+    /// should keep the raw error in logs/audit and sanitize assistant-visible
+    /// content for this exact failure.
+    fn is_empty_assistant_message(&self) -> bool {
+        match self {
+            ThinkError::Llm(message) => message
+                .contains("provider returned assistant message with neither content nor tool_calls"),
+            ThinkError::Conversion(_) | ThinkError::UnsupportedToolUseBehavior(_) => false,
+        }
+    }
+}
+
 /// Trait for calling an LLM from the think step.
 ///
 /// Messages and tools use `serde_json::Value` to stay decoupled from any
@@ -314,9 +329,20 @@ pub async fn think(
         Some(provider) => match provider.chat_with_behavior(messages, tools, tool_use_behavior).await {
             Ok(result) => result,
             Err(e) => {
-                tracing::error!("LLM call failed in think step: {e}");
+                let content = if e.is_empty_assistant_message() {
+                    tracing::error!(
+                        provider_error_kind = "empty_assistant_message",
+                        error = %e,
+                        "LLM call failed in think step; sanitized assistant-visible response"
+                    );
+                    "[LLM unavailable: model returned an empty response; retry the turn.]"
+                        .to_string()
+                } else {
+                    tracing::error!("LLM call failed in think step: {e}");
+                    format!("[LLM error: {e}]")
+                };
                 ThinkResult {
-                    response: serde_json::json!({"role": "assistant", "content": format!("[LLM error: {e}]")}),
+                    response: serde_json::json!({"role": "assistant", "content": content}),
                     tool_calls: vec![],
                     tokens: TokenUsage::default(),
                     plan: None,
@@ -1611,6 +1637,56 @@ mod tests {
         assert!(
             content.contains("LLM error") && content.contains("tool_use_behavior"),
             "expected error stub mentioning unsupported tool_use_behavior, got: {content}"
+        );
+    }
+
+    struct LlmErrorProvider {
+        message: &'static str,
+    }
+
+    #[async_trait]
+    impl LlmProvider for LlmErrorProvider {
+        async fn chat(
+            &self,
+            _messages: &[serde_json::Value],
+            _tools: &[serde_json::Value],
+        ) -> Result<ThinkResult, ThinkError> {
+            Err(ThinkError::Llm(self.message.to_string()))
+        }
+    }
+
+    #[tokio::test]
+    async fn think_sanitizes_empty_assistant_message_provider_error() {
+        let provider = LlmErrorProvider {
+            message: "request error: provider returned assistant message with neither content nor tool_calls",
+        };
+        let result = think(
+            &[],
+            &[],
+            &ReactMode::Default,
+            Some(&provider as &dyn LlmProvider),
+            &ToolUseBehavior::Auto,
+        )
+        .await;
+
+        assert!(
+            result.tool_calls.is_empty(),
+            "sanitized provider error must not invent tool calls"
+        );
+        let content = result
+            .response
+            .get("content")
+            .and_then(|c| c.as_str())
+            .unwrap_or("");
+        assert!(
+            content.contains("model returned an empty response"),
+            "expected compact user-facing empty-response text, got: {content}"
+        );
+        assert!(
+            !content.contains("LLM call failed")
+                && !content.contains("provider returned assistant message")
+                && !content.contains("neither content nor tool_calls"),
+            "raw provider detail must not be user-visible: {content}"
         );
     }
 


### PR DESCRIPTION
## Summary
- classify the known empty-assistant provider error in the runtime think step
- log raw provider detail with structured provider_error_kind=empty_assistant_message
- return compact non-leaky assistant-visible text with empty tool_calls/tokens
- add fake-provider regression coverage for sera-p4p5

## Test Plan
- cargo test -p sera-runtime
- cargo check -p sera-gateway

Refs sera-p4p5