### PR TITLE
feat(gateway): route external agent registrations

### DIFF
--- a/rust/crates/sera-gateway/src/bin/sera.rs
+++ b/rust/crates/sera-gateway/src/bin/sera.rs
@@ -2239,18 +2239,29 @@ struct ManifestDelegatorValidator {
 
 impl DelegatorValidator for ManifestDelegatorValidator {
     fn is_valid(&self, delegator: &PrincipalRef) -> bool {
-        if !matches!(delegator.kind, PrincipalKind::Agent) {
-            return false;
+        match delegator.kind {
+            PrincipalKind::Agent => {
+                let Some(agent_name) = delegator.id.0.strip_prefix("agent:") else {
+                    return false;
+                };
+                let manifests = self.manifests.read().unwrap();
+                manifests
+                    .agents
+                    .iter()
+                    .any(|agent| agent.metadata.name == agent_name)
+            }
+            PrincipalKind::Human => valid_manifest_human_delegator(&delegator.id.0),
+            _ => false,
         }
-        let Some(agent_name) = delegator.id.0.strip_prefix("agent:") else {
-            return false;
-        };
-        let manifests = self.manifests.read().unwrap();
-        manifests
-            .agents
-            .iter()
-            .any(|agent| agent.metadata.name == agent_name)
     }
+}
+
+fn valid_manifest_human_delegator(id: &str) -> bool {
+    id == "admin"
+        || id == "http-chat"
+        || id
+            .strip_prefix("discord:")
+            .is_some_and(|discord_id| !discord_id.is_empty())
 }
 
 fn external_agent_registry_from_manifests(
@@ -7494,6 +7505,36 @@ mod tests {
                 spec,
             }));
         assert!(registry.register("dynamic-session-2", registration).is_ok());
+
+        let mut human_submission = external_agent_register_submission("human-session-1", "discord:123456");
+        let human_registration = match &mut human_submission.op {
+            sera_gateway::envelope::Op::Register(
+                sera_gateway::envelope::RegisterOp::ExternalAgent(registration),
+            ) => {
+                registration.delegated_by.kind = PrincipalKind::Human;
+                registration
+            }
+            _ => unreachable!("test helper always builds external-agent registration"),
+        };
+        assert!(registry.register("human-session-1", human_registration).is_ok());
+
+        let mut unknown_human_submission = external_agent_register_submission("human-session-2", "mallory");
+        let unknown_human_registration = match &mut unknown_human_submission.op {
+            sera_gateway::envelope::Op::Register(
+                sera_gateway::envelope::RegisterOp::ExternalAgent(registration),
+            ) => {
+                registration.delegated_by.kind = PrincipalKind::Human;
+                registration
+            }
+            _ => unreachable!("test helper always builds external-agent registration"),
+        };
+        assert_eq!(
+            registry
+                .register("human-session-2", unknown_human_registration)
+                .unwrap_err()
+                .code(),
+            "register_op_invalid_delegator"
+        );
 
         manifests.write().unwrap().remove_agent("runtime-added");
         assert_eq!(

--- a/rust/crates/sera-gateway/src/bin/sera.rs
+++ b/rust/crates/sera-gateway/src/bin/sera.rs
@@ -57,6 +57,7 @@ use sera_gateway::admin::{
 use sera_gateway::agent_transport::{AgentTurnTransport, ToolEvent, TurnEvents, UsageInfo};
 use sera_gateway::capability_enforcement::{CapabilityRegistry, PolicyDenial};
 use sera_gateway::embedded_transport::EmbeddedRuntimeTransport;
+use sera_gateway::external_agent_registry::{ExternalAgentRegistry, InMemoryDelegatorValidator};
 use sera_gateway::hitl_gateway::{
     HitlAppState, InMemoryTicketStore, TicketStore, resolve_approval_routing, resolve_hitl_mode,
 };
@@ -64,7 +65,7 @@ use sera_gateway::kill_switch::{KillSwitch, admin_sock_path, spawn_admin_socket}
 use sera_gateway::scheduler::spawn_scheduler;
 #[cfg(test)]
 use sera_gateway::session_store::InMemorySessionStore;
-use sera_gateway::session_store::{SessionStore, SqliteSessionStore};
+use sera_gateway::session_store::{SessionStore, SqliteSessionStore, StoredSubmission};
 #[cfg(feature = "enterprise")]
 use sera_gateway::session_store::SqliteGitSessionStore;
 use sera_gateway::workflow_store::{
@@ -1320,6 +1321,10 @@ struct AppState {
     /// Shared Discord connector for sending replies. `None` when no Discord
     /// connector is configured.
     discord: Option<Arc<DiscordConnector>>,
+    /// Pattern B external-agent registry. `POST /api/submissions` routes
+    /// `Op::Register(RegisterOp::ExternalAgent)` here so opaque profile
+    /// sessions get a pinned ExternalAgentPrincipal before doing work.
+    external_agent_registry: Arc<ExternalAgentRegistry>,
     /// API key for authenticating requests. `None` means auth is disabled
     /// (autonomous mode — all access allowed per MVS §6.5).
     api_key: Option<String>,
@@ -2228,6 +2233,23 @@ fn validate_api_key(state: &AppState, headers: &HeaderMap) -> Result<(), StatusC
     }
 }
 
+fn external_agent_registry_from_manifests(
+    manifests: &ManifestSet,
+    inference_proxy_enabled: bool,
+) -> Arc<ExternalAgentRegistry> {
+    let mut validator = InMemoryDelegatorValidator::new();
+    for agent in &manifests.agents {
+        validator.add(PrincipalRef {
+            id: PrincipalId::new(format!("agent:{}", agent.metadata.name)),
+            kind: PrincipalKind::Agent,
+        });
+    }
+    Arc::new(ExternalAgentRegistry::new(
+        inference_proxy_enabled,
+        Arc::new(validator),
+    ))
+}
+
 // ── HTTP handlers ───────────────────────────────────────────────────────────
 
 /// Liveness — the gateway process is up and serving HTTP. Mirrors the
@@ -2236,6 +2258,87 @@ fn validate_api_key(state: &AppState, headers: &HeaderMap) -> Result<(), StatusC
 /// for traffic-gate semantics.
 async fn health_handler() -> Json<HealthResponse> {
     Json(HealthResponse { status: "ok" })
+}
+
+fn submission_event(
+    submission: &sera_gateway::envelope::Submission,
+    msg: sera_gateway::envelope::EventMsg,
+) -> sera_gateway::envelope::Event {
+    sera_gateway::envelope::Event {
+        id: uuid::Uuid::new_v4(),
+        submission_id: submission.id,
+        msg,
+        trace: submission.trace.clone(),
+        timestamp: chrono::Utc::now(),
+        parent_session_key: submission.parent_session_key.clone(),
+        parent_task_id: submission.parent_task_id.clone(),
+    }
+}
+
+fn submission_error_event(
+    submission: &sera_gateway::envelope::Submission,
+    code: impl Into<String>,
+    message: impl Into<String>,
+) -> sera_gateway::envelope::Event {
+    submission_event(
+        submission,
+        sera_gateway::envelope::EventMsg::Error {
+            code: code.into(),
+            message: message.into(),
+        },
+    )
+}
+
+async fn submission_handler(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    ValidatedJson(submission): ValidatedJson<sera_gateway::envelope::Submission>,
+) -> Result<Json<sera_gateway::envelope::Event>, StatusCode> {
+    validate_api_key(&state, &headers)?;
+
+    let event = match &submission.op {
+        sera_gateway::envelope::Op::Register(sera_gateway::envelope::RegisterOp::ExternalAgent(registration)) => {
+            match submission.session_key.clone() {
+                Some(session_key) => match state.external_agent_registry.register(&session_key, registration) {
+                    Ok(session) => submission_event(
+                        &submission,
+                        sera_gateway::envelope::EventMsg::ExternalAgentRegistered {
+                            session_key,
+                            principal: session.principal_ref,
+                            delegated_by: session.delegated_by,
+                        },
+                    ),
+                    Err(err) => submission_error_event(&submission, err.code(), err.to_string()),
+                },
+                None => submission_error_event(
+                    &submission,
+                    "register_op_missing_session_key",
+                    "external-agent registration requires submission.session_key",
+                ),
+            }
+        }
+        _ => submission_error_event(
+            &submission,
+            "unsupported_submission_op",
+            "submission queue currently accepts only RegisterOp::ExternalAgent",
+        ),
+    };
+
+    let session_key = submission
+        .session_key
+        .clone()
+        .unwrap_or_else(|| format!("submission:{}", submission.id));
+    let bundle = StoredSubmission {
+        submission,
+        emissions: vec![event.clone()],
+    };
+    state
+        .session_store
+        .append_submission(&session_key, &bundle)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    Ok(Json(event))
 }
 
 /// Default per-harness probe timeout when `SERA_READINESS_PROBE_TIMEOUT_SECS`
@@ -5813,11 +5916,13 @@ async fn run_start(config: PathBuf, port: u16, local: bool) -> anyhow::Result<()
     })?);
     let admin_audit_path = AdminAuditLogger::default_path(&data_root);
     let admin_audit = AdminAuditLogger::shared(admin_audit_path);
