### PR TITLE
security(validate): add P0 security-negative profile foundation

### DIFF
--- a/ops/validate/CLAUDE.md
+++ b/ops/validate/CLAUDE.md
@@ -20,6 +20,7 @@ Stdlib-only Python tool. No pip dependencies. Must run on the dev host with `pyt
 ## Profiles
 
 - `live_smoke` — wraps `ops/e2e/operator_task_smoke.py` via `importlib`. Source of truth for strict false-green semantics. Do NOT duplicate `validation_errors` here.
+- `security_negative` — P0 security-negative cases (`profiles/security_negative.py`). Live-safe auth-negative + bundled-fixture false-green; SSRF/CAP/ERR cases that need a model dispatch or ephemeral overlay are recorded as explicit skipped specs (`runtime_required` / `ephemeral_only`) rather than passes.
 
 ## Notes
 

--- a/ops/validate/profiles/security_negative.py
+++ b/ops/validate/profiles/security_negative.py
@@ -1,0 +1,670 @@
+"""sera-validate security_negative profile (sera-sv76.2).
+
+Runs P0 negative cases against a live SERA gateway:
+
+  - SEC-AUTH-01..06   live-safe auth-negative cases (no model required).
+  - SEC-FALSE-01..02  validate-only false-green checks against bundled fixtures.
+
+Cases that require a model or an ephemeral compose overlay (SSRF/CAP/ERR) are
+recorded as explicit skipped specs (`runtime_required` or `ephemeral_only`) so
+they surface as not-yet-implemented instead of silently passing.
+
+Stdlib only. The profile module is self-contained; it loads
+`ops/e2e/operator_task_smoke.py` via importlib for false-green semantics so the
+strict checks live in exactly one place (same trick sv76.1 uses).
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import importlib.util
+import json
+import re
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+_THIS = Path(__file__).resolve()
+_OPS_VALIDATE = _THIS.parents[1]
+_OPS_DIR = _OPS_VALIDATE.parent
+_OPERATOR_SMOKE_PATH = _OPS_DIR / "e2e" / "operator_task_smoke.py"
+_FIXTURES_DIR = _OPS_VALIDATE / "fixtures"
+
+DEFAULT_HTTP_TIMEOUT = 5.0
+
+_BEARER_TOKEN_RE = re.compile(r"Bearer\s+([A-Za-z0-9._\-]{8,})", re.IGNORECASE)
+
+
+def _load_operator_smoke() -> Any:
+    if not _OPERATOR_SMOKE_PATH.exists():
+        raise RuntimeError(f"operator_task_smoke.py not found at {_OPERATOR_SMOKE_PATH}")
+    spec = importlib.util.spec_from_file_location(
+        "operator_task_smoke_security_negative", _OPERATOR_SMOKE_PATH
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"failed to load spec for {_OPERATOR_SMOKE_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _now_iso() -> str:
+    return _dt.datetime.now(_dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+def _hdrs_to_dict(headers: Any) -> dict[str, str]:
+    out: dict[str, str] = {}
+    if headers is None:
+        return out
+    try:
+        items = list(headers.items())
+    except AttributeError:
+        try:
+            items = list(headers)
+        except TypeError:
+            return out
+    for k, v in items:
+        out[str(k)] = str(v)
+    return out
+
+
+def _http_send(
+    method: str,
+    url: str,
+    headers: dict[str, str] | None,
+    body: bytes | None,
+    timeout: float = DEFAULT_HTTP_TIMEOUT,
+) -> tuple[int | None, dict[str, str], bytes, str | None]:
+    """Issue an HTTP request without redirect-following.
+
+    Returns (status, response_headers, response_body, transport_error). When the
+    transport itself fails (DNS, connection refused, timeout) status is None and
+    the error message is reported via transport_error.
+    """
+    try:
+        req = urllib.request.Request(url, method=method, data=body)
+    except ValueError as exc:
+        return None, {}, b"", f"invalid_url: {exc}"
+    for k, v in (headers or {}).items():
+        req.add_header(k, v)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return resp.status, _hdrs_to_dict(resp.headers), resp.read(), None
+    except urllib.error.HTTPError as exc:
+        body_bytes: bytes
+        try:
+            body_bytes = exc.read() or b""
+        except Exception:  # noqa: BLE001
+            body_bytes = b""
+        return exc.code, _hdrs_to_dict(exc.headers), body_bytes, None
+    except urllib.error.URLError as exc:
+        return None, {}, b"", f"url_error: {exc.reason}"
+    except TimeoutError as exc:
+        return None, {}, b"", f"timeout: {exc}"
+    except Exception as exc:  # noqa: BLE001
+        return None, {}, b"", f"{type(exc).__name__}: {exc}"
+
+
+def _redact_response_body(body_bytes: bytes, known_secrets: set[str]) -> str:
+    """Decode + redact for storage in artifact. Best-effort utf-8 decode."""
+    try:
+        text = body_bytes.decode("utf-8")
+    except UnicodeDecodeError:
+        text = body_bytes.decode("utf-8", "replace")
+    for s in known_secrets:
+        if s and s in text:
+            text = text.replace(s, "<redacted:known-secret>")
+    text = _BEARER_TOKEN_RE.sub("Bearer <redacted:bearer>", text)
+    return text
+
+
+def _detect_leaks(
+    haystacks: list[str],
+    known_secrets: set[str],
+    forbidden_substrings: list[str] | None = None,
+) -> list[str]:
+    """Per-case leak detector. Returns a list of leak findings (empty = clean)."""
+    leaks: list[str] = []
+    for hay in haystacks:
+        if not hay:
+            continue
+        for s in known_secrets:
+            if s and s in hay:
+                leaks.append(f"known_secret_present (len={len(s)})")
+        for m in _BEARER_TOKEN_RE.finditer(hay):
+            tok = m.group(1)
+            if tok and not tok.startswith("<redacted"):
+                leaks.append(f"bearer_token_shape_present (token_prefix={tok[:4]})")
+        for needle in forbidden_substrings or []:
+            if needle and needle in hay:
+                leaks.append(f"forbidden_substring_present: {needle!r}")
+    return leaks
+
+
+# --- case helpers ------------------------------------------------------------
+
+
+def _new_case(case_id: str, category: str, **kwargs: Any) -> dict[str, Any]:
+    case: dict[str, Any] = {
+        "case_id": case_id,
+        "category": category,
+        "live_safe": True,
+        "ephemeral_only": False,
+        "runtime_required": False,
+        "skipped": False,
+        "skip_reason": None,
+        "attack": {
+            "method": None,
+            "path": None,
+            "headers": {},
+            "body": None,
+            "tool_call": None,
+            "url": None,
+        },
+        "expected": {
+            "status": None,
+            "blocked": None,
+            "failure_class": None,
+            "marker": None,
+        },
+        "actual": {
+            "status": None,
+            "body_redacted": None,
+            "card": None,
+            "audit": None,
+            "transport_error": None,
+        },
+        "evidence": {
+            "request_id": None,
+            "audit_id": None,
+            "container_log_window": None,
+        },
+        "audit_gap": False,
+        "audit_required": False,
+        "secrets_detected": False,
+        "passed": None,
+        "fail_reason": None,
+        "started_at": None,
+        "ended_at": None,
+    }
+    case.update(kwargs)
+    return case
+
+
+def _auth_case(
+    *,
+    case_id: str,
+    base: str,
+    method: str,
+    path: str,
+    headers: dict[str, str] | None,
+    body: bytes | None,
+    expected_status: int,
+    forbidden_in_body: list[str],
+    known_secrets: set[str],
+    category: str = "auth",
+) -> dict[str, Any]:
+    case = _new_case(case_id, category)
+    case["attack"]["method"] = method
+    case["attack"]["path"] = path
+    case["attack"]["headers"] = dict(headers or {})
+    case["attack"]["body"] = (
+        body.decode("utf-8", "replace") if isinstance(body, (bytes, bytearray)) else None
+    )
+    case["expected"]["status"] = expected_status
+    case["expected"]["marker"] = (
+        "no token reflection in response body or headers"
+    )
+    case["started_at"] = _now_iso()
+
+    url = base.rstrip("/") + path
+    status, resp_headers, resp_body, transport_error = _http_send(
+        method, url, headers, body
+    )
+    case["ended_at"] = _now_iso()
+
+    body_redacted = _redact_response_body(resp_body, known_secrets)
+    headers_redacted = {
+        k: ("<redacted:header>" if k.lower() in {"set-cookie", "authorization"} else v)
+        for k, v in resp_headers.items()
+    }
+    case["actual"]["status"] = status
+    case["actual"]["body_redacted"] = body_redacted
+    case["actual"]["headers_redacted"] = headers_redacted
+    case["actual"]["transport_error"] = transport_error
+
+    fail_reasons: list[str] = []
+    if transport_error is not None:
+        fail_reasons.append(f"transport_error: {transport_error}")
+    elif status != expected_status:
+        fail_reasons.append(f"status {status} != expected {expected_status}")
+
+    leak_haystacks = [body_redacted] + [str(v) for v in headers_redacted.values()]
+    leaks = _detect_leaks(
+        leak_haystacks, known_secrets, forbidden_substrings=forbidden_in_body
+    )
+    if leaks:
+        case["secrets_detected"] = True
+        fail_reasons.extend(leaks)
+
+    case["passed"] = not fail_reasons
+    case["fail_reason"] = "; ".join(fail_reasons) if fail_reasons else None
+    return case
+
+
+def _public_health_case(
+    *,
+    case_id: str,
+    base: str,
+    known_secrets: set[str],
+) -> dict[str, Any]:
+    """SEC-AUTH-06: /health and /api/health/ready must be reachable without auth."""
+    case = _new_case(case_id, "auth-public")
+    case["attack"]["method"] = "GET"
+    case["attack"]["path"] = "/health,/api/health/ready"
+    case["expected"]["marker"] = (
+        "/health 200; /api/health/ready 200 or 503 with not_ready; no auth required"
+    )
+    case["started_at"] = _now_iso()
+
+    fail_reasons: list[str] = []
+    probes: dict[str, dict[str, Any]] = {}
+    for path, allowed in (
+        ("/health", {200}),
+        ("/api/health/ready", {200, 503}),
+    ):
+        url = base.rstrip("/") + path
+        status, resp_headers, resp_body, transport_error = _http_send(
+            "GET", url, headers=None, body=None
+        )
+        body_redacted = _redact_response_body(resp_body, known_secrets)
+        probes[path] = {
+            "status": status,
+            "body_redacted": body_redacted,
+            "transport_error": transport_error,
+        }
+        if transport_error is not None:
+            fail_reasons.append(f"{path}: transport_error: {transport_error}")
+            continue
+        if status not in allowed:
+            fail_reasons.append(f"{path}: status {status} not in {sorted(allowed)}")
+            continue
+        if path == "/api/health/ready":
+            try:
+                parsed = json.loads(body_redacted) if body_redacted else None
+            except (json.JSONDecodeError, ValueError):
+                parsed = None
+            if not isinstance(parsed, dict) or "runtime_connected" not in parsed:
+                fail_reasons.append(
+                    "/api/health/ready: body must include 'runtime_connected' field"
+                )
+
+    case["ended_at"] = _now_iso()
+    case["actual"]["probes"] = probes
+
+    leak_haystacks = [str(p.get("body_redacted") or "") for p in probes.values()]
+    leaks = _detect_leaks(leak_haystacks, known_secrets)
+    if leaks:
+        case["secrets_detected"] = True
+        fail_reasons.extend(leaks)
+
+    case["passed"] = not fail_reasons
+    case["fail_reason"] = "; ".join(fail_reasons) if fail_reasons else None
+    return case
+
+
+def _validate_only_case(
+    *,
+    case_id: str,
+    fixture_name: str,
+    expected_marker: str,
+    smoke: Any,
+) -> dict[str, Any]:
+    case = _new_case(case_id, "false-green")
+    case["attack"]["path"] = f"fixtures/{fixture_name}"
+    case["expected"]["marker"] = expected_marker
+    case["started_at"] = _now_iso()
+
+    path = _FIXTURES_DIR / fixture_name
+    fail_reasons: list[str] = []
+    raised_errors: list[str] = []
+    if not path.exists():
+        fail_reasons.append(f"fixture missing: {path}")
+    else:
+        try:
+            with open(path, "r", encoding="utf-8") as handle:
+                data = json.load(handle)
+        except (OSError, json.JSONDecodeError) as exc:
+            fail_reasons.append(f"fixture unreadable: {exc}")
+            data = None
+        if isinstance(data, dict):
+            evidence = (
+                data["evidence"]
+                if isinstance(data.get("evidence"), dict)
+                else data
+            )
+            try:
+                raised_errors = list(smoke.validation_errors(evidence))
+            except Exception as exc:  # noqa: BLE001
+                fail_reasons.append(
+                    f"validation_errors raised: {type(exc).__name__}: {exc}"
+                )
+            if expected_marker and not any(
+                expected_marker in e for e in raised_errors
+            ):
+                fail_reasons.append(
+                    f"expected validation marker not raised: {expected_marker!r}; "
+                    f"got: {raised_errors!r}"
+                )
+        elif data is not None:
+            fail_reasons.append("fixture is not a JSON object")
+
+    case["ended_at"] = _now_iso()
+    case["actual"]["validation_errors"] = raised_errors
+    case["passed"] = not fail_reasons
+    case["fail_reason"] = "; ".join(fail_reasons) if fail_reasons else None
+    return case
+
+
+def _skipped_case(
+    *,
+    case_id: str,
+    category: str,
+    skip_reason: str,
+    marker: str,
+    runtime_required: bool = False,
+    ephemeral_only: bool = False,
+    audit_required: bool = False,
+) -> dict[str, Any]:
+    case = _new_case(
+        case_id,
+        category,
+        live_safe=not (runtime_required or ephemeral_only),
+        runtime_required=runtime_required,
+        ephemeral_only=ephemeral_only,
+        skipped=True,
+        skip_reason=skip_reason,
+        audit_required=audit_required,
+        audit_gap=audit_required,
+    )
+    case["expected"]["marker"] = marker
+    case["passed"] = None
+    case["fail_reason"] = None
+    return case
+
+
+# --- profile entry point -----------------------------------------------------
+
+
+def run(
+    *,
+    base: str,
+    container: str,
+    api_key: str,
+    known_secrets: set[str] | None = None,
+) -> tuple[
+    dict[str, Any], dict[str, Any], list[str], list[str], list[dict[str, Any]]
+]:
+    """Run the security_negative profile.
+
+    Returns ``(summary, evidence, errors, warnings, negative_cases)`` matching
+    the dispatch contract used by ``sera-validate.py`` ``main()``.
+    """
+    secrets: set[str] = set(known_secrets or set())
+    if api_key:
+        secrets.add(api_key)
+    secrets.add("sera_bootstrap_dev_123")
+
+    cases: list[dict[str, Any]] = []
+
+    # SEC-AUTH-01: GET /api/agents, no Authorization header.
+    cases.append(
+        _auth_case(
+            case_id="SEC-AUTH-01",
+            base=base,
+            method="GET",
+            path="/api/agents",
+            headers=None,
+            body=None,
+            expected_status=401,
+            forbidden_in_body=[],
+            known_secrets=secrets,
+        )
+    )
+    # SEC-AUTH-02: GET /api/agents with bogus bearer; body must not echo it.
+    bogus = "xxx-not-a-key"
+    cases.append(
+        _auth_case(
+            case_id="SEC-AUTH-02",
+            base=base,
+            method="GET",
+            path="/api/agents",
+            headers={"Authorization": f"Bearer {bogus}"},
+            body=None,
+            expected_status=401,
+            forbidden_in_body=[bogus],
+            known_secrets=secrets,
+        )
+    )
+    # SEC-AUTH-03: POST /api/operator/tasks with no auth.
+    cases.append(
+        _auth_case(
+            case_id="SEC-AUTH-03",
+            base=base,
+            method="POST",
+            path="/api/operator/tasks",
+            headers={"Content-Type": "application/json"},
+            body=b'{"task":"diag"}',
+            expected_status=401,
+            forbidden_in_body=[],
+            known_secrets=secrets,
+        )
+    )
+    # SEC-AUTH-04: GET /api/agents with garbage header (no Bearer prefix).
+    garbage = "garbage no-bearer-prefix"
+    cases.append(
+        _auth_case(
+            case_id="SEC-AUTH-04",
+            base=base,
+            method="GET",
+            path="/api/agents",
+            headers={"Authorization": garbage},
+            body=None,
+            expected_status=401,
+            forbidden_in_body=[garbage],
+            known_secrets=secrets,
+        )
+    )
+    # SEC-AUTH-05: GET /api/agents with empty bearer.
+    cases.append(
+        _auth_case(
+            case_id="SEC-AUTH-05",
+            base=base,
+            method="GET",
+            path="/api/agents",
+            headers={"Authorization": "Bearer "},
+            body=None,
+            expected_status=401,
+            forbidden_in_body=[],
+            known_secrets=secrets,
+        )
+    )
+    # SEC-AUTH-06: public health endpoints.
+    cases.append(
+        _public_health_case(
+            case_id="SEC-AUTH-06",
+            base=base,
+            known_secrets=secrets,
+        )
+    )
+
+    # SEC-FALSE-01..02: validate-only against bundled false-green fixtures.
+    smoke = _load_operator_smoke()
+    cases.append(
+        _validate_only_case(
+            case_id="SEC-FALSE-01",
+            fixture_name="false_green_interrupted.json",
+            expected_marker=(
+                "interrupted operator task must not be status=complete or blocked=false"
+            ),
+            smoke=smoke,
+        )
+    )
+    cases.append(
+        _validate_only_case(
+            case_id="SEC-FALSE-02",
+            fixture_name="false_green_llm_error_unblocked.json",
+            expected_marker="LLM/provider errors must be status=blocked",
+            smoke=smoke,
+        )
+    )
+
+    # Skipped specs for cases that need a model dispatch or an ephemeral overlay.
+    cases.append(
+        _skipped_case(
+            case_id="SEC-SSRF-01",
+            category="ssrf",
+            skip_reason="runtime_required",
+            marker="operator task must dispatch http_request to forbidden URL",
+            runtime_required=True,
+        )
+    )
+    cases.append(
+        _skipped_case(
+            case_id="SEC-SSRF-02",
+            category="ssrf",
+            skip_reason="runtime_required",
+            marker="cloud-metadata IP (169.254.169.254) must be blocked",
+            runtime_required=True,
+        )
+    )
+    cases.append(
+        _skipped_case(
+            case_id="SEC-SSRF-03",
+            category="ssrf",
+            skip_reason="runtime_required",
+            marker="RFC1918 (10.0.0.1) must be blocked",
+            runtime_required=True,
+        )
+    )
+    cases.append(
+        _skipped_case(
+            case_id="SEC-SSRF-04",
+            category="ssrf",
+            skip_reason="runtime_required",
+            marker="IPv6 loopback ([::1]) must be blocked",
+            runtime_required=True,
+        )
+    )
+    cases.append(
+        _skipped_case(
+            case_id="SEC-CAP-01",
+            category="capability",
+            skip_reason="runtime_required",
+            marker=(
+                "CapabilityRegistry::check denies tier-1 agent calling tier-2 tool"
+            ),
+            runtime_required=True,
+            audit_required=True,
+        )
+    )
+    cases.append(
+        _skipped_case(
+            case_id="SEC-CAP-02",
+            category="capability-live",
+            skip_reason="runtime_required",
+            marker="operator task with disallowed tool blocks; no tool result echo",
+            runtime_required=True,
+            audit_required=True,
+        )
+    )
+    cases.append(
+        _skipped_case(
+            case_id="SEC-CAP-03",
+            category="capability-missing",
+            skip_reason="ephemeral_only",
+            marker="gateway boot fails closed when policy_ref is missing",
+            ephemeral_only=True,
+        )
+    )
+    cases.append(
+        _skipped_case(
+            case_id="SEC-ERR-01",
+            category="provider-error",
+            skip_reason="runtime_required",
+            marker="card.blocked=true; reply has no provider URL or *_KEY shape",
+            runtime_required=True,
+        )
+    )
+    cases.append(
+        _skipped_case(
+            case_id="SEC-ERR-02",
+            category="empty-assistant",
+            skip_reason="ephemeral_only",
+            marker=(
+                "[LLM unavailable: model returned an empty response; retry the turn.]"
+            ),
+            ephemeral_only=True,
+        )
+    )
+    cases.append(
+        _skipped_case(
+            case_id="SEC-ERR-03",
+            category="raw-provider-error",
+            skip_reason="ephemeral_only",
+            marker="reply must not contain provider host or sk_live_ key shape",
+            ephemeral_only=True,
+        )
+    )
+
+    # Aggregate
+    counts = summarize_cases(cases)
+    summary: dict[str, Any] = {"security_negative": counts}
+
+    errors: list[str] = []
+    warnings: list[str] = []
+    for case in cases:
+        if case.get("skipped"):
+            continue
+        if case.get("secrets_detected"):
+            errors.append(f"secrets_leaked: {case['case_id']}")
+        if case.get("passed") is False:
+            errors.append(
+                f"{case['case_id']}: {case.get('fail_reason') or 'failed'}"
+            )
+        if case.get("audit_required") and case.get("audit_gap"):
+            warnings.append(f"audit_gap: {case['case_id']}")
+
+    evidence: dict[str, Any] = {
+        "base": base,
+        "container": container,
+        "case_summary": counts,
+    }
+    return summary, evidence, errors, warnings, cases
+
+
+def summarize_cases(cases: list[dict[str, Any]]) -> dict[str, int]:
+    """Compute summary counters expected by ``summary.security_negative``."""
+    counts = {
+        "cases_total": len(cases),
+        "cases_passed": 0,
+        "cases_failed": 0,
+        "audit_gaps": 0,
+        "live_only_skipped": 0,
+        "ephemeral_only_skipped": 0,
+    }
+    for case in cases:
+        if case.get("skipped"):
+            if case.get("ephemeral_only"):
+                counts["ephemeral_only_skipped"] += 1
+            elif case.get("runtime_required"):
+                counts["live_only_skipped"] += 1
+            continue
+        if case.get("passed") is True:
+            counts["cases_passed"] += 1
+        elif case.get("passed") is False:
+            counts["cases_failed"] += 1
+        if case.get("audit_required") and case.get("audit_gap"):
+            counts["audit_gaps"] += 1
+    return counts

--- a/ops/validate/sera-validate.py
+++ b/ops/validate/sera-validate.py
@@ -37,8 +37,8 @@ from typing import Any, Callable
 
 DEFAULT_BASE = "http://127.0.0.1:3001"
 DEFAULT_CONTAINER = "rust-sera-1"
-SCHEMA_VERSION = "1.0.0"
-TOOL_VERSION = "0.1.0"
+SCHEMA_VERSION = "1.1.0"
+TOOL_VERSION = "0.2.0"
 REDACTION_RULES_VERSION = "1"
 
 EXIT_PASS = 0
@@ -398,7 +398,48 @@ def validate_only(path: str) -> tuple[int, dict[str, Any]]:
 
 PROFILES: dict[str, str] = {
     "live_smoke": "Strict operator-task live smoke against rust-sera-1.",
+    "security_negative": (
+        "P0 security-negative cases (auth, false-green, "
+        "and runtime/ephemeral-skipped specs)."
+    ),
 }
+
+
+# --- profile loader ----------------------------------------------------------
+
+
+def _load_profile_module(name: str) -> Any:
+    """Load a profile sub-module by name (e.g. 'security_negative')."""
+    candidate = Path(__file__).resolve().parent / "profiles" / f"{name}.py"
+    if not candidate.exists():
+        raise HarnessError(f"profile module missing: {candidate}")
+    spec = importlib.util.spec_from_file_location(
+        f"sera_validate_profile_{name}", candidate
+    )
+    if spec is None or spec.loader is None:
+        raise HarnessError(f"failed to load spec for profile module {candidate}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def profile_security_negative(
+    *,
+    base: str,
+    container: str,
+    api_key: str,
+    known_secrets: set[str],
+) -> tuple[
+    dict[str, Any], dict[str, Any], list[str], list[str], list[dict[str, Any]]
+]:
+    """Dispatch wrapper around `profiles.security_negative.run`."""
+    module = _load_profile_module("security_negative")
+    return module.run(
+        base=base,
+        container=container,
+        api_key=api_key,
+        known_secrets=known_secrets,
+    )
 
 
 # --- CLI ---------------------------------------------------------------------
@@ -480,10 +521,24 @@ def main(argv: list[str] | None = None) -> int:
         "compose_project": "rust",
     }
 
+    negative_cases: list[dict[str, Any]] = []
     try:
         if args.profile == "live_smoke":
             summary, evidence, errors, warnings = profile_live_smoke(
                 base=base, container=args.container, api_key=api_key
+            )
+        elif args.profile == "security_negative":
+            (
+                summary,
+                evidence,
+                errors,
+                warnings,
+                negative_cases,
+            ) = profile_security_negative(
+                base=base,
+                container=args.container,
+                api_key=api_key,
+                known_secrets=known_secrets,
             )
         else:  # pragma: no cover - guarded by PROFILES check above
             raise HarnessError(f"profile {args.profile!r} not implemented")
@@ -505,7 +560,7 @@ def main(argv: list[str] | None = None) -> int:
         evidence=evidence,
         errors=errors,
         warnings=warnings,
-        negative_cases=[],
+        negative_cases=negative_cases,
     )
 
     redacted, count = redact_artifact(artifact, known_secrets=known_secrets)

--- a/ops/validate/tests/test_security_negative.py
+++ b/ops/validate/tests/test_security_negative.py
@@ -1,0 +1,240 @@
+"""Unit tests for the security_negative profile (sera-sv76.2)."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SV_PATH = ROOT / "sera-validate.py"
+PROFILE_PATH = ROOT / "profiles" / "security_negative.py"
+FIXTURES = ROOT / "fixtures"
+
+
+def _load_module(name: str, path: Path) -> object:
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def sv() -> object:
+    return _load_module("sera_validate", SV_PATH)
+
+
+@pytest.fixture(scope="module")
+def sec() -> object:
+    return _load_module("sec_neg", PROFILE_PATH)
+
+
+# --- registry ---------------------------------------------------------------
+
+
+def test_profile_registered(sv) -> None:  # type: ignore[no-untyped-def]
+    assert "security_negative" in sv.PROFILES
+    assert sv.SCHEMA_VERSION == "1.1.0"
+
+
+def test_loader_returns_module(sv) -> None:  # type: ignore[no-untyped-def]
+    module = sv._load_profile_module("security_negative")
+    assert hasattr(module, "run")
+    assert hasattr(module, "summarize_cases")
+
+
+# --- summarize_cases -------------------------------------------------------
+
+
+def test_summarize_cases_counts_pass_fail_and_skips(sec) -> None:  # type: ignore[no-untyped-def]
+    cases = [
+        {"case_id": "A", "passed": True, "skipped": False},
+        {"case_id": "B", "passed": False, "skipped": False},
+        {
+            "case_id": "C",
+            "passed": None,
+            "skipped": True,
+            "runtime_required": True,
+            "ephemeral_only": False,
+        },
+        {
+            "case_id": "D",
+            "passed": None,
+            "skipped": True,
+            "runtime_required": False,
+            "ephemeral_only": True,
+        },
+        {
+            "case_id": "E",
+            "passed": True,
+            "skipped": False,
+            "audit_required": True,
+            "audit_gap": True,
+        },
+    ]
+    counts = sec.summarize_cases(cases)
+    assert counts["cases_total"] == 5
+    assert counts["cases_passed"] == 2
+    assert counts["cases_failed"] == 1
+    assert counts["live_only_skipped"] == 1
+    assert counts["ephemeral_only_skipped"] == 1
+    assert counts["audit_gaps"] == 1
+
+
+# --- detect_leaks -----------------------------------------------------------
+
+
+def test_detect_leaks_finds_known_secret(sec) -> None:  # type: ignore[no-untyped-def]
+    leaks = sec._detect_leaks(
+        ["the api key is sk_live_abcDEFsv76 here"],
+        known_secrets={"sk_live_abcDEFsv76"},
+    )
+    assert leaks
+    assert any("known_secret_present" in s for s in leaks)
+
+
+def test_detect_leaks_finds_bare_bearer(sec) -> None:  # type: ignore[no-untyped-def]
+    leaks = sec._detect_leaks(
+        ["Authorization: Bearer raw-token-1234567890"],
+        known_secrets=set(),
+    )
+    assert leaks
+    assert any("bearer_token_shape_present" in s for s in leaks)
+
+
+def test_detect_leaks_ignores_redacted_placeholder(sec) -> None:  # type: ignore[no-untyped-def]
+    leaks = sec._detect_leaks(
+        ["Bearer <redacted:bearer> still here"],
+        known_secrets=set(),
+    )
+    assert leaks == []
+
+
+def test_detect_leaks_finds_forbidden_substring(sec) -> None:  # type: ignore[no-untyped-def]
+    leaks = sec._detect_leaks(
+        ["echo: xxx-not-a-key was reflected"],
+        known_secrets=set(),
+        forbidden_substrings=["xxx-not-a-key"],
+    )
+    assert any("forbidden_substring_present" in s for s in leaks)
+
+
+# --- redact_response_body ---------------------------------------------------
+
+
+def test_redact_response_body_strips_known_secret(sec) -> None:  # type: ignore[no-untyped-def]
+    body = b"hello secret_abc123def world"
+    redacted = sec._redact_response_body(body, {"secret_abc123def"})
+    assert "secret_abc123def" not in redacted
+    assert "<redacted:known-secret>" in redacted
+
+
+def test_redact_response_body_strips_bearer(sec) -> None:  # type: ignore[no-untyped-def]
+    body = b"Authorization: Bearer abcdef1234567890"
+    redacted = sec._redact_response_body(body, set())
+    assert "abcdef1234567890" not in redacted
+    assert "<redacted:bearer>" in redacted
+
+
+# --- validate-only false-green cases ---------------------------------------
+
+
+def test_false_green_cases_pass_against_bundled_fixtures(sec) -> None:  # type: ignore[no-untyped-def]
+    smoke = sec._load_operator_smoke()
+    case01 = sec._validate_only_case(
+        case_id="SEC-FALSE-01",
+        fixture_name="false_green_interrupted.json",
+        expected_marker=(
+            "interrupted operator task must not be status=complete or blocked=false"
+        ),
+        smoke=smoke,
+    )
+    assert case01["passed"] is True, case01
+    assert case01["actual"]["validation_errors"]
+    assert any(
+        "interrupted operator task must not be status=complete or blocked=false" in e
+        for e in case01["actual"]["validation_errors"]
+    )
+
+    case02 = sec._validate_only_case(
+        case_id="SEC-FALSE-02",
+        fixture_name="false_green_llm_error_unblocked.json",
+        expected_marker="LLM/provider errors must be status=blocked",
+        smoke=smoke,
+    )
+    assert case02["passed"] is True, case02
+
+
+def test_false_green_case_fails_when_marker_absent(sec, tmp_path) -> None:  # type: ignore[no-untyped-def]
+    # Synthesize a fixture where the false-green check should NOT fire.
+    clean = {
+        "evidence": {
+            "health": {"ok": True, "status": 200, "json": {"ok": True}},
+            "ready": {"ok": True, "status": 200, "json": {"runtime_connected": True}},
+            "agents": {"ok": True, "status": 200, "json": [{"id": "sera"}]},
+            "operator_task": {
+                "ok": True,
+                "status": 200,
+                "json": {
+                    "session_key": "k",
+                    "status": "complete",
+                    "blocked": False,
+                    "result": "all good",
+                    "failure_class": None,
+                    "next_action": None,
+                },
+            },
+            "subagents": {
+                "ok": True,
+                "status": 200,
+                "json": {"subagents": [{"agent": "operator-helper"}]},
+            },
+            "sse_lines": ["data: {\"event\": \"operator.task\"}"],
+        }
+    }
+    fixture_dir = tmp_path / "fixtures"
+    fixture_dir.mkdir()
+    fixture = fixture_dir / "clean.json"
+    fixture.write_text(json.dumps(clean), encoding="utf-8")
+    # Re-point the profile module to this temp fixtures directory.
+    saved = sec._FIXTURES_DIR
+    try:
+        sec._FIXTURES_DIR = fixture_dir
+        smoke = sec._load_operator_smoke()
+        case = sec._validate_only_case(
+            case_id="SEC-FALSE-X",
+            fixture_name="clean.json",
+            expected_marker=(
+                "interrupted operator task must not be status=complete or blocked=false"
+            ),
+            smoke=smoke,
+        )
+    finally:
+        sec._FIXTURES_DIR = saved
+    assert case["passed"] is False
+    assert case["fail_reason"]
+    assert "expected validation marker not raised" in case["fail_reason"]
+
+
+# --- skipped specs ---------------------------------------------------------
+
+
+def test_skipped_case_does_not_fake_pass(sec) -> None:  # type: ignore[no-untyped-def]
+    case = sec._skipped_case(
+        case_id="SEC-SSRF-99",
+        category="ssrf",
+        skip_reason="runtime_required",
+        marker="m",
+        runtime_required=True,
+    )
+    assert case["skipped"] is True
+    assert case["passed"] is None
+    assert case["live_safe"] is False
+    assert case["runtime_required"] is True
+    counts = sec.summarize_cases([case])
+    assert counts["cases_passed"] == 0
+    assert counts["cases_failed"] == 0
+    assert counts["live_only_skipped"] == 1


### PR DESCRIPTION
## Summary

Stacked on top of #1221 (sv76.1 runner skeleton). Adds the `security_negative`
profile to `sera-validate` with the P0 live-safe negative cases and explicit
skipped specs for cases that need a model dispatch or an ephemeral compose
overlay. Stdlib only; no changes to `ops/e2e/operator_task_smoke.py` or `rust/`.

Bead: `sera-sv76.2`. Scout: `artifacts/reports/validation/sera-sv76.2-security-negative-scout-2026-05-08.md`.

## What lands

- **`security_negative` profile** registered alongside `live_smoke`. Implementation in `ops/validate/profiles/security_negative.py` (self-contained; reuses the sv76.1 redaction + artifact pipeline).
- **8 implemented cases** (live, run against `rust-sera-1`):
  - `SEC-AUTH-01..05` — bearer / no-bearer / empty-bearer / garbage-prefix / unauthenticated POST. Assert HTTP 401 + no token reflection + no SERA_API_KEY echo + no Bearer-shape survival.
  - `SEC-AUTH-06` — public health (`/health`, `/api/health/ready`) reachable without auth, surfaces `runtime_connected`.
  - `SEC-FALSE-01..02` — validate-only against the bundled sv76.1 false-green fixtures; reuses `operator_task_smoke.validation_errors` so the strict markers (`interrupted operator task must not be status=complete or blocked=false`, `LLM/provider errors must be status=blocked`) must fire.
- **10 explicit skipped specs** (skip-not-pass) for SSRF / capability / provider-error cases that need a runtime turn or a hostile compose overlay (`runtime_required` × 7, `ephemeral_only` × 3). Recorded in `validation.negative_cases[]` so they surface in artifacts as not-yet-implemented rather than silently passing.
- **Schema bump 1.0.0 → 1.1.0** (additive). New fields:
  - `validation.negative_cases[]` — `case_id, category, attack, expected, actual, evidence, audit_gap, secrets_detected, passed, fail_reason, started_at, ended_at, skipped, skip_reason, runtime_required, ephemeral_only`.
  - `summary.security_negative` — `cases_total / cases_passed / cases_failed / audit_gaps / live_only_skipped / ephemeral_only_skipped` (control-loop consumable).
- **Per-case leak detection** runs before the artifact-wide redaction pass (`_detect_leaks` in the profile module). Catches: known-secret occurrence, bearer-shape survival, forbidden substring (e.g. the literal `xxx-not-a-key` reflection probe). Any case-level leak adds `secrets_leaked: <case_id>` to `validation.errors`.
- **No new redaction patterns**: SEC-AUTH/SEC-FALSE don't call provider hosts and never carry `sk_live_*` shapes, so the scout §4 extensions are deferred until the SSRF/ERR cases that actually need them land.

## Verification

```
$ python3 -m py_compile ops/validate/sera-validate.py \
    ops/validate/profiles/security_negative.py
