### PR TITLE
fix: repair sera-5rti review-thread defects

### DIFF
--- a/ops/validate/profiles/security_negative.py
+++ b/ops/validate/profiles/security_negative.py
@@ -106,12 +106,17 @@ def _http_send(
         return None, {}, b"", f"{type(exc).__name__}: {exc}"
 
 
+def _decode_response_body(body_bytes: bytes) -> str:
+    """Best-effort utf-8 decode for response inspection and artifacts."""
+    try:
+        return body_bytes.decode("utf-8")
+    except UnicodeDecodeError:
+        return body_bytes.decode("utf-8", "replace")
+
+
 def _redact_response_body(body_bytes: bytes, known_secrets: set[str]) -> str:
     """Decode + redact for storage in artifact. Best-effort utf-8 decode."""
-    try:
-        text = body_bytes.decode("utf-8")
-    except UnicodeDecodeError:
-        text = body_bytes.decode("utf-8", "replace")
+    text = _decode_response_body(body_bytes)
     for s in known_secrets:
         if s and s in text:
             text = text.replace(s, "<redacted:known-secret>")
@@ -224,6 +229,7 @@ def _auth_case(
     )
     case["ended_at"] = _now_iso()
 
+    body_raw = _decode_response_body(resp_body)
     body_redacted = _redact_response_body(resp_body, known_secrets)
     headers_redacted = {
         k: ("<redacted:header>" if k.lower() in {"set-cookie", "authorization"} else v)
@@ -240,7 +246,7 @@ def _auth_case(
     elif status != expected_status:
         fail_reasons.append(f"status {status} != expected {expected_status}")
 
-    leak_haystacks = [body_redacted] + [str(v) for v in headers_redacted.values()]
+    leak_haystacks = [body_raw] + [str(v) for v in resp_headers.values()]
     leaks = _detect_leaks(
         leak_haystacks, known_secrets, forbidden_substrings=forbidden_in_body
     )

--- a/ops/validate/tests/test_security_negative.py
+++ b/ops/validate/tests/test_security_negative.py
@@ -139,6 +139,35 @@ def test_redact_response_body_strips_bearer(sec) -> None:  # type: ignore[no-unt
     assert "<redacted:bearer>" in redacted
 
 
+def test_auth_case_detects_leaks_before_redacting_response(sec, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    secret = "secret_abc123def"
+    bearer = "Bearer abcdef1234567890"
+
+    def fake_send(method, url, headers, body):  # type: ignore[no-untyped-def]
+        return 401, {"Authorization": bearer}, f"reflected {secret}".encode(), None
+
+    monkeypatch.setattr(sec, "_http_send", fake_send)
+
+    case = sec._auth_case(
+        case_id="SEC-AUTH-LEAK-REGRESSION",
+        base="http://localhost:3001",
+        method="GET",
+        path="/api/agents",
+        headers=None,
+        body=None,
+        expected_status=401,
+        forbidden_in_body=[],
+        known_secrets={secret},
+    )
+
+    assert case["passed"] is False
+    assert case["secrets_detected"] is True
+    assert "known_secret_present" in case["fail_reason"]
+    assert "bearer_token_shape_present" in case["fail_reason"]
+    assert case["actual"]["body_redacted"] == "reflected <redacted:known-secret>"
+    assert case["actual"]["headers_redacted"]["Authorization"] == "<redacted:header>"
+
+
 # --- validate-only false-green cases ---------------------------------------
 
 

--- a/rust/crates/sera-gateway/src/external_agent_registry.rs
+++ b/rust/crates/sera-gateway/src/external_agent_registry.rs
@@ -90,6 +90,12 @@ pub enum RegisterError {
     )]
     EgressInvalid,
 
+    /// The protocol or external id would make an ambiguous
+    /// `ext:{protocol}:{external_id}` principal id. Wire code
+    /// `register_op_invalid_principal_id`.
+    #[error("register_op_invalid_principal_id: {0}")]
+    InvalidPrincipalId(String),
+
     /// Another Pattern B session is already registered under this
     /// `session_key`. Wire code `register_op_duplicate_session`. Replace
     /// semantics are intentionally NOT supported — see module docs.
@@ -104,6 +110,7 @@ impl RegisterError {
         match self {
             Self::InvalidDelegator(_) => "register_op_invalid_delegator",
             Self::EgressInvalid => "register_op_egress_invalid",
+            Self::InvalidPrincipalId(_) => "register_op_invalid_principal_id",
             Self::DuplicateSession(_) => "register_op_duplicate_session",
         }
     }
@@ -154,10 +161,8 @@ impl DelegatorValidator for InMemoryDelegatorValidator {
     fn is_valid(&self, delegator: &PrincipalRef) -> bool {
         // Wrong-kind rejection is structural — only Agent/Human may delegate
         // a Pattern B session. The allow-list check is the existence gate.
-        matches!(
-            delegator.kind,
-            PrincipalKind::Agent | PrincipalKind::Human
-        ) && self.known.contains(delegator)
+        matches!(delegator.kind, PrincipalKind::Agent | PrincipalKind::Human)
+            && self.known.contains(delegator)
     }
 }
 
@@ -199,6 +204,15 @@ impl ExternalAgentRegistry {
         session_key: &str,
         registration: &ExternalAgentRegistration,
     ) -> Result<ExternalAgentSession, RegisterError> {
+        if !matches!(
+            registration.delegated_by.kind,
+            PrincipalKind::Agent | PrincipalKind::Human
+        ) {
+            return Err(RegisterError::InvalidDelegator(
+                registration.delegated_by.id.0.clone(),
+            ));
+        }
+
         if !self
             .delegator_validator
             .is_valid(&registration.delegated_by)
@@ -222,8 +236,12 @@ impl ExternalAgentRegistry {
             return Err(RegisterError::DuplicateSession(session_key.to_string()));
         }
 
+        let protocol = protocol_label(&registration.protocol);
+        validate_principal_component("protocol", &protocol)?;
+        validate_principal_component("external_id", &registration.external_id)?;
+
         let principal = Principal::external_agent_with_delegator(
-            protocol_label(&registration.protocol).as_str(),
+            protocol.as_str(),
             &registration.external_id,
             &registration.delegated_by,
         );
@@ -252,10 +270,7 @@ impl ExternalAgentRegistry {
 
     /// Number of currently-registered Pattern B sessions. Test introspection.
     pub fn registered_count(&self) -> usize {
-        self.sessions
-            .read()
-            .expect("sessions lock poisoned")
-            .len()
+        self.sessions.read().expect("sessions lock poisoned").len()
     }
 }
 
@@ -266,6 +281,15 @@ fn protocol_label(protocol: &ExternalProtocol) -> String {
         ExternalProtocol::AcpCompat => "acp_compat".to_string(),
         ExternalProtocol::Custom(s) => s.clone(),
     }
+}
+
+fn validate_principal_component(field: &str, value: &str) -> Result<(), RegisterError> {
+    if value.contains(':') {
+        return Err(RegisterError::InvalidPrincipalId(format!(
+            "{field} must not contain ':'"
+        )));
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -301,6 +325,14 @@ mod tests {
         }
     }
 
+    struct PermissiveDelegatorValidator;
+
+    impl DelegatorValidator for PermissiveDelegatorValidator {
+        fn is_valid(&self, _delegator: &PrincipalRef) -> bool {
+            true
+        }
+    }
+
     fn registry_with_known(known: PrincipalRef) -> ExternalAgentRegistry {
         let validator = Arc::new(InMemoryDelegatorValidator::new().with_known(known));
         ExternalAgentRegistry::new(true, validator)
@@ -319,7 +351,10 @@ mod tests {
         assert_eq!(session.principal_ref.id.0, "ext:a2a:claude-pane-1");
         assert_eq!(session.principal_ref.kind, PrincipalKind::ExternalAgent);
         assert_eq!(session.delegated_by, parent);
-        assert_eq!(session.declared_egress, vec![EgressEndpoint::InferenceLocal]);
+        assert_eq!(
+            session.declared_egress,
+            vec![EgressEndpoint::InferenceLocal]
+        );
         assert_eq!(session.budget_handle.0, "ext:bucket:claude-pane-1");
 
         let stored = registry.get("sess-001").expect("session stored");
@@ -334,7 +369,10 @@ mod tests {
         let registry = registry_with_known(known);
 
         let err = registry
-            .register("sess-002", &registration(ExternalProtocol::A2a, "x", stranger))
+            .register(
+                "sess-002",
+                &registration(ExternalProtocol::A2a, "x", stranger),
+            )
             .unwrap_err();
 
         assert_eq!(err.code(), "register_op_invalid_delegator");
@@ -367,6 +405,25 @@ mod tests {
     }
 
     #[test]
+    fn wrong_kind_delegator_rejected_even_when_validator_accepts_it() {
+        let registry = ExternalAgentRegistry::new(true, Arc::new(PermissiveDelegatorValidator));
+        let external_agent_delegator = PrincipalRef {
+            id: PrincipalId::new("ext:a2a:child"),
+            kind: PrincipalKind::ExternalAgent,
+        };
+
+        let err = registry
+            .register(
+                "sess-permissive-wrong-kind",
+                &registration(ExternalProtocol::A2a, "x", external_agent_delegator),
+            )
+            .unwrap_err();
+
+        assert_eq!(err.code(), "register_op_invalid_delegator");
+        assert_eq!(registry.registered_count(), 0);
+    }
+
+    #[test]
     fn human_delegator_accepted() {
         let operator = human_ref("admin");
         let registry = registry_with_known(operator.clone());
@@ -388,7 +445,10 @@ mod tests {
         let registry = registry_with_known(parent.clone());
 
         registry
-            .register("sess-dup", &registration(ExternalProtocol::A2a, "first", parent.clone()))
+            .register(
+                "sess-dup",
+                &registration(ExternalProtocol::A2a, "first", parent.clone()),
+            )
             .expect("first registration should succeed");
 
         let err = registry
@@ -487,6 +547,44 @@ mod tests {
     }
 
     #[test]
+    fn delimiter_bearing_external_id_rejected_before_principal_minting() {
+        let parent = agent_ref("agent:parent");
+        let registry = registry_with_known(parent.clone());
+
+        let err = registry
+            .register(
+                "sess-delimiter-external-id",
+                &registration(ExternalProtocol::A2a, "x:y", parent),
+            )
+            .unwrap_err();
+
+        assert_eq!(err.code(), "register_op_invalid_principal_id");
+        assert!(
+            matches!(err, RegisterError::InvalidPrincipalId(ref msg) if msg.contains("external_id"))
+        );
+        assert_eq!(registry.registered_count(), 0);
+    }
+
+    #[test]
+    fn delimiter_bearing_custom_protocol_rejected_before_principal_minting() {
+        let parent = agent_ref("agent:parent");
+        let registry = registry_with_known(parent.clone());
+
+        let err = registry
+            .register(
+                "sess-delimiter-protocol",
+                &registration(ExternalProtocol::Custom("a2a:x".to_string()), "y", parent),
+            )
+            .unwrap_err();
+
+        assert_eq!(err.code(), "register_op_invalid_principal_id");
+        assert!(
+            matches!(err, RegisterError::InvalidPrincipalId(ref msg) if msg.contains("protocol"))
+        );
+        assert_eq!(registry.registered_count(), 0);
+    }
+
+    #[test]
     fn register_error_codes_are_stable_wire_strings() {
         // PR3's dispatch arm copies these into EventMsg::Error::code; pin
         // them so a refactor cannot silently break the wire contract.
@@ -494,7 +592,14 @@ mod tests {
             RegisterError::InvalidDelegator("x".into()).code(),
             "register_op_invalid_delegator"
         );
-        assert_eq!(RegisterError::EgressInvalid.code(), "register_op_egress_invalid");
+        assert_eq!(
+            RegisterError::EgressInvalid.code(),
+            "register_op_egress_invalid"
+        );
+        assert_eq!(
+            RegisterError::InvalidPrincipalId("protocol must not contain ':'".into()).code(),
+            "register_op_invalid_principal_id"
+        );
         assert_eq!(
             RegisterError::DuplicateSession("k".into()).code(),
             "register_op_duplicate_session"


### PR DESCRIPTION
## Summary
- detect security-negative response leaks against raw body/header values before redaction
- enforce Agent/Human delegator kinds inside ExternalAgentRegistry::register independent of DelegatorValidator
- reject delimiter-bearing protocol/external_id components before minting external-agent principal IDs

## Test Plan
- pytest ops/validate/tests/test_security_negative.py -q
- cd rust && cargo test -p sera-gateway external_agent_registry --lib
- git diff --check

Fixes bead: sera-5rti
Review threads addressed: 3207254773, 3207732010, 3207732015