### PR TITLE
security(validate): add Docker overlay and egress expansion

### DIFF
--- a/ops/validate/CLAUDE.md
+++ b/ops/validate/CLAUDE.md
@@ -21,6 +21,7 @@ Stdlib-only Python tool. No pip dependencies. Must run on the dev host with `pyt
 
 - `live_smoke` — wraps `ops/e2e/operator_task_smoke.py` via `importlib`. Source of truth for strict false-green semantics. Do NOT duplicate `validation_errors` here.
 - `security_negative` — P0 security-negative cases (`profiles/security_negative.py`). Live-safe auth-negative + bundled-fixture false-green; SSRF/CAP/ERR cases that need a model dispatch or ephemeral overlay are recorded as explicit skipped specs (`runtime_required` / `ephemeral_only`) rather than passes.
+- `docker_security` — static + compose-config validation for `docker-compose.security.yml` (`profiles/docker_security.py`). Default CLI mode is non-destructive and does not start containers; explicit helper calls use an ephemeral `sera-sec-<runid>` project and must clean up with `down -v --rmi local --remove-orphans`.
 
 ## Notes
 

--- a/ops/validate/docker-compose.security.yml
+++ b/ops/validate/docker-compose.security.yml
@@ -1,0 +1,30 @@
+# Security hardening overlay for ephemeral SERA validation projects.
+#
+# Intended usage (never against the long-lived production compose project):
+#   docker compose \
+#     -f rust/docker-compose.sera.yml \
+#     -f ops/validate/docker-compose.security.yml \
+#     -p sera-sec-<runid> up -d --build --wait
+#
+# Cleanup must use the same -f/-p tuple plus `down -v --remove-orphans`.
+# The overlay is deliberately conservative: if the app cannot run under these
+# hardening knobs, the validation harness records an incompatibility finding
+# rather than mutating the production compose file or falsely passing.
+
+services:
+  sera:
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    read_only: true
+    tmpfs:
+      - /tmp:rw,noexec,nosuid,size=64m
+      - /var/tmp:rw,noexec,nosuid,size=16m
+    mem_limit: 1g
+    memswap_limit: 1g
+    cpus: "2.0"
+    pids_limit: 256
+    # Reset inherited host-published ports so ephemeral validation can run
+    # alongside the live rust-sera-1 stack without binding 0.0.0.0:3001.
+    ports: !reset []

--- a/ops/validate/profiles/docker_security.py
+++ b/ops/validate/profiles/docker_security.py
@@ -1,0 +1,315 @@
+"""Docker security overlay profile and ephemeral compose helpers (sera-sv76.3).
+
+Stdlib-only. This module intentionally does not mutate host firewall state. The
+only side-effectful mode is an explicitly requested ephemeral compose lifecycle;
+it always attempts `down -v --remove-orphans` after `up`, even when startup fails.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import uuid
+from pathlib import Path
+from typing import Any, Callable, NamedTuple
+
+_THIS = Path(__file__).resolve()
+_OPS_VALIDATE = _THIS.parents[1]
+_REPO_ROOT = _OPS_VALIDATE.parents[1]
+_OVERLAY_REL = Path("ops/validate/docker-compose.security.yml")
+_BASE_COMPOSE_REL = Path("rust/docker-compose.sera.yml")
+
+REQUIRED_OVERLAY_MARKERS: list[tuple[str, str]] = [
+    ("no_new_privileges", "no-new-privileges:true"),
+    ("cap_drop_all", "cap_drop:"),
+    ("read_only_rootfs", "read_only: true"),
+    ("tmpfs_tmp", "/tmp:"),
+    ("tmpfs_var_tmp", "/var/tmp:"),
+    ("memory_limit", "mem_limit:"),
+    ("cpu_limit", "cpus:"),
+    ("pids_limit", "pids_limit:"),
+    ("published_ports_reset", "ports: !reset []"),
+]
+_SECRET_CONFIG_LINE_RE = re.compile(
+    r"(?im)^(?P<prefix>\s*[A-Z0-9_]*(?:API_KEY|TOKEN|SECRET)\s*[:=]\s*).*$"
+)
+
+
+class CommandResult(NamedTuple):
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+def _run_command(cmd: list[str], timeout: int = 60) -> CommandResult:
+    try:
+        out = subprocess.run(
+            cmd,
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=timeout,
+        )
+    except FileNotFoundError as exc:
+        return CommandResult(127, "", str(exc))
+    except subprocess.TimeoutExpired as exc:
+        return CommandResult(
+            124,
+            (exc.stdout or "") if isinstance(exc.stdout, str) else "",
+            f"timeout after {timeout}s",
+        )
+    return CommandResult(out.returncode, out.stdout, out.stderr)
+
+
+def security_project_name(run_id: str | None = None) -> str:
+    raw = run_id or uuid.uuid4().hex[:12]
+    safe = re.sub(r"[^a-zA-Z0-9_.-]+", "-", raw).strip("-._").lower()
+    if not safe:
+        safe = uuid.uuid4().hex[:12]
+    return f"sera-sec-{safe}"[:63]
+
+
+def compose_command(repo_root: Path | str, project: str, action: str) -> list[str]:
+    root = Path(repo_root)
+    prefix = [
+        "docker",
+        "compose",
+        "-f",
+        str(root / _BASE_COMPOSE_REL),
+        "-f",
+        str(root / _OVERLAY_REL),
+        "-p",
+        project,
+    ]
+    if action == "up":
+        return prefix + ["up", "-d", "--build", "--wait"]
+    if action == "down":
+        return prefix + ["down", "-v", "--rmi", "local", "--remove-orphans"]
+    if action == "config":
+        return prefix + ["config"]
+    raise ValueError(f"unsupported compose action: {action}")
+
+
+def check_overlay_text(text: str) -> dict[str, list[str]]:
+    present: list[str] = []
+    missing: list[str] = []
+    for key, marker in REQUIRED_OVERLAY_MARKERS:
+        if marker in text:
+            present.append(key)
+        else:
+            missing.append(key)
+    if "cap_drop:" in text and "ALL" not in text:
+        if "cap_drop_all" in present:
+            present.remove("cap_drop_all")
+        if "cap_drop_all" not in missing:
+            missing.append("cap_drop_all")
+    return {"present": present, "missing": missing}
+
+
+def _safe_tail(text: str, limit: int = 2000) -> str:
+    """Return a bounded command-output tail with compose env secrets removed."""
+    redacted = _SECRET_CONFIG_LINE_RE.sub(
+        lambda m: f"{m.group('prefix')}<redacted:compose-config-env>", text or ""
+    )
+    return redacted[-limit:]
+
+
+def _case(case_id: str, category: str, **kwargs: Any) -> dict[str, Any]:
+    case: dict[str, Any] = {
+        "case_id": case_id,
+        "category": category,
+        "live_safe": False,
+        "ephemeral_only": True,
+        "skipped": False,
+        "skip_reason": None,
+        "expected": None,
+        "actual": None,
+        "passed": None,
+        "finding": None,
+    }
+    case.update(kwargs)
+    return case
+
+
+def run(
+    *,
+    repo_root: Path | str | None = None,
+    run_compose: bool = False,
+    run_id: str | None = None,
+    command_runner: Callable[[list[str], int], CommandResult] = _run_command,
+) -> tuple[dict[str, Any], dict[str, Any], list[str], list[str], list[dict[str, Any]]]:
+    """Validate the Docker security overlay and optionally exercise compose.
+
+    Returns ``(summary, evidence, errors, warnings, cases)`` for the generic
+    ``sera-validate`` profile wrapper. Docker/compose unavailability is recorded
+    as a structured skip + warning, not as a pass.
+    """
+    root = Path(repo_root) if repo_root is not None else _REPO_ROOT
+    overlay_path = root / _OVERLAY_REL
+    project = security_project_name(run_id)
+    errors: list[str] = []
+    warnings: list[str] = []
+    cases: list[dict[str, Any]] = []
+    cleanup_attempted = False
+
+    evidence: dict[str, Any] = {
+        "repo_root": str(root),
+        "overlay_path": str(overlay_path),
+        "project": project,
+        "docker_version": None,
+        "compose_up": None,
+        "compose_down": None,
+    }
+
+    if not overlay_path.exists():
+        errors.append(f"overlay_missing: {overlay_path}")
+        cases.append(
+            _case(
+                "DOCKER-OVERLAY-01",
+                "overlay-static",
+                expected="overlay file exists with security hardening knobs",
+                actual="missing",
+                passed=False,
+                finding=f"overlay missing: {overlay_path}",
+            )
+        )
+        summary = _summary(False, cleanup_attempted, cases)
+        return summary, evidence, errors, warnings, cases
+
+    text = overlay_path.read_text(encoding="utf-8")
+    overlay_check = check_overlay_text(text)
+    overlay_passed = not overlay_check["missing"]
+    if not overlay_passed:
+        errors.append(f"overlay_missing_hardening: {overlay_check['missing']}")
+    cases.append(
+        _case(
+            "DOCKER-OVERLAY-01",
+            "overlay-static",
+            expected=[k for k, _ in REQUIRED_OVERLAY_MARKERS],
+            actual=overlay_check,
+            live_safe=True,
+            ephemeral_only=False,
+            passed=overlay_passed,
+            finding=None if overlay_passed else "missing required hardening markers",
+        )
+    )
+
+    version = command_runner(["docker", "version", "--format", "{{.Server.Version}}"], 20)
+    docker_available = version.returncode == 0 and bool(version.stdout.strip())
+    if docker_available:
+        evidence["docker_version"] = version.stdout.strip()
+        cases.append(
+            _case(
+                "DOCKER-PREREQ-01",
+                "docker-prereq",
+                expected="docker daemon reachable",
+                actual=version.stdout.strip(),
+                live_safe=True,
+                ephemeral_only=False,
+                passed=True,
+            )
+        )
+    else:
+        warnings.append(f"docker unavailable; compose validation skipped: {version.stderr or version.stdout}")
+        cases.append(
+            _case(
+                "DOCKER-PREREQ-01",
+                "docker-prereq",
+                expected="docker daemon reachable",
+                actual={"returncode": version.returncode, "stderr": version.stderr},
+                live_safe=True,
+                ephemeral_only=False,
+                skipped=True,
+                skip_reason="docker_unavailable",
+            )
+        )
+        summary = _summary(False, cleanup_attempted, cases)
+        return summary, evidence, errors, warnings, cases
+
+    config_result = command_runner(compose_command(root, project, "config"), 60)
+    config_passed = config_result.returncode == 0
+    if not config_passed:
+        warnings.append(
+            "docker compose config reported overlay incompatibility: "
+            f"{config_result.stderr or config_result.stdout}"
+        )
+    cases.append(
+        _case(
+            "DOCKER-COMPOSE-01",
+            "compose-config",
+            expected="base compose + security overlay render successfully",
+            actual={
+                "returncode": config_result.returncode,
+                "stdout": _safe_tail(config_result.stdout),
+                "stderr": _safe_tail(config_result.stderr),
+            },
+            passed=config_passed,
+            finding=None if config_passed else "overlay compose config incompatibility",
+        )
+    )
+
+    if run_compose:
+        up = command_runner(compose_command(root, project, "up"), 300)
+        evidence["compose_up"] = {
+            "returncode": up.returncode,
+            "stdout": _safe_tail(up.stdout),
+            "stderr": _safe_tail(up.stderr),
+        }
+        up_passed = up.returncode == 0
+        if not up_passed:
+            warnings.append(
+                "docker compose security overlay startup finding: "
+                f"{up.stderr or up.stdout}"
+            )
+        cases.append(
+            _case(
+                "DOCKER-COMPOSE-02",
+                "compose-up",
+                expected="ephemeral security overlay stack starts under hardening",
+                actual=evidence["compose_up"],
+                passed=up_passed,
+                finding=None if up_passed else "overlay startup incompatibility",
+            )
+        )
+        cleanup_attempted = True
+        down = command_runner(compose_command(root, project, "down"), 120)
+        evidence["compose_down"] = {
+            "returncode": down.returncode,
+            "stdout": _safe_tail(down.stdout),
+            "stderr": _safe_tail(down.stderr),
+        }
+        down_passed = down.returncode == 0
+        if not down_passed:
+            errors.append(f"cleanup_failed: {down.stderr or down.stdout}")
+        cases.append(
+            _case(
+                "DOCKER-CLEANUP-01",
+                "compose-cleanup",
+                expected="docker compose down -v --remove-orphans succeeds",
+                actual=evidence["compose_down"],
+                passed=down_passed,
+                finding=None if down_passed else "ephemeral cleanup failed",
+            )
+        )
+
+    summary = _summary(docker_available, cleanup_attempted, cases)
+    return summary, evidence, errors, warnings, cases
+
+
+def _summary(
+    docker_available: bool,
+    cleanup_attempted: bool,
+    cases: list[dict[str, Any]],
+) -> dict[str, Any]:
+    return {
+        "docker_security": {
+            "docker_available": docker_available,
+            "cleanup_attempted": cleanup_attempted,
+            "cases_total": len(cases),
+            "cases_passed": sum(1 for c in cases if c.get("passed") is True),
+            "cases_failed": sum(1 for c in cases if c.get("passed") is False),
+            "cases_skipped": sum(1 for c in cases if c.get("skipped")),
+            "findings": [c["finding"] for c in cases if c.get("finding")],
+        }
+    }

--- a/ops/validate/profiles/docker_security.py
+++ b/ops/validate/profiles/docker_security.py
@@ -211,7 +211,10 @@ def run(
             )
         )
     else:
-        warnings.append(f"docker unavailable; compose validation skipped: {version.stderr or version.stdout}")
+        warnings.append(
+            "docker unavailable; compose validation skipped: "
+            f"{_safe_tail(version.stderr or version.stdout)}"
+        )
         cases.append(
             _case(
                 "DOCKER-PREREQ-01",
@@ -232,7 +235,7 @@ def run(
     if not config_passed:
         warnings.append(
             "docker compose config reported overlay incompatibility: "
-            f"{config_result.stderr or config_result.stdout}"
+            f"{_safe_tail(config_result.stderr or config_result.stdout)}"
         )
     cases.append(
         _case(
@@ -260,7 +263,7 @@ def run(
         if not up_passed:
             warnings.append(
                 "docker compose security overlay startup finding: "
-                f"{up.stderr or up.stdout}"
+                f"{_safe_tail(up.stderr or up.stdout)}"
             )
         cases.append(
             _case(
@@ -281,7 +284,7 @@ def run(
         }
         down_passed = down.returncode == 0
         if not down_passed:
-            errors.append(f"cleanup_failed: {down.stderr or down.stdout}")
+            errors.append(f"cleanup_failed: {_safe_tail(down.stderr or down.stdout)}")
         cases.append(
             _case(
                 "DOCKER-CLEANUP-01",

--- a/ops/validate/profiles/security_negative.py
+++ b/ops/validate/profiles/security_negative.py
@@ -613,7 +613,7 @@ def run(
             case_id="SEC-ERR-03",
             category="raw-provider-error",
             skip_reason="ephemeral_only",
-            marker="reply must not contain provider host or sk_live_ key shape",
+            marker="reply must not contain provider host or provider credential shape",
             ephemeral_only=True,
         )
     )

--- a/ops/validate/sera-validate.py
+++ b/ops/validate/sera-validate.py
@@ -402,6 +402,9 @@ PROFILES: dict[str, str] = {
         "P0 security-negative cases (auth, false-green, "
         "and runtime/ephemeral-skipped specs)."
     ),
+    "docker_security": (
+        "Docker security overlay validation with structured compose skips/findings."
+    ),
 }
 
 
@@ -442,6 +445,21 @@ def profile_security_negative(
     )
 
 
+def profile_docker_security(
+    *, run_compose: bool = False
+) -> tuple[dict[str, Any], dict[str, Any], list[str], list[str], list[dict[str, Any]]]:
+    """Dispatch wrapper around `profiles.docker_security.run`.
+
+    The default CLI run is non-destructive: it validates the overlay file and
+    compose rendering, but does not start containers. Passing ``--run-compose``
+    explicitly exercises an ephemeral `sera-sec-<runid>` compose lifecycle and
+    records startup incompatibilities as findings while still attempting
+    cleanup.
+    """
+    module = _load_profile_module("docker_security")
+    return module.run(run_compose=run_compose)
+
+
 # --- CLI ---------------------------------------------------------------------
 
 
@@ -456,6 +474,14 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument("--api-key", default=None, help="bearer token; defaults to SERA_API_KEY discovery")
     parser.add_argument("--out", default=None, help="path for the artifact JSON")
     parser.add_argument("--validate-only", metavar="PATH", help="validate an existing artifact without live side effects")
+    parser.add_argument(
+        "--run-compose",
+        action="store_true",
+        help=(
+            "docker_security only: explicitly start an ephemeral security "
+            "compose project and clean it up"
+        ),
+    )
     parser.add_argument("--quiet", action="store_true", help="single-line summary on green; full JSON on non-green")
     return parser
 
@@ -494,6 +520,10 @@ def main(argv: list[str] | None = None) -> int:
         sys.stderr.write(f"sera-validate: unknown profile {args.profile!r}\n")
         return EXIT_HARNESS_ERROR
 
+    if args.run_compose and args.profile != "docker_security":
+        sys.stderr.write("sera-validate: --run-compose is only supported with --profile docker_security\n")
+        return EXIT_HARNESS_ERROR
+
     base = args.base.rstrip("/")
     if "://" not in base:
         sys.stderr.write(f"sera-validate: invalid --base URL: {args.base!r}\n")
@@ -502,7 +532,11 @@ def main(argv: list[str] | None = None) -> int:
     out_path = args.out or f"/tmp/sera-validate-{args.profile}.json"
 
     try:
-        api_key = discover_api_key(args.api_key, args.container)
+        api_key = (
+            ""
+            if args.profile == "docker_security"
+            else discover_api_key(args.api_key, args.container)
+        )
     except HarnessError as exc:
         sys.stderr.write(f"sera-validate: harness error: {exc}\n")
         return EXIT_HARNESS_ERROR
@@ -540,6 +574,14 @@ def main(argv: list[str] | None = None) -> int:
                 api_key=api_key,
                 known_secrets=known_secrets,
             )
+        elif args.profile == "docker_security":
+            (
+                summary,
+                evidence,
+                errors,
+                warnings,
+                negative_cases,
+            ) = profile_docker_security(run_compose=args.run_compose)
         else:  # pragma: no cover - guarded by PROFILES check above
             raise HarnessError(f"profile {args.profile!r} not implemented")
     except HarnessError as exc:

--- a/ops/validate/tests/test_docker_security.py
+++ b/ops/validate/tests/test_docker_security.py
@@ -1,0 +1,188 @@
+"""Unit tests for sv76.3 Docker security overlay helpers."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SV_PATH = ROOT / "sera-validate.py"
+PROFILE_PATH = ROOT / "profiles" / "docker_security.py"
+REPO_ROOT = ROOT.parents[1]
+OVERLAY_PATH = ROOT / "docker-compose.security.yml"
+
+
+def _load_module(name: str, path: Path) -> object:
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_profile_registered() -> None:
+    sv = _load_module("sera_validate", SV_PATH)
+    assert "docker_security" in sv.PROFILES
+
+
+def test_security_overlay_file_contains_required_hardening_knobs() -> None:
+    docker_security = _load_module("docker_security", PROFILE_PATH)
+    text = OVERLAY_PATH.read_text(encoding="utf-8")
+
+    findings = docker_security.check_overlay_text(text)
+
+    assert findings["missing"] == []
+    assert findings["present"] == [
+        "no_new_privileges",
+        "cap_drop_all",
+        "read_only_rootfs",
+        "tmpfs_tmp",
+        "tmpfs_var_tmp",
+        "memory_limit",
+        "cpu_limit",
+        "pids_limit",
+        "published_ports_reset",
+    ]
+
+
+def test_ephemeral_compose_commands_use_base_overlay_project_and_cleanup_volume() -> None:
+    docker_security = _load_module("docker_security", PROFILE_PATH)
+    project = docker_security.security_project_name("run id/with spaces")
+
+    up_cmd = docker_security.compose_command(REPO_ROOT, project, "up")
+    down_cmd = docker_security.compose_command(REPO_ROOT, project, "down")
+
+    assert project.startswith("sera-sec-run-id-with-spaces")
+    assert up_cmd == [
+        "docker",
+        "compose",
+        "-f",
+        str(REPO_ROOT / "rust" / "docker-compose.sera.yml"),
+        "-f",
+        str(OVERLAY_PATH),
+        "-p",
+        project,
+        "up",
+        "-d",
+        "--build",
+        "--wait",
+    ]
+    assert down_cmd == [
+        "docker",
+        "compose",
+        "-f",
+        str(REPO_ROOT / "rust" / "docker-compose.sera.yml"),
+        "-f",
+        str(OVERLAY_PATH),
+        "-p",
+        project,
+        "down",
+        "-v",
+        "--rmi",
+        "local",
+        "--remove-orphans",
+    ]
+
+
+def test_run_records_structured_skip_when_docker_is_unavailable() -> None:
+    docker_security = _load_module("docker_security", PROFILE_PATH)
+
+    def fake_run(_cmd: list[str], _timeout: int = 60):
+        return docker_security.CommandResult(127, "", "docker: not found")
+
+    summary, evidence, errors, warnings, cases = docker_security.run(
+        repo_root=REPO_ROOT,
+        run_compose=False,
+        command_runner=fake_run,
+    )
+
+    assert errors == []
+    assert any("docker unavailable" in warning for warning in warnings)
+    assert summary["docker_security"]["docker_available"] is False
+    prereq = next(case for case in cases if case["case_id"] == "DOCKER-PREREQ-01")
+    assert prereq["skipped"] is True
+    assert prereq["skip_reason"] == "docker_unavailable"
+    assert evidence["docker_version"] is None
+
+
+def test_run_redacts_compose_config_secret_like_environment_values() -> None:
+    docker_security = _load_module("docker_security", PROFILE_PATH)
+
+    def fake_run(cmd: list[str], _timeout: int = 60):
+        if "version" in cmd:
+            return docker_security.CommandResult(0, "24.0.0\n", "")
+        return docker_security.CommandResult(
+            0,
+            "environment:\n  SERA_API_KEY: raw-secret-value\n  RUST_LOG: info\n",
+            "",
+        )
+
+    _summary, evidence, errors, warnings, cases = docker_security.run(
+        repo_root=REPO_ROOT,
+        run_compose=False,
+        command_runner=fake_run,
+    )
+
+    serialized = str({"evidence": evidence, "cases": cases})
+    assert errors == []
+    assert warnings == []
+    assert "raw-secret-value" not in serialized
+    assert "<redacted:compose-config-env>" in serialized
+
+
+def test_main_docker_security_run_compose_passes_explicit_ephemeral_flag(tmp_path, monkeypatch) -> None:
+    sv = _load_module("sera_validate_for_docker_security_cli", SV_PATH)
+    captured: dict[str, bool] = {}
+
+    def fake_profile_docker_security(*, run_compose: bool = False):
+        captured["run_compose"] = run_compose
+        return (
+            {"docker_security": {"cases_total": 0}},
+            {"compose_up": None, "compose_down": None},
+            [],
+            [],
+            [],
+        )
+
+    monkeypatch.setattr(sv, "profile_docker_security", fake_profile_docker_security)
+    out = tmp_path / "docker-security.json"
+
+    code = sv.main([
+        "--profile",
+        "docker_security",
+        "--run-compose",
+        "--out",
+        str(out),
+        "--quiet",
+    ])
+
+    assert code == sv.EXIT_PASS
+    assert captured["run_compose"] is True
+    assert out.exists()
+
+
+def test_run_compose_cleanup_always_attempts_down_after_up_failure() -> None:
+    docker_security = _load_module("docker_security", PROFILE_PATH)
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], _timeout: int = 60):
+        calls.append(cmd)
+        if "version" in cmd:
+            return docker_security.CommandResult(0, "24.0.0\n", "")
+        if "up" in cmd:
+            return docker_security.CommandResult(1, "", "overlay incompatible")
+        return docker_security.CommandResult(0, "removed\n", "")
+
+    summary, _evidence, errors, warnings, cases = docker_security.run(
+        repo_root=REPO_ROOT,
+        run_compose=True,
+        run_id="cleanup-test",
+        command_runner=fake_run,
+    )
+
+    assert summary["docker_security"]["cleanup_attempted"] is True
+    assert any("overlay incompatible" in warning for warning in warnings)
+    assert errors == []
+    assert any(case["case_id"] == "DOCKER-COMPOSE-02" for case in cases)
+    assert any("up" in cmd for cmd in calls)
+    assert any("down" in cmd and "-v" in cmd for cmd in calls)

--- a/ops/validate/tests/test_docker_security.py
+++ b/ops/validate/tests/test_docker_security.py
@@ -130,6 +130,45 @@ def test_run_redacts_compose_config_secret_like_environment_values() -> None:
     assert "<redacted:compose-config-env>" in serialized
 
 
+def test_compose_failure_warnings_are_redacted() -> None:
+    docker_security = _load_module("docker_security", PROFILE_PATH)
+
+    def fake_run(cmd: list[str], _timeout: int = 60):
+        if "version" in cmd:
+            return docker_security.CommandResult(0, "24.0.0\n", "")
+        if "config" in cmd:
+            return docker_security.CommandResult(
+                1,
+                "",
+                "environment:\n  SERA_API_KEY: raw-config-secret\n",
+            )
+        if "up" in cmd:
+            return docker_security.CommandResult(
+                1,
+                "container log\nSERA_ADMIN_TOKEN=raw-up-secret\n",
+                "",
+            )
+        if "down" in cmd:
+            return docker_security.CommandResult(
+                1,
+                "",
+                "cleanup log\nSERA_SECRET: raw-down-secret\n",
+            )
+        return docker_security.CommandResult(0, "", "")
+
+    _summary, _evidence, errors, warnings, _cases = docker_security.run(
+        repo_root=REPO_ROOT,
+        run_compose=True,
+        command_runner=fake_run,
+    )
+    serialized = str({"errors": errors, "warnings": warnings})
+
+    assert "raw-config-secret" not in serialized
+    assert "raw-up-secret" not in serialized
+    assert "raw-down-secret" not in serialized
+    assert "<redacted:compose-config-env>" in serialized
+
+
 def test_main_docker_security_run_compose_passes_explicit_ephemeral_flag(tmp_path, monkeypatch) -> None:
     sv = _load_module("sera_validate_for_docker_security_cli", SV_PATH)
     captured: dict[str, bool] = {}

--- a/rust/crates/sera-tools/tests/docker_egress_acceptance.rs
+++ b/rust/crates/sera-tools/tests/docker_egress_acceptance.rs
@@ -451,9 +451,12 @@ fn forbidden_egress_targets() -> &'static [ForbiddenEgressTarget] {
             marker: "ipv6_private_ula_exit=",
         },
         ForbiddenEgressTarget {
-            name: "ipv6_link_local",
-            url: "http://[fe80::1]/",
-            marker: "ipv6_link_local_exit=",
+            name: "ipv6_link_local_scoped",
+            // IPv6 link-local probes must include an interface scope to be
+            // routable; the percent-encoded zone id keeps this URL valid in
+            // wget/curl parsers while still exercising the policy path.
+            url: "http://[fe80::1%25eth0]/",
+            marker: "ipv6_link_local_scoped_exit=",
         },
     ]
 }

--- a/rust/crates/sera-tools/tests/docker_egress_acceptance.rs
+++ b/rust/crates/sera-tools/tests/docker_egress_acceptance.rs
@@ -512,7 +512,7 @@ fn sv76_3_forbidden_target_matrix_covers_metadata_private_link_local_and_ipv6() 
     assert!(urls.contains(&"http://192.168.0.1/"));
     assert!(urls.contains(&"http://[::1]/"));
     assert!(urls.contains(&"http://[fc00::1]/"));
-    assert!(urls.contains(&"http://[fe80::1]/"));
+    assert!(urls.contains(&"http://[fe80::1%25eth0]/"));
     assert!(targets.iter().all(|t| t.marker.ends_with("_exit=")));
 }
 

--- a/rust/crates/sera-tools/tests/docker_egress_acceptance.rs
+++ b/rust/crates/sera-tools/tests/docker_egress_acceptance.rs
@@ -67,11 +67,11 @@ const HARNESS_IMAGE: &str =
 const GATEWAY_IMAGE: &str =
     "nginx:alpine@sha256:5616878291a2eed594aee8db4dade5878cf7edcb475e59193904b198d9b830de";
 
-/// Tear-down guard for a (network, gateway-stand-in) pair. Runs `docker rm
-/// -f` + `docker network rm` on `Drop` so a panicking test still removes
-/// its bridge. Both commands are best-effort — failures are swallowed so
-/// the guard is safe to drop multiple times or against partially-removed
-/// resources.
+/// Tear-down guard for a per-test Docker bridge. Runs `docker rm -f` for
+/// the gateway-stand-in and any other active endpoints, then removes the
+/// network on `Drop` so a panicking/timed-out test still removes its bridge.
+/// All commands are best-effort — failures are swallowed so the guard is
+/// safe to drop multiple times or against partially-removed resources.
 struct BridgeGuard {
     network: String,
     container: String,
@@ -79,17 +79,69 @@ struct BridgeGuard {
 
 impl Drop for BridgeGuard {
     fn drop(&mut self) {
-        let _ = Command::new("docker")
-            .args(["rm", "-f", &self.container])
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status();
-        let _ = Command::new("docker")
-            .args(["network", "rm", &self.network])
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status();
+        remove_container(&self.container);
+        remove_attached_containers(&self.network);
+        for _ in 0..10 {
+            let removed = Command::new("docker")
+                .args(["network", "rm", &self.network])
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status()
+                .map(|status| status.success())
+                .unwrap_or(false);
+            if removed {
+                return;
+            }
+            remove_attached_containers(&self.network);
+            std::thread::sleep(Duration::from_millis(100));
+        }
     }
+}
+
+fn remove_container(container: &str) {
+    let _ = Command::new("docker")
+        .args(["rm", "-f", container])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+}
+
+fn remove_attached_containers(network: &str) {
+    let out = Command::new("docker")
+        .args([
+            "network",
+            "inspect",
+            "--format",
+            "{{range $id, $_ := .Containers}}{{println $id}}{{end}}",
+            network,
+        ])
+        .output();
+    let Ok(out) = out else {
+        return;
+    };
+    if !out.status.success() {
+        return;
+    }
+    for container_id in String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+    {
+        remove_container(container_id);
+    }
+}
+
+fn assert_network_removed(network: &str) {
+    let inspect = Command::new("docker")
+        .args(["network", "inspect", network])
+        .output()
+        .expect("spawn docker network inspect");
+    assert!(
+        !inspect.status.success(),
+        "bridge guard should remove network {network}; inspect stdout: {:?}, stderr: {:?}",
+        String::from_utf8_lossy(&inspect.stdout),
+        String::from_utf8_lossy(&inspect.stderr)
+    );
 }
 
 fn docker_available() -> bool {
@@ -98,6 +150,93 @@ fn docker_available() -> bool {
         .output()
         .map(|o| o.status.success() && !o.stdout.is_empty())
         .unwrap_or(false)
+}
+
+#[test]
+fn bridge_guard_removes_extra_active_endpoints_before_network_rm() {
+    if !docker_available() {
+        skip(
+            "bridge_guard_removes_extra_active_endpoints_before_network_rm",
+            "docker unavailable",
+        );
+        return;
+    }
+    if let Err(e) = pull_image(HARNESS_IMAGE) {
+        skip(
+            "bridge_guard_removes_extra_active_endpoints_before_network_rm",
+            format!("harness image unavailable: {e}"),
+        );
+        return;
+    }
+
+    let suffix = Uuid::new_v4().to_string();
+    let network = format!("sera-eq0m-bridge-guard-cleanup-{suffix}");
+    let extra_container = format!("{network}-extra");
+
+    let net = Command::new("docker")
+        .args([
+            "network",
+            "create",
+            "--internal",
+            "--driver=bridge",
+            &network,
+        ])
+        .output()
+        .expect("spawn docker network create");
+    assert!(
+        net.status.success(),
+        "docker network create failed: {}",
+        String::from_utf8_lossy(&net.stderr)
+    );
+
+    let run = Command::new("docker")
+        .args([
+            "run",
+            "-d",
+            "--rm",
+            "--name",
+            &extra_container,
+            "--network",
+            &network,
+            HARNESS_IMAGE,
+            "sh",
+            "-c",
+            "sleep 60",
+        ])
+        .output()
+        .expect("spawn docker run extra endpoint");
+    if !run.status.success() {
+        let _ = Command::new("docker")
+            .args(["network", "rm", &network])
+            .status();
+        panic!(
+            "docker run extra endpoint failed: {}",
+            String::from_utf8_lossy(&run.stderr)
+        );
+    }
+
+    drop(BridgeGuard {
+        network: network.clone(),
+        container: format!("{network}-missing-gateway"),
+    });
+
+    let container_inspect = Command::new("docker")
+        .args(["container", "inspect", &extra_container])
+        .output()
+        .expect("spawn docker container inspect");
+    assert!(
+        !container_inspect.status.success(),
+        "bridge guard should remove extra endpoint container {extra_container}"
+    );
+
+    let network_inspect = Command::new("docker")
+        .args(["network", "inspect", &network])
+        .output()
+        .expect("spawn docker network inspect");
+    assert!(
+        !network_inspect.status.success(),
+        "bridge guard should remove network {network} after endpoints are gone"
+    );
 }
 
 fn pull_image(image: &str) -> Result<(), String> {
@@ -267,6 +406,72 @@ fn strict_inference_local() -> EgressManifest {
     }
 }
 
+#[derive(Clone, Copy, Debug)]
+struct ForbiddenEgressTarget {
+    name: &'static str,
+    url: &'static str,
+    marker: &'static str,
+}
+
+fn forbidden_egress_targets() -> &'static [ForbiddenEgressTarget] {
+    &[
+        ForbiddenEgressTarget {
+            name: "metadata",
+            url: "http://169.254.169.254/latest/meta-data/",
+            marker: "metadata_exit=",
+        },
+        ForbiddenEgressTarget {
+            name: "link_local_ipv4",
+            url: "http://169.254.1.1/",
+            marker: "link_local_ipv4_exit=",
+        },
+        ForbiddenEgressTarget {
+            name: "rfc1918_10",
+            url: "http://10.0.0.1/",
+            marker: "rfc1918_10_exit=",
+        },
+        ForbiddenEgressTarget {
+            name: "rfc1918_172",
+            url: "http://172.16.0.1/",
+            marker: "rfc1918_172_exit=",
+        },
+        ForbiddenEgressTarget {
+            name: "rfc1918_192",
+            url: "http://192.168.0.1/",
+            marker: "rfc1918_192_exit=",
+        },
+        ForbiddenEgressTarget {
+            name: "ipv6_loopback",
+            url: "http://[::1]/",
+            marker: "ipv6_loopback_exit=",
+        },
+        ForbiddenEgressTarget {
+            name: "ipv6_private_ula",
+            url: "http://[fc00::1]/",
+            marker: "ipv6_private_ula_exit=",
+        },
+        ForbiddenEgressTarget {
+            name: "ipv6_link_local",
+            url: "http://[fe80::1]/",
+            marker: "ipv6_link_local_exit=",
+        },
+    ]
+}
+
+fn denied_probe_script(targets: &[ForbiddenEgressTarget]) -> String {
+    let mut script = String::new();
+    for target in targets {
+        script.push_str(&format!(
+            "timeout 4 wget -q -O- -T 2 {} >/tmp/{}_body 2>&1; echo \"{}$?\"; ",
+            target.url, target.name, target.marker
+        ));
+    }
+    script.push_str(
+        "wget -q -O- --timeout=5 http://inference.local/ 2>&1; echo \"inference_exit=$?\"",
+    );
+    script
+}
+
 /// Pull both required images. Returns `Err` if either pull fails so the
 /// caller can `skip()` the test rather than panic — a freshly-cloned dev
 /// box without internet still passes `cargo test`.
@@ -292,6 +497,22 @@ fn parse_marker(stdout: &str, marker: &str) -> Option<i32> {
         .and_then(|v| v.trim().parse::<i32>().ok())
 }
 
+#[test]
+fn sv76_3_forbidden_target_matrix_covers_metadata_private_link_local_and_ipv6() {
+    let targets = forbidden_egress_targets();
+    let urls = targets.iter().map(|t| t.url).collect::<Vec<_>>();
+
+    assert!(urls.contains(&"http://169.254.169.254/latest/meta-data/"));
+    assert!(urls.contains(&"http://169.254.1.1/"));
+    assert!(urls.contains(&"http://10.0.0.1/"));
+    assert!(urls.contains(&"http://172.16.0.1/"));
+    assert!(urls.contains(&"http://192.168.0.1/"));
+    assert!(urls.contains(&"http://[::1]/"));
+    assert!(urls.contains(&"http://[fc00::1]/"));
+    assert!(urls.contains(&"http://[fe80::1]/"));
+    assert!(targets.iter().all(|t| t.marker.ends_with("_exit=")));
+}
+
 // ── Test 1 — direct dial denied ─────────────────────────────────────────────
 //
 // The bridge is `--internal`, so the embedded resolver cannot reach
@@ -315,13 +536,14 @@ async fn eq0m_test1_strict_blocks_direct_anthropic_dial() {
         skip(test_name, "DockerSandboxProvider::new failed");
         return;
     };
-    let (_guard, bridge) = match provision_bridge(test_name) {
+    let (guard, bridge) = match provision_bridge(test_name) {
         Ok(v) => v,
         Err(e) => {
             skip(test_name, format!("bridge provisioning: {e}"));
             return;
         }
     };
+    let network_name = bridge.network_name.clone();
 
     let config = SandboxConfig {
         image: Some(HARNESS_IMAGE.to_string()),
@@ -339,6 +561,8 @@ async fn eq0m_test1_strict_blocks_direct_anthropic_dial() {
         .await
         .expect("execute");
     provider.destroy(&handle).await.expect("destroy");
+    drop(guard);
+    assert_network_removed(&network_name);
 
     let inner_exit = parse_marker(&result.stdout, "exit=").unwrap_or_else(|| {
         panic!(
@@ -377,13 +601,14 @@ async fn eq0m_test2_strict_allows_inference_local_to_gateway() {
         skip(test_name, "DockerSandboxProvider::new failed");
         return;
     };
-    let (_guard, bridge) = match provision_bridge(test_name) {
+    let (guard, bridge) = match provision_bridge(test_name) {
         Ok(v) => v,
         Err(e) => {
             skip(test_name, format!("bridge provisioning: {e}"));
             return;
         }
     };
+    let network_name = bridge.network_name.clone();
 
     let config = SandboxConfig {
         image: Some(HARNESS_IMAGE.to_string()),
@@ -401,6 +626,8 @@ async fn eq0m_test2_strict_allows_inference_local_to_gateway() {
         .await
         .expect("execute");
     provider.destroy(&handle).await.expect("destroy");
+    drop(guard);
+    assert_network_removed(&network_name);
 
     let inner_exit = parse_marker(&result.stdout, "exit=").unwrap_or_else(|| {
         panic!(
@@ -459,13 +686,14 @@ async fn eq0m_test3_strict_ignores_stale_anthropic_api_key_env() {
         skip(test_name, "DockerSandboxProvider::new failed");
         return;
     };
-    let (_guard, bridge) = match provision_bridge(test_name) {
+    let (guard, bridge) = match provision_bridge(test_name) {
         Ok(v) => v,
         Err(e) => {
             skip(test_name, format!("bridge provisioning: {e}"));
             return;
         }
     };
+    let network_name = bridge.network_name.clone();
 
     const LEAKED_KEY: &str = "sk-leaked-eq0m-test3-must-not-bypass";
     let mut env = HashMap::new();
@@ -491,6 +719,8 @@ async fn eq0m_test3_strict_ignores_stale_anthropic_api_key_env() {
         .await
         .expect("execute");
     provider.destroy(&handle).await.expect("destroy");
+    drop(guard);
+    assert_network_removed(&network_name);
 
     assert!(
         result.stdout.contains(&format!("key={LEAKED_KEY}")),
@@ -532,6 +762,87 @@ async fn eq0m_test3_strict_ignores_stale_anthropic_api_key_env() {
         "positive control body must come from the nginx gateway-stand-in; \
          stdout: {:?}",
         result.stdout
+    );
+}
+
+// ── Test 4 — metadata/private/link-local/IPv6 targets denied ───────────────
+//
+// This expands the original public-provider denial beyond DNS-only targets.
+// Every forbidden URL must fail on the strict internal bridge, while
+// inference.local remains reachable as a positive control. A leaked provider
+// key is present to prove credentials do not bypass the kernel-layer boundary.
+
+#[tokio::test]
+async fn sv76_3_strict_blocks_metadata_private_link_local_and_ipv6_targets() {
+    let test_name = "sv76-3-egress-expanded";
+    if !docker_available() {
+        skip(test_name, "docker daemon not reachable");
+        return;
+    }
+    if let Err(e) = ensure_images() {
+        skip(test_name, format!("image pull: {e}"));
+        return;
+    }
+    let Ok(provider) = DockerSandboxProvider::new() else {
+        skip(test_name, "DockerSandboxProvider::new failed");
+        return;
+    };
+    let (guard, bridge) = match provision_bridge(test_name) {
+        Ok(v) => v,
+        Err(e) => {
+            skip(test_name, format!("bridge provisioning: {e}"));
+            return;
+        }
+    };
+    let network_name = bridge.network_name.clone();
+
+    const LEAKED_KEY: &str = "sk-expanded...deny";
+    let mut env = HashMap::new();
+    env.insert("OPENAI_API_KEY".to_string(), LEAKED_KEY.to_string());
+    let config = SandboxConfig {
+        image: Some(HARNESS_IMAGE.to_string()),
+        egress: Some(strict_inference_local()),
+        egress_bridge: Some(bridge),
+        env,
+        ..Default::default()
+    };
+    let handle = provider.create(&config).await.expect("create");
+    let result = provider
+        .execute(
+            &handle,
+            &denied_probe_script(forbidden_egress_targets()),
+            &HashMap::new(),
+        )
+        .await
+        .expect("execute");
+    provider.destroy(&handle).await.expect("destroy");
+    drop(guard);
+    assert_network_removed(&network_name);
+
+    for target in forbidden_egress_targets() {
+        let inner_exit = parse_marker(&result.stdout, target.marker).unwrap_or_else(|| {
+            panic!(
+                "stdout must contain `{}` marker for {}; got stdout: {:?}, stderr: {:?}",
+                target.marker, target.url, result.stdout, result.stderr
+            )
+        });
+        assert_ne!(
+            inner_exit, 0,
+            "strict bridge must deny {}; got inner exit=0 — stdout: {:?}, stderr: {:?}",
+            target.url, result.stdout, result.stderr
+        );
+    }
+
+    let inference_exit = parse_marker(&result.stdout, "inference_exit=").unwrap_or_else(|| {
+        panic!(
+            "stdout must contain `inference_exit=N` marker; got stdout: {:?}, stderr: {:?}",
+            result.stdout, result.stderr
+        )
+    });
+    assert_eq!(
+        inference_exit, 0,
+        "positive control: inference.local must remain reachable — stdout: {:?}, stderr: {:?}",
+        result.stdout, result.stderr
     );
 }
 


### PR DESCRIPTION
## Summary
- keep the security_negative SEC-ERR-03 expected marker grep-clean by avoiding provider-key-looking literal text
- add `ops/validate/docker-compose.security.yml` hardening overlay for ephemeral validation projects
- add `docker_security` validation profile and CLI `--run-compose` lifecycle helper with cleanup/findings
- expand Docker egress acceptance coverage for metadata, link-local/private IPv4, IPv6 loopback/ULA/link-local, allowed `inference.local` stand-in, and leaked env key denial

## Stack hygiene
This PR was rebuilt onto `main` with only code-bearing commits. The earlier `.beads/issues.jsonl` churn commit from draft PR #1225 was intentionally dropped.

## Test Plan
- `python3 -m py_compile ops/validate/sera-validate.py ops/validate/profiles/security_negative.py ops/validate/profiles/docker_security.py ops/validate/tests/test_docker_security.py`
- `python3 -m pytest ops/validate/tests/test_docker_security.py ops/validate/tests/test_security_negative.py -q`
- worker-reported before rebase: `python3 -m pytest ops/validate/tests -q`
- worker-reported before rebase: `python3 ops/validate/sera-validate.py --profile docker_security --out /tmp/sera-validate-docker-security-kanban-t_dd12048d.json --quiet`
- worker-reported before rebase: `python3 ops/validate/sera-validate.py --profile docker_security --run-compose --out /tmp/sera-validate-docker-security-runcompose-kanban-t_dd12048d.json --quiet` (warn: compose up timed out after 300s; cleanup passed; no leftover `sera-sec` resources)
- worker-reported before rebase: `cargo check -p sera-tools --features docker`
- worker-reported before rebase: `cargo test -p sera-tools --features docker --test docker_egress_acceptance -- --test-threads=1`

Closes `sera-sv76.3` after review/merge.
