### PR TITLE
test(gateway): pin parent_session_key nesting invariant (sera-plcv M1 AC2/AC3)

### DIFF
--- a/rust/crates/sera-gateway/src/bin/sera.rs
+++ b/rust/crates/sera-gateway/src/bin/sera.rs
@@ -7692,6 +7692,78 @@ mod tests {
         assert_eq!(registry.registered_count(), 0);
     }
 
+    /// sera-plcv M1 AC2/AC3 invariant: `parent_session_key` on a Pattern B
+    /// `Op::Register(ExternalAgent)` envelope must survive end-to-end so a
+    /// Pattern A turn (parent) and a Pattern B child registration land under
+    /// "exactly one EventStream with both nested" (bead AC4). Two surfaces
+    /// must keep the link:
+    ///   1. The emitted `ExternalAgentRegistered` event echoes
+    ///      `parent_session_key` so live consumers can stitch the
+    ///      registration onto the parent's stream as it happens.
+    ///   2. The persisted submission in `session_store` retains
+    ///      `parent_session_key` so an offline replay of the child session
+    ///      can reproduce the parent linkage without re-querying live state.
+    ///
+    /// Both surfaces already wire `parent_session_key` through (see
+    /// `submission_event` and `submission_handler`'s `StoredSubmission`
+    /// build); this test pins that contract so a future seam refactor can't
+    /// silently drop the field and erase the M1 nesting evidence.
+    #[tokio::test]
+    async fn submissions_route_register_preserves_parent_session_key_for_nesting() {
+        let state = test_state();
+        let session_store = Arc::clone(&state.session_store);
+        let app = build_router(state);
+
+        let mut submission =
+            external_agent_register_submission("ext-nested-child", "agent:sera");
+        submission.parent_session_key = Some("parent-session-A".to_string());
+        let submission_id = submission.id;
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/submissions")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&submission).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 8192)
+            .await
+            .unwrap();
+        let event: sera_gateway::envelope::Event =
+            serde_json::from_slice(&body).expect("response decodes as Event");
+        assert!(
+            matches!(
+                event.msg,
+                sera_gateway::envelope::EventMsg::ExternalAgentRegistered { .. }
+            ),
+            "expected ExternalAgentRegistered, got {:?}",
+            event.msg,
+        );
+        assert_eq!(
+            event.parent_session_key.as_deref(),
+            Some("parent-session-A"),
+            "emitted event must echo parent_session_key for one-EventStream nesting",
+        );
+
+        let replayed = session_store.replay("ext-nested-child").await.unwrap();
+        assert_eq!(replayed.len(), 1, "registration must persist exactly once");
+        assert_eq!(
+            replayed[0].id, submission_id,
+            "persisted submission must be the one we sent",
+        );
+        assert_eq!(
+            replayed[0].parent_session_key.as_deref(),
+            Some("parent-session-A"),
+            "persisted submission must retain parent_session_key for offline replay",
+        );
+    }
+
     #[test]
     fn submissions_route_register_validator_tracks_manifest_updates() {
         let manifests = Arc::new(std::sync::RwLock::new(test_manifests()));


### PR DESCRIPTION
## Summary
- Adds one regression-guard integration test that drives Pattern B `Op::Register(ExternalAgent)` through the live gateway router with `parent_session_key=Some(_)` and asserts the link survives both the emitted `ExternalAgentRegistered` event and the persisted `Submission` in the session store.
- No production code changes — pins the contract that `submission_event` and `submission_handler` already implement so a future seam refactor cannot silently drop the field and erase the M1 nesting evidence.

## Why this advances `sera-plcv` M1
- Bead `sera-plcv` AC4 says a top-level `Op::UserTurn` that delegates first to Hermes (Pattern A) then to a Claude Code session (Pattern B) must produce **exactly one EventStream with both nested**. That nesting is observable downstream only if `parent_session_key` survives the registration path — every existing route / registry / persistence test today passes `parent_session_key: None`, so the production wire-through was load-bearing for AC2/AC3 with zero coverage.
- AC4 (audit chain) and AC5 (kill-switch rollback) are already merged (#1244, #1246). AC1/AC2/AC3 full side-by-side delegation proof remains unproven; this slice closes one well-defined gap (the nesting invariant on the registration path) without redeploying live SERA or touching the PA-3 `/api/chat` path.

## Verification
```
cargo test -p sera-gateway --bin sera-gateway submissions_route_register_preserves_parent_session_key_for_nesting
# → 1 passed, 326 filtered out

cargo test -p sera-gateway --test register_op_external_agent
# → 8 passed; 0 failed

cargo test -p sera-gateway --bin sera-gateway submissions_route_register
# → 5 passed (4 existing + the new one)

cargo test -p sera-gateway --bin sera-gateway external_agent_register_audit
# → 4 passed
```

## sera-plcv acceptance state after this PR
- Advances: AC2/AC3 — `parent_session_key` nesting invariant on Pattern B registration is now pinned by an end-to-end test.
- Still unproven on `main`: AC1/AC2/AC3 full Hermes (Pattern A) + Claude Code (Pattern B) side-by-side delegation under one `Op::UserTurn`, including the cross-harness EventStream stitch and per-delegation budget attribution. AC4 audit chain (merged #1244) and AC5 kill-switch rollback (merged #1246) remain green.

## Test plan
- [x] Targeted test passes locally
- [x] All other `submissions_route_register*` tests still pass
- [x] `register_op_external_agent.rs` integration tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)