OK_COMPILE

$ python3 -m pytest ops/validate/tests -q
33 passed   # 21 sv76.1 + 12 new

$ python3 ops/validate/sera-validate.py --profile security_negative \
    --base http://127.0.0.1:3001 --container rust-sera-1 \
    --out /tmp/sera-security-negative-omc.json --quiet
sera-validate: pass profile=security_negative artifact=/tmp/sera-security-negative-omc.json
EXIT=0
```

Artifact:

- `schema_version=1.1.0`, `profile=security_negative`, `verdict=pass`, `exit_code=0`.
- `summary.security_negative = { cases_total: 18, cases_passed: 8, cases_failed: 0, audit_gaps: 0, live_only_skipped: 7, ephemeral_only_skipped: 3 }`.
- `redaction.applied=true`, `redacted_count=3`, `validation.errors=[]`, `validation.warnings=[]`.

Leak grep over the artifact:

```
$ grep -E "(Bearer [A-Za-z0-9._\-]{8,} |sera_api_key=|SERA_API_KEY=|sk_(live|test)_)" \
       /tmp/sera-security-negative-omc.json
"marker": "reply must not contain provider host or sk_live_ key shape"
```

The only `sk_live_` hit is the literal **marker text of the skipped SEC-ERR-03 spec** describing what it expects to detect — not a real secret. The 64-char live `SERA_API_KEY` was confirmed absent from the artifact.

## Test plan

- [x] `python3 -m py_compile` on both source files.
- [x] `python3 -m pytest ops/validate/tests -q` — 33 passed.
- [x] Live run vs `rust-sera-1` — all 6 auth cases + 2 false-green pass; 10 skipped with proper reasons.
- [x] Manual leak grep over the artifact (`Bearer …`, `sera_api_key=`, `SERA_API_KEY=`, `sk_(live|test)_`).
- [x] `docker inspect rust-sera-1` ⇒ extract `SERA_API_KEY` ⇒ `grep -F` against artifact ⇒ absent.

## Out of scope (followup beads expected)

- Live SSRF / CAP / ERR cases require an operator-task dispatch with a model or an ephemeral mock LLM overlay (`docker compose -p sera-sec-<runid>`).
- The capability OCSF audit-read API is not yet wired; SEC-CAP-01..02 carry `audit_required=true` and will set `audit_gap=true → warn` only when the primary signal is positive.
- Provider-host / `sk_(live|test)_` redaction extensions land alongside the cases that actually exercise them.

## Stacking

Base: `feat/sera-sv76-validate-runner-omc` (PR #1221).
Once #1221 merges, GitHub will retarget this PR's base to `main` automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)