### PR TITLE
feat(gateway): register Pattern B external agent sessions

### DIFF
--- a/rust/crates/sera-gateway/src/external_agent_registry.rs
+++ b/rust/crates/sera-gateway/src/external_agent_registry.rs
@@ -1,0 +1,503 @@
+//! In-memory registry of Pattern B external-agent sessions (sera-pcvp PR2).
+//!
+//! Each entry is keyed by the SQ-envelope `session_key` and records the typed
+//! handshake the gateway pinned at registration: who delegated the session,
+//! the egress allow-list it declared, the budget bucket it is bound to, and
+//! the minted [`PrincipalRef`].
+//!
+//! ## Why this exists
+//!
+//! Pattern A harnesses (Agent / Connector / Plugin manifest variants of
+//! [`RegisterOp`]) flow through the existing manifest path. Pattern B
+//! sessions — a clawhip-launched Claude Code pane, an OMC orchestrator pane,
+//! a Hermes profile, an external A2A/ACP agent — assert their own identity
+//! over the SQ envelope. The gateway must:
+//!
+//! 1. Refuse a registration whose `delegated_by` is unknown or wrong-kind
+//!    (anti-laundering invariant; SPEC-gateway §1d).
+//! 2. Enforce that a session that intends to talk to the LLM proxy actually
+//!    declared `EgressEndpoint::InferenceLocal` in its allow-list (mirrors
+//!    `EgressManifest::allows_inference_local` for the typed handshake).
+//! 3. Refuse re-binding the same `session_key` to a different principal —
+//!    the BYOH registry replaces on collision because catalogs are
+//!    idempotent; Pattern B sessions are *identity*, so a duplicate
+//!    `session_key` is a programmer error and must surface as one.
+//! 4. Mint the principal via [`Principal::external_agent_with_delegator`] so
+//!    the call-site explicitly threads `delegated_by`.
+//!
+//! ## Integration seam (deferred to PR3)
+//!
+//! There is no production `Op::Register` dispatch arm in
+//! `sera-gateway/src/bin/sera.rs` today — `Op::Register(_)` is a wildcard
+//! audit arm in [`session_store::op_kind_label`] and a no-op in
+//! [`sera_runtime::stdio`]. PR2 ships the pure handler + module-seam
+//! integration tests; the production wire-up (call this registry from a
+//! `Submission` arrival, emit `EventMsg::SessionTransition` on success and
+//! `EventMsg::Error { code, message }` on failure) is the smallest PR3
+//! delta. See `tests/register_op_external_agent.rs` for the seam shape.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, RwLock};
+
+use chrono::{DateTime, Utc};
+use thiserror::Error;
+
+use sera_types::envelope::{BudgetHandle, ExternalAgentRegistration, ExternalProtocol};
+use sera_types::principal::{Principal, PrincipalKind, PrincipalRef};
+use sera_types::sandbox::EgressEndpoint;
+
+/// One Pattern B session pinned by the gateway at registration time.
+///
+/// Cloneable so the registry can return a snapshot without holding the lock.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExternalAgentSession {
+    /// Lightweight reference to the freshly minted ExternalAgentPrincipal —
+    /// suitable for embedding in events and audit rows.
+    pub principal_ref: PrincipalRef,
+    /// The principal that delegated this session into existence. Validated
+    /// at registration; downstream code may trust it.
+    pub delegated_by: PrincipalRef,
+    /// The egress allow-list the registering session declared. Recorded as
+    /// pinned scope; sera-eq0m's kernel/sandbox layer is the enforcement.
+    pub declared_egress: Vec<EgressEndpoint>,
+    /// Budget bucket key. Today an opaque newtype wrapper over a string;
+    /// sera-plcv will replace the inner shape without re-touching this field.
+    pub budget_handle: BudgetHandle,
+    /// Wall-clock registration timestamp. Used by audit + `bd remember`-style
+    /// observability tooling; not load-bearing for authorization.
+    pub registered_at: DateTime<Utc>,
+}
+
+/// Errors a Pattern B registration can surface back to the SQ caller.
+///
+/// `code()` returns the stable wire identifier the production dispatch arm
+/// (PR3) will copy into [`EventMsg::Error::code`]. Tests pin both the wire
+/// code and the human-readable message so a future seam refactor can't
+/// silently downgrade the contract.
+#[derive(Debug, Clone, Error, PartialEq, Eq)]
+pub enum RegisterError {
+    /// The submitted `delegated_by` principal is not on the validator's
+    /// allow-list, or is the wrong kind. The wire code is
+    /// `register_op_invalid_delegator`.
+    #[error("register_op_invalid_delegator: unknown or wrong-kind delegator '{0}'")]
+    InvalidDelegator(String),
+
+    /// The LLM proxy is enabled but the registration did not include
+    /// [`EgressEndpoint::InferenceLocal`] in `declared_egress`. Wire code
+    /// `register_op_egress_invalid`.
+    #[error(
+        "register_op_egress_invalid: declared_egress must include InferenceLocal when the LLM proxy is enabled"
+    )]
+    EgressInvalid,
+
+    /// Another Pattern B session is already registered under this
+    /// `session_key`. Wire code `register_op_duplicate_session`. Replace
+    /// semantics are intentionally NOT supported — see module docs.
+    #[error("register_op_duplicate_session: session_key '{0}' already bound")]
+    DuplicateSession(String),
+}
+
+impl RegisterError {
+    /// Stable wire-level error code consumed by `EventMsg::Error::code` in
+    /// the PR3 dispatch arm.
+    pub fn code(&self) -> &'static str {
+        match self {
+            Self::InvalidDelegator(_) => "register_op_invalid_delegator",
+            Self::EgressInvalid => "register_op_egress_invalid",
+            Self::DuplicateSession(_) => "register_op_duplicate_session",
+        }
+    }
+}
+
+/// Resolves whether a [`PrincipalRef`] is permitted to be a `delegated_by`
+/// for a Pattern B registration.
+///
+/// Today the gateway has no production principal store — the closest seams
+/// are the API-key middleware (which operates on tokens, not principals) and
+/// `PrincipalPolicyStore` (which serves policy, not existence). PR3 will
+/// back this trait with whatever store sera-db lands; PR2 ships an in-memory
+/// allow-list so the handler logic is testable without a database fixture.
+pub trait DelegatorValidator: Send + Sync {
+    /// Returns `true` iff the principal is a valid Pattern B delegator.
+    /// Implementations MUST also enforce the kind invariant: only
+    /// [`PrincipalKind::Agent`] and [`PrincipalKind::Human`] may delegate
+    /// (see SPEC-gateway §1d / scout report §2.5 step 2).
+    fn is_valid(&self, delegator: &PrincipalRef) -> bool;
+}
+
+/// In-memory delegator allow-list for tests and bootstrap fixtures.
+///
+/// Production gateways will swap this for a sera-db-backed implementation in
+/// PR3 without re-shaping callers.
+#[derive(Debug, Default, Clone)]
+pub struct InMemoryDelegatorValidator {
+    known: HashSet<PrincipalRef>,
+}
+
+impl InMemoryDelegatorValidator {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Builder-style add for fixture setup.
+    pub fn with_known(mut self, delegator: PrincipalRef) -> Self {
+        self.known.insert(delegator);
+        self
+    }
+
+    pub fn add(&mut self, delegator: PrincipalRef) {
+        self.known.insert(delegator);
+    }
+}
+
+impl DelegatorValidator for InMemoryDelegatorValidator {
+    fn is_valid(&self, delegator: &PrincipalRef) -> bool {
+        // Wrong-kind rejection is structural — only Agent/Human may delegate
+        // a Pattern B session. The allow-list check is the existence gate.
+        matches!(
+            delegator.kind,
+            PrincipalKind::Agent | PrincipalKind::Human
+        ) && self.known.contains(delegator)
+    }
+}
+
+/// Registry of currently-active Pattern B sessions, keyed by the SQ envelope
+/// `session_key`.
+///
+/// Owns the `inference_proxy_enabled` flag so the egress invariant is
+/// enforced at registration rather than threaded through every caller.
+pub struct ExternalAgentRegistry {
+    sessions: RwLock<HashMap<String, ExternalAgentSession>>,
+    inference_proxy_enabled: bool,
+    delegator_validator: Arc<dyn DelegatorValidator>,
+}
+
+impl ExternalAgentRegistry {
+    /// Build a registry. `inference_proxy_enabled` mirrors the gateway's
+    /// `--inference-proxy` flag (today: `inference_proxy_eq0m_acceptance`
+    /// fixtures). When `true`, registrations missing
+    /// [`EgressEndpoint::InferenceLocal`] are rejected.
+    pub fn new(
+        inference_proxy_enabled: bool,
+        delegator_validator: Arc<dyn DelegatorValidator>,
+    ) -> Self {
+        Self {
+            sessions: RwLock::new(HashMap::new()),
+            inference_proxy_enabled,
+            delegator_validator,
+        }
+    }
+
+    /// Register a Pattern B session. The `session_key` is the SQ envelope's
+    /// `Submission::session_key` — the registry does not invent one.
+    ///
+    /// On success, returns a clone of the stored [`ExternalAgentSession`] so
+    /// the caller can immediately reference the minted principal without
+    /// re-locking. On failure, the registry state is unchanged.
+    pub fn register(
+        &self,
+        session_key: &str,
+        registration: &ExternalAgentRegistration,
+    ) -> Result<ExternalAgentSession, RegisterError> {
+        if !self
+            .delegator_validator
+            .is_valid(&registration.delegated_by)
+        {
+            return Err(RegisterError::InvalidDelegator(
+                registration.delegated_by.id.0.clone(),
+            ));
+        }
+
+        if self.inference_proxy_enabled
+            && !registration
+                .declared_egress
+                .iter()
+                .any(|e| matches!(e, EgressEndpoint::InferenceLocal))
+        {
+            return Err(RegisterError::EgressInvalid);
+        }
+
+        let mut guard = self.sessions.write().expect("sessions lock poisoned");
+        if guard.contains_key(session_key) {
+            return Err(RegisterError::DuplicateSession(session_key.to_string()));
+        }
+
+        let principal = Principal::external_agent_with_delegator(
+            protocol_label(&registration.protocol).as_str(),
+            &registration.external_id,
+            &registration.delegated_by,
+        );
+
+        let session = ExternalAgentSession {
+            principal_ref: principal.as_ref(),
+            delegated_by: registration.delegated_by.clone(),
+            declared_egress: registration.declared_egress.clone(),
+            budget_handle: registration.budget_handle.clone(),
+            registered_at: Utc::now(),
+        };
+
+        guard.insert(session_key.to_string(), session.clone());
+        Ok(session)
+    }
+
+    /// Look up a stored session by its SQ envelope `session_key`. Returns
+    /// `None` if no Pattern B session has registered under that key.
+    pub fn get(&self, session_key: &str) -> Option<ExternalAgentSession> {
+        self.sessions
+            .read()
+            .expect("sessions lock poisoned")
+            .get(session_key)
+            .cloned()
+    }
+
+    /// Number of currently-registered Pattern B sessions. Test introspection.
+    pub fn registered_count(&self) -> usize {
+        self.sessions
+            .read()
+            .expect("sessions lock poisoned")
+            .len()
+    }
+}
+
+/// Snake-case protocol label used in `Principal::id = "ext:{protocol}:{external_id}"`.
+fn protocol_label(protocol: &ExternalProtocol) -> String {
+    match protocol {
+        ExternalProtocol::A2a => "a2a".to_string(),
+        ExternalProtocol::AcpCompat => "acp_compat".to_string(),
+        ExternalProtocol::Custom(s) => s.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sera_types::principal::PrincipalId;
+
+    fn agent_ref(id: &str) -> PrincipalRef {
+        PrincipalRef {
+            id: PrincipalId::new(id),
+            kind: PrincipalKind::Agent,
+        }
+    }
+
+    fn human_ref(id: &str) -> PrincipalRef {
+        PrincipalRef {
+            id: PrincipalId::new(id),
+            kind: PrincipalKind::Human,
+        }
+    }
+
+    fn registration(
+        protocol: ExternalProtocol,
+        external_id: &str,
+        delegated_by: PrincipalRef,
+    ) -> ExternalAgentRegistration {
+        ExternalAgentRegistration {
+            protocol,
+            external_id: external_id.to_string(),
+            delegated_by,
+            declared_egress: vec![EgressEndpoint::InferenceLocal],
+            budget_handle: BudgetHandle(format!("ext:bucket:{external_id}")),
+        }
+    }
+
+    fn registry_with_known(known: PrincipalRef) -> ExternalAgentRegistry {
+        let validator = Arc::new(InMemoryDelegatorValidator::new().with_known(known));
+        ExternalAgentRegistry::new(true, validator)
+    }
+
+    #[test]
+    fn register_then_lookup_returns_session() {
+        let parent = agent_ref("agent:parent-1");
+        let registry = registry_with_known(parent.clone());
+        let reg = registration(ExternalProtocol::A2a, "claude-pane-1", parent.clone());
+
+        let session = registry
+            .register("sess-001", &reg)
+            .expect("registration should succeed");
+
+        assert_eq!(session.principal_ref.id.0, "ext:a2a:claude-pane-1");
+        assert_eq!(session.principal_ref.kind, PrincipalKind::ExternalAgent);
+        assert_eq!(session.delegated_by, parent);
+        assert_eq!(session.declared_egress, vec![EgressEndpoint::InferenceLocal]);
+        assert_eq!(session.budget_handle.0, "ext:bucket:claude-pane-1");
+
+        let stored = registry.get("sess-001").expect("session stored");
+        assert_eq!(stored, session);
+        assert_eq!(registry.registered_count(), 1);
+    }
+
+    #[test]
+    fn unknown_delegator_rejected() {
+        let known = agent_ref("agent:known");
+        let stranger = agent_ref("agent:stranger");
+        let registry = registry_with_known(known);
+
+        let err = registry
+            .register("sess-002", &registration(ExternalProtocol::A2a, "x", stranger))
+            .unwrap_err();
+
+        assert_eq!(err.code(), "register_op_invalid_delegator");
+        assert!(matches!(err, RegisterError::InvalidDelegator(ref id) if id == "agent:stranger"));
+        assert_eq!(registry.registered_count(), 0);
+    }
+
+    #[test]
+    fn wrong_kind_delegator_rejected_even_when_id_in_allowlist() {
+        // Allow-list contains an *Agent*-kind principal, but the submitter
+        // claims an *ExternalAgent*-kind delegator with the same id. That is
+        // a kind-confusion attempt and must be rejected.
+        let agent = agent_ref("agent:p");
+        let validator = Arc::new(InMemoryDelegatorValidator::new().with_known(agent.clone()));
+        let registry = ExternalAgentRegistry::new(true, validator);
+
+        let confused = PrincipalRef {
+            id: agent.id.clone(),
+            kind: PrincipalKind::ExternalAgent,
+        };
+        let err = registry
+            .register(
+                "sess-003",
+                &registration(ExternalProtocol::A2a, "x", confused),
+            )
+            .unwrap_err();
+
+        assert_eq!(err.code(), "register_op_invalid_delegator");
+        assert_eq!(registry.registered_count(), 0);
+    }
+
+    #[test]
+    fn human_delegator_accepted() {
+        let operator = human_ref("admin");
+        let registry = registry_with_known(operator.clone());
+
+        let session = registry
+            .register(
+                "sess-004",
+                &registration(ExternalProtocol::AcpCompat, "ops-pane", operator.clone()),
+            )
+            .expect("human delegator must be valid");
+
+        assert_eq!(session.principal_ref.id.0, "ext:acp_compat:ops-pane");
+        assert_eq!(session.delegated_by, operator);
+    }
+
+    #[test]
+    fn duplicate_session_key_rejected() {
+        let parent = agent_ref("agent:parent");
+        let registry = registry_with_known(parent.clone());
+
+        registry
+            .register("sess-dup", &registration(ExternalProtocol::A2a, "first", parent.clone()))
+            .expect("first registration should succeed");
+
+        let err = registry
+            .register(
+                "sess-dup",
+                &registration(ExternalProtocol::A2a, "second", parent),
+            )
+            .unwrap_err();
+
+        assert_eq!(err.code(), "register_op_duplicate_session");
+        assert!(matches!(err, RegisterError::DuplicateSession(ref k) if k == "sess-dup"));
+        // The first registration is still the one that holds the slot — the
+        // duplicate did NOT replace it.
+        let stored = registry.get("sess-dup").unwrap();
+        assert_eq!(stored.principal_ref.id.0, "ext:a2a:first");
+        assert_eq!(registry.registered_count(), 1);
+    }
+
+    #[test]
+    fn same_external_id_distinct_protocol_ok() {
+        // Two sessions can share an `external_id` as long as their protocol
+        // (or session_key) differs — the principal id includes the protocol,
+        // and the registry is keyed by session_key.
+        let parent = agent_ref("agent:parent");
+        let registry = registry_with_known(parent.clone());
+
+        let a = registry
+            .register(
+                "sess-a2a",
+                &registration(ExternalProtocol::A2a, "bot", parent.clone()),
+            )
+            .unwrap();
+        let b = registry
+            .register(
+                "sess-acp",
+                &registration(ExternalProtocol::AcpCompat, "bot", parent),
+            )
+            .unwrap();
+
+        assert_eq!(a.principal_ref.id.0, "ext:a2a:bot");
+        assert_eq!(b.principal_ref.id.0, "ext:acp_compat:bot");
+        assert_ne!(a.principal_ref, b.principal_ref);
+        assert_eq!(registry.registered_count(), 2);
+    }
+
+    #[test]
+    fn missing_inference_local_rejected_when_proxy_enabled() {
+        let parent = agent_ref("agent:parent");
+        let validator = Arc::new(InMemoryDelegatorValidator::new().with_known(parent.clone()));
+        let registry = ExternalAgentRegistry::new(true, validator);
+
+        let mut reg = registration(ExternalProtocol::A2a, "x", parent);
+        reg.declared_egress = vec![EgressEndpoint::Domain {
+            name: "api.github.com".to_string(),
+        }];
+
+        let err = registry.register("sess-egress", &reg).unwrap_err();
+        assert_eq!(err.code(), "register_op_egress_invalid");
+        assert_eq!(registry.registered_count(), 0);
+    }
+
+    #[test]
+    fn missing_inference_local_accepted_when_proxy_disabled() {
+        // Off-proxy deployments do not require InferenceLocal — the egress
+        // invariant is the LLM proxy's invariant, not a global one.
+        let parent = agent_ref("agent:parent");
+        let validator = Arc::new(InMemoryDelegatorValidator::new().with_known(parent.clone()));
+        let registry = ExternalAgentRegistry::new(false, validator);
+
+        let mut reg = registration(ExternalProtocol::A2a, "x", parent);
+        reg.declared_egress = vec![]; // empty allow-list
+
+        let session = registry
+            .register("sess-noproxy", &reg)
+            .expect("proxy-disabled registry must accept any egress");
+        assert!(session.declared_egress.is_empty());
+    }
+
+    #[test]
+    fn custom_protocol_label_threaded_into_principal_id() {
+        let parent = agent_ref("agent:parent");
+        let registry = registry_with_known(parent.clone());
+
+        let session = registry
+            .register(
+                "sess-custom",
+                &registration(
+                    ExternalProtocol::Custom("hermes".to_string()),
+                    "profile-7",
+                    parent,
+                ),
+            )
+            .unwrap();
+
+        assert_eq!(session.principal_ref.id.0, "ext:hermes:profile-7");
+    }
+
+    #[test]
+    fn register_error_codes_are_stable_wire_strings() {
+        // PR3's dispatch arm copies these into EventMsg::Error::code; pin
+        // them so a refactor cannot silently break the wire contract.
+        assert_eq!(
+            RegisterError::InvalidDelegator("x".into()).code(),
+            "register_op_invalid_delegator"
+        );
+        assert_eq!(RegisterError::EgressInvalid.code(), "register_op_egress_invalid");
+        assert_eq!(
+            RegisterError::DuplicateSession("k".into()).code(),
+            "register_op_duplicate_session"
+        );
+    }
+}

--- a/rust/crates/sera-gateway/src/lib.rs
+++ b/rust/crates/sera-gateway/src/lib.rs
@@ -10,6 +10,7 @@ pub mod connector;
 pub mod constitutional_config;
 pub mod db_backend;
 pub mod envelope;
+pub mod external_agent_registry;
 pub mod generation;
 #[cfg(feature = "gh-api")]
 pub mod github_poller;

--- a/rust/crates/sera-gateway/tests/register_op_external_agent.rs
+++ b/rust/crates/sera-gateway/tests/register_op_external_agent.rs
@@ -1,0 +1,299 @@
+//! Integration tests for `Op::Register(RegisterOp::ExternalAgent(_))`
+//! handling (sera-pcvp PR2).
+//!
+//! These tests exercise the same module seam the production SQ admission arm
+//! will call in PR3:
+//!
+//! 1. Pull the `Submission`'s `session_key` and the `ExternalAgentRegistration`
+//!    payload from `Op::Register(RegisterOp::ExternalAgent(_))`.
+//! 2. Call [`ExternalAgentRegistry::register`].
+//! 3. On `Ok(session)`: emit `EventMsg::SessionTransition { from:
+//!    "registering", to: "active" }` (the test fixture asserts the EventMsg
+//!    shape verbatim).
+//! 4. On `Err(e)`: emit `EventMsg::Error { code: e.code(), message: e.to_string() }`.
+//! 5. After registration, resolve the new principal's [`PrincipalPolicy`] via
+//!    [`PolicyResolver`] and verify default-deny — the registry must NOT
+//!    widen the `ExternalAgent` policy default.
+//!
+//! Mirrors `byoh_registration_handshake.rs` style — a module-seam integration
+//! without spinning up a runtime child or `AppState`. The contract under
+//! test is the registry handler logic; the production wire-up that calls
+//! into it is intentionally a separate (PR3) delta.
+
+use std::sync::Arc;
+
+use sera_gateway::external_agent_registry::{
+    DelegatorValidator, ExternalAgentRegistry, InMemoryDelegatorValidator, RegisterError,
+};
+use sera_gateway::policy_resolution::PolicyResolver;
+use sera_types::envelope::{
+    BudgetHandle, EventMsg, ExternalAgentRegistration, ExternalProtocol, Op, RegisterOp,
+    Submission, W3cTraceContext,
+};
+use sera_types::principal::{Principal, PrincipalId, PrincipalKind, PrincipalRef};
+use sera_types::sandbox::EgressEndpoint;
+use uuid::Uuid;
+
+// ── fixtures ────────────────────────────────────────────────────────────────
+
+fn agent_ref(id: &str) -> PrincipalRef {
+    PrincipalRef {
+        id: PrincipalId::new(id),
+        kind: PrincipalKind::Agent,
+    }
+}
+
+fn submission_for(session_key: &str, op: Op) -> Submission {
+    Submission {
+        id: Uuid::new_v4(),
+        op,
+        trace: W3cTraceContext::default(),
+        change_artifact: None,
+        session_key: Some(session_key.to_string()),
+        parent_session_key: None,
+        parent_task_id: None,
+    }
+}
+
+fn external_agent_op(reg: ExternalAgentRegistration) -> Op {
+    Op::Register(RegisterOp::ExternalAgent(reg))
+}
+
+/// The exact seam PR3 will wire into `bin/sera.rs`. Pulled out into a helper
+/// so the test surface mirrors the production dispatch arm one-for-one and a
+/// future refactor of either side can't drift them apart silently.
+fn handle_register_submission(
+    registry: &ExternalAgentRegistry,
+    submission: &Submission,
+) -> EventMsg {
+    let Some(session_key) = submission.session_key.as_deref() else {
+        // No session_key → not a Pattern B registration. PR3 will surface a
+        // protocol-level error here; the test path always supplies one.
+        return EventMsg::Error {
+            code: "register_op_invalid_delegator".to_string(),
+            message: "missing session_key".to_string(),
+        };
+    };
+    let Op::Register(RegisterOp::ExternalAgent(ref reg)) = submission.op else {
+        unreachable!("test driver must construct an ExternalAgent register op");
+    };
+    match registry.register(session_key, reg) {
+        Ok(_) => EventMsg::SessionTransition {
+            from: "registering".to_string(),
+            to: "active".to_string(),
+        },
+        Err(e) => EventMsg::Error {
+            code: e.code().to_string(),
+            message: e.to_string(),
+        },
+    }
+}
+
+fn registry_with_proxy(parent: PrincipalRef, proxy_enabled: bool) -> ExternalAgentRegistry {
+    let validator: Arc<dyn DelegatorValidator> =
+        Arc::new(InMemoryDelegatorValidator::new().with_known(parent));
+    ExternalAgentRegistry::new(proxy_enabled, validator)
+}
+
+fn valid_registration(parent: PrincipalRef) -> ExternalAgentRegistration {
+    ExternalAgentRegistration {
+        protocol: ExternalProtocol::A2a,
+        external_id: "claude-code-pane-1".to_string(),
+        delegated_by: parent,
+        declared_egress: vec![EgressEndpoint::InferenceLocal],
+        budget_handle: BudgetHandle("ext:a2a:claude-code-pane-1".to_string()),
+    }
+}
+
+// ── tests ───────────────────────────────────────────────────────────────────
+
+/// **Happy path.** A submission carrying `Op::Register(ExternalAgent(_))`
+/// with a known delegator and InferenceLocal in the egress list yields a
+/// `SessionTransition` event and the registry now holds the session.
+#[test]
+fn submit_external_agent_registers_principal() {
+    let parent = agent_ref("agent:parent-1");
+    let registry = registry_with_proxy(parent.clone(), true);
+
+    let submission = submission_for("sess-1", external_agent_op(valid_registration(parent.clone())));
+    let event = handle_register_submission(&registry, &submission);
+
+    match event {
+        EventMsg::SessionTransition { from, to } => {
+            assert_eq!(from, "registering");
+            assert_eq!(to, "active");
+        }
+        other => panic!("expected SessionTransition, got {other:?}"),
+    }
+
+    let stored = registry.get("sess-1").expect("session stored");
+    assert_eq!(stored.principal_ref.id.0, "ext:a2a:claude-code-pane-1");
+    assert_eq!(stored.principal_ref.kind, PrincipalKind::ExternalAgent);
+    // Anti-laundering invariant: the delegator is recorded against the session.
+    assert_eq!(stored.delegated_by, parent);
+}
+
+/// Unknown delegator → `register_op_invalid_delegator` error and no state change.
+#[test]
+fn submit_external_agent_with_unknown_delegator_rejected() {
+    let known = agent_ref("agent:known");
+    let stranger = agent_ref("agent:stranger");
+    let registry = registry_with_proxy(known, true);
+
+    let submission = submission_for(
+        "sess-rej",
+        external_agent_op(valid_registration(stranger)),
+    );
+    let event = handle_register_submission(&registry, &submission);
+
+    match event {
+        EventMsg::Error { code, .. } => {
+            assert_eq!(code, "register_op_invalid_delegator");
+        }
+        other => panic!("expected Error event, got {other:?}"),
+    }
+    assert_eq!(registry.registered_count(), 0);
+    assert!(registry.get("sess-rej").is_none());
+}
+
+/// After registration, the freshly minted `ExternalAgent` principal must
+/// resolve to the default-deny `PrincipalPolicy`. The registry must never
+/// widen this — PR3's dispatch arm relies on it for AuthZ at tool dispatch.
+#[tokio::test]
+async fn external_agent_principal_inherits_default_policy() {
+    let parent = agent_ref("agent:parent-1");
+    let registry = registry_with_proxy(parent.clone(), true);
+
+    let submission = submission_for("sess-pol", external_agent_op(valid_registration(parent)));
+    let event = handle_register_submission(&registry, &submission);
+    assert!(matches!(event, EventMsg::SessionTransition { .. }));
+
+    let stored = registry.get("sess-pol").expect("session stored");
+    let principal = Principal::external_agent("a2a", "claude-code-pane-1");
+    assert_eq!(stored.principal_ref, principal.as_ref());
+
+    let resolver = PolicyResolver::in_memory();
+    let policy = resolver.resolve(&principal).await;
+    assert_eq!(policy.max_delegation_depth, 0, "default-deny depth");
+    assert!(
+        policy.allowed_tool_scopes.is_empty(),
+        "default-deny must yield empty tool scopes"
+    );
+    assert!(
+        !policy.allow_subagent_spawn,
+        "default-deny must forbid subagent spawn"
+    );
+}
+
+/// `delegated_by` is recorded on the session record so the audit trail can
+/// trace any later action by this principal back to the parent that
+/// delegated it.
+#[test]
+fn delegator_is_recorded_for_audit() {
+    let parent = agent_ref("agent:audit-parent");
+    let registry = registry_with_proxy(parent.clone(), true);
+
+    let submission = submission_for(
+        "sess-audit",
+        external_agent_op(valid_registration(parent.clone())),
+    );
+    let event = handle_register_submission(&registry, &submission);
+    assert!(matches!(event, EventMsg::SessionTransition { .. }));
+
+    let stored = registry.get("sess-audit").unwrap();
+    assert_eq!(stored.delegated_by.id.0, "agent:audit-parent");
+    assert_eq!(stored.delegated_by.kind, PrincipalKind::Agent);
+}
+
+/// Egress allow-list missing `InferenceLocal` is rejected when the LLM proxy
+/// is enabled — `register_op_egress_invalid`.
+#[test]
+fn declared_egress_must_include_inference_local_when_proxy_enabled() {
+    let parent = agent_ref("agent:parent-1");
+    let registry = registry_with_proxy(parent.clone(), true);
+
+    let mut reg = valid_registration(parent);
+    reg.declared_egress = vec![EgressEndpoint::Domain {
+        name: "api.github.com".to_string(),
+    }];
+
+    let submission = submission_for("sess-egress", external_agent_op(reg));
+    let event = handle_register_submission(&registry, &submission);
+
+    match event {
+        EventMsg::Error { code, .. } => assert_eq!(code, "register_op_egress_invalid"),
+        other => panic!("expected egress error, got {other:?}"),
+    }
+    assert_eq!(registry.registered_count(), 0);
+}
+
+/// Egress invariant is *only* the LLM proxy's invariant — when the proxy is
+/// disabled, missing `InferenceLocal` is acceptable.
+#[test]
+fn declared_egress_relaxed_when_proxy_disabled() {
+    let parent = agent_ref("agent:parent-1");
+    let registry = registry_with_proxy(parent.clone(), false);
+
+    let mut reg = valid_registration(parent);
+    reg.declared_egress = vec![];
+
+    let submission = submission_for("sess-noproxy", external_agent_op(reg));
+    let event = handle_register_submission(&registry, &submission);
+    assert!(matches!(event, EventMsg::SessionTransition { .. }));
+    assert_eq!(registry.registered_count(), 1);
+}
+
+/// Re-registering the same `session_key` is rejected with
+/// `register_op_duplicate_session`. The first session keeps the slot — the
+/// duplicate did NOT replace it. (Pattern B sessions are *identity*, not
+/// idempotent catalogs; replace semantics would silently swap principal
+/// under a live session.)
+#[test]
+fn duplicate_session_key_rejected_via_event_error() {
+    let parent = agent_ref("agent:parent");
+    let registry = registry_with_proxy(parent.clone(), true);
+
+    let first = valid_registration(parent.clone());
+    let mut second = valid_registration(parent);
+    second.external_id = "different-pane".to_string();
+
+    let event_a = handle_register_submission(
+        &registry,
+        &submission_for("sess-dup", external_agent_op(first)),
+    );
+    assert!(matches!(event_a, EventMsg::SessionTransition { .. }));
+
+    let event_b = handle_register_submission(
+        &registry,
+        &submission_for("sess-dup", external_agent_op(second)),
+    );
+    match event_b {
+        EventMsg::Error { code, .. } => assert_eq!(code, "register_op_duplicate_session"),
+        other => panic!("expected duplicate error, got {other:?}"),
+    }
+
+    let stored = registry.get("sess-dup").unwrap();
+    assert_eq!(
+        stored.principal_ref.id.0, "ext:a2a:claude-code-pane-1",
+        "first registration must keep the slot"
+    );
+}
+
+/// `RegisterError::code()` is the contract surface PR3's dispatch arm copies
+/// into `EventMsg::Error::code`. Pin the wire strings so a future refactor
+/// cannot silently downgrade them.
+#[test]
+fn register_error_codes_match_wire_contract() {
+    assert_eq!(
+        RegisterError::InvalidDelegator("agent:x".into()).code(),
+        "register_op_invalid_delegator"
+    );
+    assert_eq!(
+        RegisterError::EgressInvalid.code(),
+        "register_op_egress_invalid"
+    );
+    assert_eq!(
+        RegisterError::DuplicateSession("k".into()).code(),
+        "register_op_duplicate_session"
+    );
+}


### PR DESCRIPTION
## Summary

PR2 of the [sera-pcvp](../issues?q=is%3Aissue+sera-pcvp) 3-PR slice (sequel to #1222 — types-only). Adds the gateway-side handler + registry that records Pattern B `ExternalAgentPrincipal` sessions when an `Op::Register(RegisterOp::ExternalAgent(_))` submission arrives.

- **`rust/crates/sera-gateway/src/external_agent_registry.rs`** — in-memory registry keyed by SQ-envelope `session_key`. Pure handler that validates `delegated_by`, enforces the `InferenceLocal` egress invariant when the LLM proxy is enabled, refuses duplicate `session_key`, and mints the principal via `Principal::external_agent_with_delegator`.
- Stable wire-error codes (`register_op_invalid_delegator`, `register_op_egress_invalid`, `register_op_duplicate_session`) exposed via `RegisterError::code()` so the PR3 dispatch arm can copy them directly into `EventMsg::Error::code`.
- `DelegatorValidator` trait seam — `InMemoryDelegatorValidator` today; sera-db-backed implementation in PR3 without re-shaping callers.

## Why no `bin/sera.rs` change

There is no production `Op::Register` dispatch arm yet (the scout report flagged this — `bin/sera.rs` has no arm; `session_store::op_kind_label` has a wildcard audit label; `sera_runtime::stdio` returns `vec![]`). PR2 ships the pure handler + a module-seam integration test that exercises the exact admission path PR3 will wire in. See `tests/register_op_external_agent.rs::handle_register_submission` — that helper is the one-for-one shape the PR3 SQ arm will paste into `bin/sera.rs`.

## Tests

- **10 registry unit tests** (`external_agent_registry.rs`): register-then-lookup, unknown delegator rejected, wrong-kind delegator rejected (kind-confusion guard), human delegator accepted, duplicate session_key rejected (and original retained), same `external_id` distinct protocols both accepted, egress invariant enforced when proxy enabled, egress invariant relaxed when proxy disabled, custom protocol label, wire-code stability.
- **8 module-seam integration tests** (`tests/register_op_external_agent.rs`): valid registration → `SessionTransition`, unknown delegator → `Error{code: "register_op_invalid_delegator"}`, default-deny `PrincipalPolicy` after registration, `delegated_by` recorded for audit, missing `InferenceLocal` rejected when proxy enabled, missing `InferenceLocal` accepted when proxy disabled, duplicate `session_key` rejected via `EventMsg::Error`, wire-code/stable-string contract pin.

### Verification

```
cargo check  -p sera-gateway                                  # ✓
cargo test   -p sera-gateway --lib external_agent_registry    # ✓ 10 passed
cargo test   -p sera-gateway --test register_op_external_agent # ✓ 8 passed
```

`cargo clippy -p sera-gateway -- -D warnings` reports several pre-existing warnings (MutexGuard-across-await in `bin/sera.rs` / `constitutional_config.rs`, an unused import in `routes/a2a.rs`) that are outside this PR's scope. **No new clippy warnings introduced by this PR.**

## Test plan

- [ ] CI green on this branch
- [ ] Reviewer reviews the registry + integration test seam
- [ ] PR3 (Pattern B smoke) wires `external_agent_registry` into `bin/sera.rs` SQ admission and ships the bead's named acceptance test

## Out of scope

- **PR3 (sera-pcvp.3)** — Pattern B smoke (`tests/pcvp_smoke.rs`): boot a gateway with the inference proxy enabled, drive `Op::Register(ExternalAgent(_))` end-to-end, assert one inference-proxy call lands with `BudgetCtx.principal` matching the minted ExternalAgent id.
- Optional PR4 — launcher integration (`scripts/sera-omc` / `scripts/sera-omx`) emits the registration op at session start. Different code-owner area; better as a sibling bead.
- Bead `sera-pcvp` is **NOT closed** by this PR — PR3 is still required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)