### PR TITLE
feat(gateway): production-path BYOH dispatch interceptor on Stdio (sera-plcv M1 AC2)

### DIFF
--- a/rust/crates/sera-gateway/src/byoh_dispatch_interceptor.rs
+++ b/rust/crates/sera-gateway/src/byoh_dispatch_interceptor.rs
@@ -1,0 +1,266 @@
+//! BYOH dispatch interceptor (sera-plcv M1 AC2, production-path slice).
+//!
+//! Pattern A only — Pattern B sessions do not share a tool catalog with the
+//! gateway, so this module's contract does not apply there.
+//!
+//! ## What this is
+//!
+//! A gateway-owned transport decorator that applies
+//! [`ByohCatalogRegistry::prepare_outbound_call`] to every
+//! [`EventMsg::ToolCallBegin`] frame as it crosses the Stdio/NDJSON seam from a
+//! BYOH harness. When the registry decides the harness's emitted name must be
+//! suppressed and forwarded as a canonical (e.g. Hermes `Read` →
+//! `read_file`), the interceptor rewrites the `tool` field on the event
+//! *before* it reaches any consumer.
+//!
+//! This is the production-path counterpart to the in-process composition
+//! probe pinned by [`hermes_pattern_a_stdio_dispatch`]: that test consults the
+//! registry from inside the test loop, which only proves the contract is
+//! consultable. This module proves the contract is *automatically* applied at
+//! the transport seam, regardless of what the consumer remembers to do.
+//!
+//! ## What this is not
+//!
+//! - Not a registration channel. Registration uses the existing canonical
+//!   seam, [`ByohCatalogRegistry::register_harness`]. A wire-level
+//!   `Op::Register(RegisterOp::ByohCatalog)` variant is a follow-up that
+//!   requires a public protocol change; until then, the gateway pre-registers
+//!   harnesses out-of-band.
+//! - Not a harness-side enforcer. The harness is still responsible for not
+//!   invoking its own internal implementation when the catalog says
+//!   suppressed; this interceptor only guarantees the gateway sees the
+//!   canonical name.
+//! - Not a strict failure mode. If the registry returns an error
+//!   (unregistered harness, unknown tool), the interceptor passes the frame
+//!   through unchanged. Hard failure on unknown harnesses belongs with the
+//!   downstream dispatcher.
+//!
+//! [`hermes_pattern_a_stdio_dispatch`]: ../../tests/hermes_pattern_a_stdio_dispatch.rs
+
+use std::pin::Pin;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tokio_stream::{Stream, StreamExt};
+
+use crate::byoh_registration::{ByohCatalogRegistry, OutboundCallDecision};
+use crate::envelope::{Event, EventMsg, Submission};
+use crate::transport::{Transport, TransportError};
+
+/// Rewrite a single [`Event`] using the registry's outbound-call decision for
+/// the given `harness_id`.
+///
+/// When the event is a [`EventMsg::ToolCallBegin`] *and* the registry says
+/// `SuppressInternalAndForward { canonical }` *and* the canonical name
+/// differs from the emitted name, returns a new [`Event`] with the
+/// `tool` field replaced. Otherwise returns the input unchanged.
+///
+/// All other [`OutboundCallDecision`] outcomes and all
+/// [`crate::byoh_registration::DispatchError`] cases pass through. See module
+/// docs for the rationale.
+pub fn intercept_outbound_event(
+    registry: &ByohCatalogRegistry,
+    harness_id: &str,
+    mut event: Event,
+) -> Event {
+    let canonical_rewrite: Option<String> = match &event.msg {
+        EventMsg::ToolCallBegin { tool, .. } => match registry
+            .prepare_outbound_call(harness_id, tool)
+        {
+            Ok(OutboundCallDecision::SuppressInternalAndForward { canonical })
+                if canonical != *tool =>
+            {
+                Some(canonical)
+            }
+            _ => None,
+        },
+        _ => None,
+    };
+
+    if let Some(canonical) = canonical_rewrite
+        && let EventMsg::ToolCallBegin { tool, .. } = &mut event.msg
+    {
+        *tool = canonical;
+    }
+
+    event
+}
+
+/// Transport decorator that wraps an inner [`Transport`] reading from a
+/// Pattern A BYOH harness and applies [`intercept_outbound_event`] to every
+/// frame in `recv_events`. `send_submission` and `close` are forwarded
+/// untouched.
+pub struct ByohInterceptingTransport {
+    inner: Box<dyn Transport>,
+    registry: Arc<ByohCatalogRegistry>,
+    harness_id: String,
+}
+
+impl ByohInterceptingTransport {
+    /// Wrap `inner` so its outbound `ToolCallBegin` frames are rewritten via
+    /// `registry` for the given `harness_id`.
+    pub fn new(
+        inner: Box<dyn Transport>,
+        registry: Arc<ByohCatalogRegistry>,
+        harness_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            inner,
+            registry,
+            harness_id: harness_id.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl Transport for ByohInterceptingTransport {
+    async fn send_submission(&self, submission: Submission) -> Result<(), TransportError> {
+        self.inner.send_submission(submission).await
+    }
+
+    async fn recv_events(
+        &self,
+    ) -> Result<Pin<Box<dyn Stream<Item = Event> + Send>>, TransportError> {
+        let inner_stream = self.inner.recv_events().await?;
+        let registry = Arc::clone(&self.registry);
+        let harness_id = self.harness_id.clone();
+        let mapped = inner_stream
+            .map(move |evt| intercept_outbound_event(&registry, &harness_id, evt));
+        Ok(Box::pin(mapped))
+    }
+
+    async fn close(&self) -> Result<(), TransportError> {
+        self.inner.close().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::byoh_catalog::{GatewayToolDecl, HarnessCatalog, HarnessToolDecl};
+    use chrono::Utc;
+    use serde_json::json;
+    use uuid::Uuid;
+
+    fn h(name: &str) -> HarnessToolDecl {
+        HarnessToolDecl {
+            name: name.to_string(),
+            description: format!("harness {name}"),
+            schema: json!({"type": "object"}),
+        }
+    }
+
+    fn g(name: &str, aliases: &[&str]) -> GatewayToolDecl {
+        GatewayToolDecl {
+            name: name.to_string(),
+            aliases: aliases.iter().map(|s| s.to_string()).collect(),
+            description: format!("gateway {name}"),
+            schema: json!({"type": "object", "properties": {"path": {"type": "string"}}}),
+        }
+    }
+
+    fn tool_call_begin(tool: &str) -> Event {
+        Event {
+            id: Uuid::nil(),
+            submission_id: Uuid::nil(),
+            msg: EventMsg::ToolCallBegin {
+                turn_id: Uuid::nil(),
+                call_id: "call-1".into(),
+                tool: tool.to_string(),
+                arguments: json!({"path": "/etc/passwd"}),
+            },
+            trace: Default::default(),
+            timestamp: Utc::now(),
+            parent_session_key: None,
+            parent_task_id: None,
+        }
+    }
+
+    fn registered_registry() -> ByohCatalogRegistry {
+        let registry = ByohCatalogRegistry::new(vec![g("read_file", &["Read"])]);
+        registry
+            .register_harness(HarnessCatalog {
+                harness_id: "hermes-acp".into(),
+                tools: vec![h("Read"), h("Bash")],
+            })
+            .expect("registration ok");
+        registry
+    }
+
+    #[test]
+    fn aliased_tool_call_begin_is_rewritten_to_canonical() {
+        let registry = registered_registry();
+        let evt = intercept_outbound_event(&registry, "hermes-acp", tool_call_begin("Read"));
+        match evt.msg {
+            EventMsg::ToolCallBegin { tool, arguments, .. } => {
+                assert_eq!(tool, "read_file", "alias must be rewritten");
+                assert_eq!(arguments["path"], "/etc/passwd", "args untouched");
+            }
+            other => panic!("expected ToolCallBegin, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn passthrough_tool_call_begin_is_unchanged() {
+        let registry = registered_registry();
+        let evt = intercept_outbound_event(&registry, "hermes-acp", tool_call_begin("Bash"));
+        match evt.msg {
+            EventMsg::ToolCallBegin { tool, .. } => assert_eq!(tool, "Bash"),
+            other => panic!("expected ToolCallBegin, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn canonical_name_is_left_unchanged() {
+        // The harness emits the canonical itself — no rewrite needed.
+        let registry = registered_registry();
+        let evt = intercept_outbound_event(&registry, "hermes-acp", tool_call_begin("read_file"));
+        match evt.msg {
+            EventMsg::ToolCallBegin { tool, .. } => assert_eq!(tool, "read_file"),
+            other => panic!("expected ToolCallBegin, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unregistered_harness_passes_through_unchanged() {
+        // Documented graceful path: an unregistered harness is the
+        // dispatcher's problem, not the interceptor's.
+        let registry = ByohCatalogRegistry::new(vec![g("read_file", &["Read"])]);
+        let evt = intercept_outbound_event(&registry, "ghost", tool_call_begin("Read"));
+        match evt.msg {
+            EventMsg::ToolCallBegin { tool, .. } => assert_eq!(tool, "Read"),
+            other => panic!("expected ToolCallBegin, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unknown_tool_passes_through_unchanged() {
+        let registry = registered_registry();
+        let evt = intercept_outbound_event(&registry, "hermes-acp", tool_call_begin("Mystery"));
+        match evt.msg {
+            EventMsg::ToolCallBegin { tool, .. } => assert_eq!(tool, "Mystery"),
+            other => panic!("expected ToolCallBegin, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn non_tool_call_event_passes_through_unchanged() {
+        let registry = registered_registry();
+        let evt = Event {
+            id: Uuid::nil(),
+            submission_id: Uuid::nil(),
+            msg: EventMsg::StreamingDelta {
+                delta: "hello".into(),
+            },
+            trace: Default::default(),
+            timestamp: Utc::now(),
+            parent_session_key: None,
+            parent_task_id: None,
+        };
+        let after = intercept_outbound_event(&registry, "hermes-acp", evt);
+        match after.msg {
+            EventMsg::StreamingDelta { delta } => assert_eq!(delta, "hello"),
+            other => panic!("expected StreamingDelta, got {other:?}"),
+        }
+    }
+}

--- a/rust/crates/sera-gateway/src/lib.rs
+++ b/rust/crates/sera-gateway/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod admin;
 pub mod agent_transport;
 pub mod byoh_catalog;
+pub mod byoh_dispatch_interceptor;
 pub mod byoh_registration;
 pub mod capability_enforcement;
 pub mod embedded_transport;

--- a/rust/crates/sera-gateway/tests/hermes_pattern_a_stdio_byoh_interceptor.rs
+++ b/rust/crates/sera-gateway/tests/hermes_pattern_a_stdio_byoh_interceptor.rs
@@ -1,0 +1,253 @@
+//! sera-plcv M1 AC2 (Pattern A, production-path slice): a wire-level Stdio
+//! probe asserting that the gateway-owned [`ByohInterceptingTransport`]
+//! decorator automatically applies [`ByohCatalogRegistry::prepare_outbound_call`]
+//! to a harness-emitted `ToolCallBegin`, rewriting the alias `Read` to the
+//! canonical `read_file` *before* it reaches any consumer.
+//!
+//! ## What this proves over PR #1252
+//!
+//! `tests/hermes_pattern_a_stdio_dispatch.rs` (PR #1252) composed
+//! [`AppServerTransport::Stdio`] (sera-5mbr) with [`ByohCatalogRegistry`]
+//! (sera-w2dh) but did the rewrite inline in the test loop. That proves the
+//! contract is *consultable*; it does not prove the contract is *enforced* on
+//! the production transport path. A real consumer that forgot to call
+//! `prepare_outbound_call` would silently emit the harness alias to gateway
+//! dispatch — capability laundering.
+//!
+//! This test moves the dispatch decision into a transport-layer wrapper:
+//!
+//! 1. Spawn the same Hermes-shaped Stdio child as PR #1252 (one
+//!    `ToolCallBegin` with `tool="Read"`, then `TurnCompleted`).
+//! 2. Pre-register the harness catalog on the gateway (canonical registration
+//!    seam — wire-level `Op::Register(RegisterOp::ByohCatalog)` is a public
+//!    protocol change tracked as a follow-up).
+//! 3. Wrap the live Stdio transport with [`ByohInterceptingTransport`].
+//! 4. Drive `recv_events` from the *wrapped* transport.
+//! 5. Assert the consumer observes `tool == "read_file"` — no test-side call
+//!    to the registry, because the wrapper applies the decision.
+//!
+//! ## What this still does not prove
+//!
+//! - Wire-level catalog registration over the Stdio NDJSON channel. Today
+//!   the registry is seeded out-of-band; an `Op::Register(RegisterOp::ByohCatalog)`
+//!   variant or an equivalent first-frame catalog handshake is the next slice.
+//! - Harness-side suppression of internal implementations. The interceptor
+//!   guarantees the gateway sees the canonical name; the harness must still
+//!   honour `suppressed_internals` locally.
+
+#![cfg(feature = "stdio")]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde_json::json;
+use tokio_stream::StreamExt;
+use uuid::Uuid;
+
+use sera_gateway::byoh_catalog::{GatewayToolDecl, HarnessCatalog, HarnessToolDecl};
+use sera_gateway::byoh_dispatch_interceptor::ByohInterceptingTransport;
+use sera_gateway::byoh_registration::ByohCatalogRegistry;
+use sera_gateway::envelope::{EventMsg, Op, Submission};
+use sera_gateway::transport::AppServerTransport;
+
+/// Bash one-shot identical in shape to the PR #1252 probe: emit a
+/// `ToolCallBegin` whose `tool` is the harness-internal alias `Read`, then
+/// close the turn. The interceptor under test must rewrite this frame.
+const HERMES_STDIO_PROBE_SCRIPT: &str = r#"
+read line
+echo '{"id":"00000000-0000-0000-0000-000000000010","submission_id":"00000000-0000-0000-0000-000000000000","msg":{"type":"tool_call_begin","turn_id":"00000000-0000-0000-0000-000000000020","call_id":"call-1","tool":"Read","arguments":{"path":"/etc/passwd"}},"timestamp":"2024-01-01T00:00:00Z"}'
+echo '{"id":"00000000-0000-0000-0000-000000000011","submission_id":"00000000-0000-0000-0000-000000000000","msg":{"type":"turn_completed","turn_id":"00000000-0000-0000-0000-000000000020","tokens":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}},"timestamp":"2024-01-01T00:00:00Z"}'
+"#;
+
+fn user_turn_submission() -> Submission {
+    Submission {
+        id: Uuid::new_v4(),
+        op: Op::UserTurn {
+            items: vec![json!({"role":"user","content":"read /etc/passwd"})],
+            cwd: None,
+            approval_policy: None,
+            sandbox_policy: None,
+            model_override: None,
+            effort: None,
+            final_output_schema: None,
+        },
+        trace: Default::default(),
+        change_artifact: None,
+        session_key: Some("hermes-pattern-a-session".to_string()),
+        parent_session_key: None,
+        parent_task_id: None,
+    }
+}
+
+fn h(name: &str) -> HarnessToolDecl {
+    HarnessToolDecl {
+        name: name.to_string(),
+        description: format!("hermes-acp internal {name}"),
+        schema: json!({"type": "object"}),
+    }
+}
+
+fn g(name: &str, aliases: &[&str]) -> GatewayToolDecl {
+    GatewayToolDecl {
+        name: name.to_string(),
+        aliases: aliases.iter().map(|s| s.to_string()).collect(),
+        description: format!("gateway canonical {name}"),
+        schema: json!({"type": "object", "properties": {"path": {"type": "string"}}}),
+    }
+}
+
+/// **The AC2 production-path probe.** When the live Stdio transport is
+/// wrapped with [`ByohInterceptingTransport`], a harness emitting alias
+/// `Read` lands on the consumer as canonical `read_file`. The consumer makes
+/// no call to the registry — that is the whole point.
+#[tokio::test]
+async fn intercepting_transport_rewrites_aliased_tool_call_begin_on_wire() {
+    // (1) Spawn the Hermes-ACP-shaped child via the public Stdio transport.
+    let cfg = AppServerTransport::Stdio {
+        command: "bash".to_string(),
+        args: vec!["-c".to_string(), HERMES_STDIO_PROBE_SCRIPT.to_string()],
+        env: HashMap::new(),
+    };
+    let inner = cfg
+        .connect()
+        .await
+        .expect("Stdio variant must reach a real transport (sera-5mbr)");
+
+    // (2) Pre-register the harness catalog. This is the canonical
+    //     registration seam (sera-w2dh); a wire-level
+    //     `Op::Register(RegisterOp::ByohCatalog)` is a follow-up.
+    let registry = Arc::new(ByohCatalogRegistry::new(vec![g("read_file", &["Read"])]));
+    let reconciled = registry
+        .register_harness(HarnessCatalog {
+            harness_id: "hermes-acp".into(),
+            tools: vec![h("Read"), h("Bash")],
+        })
+        .expect("registration ok (sera-w2dh)");
+    assert!(
+        reconciled.is_suppressed_internal("Read"),
+        "registration must mark harness 'Read' as suppressed"
+    );
+    assert_eq!(
+        reconciled.name_map.get("Read"),
+        Some(&"read_file".to_string()),
+        "registration must map harness 'Read' -> canonical 'read_file'"
+    );
+
+    // (3) Compose: wrap the live Stdio transport with the interceptor.
+    let transport = ByohInterceptingTransport::new(inner, Arc::clone(&registry), "hermes-acp");
+
+    // (4) Drive the wire. The consumer makes no registry call.
+    use sera_gateway::transport::Transport;
+    transport
+        .send_submission(user_turn_submission())
+        .await
+        .expect("send_submission");
+
+    let mut stream = transport.recv_events().await.expect("recv_events");
+
+    let timeout = tokio::time::sleep(Duration::from_secs(5));
+    tokio::pin!(timeout);
+
+    let mut observed_tool: Option<String> = None;
+    let mut observed_args: Option<serde_json::Value> = None;
+    let mut saw_completed = false;
+
+    loop {
+        tokio::select! {
+            _ = &mut timeout => panic!("timed out waiting for tool_call_begin / turn_completed"),
+            evt = stream.next() => {
+                let Some(evt) = evt else { break };
+                match evt.msg {
+                    EventMsg::ToolCallBegin { tool, arguments, .. } => {
+                        observed_tool = Some(tool);
+                        observed_args = Some(arguments);
+                    }
+                    EventMsg::TurnCompleted { .. } => {
+                        saw_completed = true;
+                        break;
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    // (5) AC2 production-path invariant: the alias has been rewritten by the
+    //     transport layer before the consumer saw it.
+    let observed_tool = observed_tool.expect("must observe a ToolCallBegin frame");
+    let observed_args = observed_args.expect("must observe arguments");
+    assert_eq!(
+        observed_tool, "read_file",
+        "interceptor must rewrite alias 'Read' to canonical 'read_file' on the wire; got '{observed_tool}'"
+    );
+    assert_eq!(
+        observed_args["path"], "/etc/passwd",
+        "tool arguments must reach the consumer untouched"
+    );
+    assert!(saw_completed, "harness must close the turn cleanly");
+
+    transport.close().await.expect("close transport");
+}
+
+/// Negative control: with a non-colliding tool name, the interceptor must not
+/// alter the frame. Proves the wrapper is selective, not a blanket rewriter.
+#[tokio::test]
+async fn intercepting_transport_does_not_rewrite_non_colliding_tool() {
+    const NON_COLLIDING_PROBE: &str = r#"
+read line
+echo '{"id":"00000000-0000-0000-0000-000000000010","submission_id":"00000000-0000-0000-0000-000000000000","msg":{"type":"tool_call_begin","turn_id":"00000000-0000-0000-0000-000000000020","call_id":"call-2","tool":"Bash","arguments":{"cmd":"ls"}},"timestamp":"2024-01-01T00:00:00Z"}'
+echo '{"id":"00000000-0000-0000-0000-000000000011","submission_id":"00000000-0000-0000-0000-000000000000","msg":{"type":"turn_completed","turn_id":"00000000-0000-0000-0000-000000000020","tokens":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}},"timestamp":"2024-01-01T00:00:00Z"}'
+"#;
+
+    let cfg = AppServerTransport::Stdio {
+        command: "bash".to_string(),
+        args: vec!["-c".to_string(), NON_COLLIDING_PROBE.to_string()],
+        env: HashMap::new(),
+    };
+    let inner = cfg.connect().await.expect("spawn");
+
+    let registry = Arc::new(ByohCatalogRegistry::new(vec![g("read_file", &["Read"])]));
+    registry
+        .register_harness(HarnessCatalog {
+            harness_id: "hermes-acp".into(),
+            tools: vec![h("Read"), h("Bash")],
+        })
+        .expect("registration ok");
+
+    let transport = ByohInterceptingTransport::new(inner, Arc::clone(&registry), "hermes-acp");
+
+    use sera_gateway::transport::Transport;
+    transport
+        .send_submission(user_turn_submission())
+        .await
+        .expect("send_submission");
+    let mut stream = transport.recv_events().await.expect("recv_events");
+
+    let timeout = tokio::time::sleep(Duration::from_secs(5));
+    tokio::pin!(timeout);
+
+    let mut observed_tool: Option<String> = None;
+    let mut saw_completed = false;
+    loop {
+        tokio::select! {
+            _ = &mut timeout => panic!("timed out"),
+            evt = stream.next() => {
+                let Some(evt) = evt else { break };
+                match evt.msg {
+                    EventMsg::ToolCallBegin { tool, .. } => observed_tool = Some(tool),
+                    EventMsg::TurnCompleted { .. } => { saw_completed = true; break; }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    assert_eq!(
+        observed_tool.as_deref(),
+        Some("Bash"),
+        "non-colliding tool must pass through unchanged"
+    );
+    assert!(saw_completed);
+    transport.close().await.expect("close");
+}


### PR DESCRIPTION
## Summary

- Adds `byoh_dispatch_interceptor` (sera-gateway): a transport decorator that automatically applies `ByohCatalogRegistry::prepare_outbound_call` to every harness-emitted `EventMsg::ToolCallBegin` as it crosses the Stdio/NDJSON seam. When the registry decides *suppress + forward as canonical* (e.g. Hermes alias `Read` → `read_file`), the `tool` field is rewritten on the wire before any consumer sees it.
- New integration test `hermes_pattern_a_stdio_byoh_interceptor.rs` proves the rewrite happens at the transport layer with no test-side registry call (the production-path advance over PR #1252's in-process composition probe).
- Wire-level catalog registration over NDJSON (`Op::Register(RegisterOp::ByohCatalog)`) remains a follow-up — see report. This slice uses the canonical in-process registration seam (`ByohCatalogRegistry::register_harness`), which the task explicitly accepts as the nearest seam.

## Why this advances `sera-plcv` AC2

PR #1252 (https://github.com/TKCen/sera/pull/1252, squash `df34e52c`) proved the registry contract is *consultable* in-process — but the dispatch decision lived inside the test loop. A real consumer that forgot to call `prepare_outbound_call` would silently emit harness aliases to gateway dispatch (capability laundering). This slice moves the decision into the transport layer, so the gateway sees canonical names by construction whenever `ByohInterceptingTransport` wraps the Stdio transport.

## Test plan

- [x] `cargo test -p sera-gateway --features stdio --test hermes_pattern_a_stdio_byoh_interceptor --test hermes_pattern_a_stdio_dispatch --test byoh_registration_handshake` — 6 passed (new production-path probe + PR #1252 composition probe + sera-w2dh handshake).
- [x] `cargo test -p sera-gateway --lib byoh_dispatch_interceptor` — 6 unit tests passed (rewrite path, passthrough, canonical-equals-emitted, unregistered-harness graceful pass, unknown-tool graceful pass, non-`ToolCallBegin` untouched).
- [x] `cargo test -p sera-gateway --features stdio` — full lib unit tests `214 passed`. Two pre-existing failures in `bin "sera-gateway" test` (`production_e2e::{discord,http_chat}_path_round_trip`) are environment-only — they panic at `sera-gateway/src/bin/sera.rs:12310` with "sera-runtime binary not found", same on origin/main `1202724e`.
- [x] `cargo clippy -p sera-gateway --lib --features stdio -- -D warnings` — clean.
- [ ] Wire-level `Op::Register(RegisterOp::ByohCatalog)` NDJSON handshake — out of scope for this slice; tracked as follow-up in OMC report.

Pre-existing clippy noise (MutexGuard-across-await in `bin/sera.rs` and `constitutional_config.rs`, unused `DynLoopbackTransport` import in `routes/a2a.rs`) is unrelated to this slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)