+    let external_agent_registry = external_agent_registry_from_manifests(&manifests, true);
 
     let state = Arc::new(AppState {
         db: Arc::new(Mutex::new(db)),
         manifests: Arc::new(std::sync::RwLock::new(manifests)),
         discord: shared_discord,
+        external_agent_registry,
         api_key,
         lane_queue: Mutex::new(LaneQueue::new_with_counter_store(
             10,
@@ -6337,6 +6442,8 @@ fn build_router(state: Arc<AppState>) -> Router {
         // before dispatching real turns.
         .route("/api/health/ready", get(readiness_handler))
         .route("/api/auth/me", get(auth_me_handler))
+        .route("/api/submissions", post(submission_handler))
+        .route("/api/sq", post(submission_handler))
         .route("/api/chat", post(chat_handler))
         .route("/api/operator/tasks", post(operator_task_handler))
         // sera-mplr / J.0.4 ESC-cancel: abort the in-flight HTTP turn for a
@@ -6668,6 +6775,10 @@ mod tests {
         parse_manifests(TEMPLATE_YAML).unwrap()
     }
 
+    fn test_external_agent_registry() -> Arc<ExternalAgentRegistry> {
+        external_agent_registry_from_manifests(&test_manifests(), true)
+    }
+
     async fn test_harnesses() -> std::collections::HashMap<String, Arc<dyn AgentTurnTransport>> {
         let mut h: std::collections::HashMap<String, Arc<dyn AgentTurnTransport>> =
             std::collections::HashMap::new();
@@ -6687,6 +6798,7 @@ mod tests {
             db: Arc::new(Mutex::new(SqliteDb::open_in_memory().unwrap())),
             manifests: Arc::new(std::sync::RwLock::new(test_manifests())),
             discord: None,
+            external_agent_registry: test_external_agent_registry(),
             api_key: None,
             lane_queue: Mutex::new(LaneQueue::new(10, QueueMode::Collect)),
             hook_registry,
@@ -6739,6 +6851,7 @@ mod tests {
             db: Arc::new(Mutex::new(SqliteDb::open_in_memory().unwrap())),
             manifests: Arc::new(std::sync::RwLock::new(test_manifests())),
             discord: None,
+            external_agent_registry: test_external_agent_registry(),
             api_key: None,
             lane_queue: Mutex::new(LaneQueue::new(10, QueueMode::Collect)),
             hook_registry,
@@ -6791,6 +6904,7 @@ mod tests {
             db: Arc::new(Mutex::new(SqliteDb::open_in_memory().unwrap())),
             manifests: Arc::new(std::sync::RwLock::new(test_manifests())),
             discord: None,
+            external_agent_registry: test_external_agent_registry(),
             api_key: Some(key.to_owned()),
             lane_queue: Mutex::new(LaneQueue::new(10, QueueMode::Collect)),
             hook_registry,
@@ -6843,6 +6957,7 @@ mod tests {
             db: Arc::new(Mutex::new(SqliteDb::open_in_memory().unwrap())),
             manifests: Arc::new(std::sync::RwLock::new(test_manifests())),
             discord: None,
+            external_agent_registry: test_external_agent_registry(),
             api_key: Some(key.to_owned()),
             lane_queue: Mutex::new(LaneQueue::new(10, QueueMode::Collect)),
             hook_registry,
@@ -7143,6 +7258,95 @@ mod tests {
         assert_eq!(json["status"], "ok");
     }
 
+    fn external_agent_register_submission(
+        session_key: &str,
+        delegated_by: &str,
+    ) -> sera_gateway::envelope::Submission {
+        use sera_gateway::envelope::{
+            BudgetHandle, ExternalAgentRegistration, ExternalProtocol, Op, RegisterOp,
+            W3cTraceContext,
+        };
+        sera_gateway::envelope::Submission {
+            id: uuid::Uuid::new_v4(),
+            op: Op::Register(RegisterOp::ExternalAgent(ExternalAgentRegistration {
+                protocol: ExternalProtocol::A2a,
+                external_id: format!("worker-{session_key}"),
+                delegated_by: PrincipalRef {
+                    id: PrincipalId::new(delegated_by),
+                    kind: PrincipalKind::Agent,
+                },
+                declared_egress: vec![sera_types::sandbox::EgressEndpoint::InferenceLocal],
+                budget_handle: BudgetHandle(format!("budget:{session_key}")),
+            })),
+            trace: W3cTraceContext::default(),
+            change_artifact: None,
+            session_key: Some(session_key.to_string()),
+            parent_session_key: None,
+            parent_task_id: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn submissions_route_registers_external_agent_and_emits_event() {
+        let state = test_state();
+        let registry = Arc::clone(&state.external_agent_registry);
+        let app = build_router(state);
+        let submission = external_agent_register_submission("ext-session-1", "agent:sera");
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/submissions")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&submission).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 8192)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["submission_id"], submission.id.to_string());
+        assert_eq!(json["msg"]["type"], "external_agent_registered");
+        assert_eq!(json["msg"]["session_key"], "ext-session-1");
+        assert_eq!(json["msg"]["delegated_by"]["id"], "agent:sera");
+        assert_eq!(registry.registered_count(), 1);
+        assert!(registry.get("ext-session-1").is_some());
+    }
+
+    #[tokio::test]
+    async fn submissions_route_register_failure_emits_error_event() {
+        let state = test_state();
+        let registry = Arc::clone(&state.external_agent_registry);
+        let app = build_router(state);
+        let submission = external_agent_register_submission("ext-session-bad", "agent:unknown");
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/sq")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&submission).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 8192)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["msg"]["type"], "error");
+        assert_eq!(json["msg"]["code"], "register_op_invalid_delegator");
+        assert_eq!(registry.registered_count(), 0);
+    }
+
     // -- Readiness endpoint (empty-reply race fix) --
     //
     // The race: after `docker restart`, axum binds and `/api/health` answers
@@ -7353,6 +7557,7 @@ spec:
             db: Arc::new(Mutex::new(SqliteDb::open_in_memory().unwrap())),
             manifests: Arc::new(std::sync::RwLock::new(parse_manifests(STRICT_AGENT_YAML).unwrap())),
             discord: None,
+            external_agent_registry: test_external_agent_registry(),
             api_key: None,
             lane_queue: Mutex::new(LaneQueue::new(10, QueueMode::Collect)),
             hook_registry,
@@ -8112,6 +8317,7 @@ spec:
             db: Arc::new(Mutex::new(SqliteDb::open_in_memory().unwrap())),
             manifests: Arc::new(std::sync::RwLock::new(test_manifests())),
             discord: None,
+            external_agent_registry: test_external_agent_registry(),
             api_key: None,
             lane_queue: Mutex::new(LaneQueue::new(10, QueueMode::Collect)),
             hook_registry,
@@ -8167,6 +8373,7 @@ spec:
             db: Arc::new(Mutex::new(SqliteDb::open_in_memory().unwrap())),
             manifests: Arc::new(std::sync::RwLock::new(test_manifests())),
             discord: None,
+            external_agent_registry: test_external_agent_registry(),
             api_key: Some("my-key".to_owned()),
             lane_queue: Mutex::new(LaneQueue::new(10, QueueMode::Collect)),
             hook_registry,
@@ -8223,6 +8430,7 @@ spec:
             db: Arc::new(Mutex::new(SqliteDb::open_in_memory().unwrap())),
             manifests: Arc::new(std::sync::RwLock::new(test_manifests())),
             discord: None,
+            external_agent_registry: test_external_agent_registry(),
             api_key: Some("my-key".to_owned()),
             lane_queue: Mutex::new(LaneQueue::new(10, QueueMode::Collect)),
             hook_registry,
@@ -8282,6 +8490,7 @@ spec:
             db: Arc::new(Mutex::new(SqliteDb::open_in_memory().unwrap())),
             manifests: Arc::new(std::sync::RwLock::new(test_manifests())),
             discord: None,
+            external_agent_registry: test_external_agent_registry(),
             api_key: Some("my-key".to_owned()),
             lane_queue: Mutex::new(LaneQueue::new(10, QueueMode::Collect)),
             hook_registry,
@@ -10960,6 +11169,7 @@ spec:
             db: Arc::new(Mutex::new(SqliteDb::open_in_memory().unwrap())),
             manifests: Arc::new(std::sync::RwLock::new(test_manifests())),
             discord: None,
+            external_agent_registry: test_external_agent_registry(),
             api_key: None,
             lane_queue: Mutex::new(LaneQueue::new(10, QueueMode::Collect)),
             hook_registry,
@@ -11054,6 +11264,7 @@ spec:
                 db: Arc::new(Mutex::new(SqliteDb::open_in_memory().unwrap())),
                 manifests: Arc::new(std::sync::RwLock::new(test_manifests())),
                 discord: None,
+            external_agent_registry: test_external_agent_registry(),
                 api_key: Some("secret".to_owned()),
                 lane_queue: Mutex::new(LaneQueue::new(10, QueueMode::Collect)),
                 hook_registry,
@@ -11147,6 +11358,7 @@ spec:
                 db: Arc::new(Mutex::new(SqliteDb::open_in_memory().unwrap())),
                 manifests: Arc::new(std::sync::RwLock::new(test_manifests())),
                 discord: None,
+            external_agent_registry: test_external_agent_registry(),
                 api_key: Some("secret".to_owned()),
                 lane_queue: Mutex::new(LaneQueue::new(10, QueueMode::Collect)),
                 hook_registry,
@@ -11898,6 +12110,7 @@ spec:
                 db: Arc::new(Mutex::new(SqliteDb::open_in_memory().unwrap())),
                 manifests: Arc::new(std::sync::RwLock::new(manifests)),
                 discord: None,
+            external_agent_registry: test_external_agent_registry(),
                 api_key: None,
                 lane_queue: Mutex::new(LaneQueue::new(10, QueueMode::Collect)),
                 hook_registry,

--- a/rust/crates/sera-gateway/src/bin/sera.rs
+++ b/rust/crates/sera-gateway/src/bin/sera.rs
@@ -57,7 +57,7 @@ use sera_gateway::admin::{
 use sera_gateway::agent_transport::{AgentTurnTransport, ToolEvent, TurnEvents, UsageInfo};
 use sera_gateway::capability_enforcement::{CapabilityRegistry, PolicyDenial};
 use sera_gateway::embedded_transport::EmbeddedRuntimeTransport;
-use sera_gateway::external_agent_registry::{ExternalAgentRegistry, InMemoryDelegatorValidator};
+use sera_gateway::external_agent_registry::{DelegatorValidator, ExternalAgentRegistry};
 use sera_gateway::hitl_gateway::{
     HitlAppState, InMemoryTicketStore, TicketStore, resolve_approval_routing, resolve_hitl_mode,
 };
@@ -2233,20 +2233,33 @@ fn validate_api_key(state: &AppState, headers: &HeaderMap) -> Result<(), StatusC
     }
 }
 
+struct ManifestDelegatorValidator {
+    manifests: Arc<std::sync::RwLock<ManifestSet>>,
+}
+
+impl DelegatorValidator for ManifestDelegatorValidator {
+    fn is_valid(&self, delegator: &PrincipalRef) -> bool {
+        if !matches!(delegator.kind, PrincipalKind::Agent) {
+            return false;
+        }
+        let Some(agent_name) = delegator.id.0.strip_prefix("agent:") else {
+            return false;
+        };
+        let manifests = self.manifests.read().unwrap();
+        manifests
+            .agents
+            .iter()
+            .any(|agent| agent.metadata.name == agent_name)
+    }
+}
+
 fn external_agent_registry_from_manifests(
-    manifests: &ManifestSet,
+    manifests: Arc<std::sync::RwLock<ManifestSet>>,
     inference_proxy_enabled: bool,
 ) -> Arc<ExternalAgentRegistry> {
-    let mut validator = InMemoryDelegatorValidator::new();
-    for agent in &manifests.agents {
-        validator.add(PrincipalRef {
-            id: PrincipalId::new(format!("agent:{}", agent.metadata.name)),
-            kind: PrincipalKind::Agent,
-        });
-    }
     Arc::new(ExternalAgentRegistry::new(
         inference_proxy_enabled,
-        Arc::new(validator),
+        Arc::new(ManifestDelegatorValidator { manifests }),
     ))
 }
 
@@ -2289,12 +2302,26 @@ fn submission_error_event(
     )
 }
 
+fn safe_submission_session_key(key: &str) -> bool {
+    !key.is_empty()
+        && key
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b':' | b'.' | b'_' | b'-'))
+        && key.split(':').all(|part| part != "." && part != "..")
+}
+
 async fn submission_handler(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
     ValidatedJson(submission): ValidatedJson<sera_gateway::envelope::Submission>,
 ) -> Result<Json<sera_gateway::envelope::Event>, StatusCode> {
     validate_api_key(&state, &headers)?;
+
+    if let Some(session_key) = submission.session_key.as_deref()
+        && !safe_submission_session_key(session_key)
+    {
+        return Err(StatusCode::BAD_REQUEST);
+    }
 
     let event = match &submission.op {
         sera_gateway::envelope::Op::Register(sera_gateway::envelope::RegisterOp::ExternalAgent(registration)) => {
@@ -5916,11 +5943,12 @@ async fn run_start(config: PathBuf, port: u16, local: bool) -> anyhow::Result<()
     })?);
     let admin_audit_path = AdminAuditLogger::default_path(&data_root);
     let admin_audit = AdminAuditLogger::shared(admin_audit_path);
-    let external_agent_registry = external_agent_registry_from_manifests(&manifests, true);
+    let manifests = Arc::new(std::sync::RwLock::new(manifests));
+    let external_agent_registry = external_agent_registry_from_manifests(Arc::clone(&manifests), true);
 
     let state = Arc::new(AppState {
         db: Arc::new(Mutex::new(db)),
-        manifests: Arc::new(std::sync::RwLock::new(manifests)),
+        manifests,
         discord: shared_discord,
         external_agent_registry,
         api_key,
@@ -6776,7 +6804,10 @@ mod tests {
     }
 
     fn test_external_agent_registry() -> Arc<ExternalAgentRegistry> {
-        external_agent_registry_from_manifests(&test_manifests(), true)
+        external_agent_registry_from_manifests(
+            Arc::new(std::sync::RwLock::new(test_manifests())),
+            true,
+        )
     }
 
     async fn test_harnesses() -> std::collections::HashMap<String, Arc<dyn AgentTurnTransport>> {
@@ -7345,6 +7376,66 @@ mod tests {
         assert_eq!(json["msg"]["type"], "error");
         assert_eq!(json["msg"]["code"], "register_op_invalid_delegator");
         assert_eq!(registry.registered_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn submissions_route_register_rejects_unsafe_session_key() {
+        let state = test_state();
+        let registry = Arc::clone(&state.external_agent_registry);
+        let app = build_router(state);
+        let submission = external_agent_register_submission("../escape", "agent:sera");
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/submissions")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&submission).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(registry.registered_count(), 0);
+    }
+
+    #[test]
+    fn submissions_route_register_validator_tracks_manifest_updates() {
+        let manifests = Arc::new(std::sync::RwLock::new(test_manifests()));
+        let registry = external_agent_registry_from_manifests(Arc::clone(&manifests), true);
+        let submission = external_agent_register_submission("dynamic-session-1", "agent:runtime-added");
+        let registration = match &submission.op {
+            sera_gateway::envelope::Op::Register(
+                sera_gateway::envelope::RegisterOp::ExternalAgent(registration),
+            ) => registration,
+            _ => unreachable!("test helper always builds external-agent registration"),
+        };
+
+        assert_eq!(
+            registry.register("dynamic-session-1", registration).unwrap_err().code(),
+            "register_op_invalid_delegator"
+        );
+
+        let spec = {
+            let guard = manifests.read().unwrap();
+            guard.agent_spec("sera").unwrap().unwrap()
+        };
+        manifests
+            .write()
+            .unwrap()
+            .upsert_agent(agent_manifest_from_request(RegisterAgentRequest {
+                name: "runtime-added".to_string(),
+                spec,
+            }));
+        assert!(registry.register("dynamic-session-2", registration).is_ok());
+
+        manifests.write().unwrap().remove_agent("runtime-added");
+        assert_eq!(
+            registry.register("dynamic-session-3", registration).unwrap_err().code(),
+            "register_op_invalid_delegator"
+        );
     }
 
     // -- Readiness endpoint (empty-reply race fix) --

--- a/rust/crates/sera-gateway/src/bin/sera.rs
+++ b/rust/crates/sera-gateway/src/bin/sera.rs
@@ -2323,18 +2323,22 @@ async fn submission_handler(
         return Err(StatusCode::BAD_REQUEST);
     }
 
+    let mut registered_session_key = None;
     let event = match &submission.op {
         sera_gateway::envelope::Op::Register(sera_gateway::envelope::RegisterOp::ExternalAgent(registration)) => {
             match submission.session_key.clone() {
                 Some(session_key) => match state.external_agent_registry.register(&session_key, registration) {
-                    Ok(session) => submission_event(
-                        &submission,
-                        sera_gateway::envelope::EventMsg::ExternalAgentRegistered {
-                            session_key,
-                            principal: session.principal_ref,
-                            delegated_by: session.delegated_by,
-                        },
-                    ),
+                    Ok(session) => {
+                        registered_session_key = Some(session_key.clone());
+                        submission_event(
+                            &submission,
+                            sera_gateway::envelope::EventMsg::ExternalAgentRegistered {
+                                session_key,
+                                principal: session.principal_ref,
+                                delegated_by: session.delegated_by,
+                            },
+                        )
+                    }
                     Err(err) => submission_error_event(&submission, err.code(), err.to_string()),
                 },
                 None => submission_error_event(
@@ -2359,11 +2363,17 @@ async fn submission_handler(
         submission,
         emissions: vec![event.clone()],
     };
-    state
+    if state
         .session_store
         .append_submission(&session_key, &bundle)
         .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        .is_err()
+    {
+        if let Some(session_key) = registered_session_key.as_deref() {
+            state.external_agent_registry.unregister(session_key);
+        }
+        return Err(StatusCode::INTERNAL_SERVER_ERROR);
+    }
 
     Ok(Json(event))
 }
@@ -7317,6 +7327,33 @@ mod tests {
         }
     }
 
+    struct FailingSessionStore;
+
+    #[async_trait::async_trait]
+    impl SessionStore for FailingSessionStore {
+        async fn append_submission(
+            &self,
+            _session_id: &str,
+            _bundle: &StoredSubmission,
+        ) -> Result<sera_gateway::session_store::SubmissionRef, sera_gateway::session_store::SessionStoreError> {
+            Err(std::io::Error::other("forced session-store append failure").into())
+        }
+
+        async fn head(
+            &self,
+            _session_id: &str,
+        ) -> Result<Option<sera_gateway::session_store::SubmissionRef>, sera_gateway::session_store::SessionStoreError> {
+            Ok(None)
+        }
+
+        async fn replay(
+            &self,
+            _session_id: &str,
+        ) -> Result<Vec<sera_gateway::envelope::Submission>, sera_gateway::session_store::SessionStoreError> {
+            Ok(Vec::new())
+        }
+    }
+
     #[tokio::test]
     async fn submissions_route_registers_external_agent_and_emits_event() {
         let state = test_state();
@@ -7376,6 +7413,33 @@ mod tests {
         assert_eq!(json["msg"]["type"], "error");
         assert_eq!(json["msg"]["code"], "register_op_invalid_delegator");
         assert_eq!(registry.registered_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn submissions_route_rolls_back_registration_when_persistence_fails() {
+        let mut state = test_state();
+        let registry = Arc::clone(&state.external_agent_registry);
+        Arc::get_mut(&mut state)
+            .expect("test keeps sole AppState reference until router build")
+            .session_store = Arc::new(FailingSessionStore);
+        let app = build_router(state);
+        let submission = external_agent_register_submission("ext-session-rollback", "agent:sera");
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/submissions")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&submission).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(registry.registered_count(), 0);
+        assert!(registry.get("ext-session-rollback").is_none());
     }
 
     #[tokio::test]

--- a/rust/crates/sera-gateway/src/external_agent_registry.rs
+++ b/rust/crates/sera-gateway/src/external_agent_registry.rs
@@ -264,6 +264,19 @@ impl ExternalAgentRegistry {
             .cloned()
     }
 
+    /// Remove a registered Pattern B session by SQ envelope `session_key`.
+    ///
+    /// This is intentionally narrow: production request handling uses it only
+    /// to roll back an in-memory registration when durable submission append
+    /// fails, so callers do not strand a reserved session key after returning
+    /// HTTP 500.
+    pub fn unregister(&self, session_key: &str) -> Option<ExternalAgentSession> {
+        self.sessions
+            .write()
+            .expect("sessions lock poisoned")
+            .remove(session_key)
+    }
+
     /// Number of currently-registered Pattern B sessions. Test introspection.
     pub fn registered_count(&self) -> usize {
         self.sessions.read().expect("sessions lock poisoned").len()

--- a/rust/crates/sera-gateway/src/external_agent_registry.rs
+++ b/rust/crates/sera-gateway/src/external_agent_registry.rs
@@ -25,16 +25,12 @@
 //! 4. Mint the principal via [`Principal::external_agent_with_delegator`] so
 //!    the call-site explicitly threads `delegated_by`.
 //!
-//! ## Integration seam (deferred to PR3)
+//! ## Production dispatch
 //!
-//! There is no production `Op::Register` dispatch arm in
-//! `sera-gateway/src/bin/sera.rs` today — `Op::Register(_)` is a wildcard
-//! audit arm in [`session_store::op_kind_label`] and a no-op in
-//! [`sera_runtime::stdio`]. PR2 ships the pure handler + module-seam
-//! integration tests; the production wire-up (call this registry from a
-//! `Submission` arrival, emit `EventMsg::SessionTransition` on success and
-//! `EventMsg::Error { code, message }` on failure) is the smallest PR3
-//! delta. See `tests/register_op_external_agent.rs` for the seam shape.
+//! `sera-gateway/src/bin/sera.rs` wires `POST /api/submissions` and
+//! `POST /api/sq` to this registry for `Op::Register(RegisterOp::ExternalAgent)`.
+//! The route appends each accepted submission plus the emitted EventMsg to the
+//! session store before returning the event to the caller.
 
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, RwLock};

--- a/rust/crates/sera-types/src/envelope.rs
+++ b/rust/crates/sera-types/src/envelope.rs
@@ -246,6 +246,12 @@ pub enum EventMsg {
         ticket_id: String,
         session_key: String,
     },
+    /// Pattern B external-agent registration was accepted and pinned by the gateway.
+    ExternalAgentRegistered {
+        session_key: String,
+        principal: crate::principal::PrincipalRef,
+        delegated_by: crate::principal::PrincipalRef,
+    },
     /// Guardian pre-approval LLM risk assessment (sera-k600 / SPEC-hitl-approval §2b).
     /// Emitted by the runtime when a `SecurityAnalyzer` returns a structured
     /// `GuardianAssessment` for a proposed tool call. Carries the analyzer


### PR DESCRIPTION
## Summary
- wires POST /api/submissions and /api/sq to the external-agent registry for Pattern B RegisterOp submissions
- emits ExternalAgentRegistered events and appends the submission/event bundle to the session store
- adds focused route coverage for successful registration and invalid delegator errors

## Test Plan
- cargo test -p sera-gateway submissions_route_register --bin sera-gateway
- git diff --check

Bead: sera-pcvp