### PR TITLE
feat(gateway): Discord typing + reactions and guarded peer-bot handoff

### DIFF
--- a/rust/crates/sera-config/src/manifest_loader.rs
+++ b/rust/crates/sera-config/src/manifest_loader.rs
@@ -499,6 +499,54 @@ spec:
         assert_eq!(spec.kind, "discord");
         assert_eq!(spec.agent.as_deref(), Some("sera"));
         assert_eq!(spec.token.unwrap().secret, "connectors/discord-main/token");
+        // peer_bots defaults to empty when absent — strict default
+        // (sera-yeg.1): no peer bots accepted unless explicitly listed.
+        assert!(spec.peer_bots.is_empty());
+    }
+
+    #[test]
+    fn connector_spec_peer_bots_parses_list() {
+        let yaml = r#"
+apiVersion: sera.dev/v1
+kind: Connector
+metadata:
+  name: discord-main
+spec:
+  kind: discord
+  token:
+    secret: connectors/discord-main/token
+  agent: sera
+  peer_bots:
+    - "987654321012345678"
+    - "Sera 2.0"
+"#;
+        let set = parse_manifests(yaml).unwrap();
+        let spec = set.connector_spec("discord-main").unwrap().unwrap();
+        assert_eq!(
+            spec.peer_bots,
+            vec!["987654321012345678".to_string(), "Sera 2.0".to_string()],
+        );
+    }
+
+    #[test]
+    fn connector_spec_peer_bots_accepts_camel_case_alias() {
+        // YAML conventions vary; accept both `peer_bots` and `peerBots`
+        // so operators following the camelCase convention used by some
+        // other specs in this repo aren't surprised.
+        let yaml = r#"
+apiVersion: sera.dev/v1
+kind: Connector
+metadata:
+  name: discord-main
+spec:
+  kind: discord
+  agent: sera
+  peerBots:
+    - hermes-bot-id
+"#;
+        let set = parse_manifests(yaml).unwrap();
+        let spec = set.connector_spec("discord-main").unwrap().unwrap();
+        assert_eq!(spec.peer_bots, vec!["hermes-bot-id".to_string()]);
     }
 
     #[test]

--- a/rust/crates/sera-gateway/src/bin/sera.rs
+++ b/rust/crates/sera-gateway/src/bin/sera.rs
@@ -4739,23 +4739,12 @@ async fn process_message(state: &AppState, msg: &DiscordMessage) -> anyhow::Resu
         "Received Discord message"
     );
 
-    // Filter: Only respond to DMs or when mentioned.
-    // Ignore messages in other channels that don't mention the bot.
+    // Gate the message through `gate_message` so bot-authored messages run
+    // through the peer-bot policy *before* the generic human/public-channel
+    // filter (sera-yeg.1 repair). Without this ordering, unrelated bots and
+    // peer bots without handoff in public channels were silently dropped
+    // before any audit row was written.
     let is_explicit_handoff = msg.is_dm || msg.mentions_bot;
-    if !is_explicit_handoff {
-        tracing::debug!(
-            user = %msg.username,
-            channel = %msg.channel_id,
-            "Ignoring message - not a DM and bot not mentioned"
-        );
-        return Ok(());
-    }
-
-    // Peer-bot policy (sera-yeg.1). Reads configured `peer_bots` from the
-    // Discord connector spec. Self bot is already dropped at parse time but
-    // we keep the defense-in-depth check; unrelated bots and peer bots
-    // without explicit handoff are recorded in the audit log with a reason
-    // so this failure mode stays visible to operators.
     let peer_bots: Vec<String> = {
         let manifests = state.manifests.read().unwrap();
         manifests
@@ -4776,7 +4765,7 @@ async fn process_message(state: &AppState, msg: &DiscordMessage) -> anyhow::Resu
         .discord
         .as_ref()
         .and_then(|dc| dc.bot_user_id());
-    let policy = crate::discord::decide_bot_policy(
+    let gate = crate::discord::gate_message(
         msg.is_bot,
         &msg.user_id,
         &msg.username,
@@ -4784,34 +4773,45 @@ async fn process_message(state: &AppState, msg: &DiscordMessage) -> anyhow::Resu
         is_explicit_handoff,
         &peer_bots,
     );
-    if policy != crate::discord::BotPolicyDecision::Accept {
-        tracing::info!(
-            user = %msg.username,
-            user_id = %msg.user_id,
-            channel = %msg.channel_id,
-            reason = %policy.audit_reason(),
-            "Ignoring bot message under peer-bot policy"
-        );
-        {
-            let db = state.db.lock().await;
-            let _ = db.append_audit(
-                "discord_message_ignored",
-                &msg.user_id,
-                "agent",
-                Some(
-                    &serde_json::json!({
-                        "username": msg.username,
-                        "channel_id": msg.channel_id,
-                        "reason": policy.audit_reason(),
-                        "is_bot": msg.is_bot,
-                        "mentions_bot": msg.mentions_bot,
-                        "is_dm": msg.is_dm,
-                    })
-                    .to_string(),
-                ),
+    match gate {
+        crate::discord::MessageGateDecision::IgnoreHumanNoHandoff => {
+            tracing::debug!(
+                user = %msg.username,
+                channel = %msg.channel_id,
+                "Ignoring message - not a DM and bot not mentioned"
             );
+            return Ok(());
         }
-        return Ok(());
+        crate::discord::MessageGateDecision::IgnoreBot(decision) => {
+            tracing::info!(
+                user = %msg.username,
+                user_id = %msg.user_id,
+                channel = %msg.channel_id,
+                reason = %decision.audit_reason(),
+                "Ignoring bot message under peer-bot policy"
+            );
+            {
+                let db = state.db.lock().await;
+                let _ = db.append_audit(
+                    "discord_message_ignored",
+                    &msg.user_id,
+                    "agent",
+                    Some(
+                        &serde_json::json!({
+                            "username": msg.username,
+                            "channel_id": msg.channel_id,
+                            "reason": decision.audit_reason(),
+                            "is_bot": msg.is_bot,
+                            "mentions_bot": msg.mentions_bot,
+                            "is_dm": msg.is_dm,
+                        })
+                        .to_string(),
+                    ),
+                );
+            }
+            return Ok(());
+        }
+        crate::discord::MessageGateDecision::Accept => {}
     }
 
     // Principal kind: peer-bot handoffs are classified as Agent so audit /
@@ -8874,6 +8874,134 @@ spec:
         assert_eq!(transcript[1].role, "assistant");
         // The reply will be an error (no real LLM), but it should be recorded.
         assert!(transcript[1].content.is_some());
+    }
+
+    /// Patch the discord connector spec in `state.manifests` to set
+    /// `peer_bots = peers`. Tests below need this because the default
+    /// `TEMPLATE_YAML` leaves peer_bots empty.
+    fn inject_peer_bots(state: &AppState, peers: &[&str]) {
+        let mut manifests = state.manifests.write().unwrap();
+        for cm in &mut manifests.connectors {
+            if let Some(obj) = cm.spec.as_object_mut()
+                && obj.get("kind").and_then(|k| k.as_str()) == Some("discord")
+            {
+                obj.insert(
+                    "peer_bots".to_string(),
+                    serde_json::json!(peers.iter().map(|p| p.to_string()).collect::<Vec<_>>()),
+                );
+            }
+        }
+    }
+
+    /// Repair regression test (sera-yeg.1): an unrelated bot posting in a
+    /// guild channel without DM/@-mention used to be silently dropped by
+    /// the `!is_explicit_handoff` early return *before* the peer-bot
+    /// policy ran. `process_message` must now route through the bot
+    /// policy first and emit a `discord_message_ignored` audit row with
+    /// reason `ignored_unrelated_bot`.
+    #[tokio::test]
+    async fn process_message_audits_unrelated_bot_in_public_channel() {
+        let state = test_state_async().await;
+        inject_peer_bots(&state, &["peer-1"]);
+
+        let msg = DiscordMessage {
+            channel_id: "ch_pub".into(),
+            user_id: "stranger-bot".into(),
+            username: "stranger".into(),
+            content: "noise".into(),
+            message_id: "msg_unrelated_pub".into(),
+            // The key scenario: not a DM, no @-mention. Pre-repair this
+            // would have hit the silent human early-return.
+            is_dm: false,
+            mentions_bot: false,
+            is_bot: true,
+        };
+        process_message(&state, &msg).await.expect("process_message");
+
+        let db = state.db.lock().await;
+        let audits = db.query_audit(50).expect("query_audit");
+        let ignored: Vec<&_> = audits
+            .iter()
+            .filter(|a| a.event_type == "discord_message_ignored")
+            .collect();
+        assert_eq!(ignored.len(), 1, "expected one ignored audit row");
+        let row = ignored[0];
+        assert_eq!(row.actor_id, "stranger-bot");
+        let details: serde_json::Value =
+            serde_json::from_str(row.details.as_deref().expect("details")).unwrap();
+        assert_eq!(details["reason"], "ignored_unrelated_bot");
+        assert_eq!(details["is_bot"], true);
+        assert_eq!(details["is_dm"], false);
+        assert_eq!(details["mentions_bot"], false);
+    }
+
+    /// Repair regression test (sera-yeg.1): a *configured* peer bot
+    /// posting in a guild channel without DM/@-mention must surface as
+    /// `ignored_peer_bot_no_handoff` in the live audit log. Pre-repair
+    /// this path also disappeared via the human early return.
+    #[tokio::test]
+    async fn process_message_audits_peer_bot_without_handoff() {
+        let state = test_state_async().await;
+        inject_peer_bots(&state, &["peer-1"]);
+
+        let msg = DiscordMessage {
+            channel_id: "ch_pub".into(),
+            user_id: "peer-1".into(),
+            username: "hermes".into(),
+            content: "drive-by chatter".into(),
+            message_id: "msg_peer_no_handoff".into(),
+            is_dm: false,
+            mentions_bot: false,
+            is_bot: true,
+        };
+        process_message(&state, &msg).await.expect("process_message");
+
+        let db = state.db.lock().await;
+        let audits = db.query_audit(50).expect("query_audit");
+        let ignored: Vec<&_> = audits
+            .iter()
+            .filter(|a| a.event_type == "discord_message_ignored")
+            .collect();
+        assert_eq!(ignored.len(), 1, "expected one ignored audit row");
+        let details: serde_json::Value = serde_json::from_str(
+            ignored[0].details.as_deref().expect("details"),
+        )
+        .unwrap();
+        assert_eq!(details["reason"], "ignored_peer_bot_no_handoff");
+    }
+
+    /// Preserve the original human behavior: a human message in a guild
+    /// channel without an @-mention must still be silently ignored — no
+    /// `discord_message_ignored` audit row, no LLM call. The bug repair
+    /// changed bot ordering but must not have made humans noisier.
+    #[tokio::test]
+    async fn process_message_human_no_handoff_stays_silent() {
+        let state = test_state_async().await;
+
+        let msg = DiscordMessage {
+            channel_id: "ch_pub".into(),
+            user_id: "alice".into(),
+            username: "alice".into(),
+            content: "hey channel".into(),
+            message_id: "msg_human_pub".into(),
+            is_dm: false,
+            mentions_bot: false,
+            is_bot: false,
+        };
+        process_message(&state, &msg).await.expect("process_message");
+
+        let db = state.db.lock().await;
+        let audits = db.query_audit(50).expect("query_audit");
+        assert!(
+            audits
+                .iter()
+                .all(|a| a.event_type != "discord_message_ignored"),
+            "human non-handoff must not create an ignored audit row",
+        );
+        assert!(
+            audits.iter().all(|a| a.event_type != "discord_message"),
+            "human non-handoff must not record a received audit either",
+        );
     }
 
     #[tokio::test]

--- a/rust/crates/sera-gateway/src/bin/sera.rs
+++ b/rust/crates/sera-gateway/src/bin/sera.rs
@@ -4735,12 +4735,14 @@ async fn process_message(state: &AppState, msg: &DiscordMessage) -> anyhow::Resu
         channel = %msg.channel_id,
         is_dm = %msg.is_dm,
         mentions_bot = %msg.mentions_bot,
+        is_bot = %msg.is_bot,
         "Received Discord message"
     );
 
     // Filter: Only respond to DMs or when mentioned.
     // Ignore messages in other channels that don't mention the bot.
-    if !msg.is_dm && !msg.mentions_bot {
+    let is_explicit_handoff = msg.is_dm || msg.mentions_bot;
+    if !is_explicit_handoff {
         tracing::debug!(
             user = %msg.username,
             channel = %msg.channel_id,
@@ -4749,33 +4751,164 @@ async fn process_message(state: &AppState, msg: &DiscordMessage) -> anyhow::Resu
         return Ok(());
     }
 
+    // Peer-bot policy (sera-yeg.1). Reads configured `peer_bots` from the
+    // Discord connector spec. Self bot is already dropped at parse time but
+    // we keep the defense-in-depth check; unrelated bots and peer bots
+    // without explicit handoff are recorded in the audit log with a reason
+    // so this failure mode stays visible to operators.
+    let peer_bots: Vec<String> = {
+        let manifests = state.manifests.read().unwrap();
+        manifests
+            .connectors
+            .iter()
+            .filter_map(|c| {
+                let spec: ConnectorSpec = serde_json::from_value(c.spec.clone()).ok()?;
+                if spec.kind == "discord" {
+                    Some(spec.peer_bots)
+                } else {
+                    None
+                }
+            })
+            .next()
+            .unwrap_or_default()
+    };
+    let self_bot_id = state
+        .discord
+        .as_ref()
+        .and_then(|dc| dc.bot_user_id());
+    let policy = crate::discord::decide_bot_policy(
+        msg.is_bot,
+        &msg.user_id,
+        &msg.username,
+        self_bot_id.as_deref(),
+        is_explicit_handoff,
+        &peer_bots,
+    );
+    if policy != crate::discord::BotPolicyDecision::Accept {
+        tracing::info!(
+            user = %msg.username,
+            user_id = %msg.user_id,
+            channel = %msg.channel_id,
+            reason = %policy.audit_reason(),
+            "Ignoring bot message under peer-bot policy"
+        );
+        {
+            let db = state.db.lock().await;
+            let _ = db.append_audit(
+                "discord_message_ignored",
+                &msg.user_id,
+                "agent",
+                Some(
+                    &serde_json::json!({
+                        "username": msg.username,
+                        "channel_id": msg.channel_id,
+                        "reason": policy.audit_reason(),
+                        "is_bot": msg.is_bot,
+                        "mentions_bot": msg.mentions_bot,
+                        "is_dm": msg.is_dm,
+                    })
+                    .to_string(),
+                ),
+            );
+        }
+        return Ok(());
+    }
+
+    // Principal kind: peer-bot handoffs are classified as Agent so audit /
+    // routing layers can distinguish them from human submissions
+    // (sera-yeg.1).
+    let principal_kind = if msg.is_bot {
+        PrincipalKind::Agent
+    } else {
+        PrincipalKind::Human
+    };
+    let principal_kind_str = if msg.is_bot { "agent" } else { "human" };
+
+    // UX affordance: 👀 reaction + typing indicator while we process this
+    // accepted turn (sera-yeg.2). Both degrade gracefully — failures (missing
+    // permissions, transport errors) are logged at debug and never propagate.
+    let typing_task = state
+        .discord
+        .as_ref()
+        .map(|dc| start_typing_indicator(Arc::clone(dc), msg.channel_id.clone()));
+    add_reaction_best_effort(state, &msg.channel_id, &msg.message_id, "👀").await;
+
     // Audit: Discord message received.
     {
         let db = state.db.lock().await;
         let _ = db.append_audit(
             "discord_message",
             &msg.user_id,
-            "human",
+            principal_kind_str,
             Some(
                 &serde_json::json!({
                     "username": msg.username,
                     "channel_id": msg.channel_id,
                     "message_len": msg.content.len(),
+                    "is_bot": msg.is_bot,
                 })
                 .to_string(),
             ),
         );
     }
 
+    // Run the inner turn pipeline. We wrap everything below in an async block
+    // so the typing/reaction lifecycle finalizes consistently (✅ on success,
+    // ❌ on failure) regardless of where the inner pipeline returns.
+    let outcome = process_message_inner(state, msg, is_explicit_handoff, principal_kind).await;
+    if let Some(handle) = typing_task {
+        handle.abort();
+    }
+    remove_reaction_best_effort(state, &msg.channel_id, &msg.message_id, "👀").await;
+    let final_emoji = match outcome.as_ref() {
+        Ok(TurnOutcome::Success) => Some("✅"),
+        Ok(TurnOutcome::Rejected) | Err(_) => Some("❌"),
+        Ok(TurnOutcome::Queued) => None,
+    };
+    if let Some(emoji) = final_emoji {
+        add_reaction_best_effort(state, &msg.channel_id, &msg.message_id, emoji).await;
+    }
+    outcome.map(|_| ())
+}
+
+/// Final state of an accepted Discord turn — drives the reaction lifecycle.
+enum TurnOutcome {
+    /// Turn ran to completion and a reply was sent.
+    Success,
+    /// A hook or runtime check stopped the turn before completion (a
+    /// user-facing error message was already sent). UX-wise this is the same
+    /// as a failure, so we land on ❌.
+    Rejected,
+    /// Message was queued behind another in-flight turn; no final reaction
+    /// — the dispatched turn will own the lifecycle.
+    Queued,
+}
+
+/// Inner pipeline for an accepted Discord turn. Extracted so
+/// `process_message` can finalize the UX-affordance lifecycle (typing /
+/// reaction) in one place regardless of where the pipeline returns.
+async fn process_message_inner(
+    state: &AppState,
+    msg: &DiscordMessage,
+    _is_explicit_handoff: bool,
+    principal_kind: PrincipalKind,
+) -> anyhow::Result<TurnOutcome> {
     // Load hook chains from manifests.
     let chains = state.manifests.read().unwrap().hook_chain_specs();
 
     // Build principal for hook context.
     let principal = PrincipalRef {
         id: PrincipalId::new(&msg.user_id),
-        kind: PrincipalKind::Human,
+        kind: principal_kind,
     };
-    let principal_json = serde_json::json!({"id": msg.user_id, "kind": "human"});
+    let principal_kind_str = match principal_kind {
+        PrincipalKind::Human => "human",
+        PrincipalKind::Agent => "agent",
+        PrincipalKind::ExternalAgent => "external_agent",
+        PrincipalKind::Service => "service",
+        PrincipalKind::System => "system",
+    };
+    let principal_json = serde_json::json!({"id": msg.user_id, "kind": principal_kind_str});
 
     // ── pre_route: after ingress, before agent resolution ──
     let pre_route_ctx = HookContext {
@@ -4797,7 +4930,7 @@ async fn process_message(state: &AppState, msg: &DiscordMessage) -> anyhow::Resu
         HookResult::Reject { reason, .. } => {
             tracing::info!(reason = %reason, "pre_route hook rejected message");
             send_error_to_discord(state, &msg.channel_id, reason).await;
-            return Ok(());
+            return Ok(TurnOutcome::Rejected);
         }
         HookResult::Redirect { target, .. } => {
             tracing::warn!(target = %target, "pre_route Redirect not yet supported, treating as Continue");
@@ -4832,7 +4965,7 @@ async fn process_message(state: &AppState, msg: &DiscordMessage) -> anyhow::Resu
             let err_msg = format!("Agent '{agent_name}' not found in manifests");
             tracing::error!("{err_msg}");
             send_error_to_discord(state, &msg.channel_id, &err_msg).await;
-            return Ok(());
+            return Ok(TurnOutcome::Rejected);
         }
     };
 
@@ -4845,7 +4978,7 @@ async fn process_message(state: &AppState, msg: &DiscordMessage) -> anyhow::Resu
             let err_msg = format!("No runtime supervisor for agent '{agent_name}'");
             tracing::error!("{err_msg}");
             send_error_to_discord(state, &msg.channel_id, &err_msg).await;
-            return Ok(());
+            return Ok(TurnOutcome::Rejected);
         }
     };
 
@@ -4900,7 +5033,7 @@ async fn process_message(state: &AppState, msg: &DiscordMessage) -> anyhow::Resu
         HookResult::Reject { reason, .. } => {
             tracing::info!(reason = %reason, "post_route hook rejected message");
             send_error_to_discord(state, &msg.channel_id, reason).await;
-            return Ok(());
+            return Ok(TurnOutcome::Rejected);
         }
         HookResult::Redirect { target, .. } => {
             tracing::warn!(target = %target, "post_route Redirect not yet supported, treating as Continue");
@@ -4924,7 +5057,7 @@ async fn process_message(state: &AppState, msg: &DiscordMessage) -> anyhow::Resu
         HookResult::Reject { reason, .. } => {
             tracing::info!(reason = %reason, "pre_turn hook rejected message");
             send_error_to_discord(state, &msg.channel_id, reason).await;
-            return Ok(());
+            return Ok(TurnOutcome::Rejected);
         }
         HookResult::Redirect { target, .. } => {
             tracing::warn!(target = %target, "pre_turn Redirect not yet supported, treating as Continue");
@@ -4943,11 +5076,11 @@ async fn process_message(state: &AppState, msg: &DiscordMessage) -> anyhow::Resu
             }
             sera_db::lane_queue::EnqueueResult::Queued => {
                 tracing::info!(session_key = %session_key, "Message queued behind active turn");
-                return Ok(());
+                return Ok(TurnOutcome::Queued);
             }
             sera_db::lane_queue::EnqueueResult::Steer => {
                 tracing::info!(session_key = %session_key, "Steer event queued for tool boundary injection");
-                return Ok(());
+                return Ok(TurnOutcome::Queued);
             }
             sera_db::lane_queue::EnqueueResult::Interrupt => {
                 tracing::info!(session_key = %session_key, "Interrupt: active run should be aborted");
@@ -4956,7 +5089,7 @@ async fn process_message(state: &AppState, msg: &DiscordMessage) -> anyhow::Resu
             }
             sera_db::lane_queue::EnqueueResult::Closed => {
                 tracing::warn!(session_key = %session_key, "Lane queue is closed; dropping incoming Discord message");
-                return Ok(());
+                return Ok(TurnOutcome::Rejected);
             }
         }
     }
@@ -5013,7 +5146,7 @@ async fn process_message(state: &AppState, msg: &DiscordMessage) -> anyhow::Resu
         HookResult::Reject { reason, .. } => {
             tracing::info!(reason = %reason, "post_turn hook rejected reply");
             send_error_to_discord(state, &msg.channel_id, reason).await;
-            return Ok(());
+            return Ok(TurnOutcome::Rejected);
         }
         HookResult::Redirect { target, .. } => {
             tracing::warn!(target = %target, "post_turn Redirect not yet supported, treating as Continue");
@@ -5156,7 +5289,81 @@ async fn process_message(state: &AppState, msg: &DiscordMessage) -> anyhow::Resu
         }
     }
 
-    Ok(())
+    Ok(TurnOutcome::Success)
+}
+
+/// Start a background task that periodically triggers the Discord typing
+/// indicator on `channel_id` until the returned handle is aborted. The
+/// indicator self-expires after ~10 seconds on Discord's side, so we
+/// re-trigger every 8 seconds while a turn is in flight (sera-yeg.2). All
+/// failures degrade gracefully — logged at debug level only.
+fn start_typing_indicator(
+    connector: Arc<crate::discord::DiscordConnector>,
+    channel_id: String,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        // Trigger once immediately so the indicator appears without waiting
+        // for the first interval tick.
+        if let Err(e) = connector.trigger_typing(&channel_id).await {
+            tracing::debug!(channel_id = %channel_id, error = %e, "Discord typing trigger failed");
+        }
+        let mut interval =
+            tokio::time::interval(std::time::Duration::from_secs(8));
+        // Skip the first tick (already triggered above).
+        interval.tick().await;
+        loop {
+            interval.tick().await;
+            if let Err(e) = connector.trigger_typing(&channel_id).await {
+                tracing::debug!(channel_id = %channel_id, error = %e, "Discord typing trigger failed");
+            }
+        }
+    })
+}
+
+/// Add an emoji reaction on a Discord message. Best-effort UX affordance —
+/// failures (missing permission, transport error) are logged at debug only
+/// and never propagated to the caller (sera-yeg.2).
+async fn add_reaction_best_effort(
+    state: &AppState,
+    channel_id: &str,
+    message_id: &str,
+    emoji: &str,
+) {
+    let Some(ref dc) = state.discord else {
+        return;
+    };
+    if let Err(e) = dc.add_reaction(channel_id, message_id, emoji).await {
+        tracing::debug!(
+            channel_id = %channel_id,
+            message_id = %message_id,
+            emoji = %emoji,
+            error = %e,
+            "Discord add_reaction failed (low-noise — UX affordance only)",
+        );
+    }
+}
+
+/// Remove the bot's own emoji reaction on a Discord message. Best-effort UX
+/// affordance — failures are logged at debug only and never propagated
+/// (sera-yeg.2).
+async fn remove_reaction_best_effort(
+    state: &AppState,
+    channel_id: &str,
+    message_id: &str,
+    emoji: &str,
+) {
+    let Some(ref dc) = state.discord else {
+        return;
+    };
+    if let Err(e) = dc.remove_own_reaction(channel_id, message_id, emoji).await {
+        tracing::debug!(
+            channel_id = %channel_id,
+            message_id = %message_id,
+            emoji = %emoji,
+            error = %e,
+            "Discord remove_reaction failed (low-noise — UX affordance only)",
+        );
+    }
 }
 
 // ── sera init ───────────────────────────────────────────────────────────────
@@ -8642,6 +8849,7 @@ spec:
             message_id: "msg_001".into(),
             is_dm: true, // Must be DM or mention bot to trigger processing
             mentions_bot: false,
+            is_bot: false,
         })
         .await
         .unwrap();
@@ -12918,6 +13126,7 @@ spec:
                 message_id: "msg_ov7z_1".into(),
                 is_dm: true,
                 mentions_bot: false,
+                is_bot: false,
             })
             .await
             .expect("send discord message");
@@ -13140,6 +13349,7 @@ spec:
                 message_id: "msg_ve9x_1".into(),
                 is_dm: true,
                 mentions_bot: false,
+                is_bot: false,
             })
             .await
             .expect("send discord message");

--- a/rust/crates/sera-gateway/src/bin/sera.rs
+++ b/rust/crates/sera-gateway/src/bin/sera.rs
@@ -4729,6 +4729,46 @@ async fn event_loop(state: Arc<AppState>, mut rx: mpsc::Receiver<DiscordMessage>
     }
 }
 
+/// Look up the `peer_bots` allowlist for the Discord connector that produced
+/// a given message.
+///
+/// Multiple Discord connectors can be spawned from one manifest set, each
+/// with its own `peer_bots` list. The selection boundary at
+/// [`process_message`] must therefore key off the connector identity stamped
+/// on the inbound [`DiscordMessage`] rather than folding across all
+/// connectors. The previous implementation took `.next()` on the iterator —
+/// meaning a message from connector B could be evaluated against connector
+/// A's allowlist, denying valid peer-bot handoffs or accepting unauthorized
+/// bots depending on list ordering (Codex review comment 3274130773).
+///
+/// Returns an empty `Vec` when no matching connector is found or when the
+/// message has no `connector_name` stamped (synthetic test messages that
+/// don't set one are conservatively treated as untrusted — no peer-bot
+/// admission). Extracted as a free function so tests can exercise the
+/// selection boundary directly without spinning up multiple gateway
+/// listeners.
+fn peer_bots_for_connector(
+    manifests: &sera_config::manifest_loader::ManifestSet,
+    connector_name: Option<&str>,
+) -> Vec<String> {
+    let Some(name) = connector_name else {
+        return Vec::new();
+    };
+    manifests
+        .connectors
+        .iter()
+        .find(|c| c.metadata.name == name)
+        .and_then(|c| {
+            let spec: ConnectorSpec = serde_json::from_value(c.spec.clone()).ok()?;
+            if spec.kind == "discord" {
+                Some(spec.peer_bots)
+            } else {
+                None
+            }
+        })
+        .unwrap_or_default()
+}
+
 async fn process_message(state: &AppState, msg: &DiscordMessage) -> anyhow::Result<()> {
     tracing::info!(
         user = %msg.username,
@@ -4747,19 +4787,7 @@ async fn process_message(state: &AppState, msg: &DiscordMessage) -> anyhow::Resu
     let is_explicit_handoff = msg.is_dm || msg.mentions_bot;
     let peer_bots: Vec<String> = {
         let manifests = state.manifests.read().unwrap();
-        manifests
-            .connectors
-            .iter()
-            .filter_map(|c| {
-                let spec: ConnectorSpec = serde_json::from_value(c.spec.clone()).ok()?;
-                if spec.kind == "discord" {
-                    Some(spec.peer_bots)
-                } else {
-                    None
-                }
-            })
-            .next()
-            .unwrap_or_default()
+        peer_bots_for_connector(&manifests, msg.connector_name.as_deref())
     };
     let self_bot_id = state
         .discord
@@ -6001,6 +6029,7 @@ async fn run_start(config: PathBuf, port: u16, local: bool) -> anyhow::Result<()
         let connector = Arc::new(DiscordConnector::new(
             &token,
             &agent_name,
+            &cm.metadata.name,
             discord_tx.clone(),
             Arc::clone(&shutting_down),
         ));
@@ -8850,6 +8879,7 @@ spec:
             is_dm: true, // Must be DM or mention bot to trigger processing
             mentions_bot: false,
             is_bot: false,
+            connector_name: None,
         })
         .await
         .unwrap();
@@ -8915,6 +8945,7 @@ spec:
             is_dm: false,
             mentions_bot: false,
             is_bot: true,
+            connector_name: Some("discord-main".into()),
         };
         process_message(&state, &msg).await.expect("process_message");
 
@@ -8953,6 +8984,7 @@ spec:
             is_dm: false,
             mentions_bot: false,
             is_bot: true,
+            connector_name: Some("discord-main".into()),
         };
         process_message(&state, &msg).await.expect("process_message");
 
@@ -8987,6 +9019,7 @@ spec:
             is_dm: false,
             mentions_bot: false,
             is_bot: false,
+            connector_name: None,
         };
         process_message(&state, &msg).await.expect("process_message");
 
@@ -9002,6 +9035,152 @@ spec:
             audits.iter().all(|a| a.event_type != "discord_message"),
             "human non-handoff must not record a received audit either",
         );
+    }
+
+    /// Patch `state.manifests` to contain two Discord connectors named
+    /// `connector-a` and `connector-b` with the supplied `peer_bots` lists.
+    /// Replaces the single TEMPLATE_YAML `discord-main` connector so tests
+    /// can exercise per-connector `peer_bots` selection at the actual
+    /// boundary in `process_message` (sera-yeg.1 follow-up — Codex 3274130773).
+    ///
+    /// We clone the template connector (rather than constructing one) so
+    /// the test fixture stays decoupled from the `ConfigManifest` envelope
+    /// shape — only the connector identity and `peer_bots` differ between
+    /// the two clones.
+    fn inject_two_discord_connectors(state: &AppState, a_peers: &[&str], b_peers: &[&str]) {
+        let mut manifests = state.manifests.write().unwrap();
+        let template = manifests
+            .connectors
+            .iter()
+            .find(|c| {
+                serde_json::from_value::<ConnectorSpec>(c.spec.clone())
+                    .map(|s| s.kind == "discord")
+                    .unwrap_or(false)
+            })
+            .cloned()
+            .expect("TEMPLATE_YAML provides at least one discord connector");
+        manifests.connectors.retain(|c| {
+            serde_json::from_value::<ConnectorSpec>(c.spec.clone())
+                .map(|s| s.kind != "discord")
+                .unwrap_or(true)
+        });
+        for (name, peers) in [("connector-a", a_peers), ("connector-b", b_peers)] {
+            let mut clone = template.clone();
+            clone.metadata.name = name.to_string();
+            if let Some(obj) = clone.spec.as_object_mut() {
+                obj.insert(
+                    "peer_bots".to_string(),
+                    serde_json::json!(
+                        peers.iter().map(|p| p.to_string()).collect::<Vec<_>>()
+                    ),
+                );
+            }
+            manifests.connectors.push(clone);
+        }
+    }
+
+    /// Helper-boundary regression (Codex comment 3274130773): the
+    /// `peer_bots_for_connector` extractor must pick the allowlist for the
+    /// connector named on the inbound message, not the first discord
+    /// connector encountered in the manifest list.
+    #[tokio::test]
+    async fn peer_bots_for_connector_selects_per_connector_allowlist() {
+        let state = test_state_async().await;
+        inject_two_discord_connectors(&state, &["peer-A"], &["peer-B"]);
+        let manifests = state.manifests.read().unwrap();
+
+        // Message tagged with connector-a sees only peer-A — peer-B is not
+        // unioned in from connector-b.
+        let a = peer_bots_for_connector(&manifests, Some("connector-a"));
+        assert_eq!(a, vec!["peer-A".to_string()]);
+        // And vice-versa.
+        let b = peer_bots_for_connector(&manifests, Some("connector-b"));
+        assert_eq!(b, vec!["peer-B".to_string()]);
+
+        // Unknown / unstamped messages get the empty allowlist — no
+        // peer-bot admission is granted to a synthetic message without
+        // connector identity.
+        assert!(peer_bots_for_connector(&manifests, Some("ghost")).is_empty());
+        assert!(peer_bots_for_connector(&manifests, None).is_empty());
+    }
+
+    /// Integration regression (Codex comment 3274130773): a bot that is in
+    /// connector-a's `peer_bots` must NOT be admitted when the message
+    /// arrives stamped from connector-b. With the pre-repair code (taking
+    /// `.next()` over discord connectors) this would have audited as
+    /// `ignored_peer_bot_no_handoff` (i.e. treated as a known peer just
+    /// missing handoff) rather than `ignored_unrelated_bot`, leaking
+    /// authorization across connectors.
+    #[tokio::test]
+    async fn process_message_uses_source_connectors_peer_bots_not_first() {
+        let state = test_state_async().await;
+        inject_two_discord_connectors(&state, &["peer-A"], &["peer-B"]);
+
+        // peer-A posts to connector-b. From connector-b's perspective this
+        // is just an unrelated bot.
+        let msg = DiscordMessage {
+            channel_id: "ch_pub".into(),
+            user_id: "peer-A".into(),
+            username: "peer-A".into(),
+            content: "crossing the streams".into(),
+            message_id: "msg_cross_a_to_b".into(),
+            is_dm: true,
+            mentions_bot: false,
+            is_bot: true,
+            connector_name: Some("connector-b".into()),
+        };
+        process_message(&state, &msg).await.expect("process_message");
+
+        let db = state.db.lock().await;
+        let audits = db.query_audit(50).expect("query_audit");
+        let ignored: Vec<&_> = audits
+            .iter()
+            .filter(|a| a.event_type == "discord_message_ignored")
+            .collect();
+        assert_eq!(
+            ignored.len(),
+            1,
+            "peer-A on connector-b must be ignored exactly once",
+        );
+        let details: serde_json::Value =
+            serde_json::from_str(ignored[0].details.as_deref().expect("details")).unwrap();
+        assert_eq!(
+            details["reason"], "ignored_unrelated_bot",
+            "peer-A is NOT a peer on connector-b — must not be audited as peer-bot",
+        );
+    }
+
+    /// Symmetric integration regression: peer-B posting to connector-a
+    /// must also be classified as unrelated, not as a recognized peer
+    /// (sera-yeg.1 follow-up — Codex 3274130773).
+    #[tokio::test]
+    async fn process_message_isolates_connector_b_peers_from_connector_a() {
+        let state = test_state_async().await;
+        inject_two_discord_connectors(&state, &["peer-A"], &["peer-B"]);
+
+        let msg = DiscordMessage {
+            channel_id: "ch_pub".into(),
+            user_id: "peer-B".into(),
+            username: "peer-B".into(),
+            content: "wrong door".into(),
+            message_id: "msg_cross_b_to_a".into(),
+            is_dm: true,
+            mentions_bot: false,
+            is_bot: true,
+            connector_name: Some("connector-a".into()),
+        };
+        process_message(&state, &msg).await.expect("process_message");
+
+        let db = state.db.lock().await;
+        let audits = db.query_audit(50).expect("query_audit");
+        let ignored: Vec<&_> = audits
+            .iter()
+            .filter(|a| a.event_type == "discord_message_ignored")
+            .collect();
+        assert_eq!(ignored.len(), 1);
+        let details: serde_json::Value =
+            serde_json::from_str(ignored[0].details.as_deref().expect("details")).unwrap();
+        assert_eq!(details["reason"], "ignored_unrelated_bot");
     }
 
     #[tokio::test]
@@ -13255,6 +13434,7 @@ spec:
                 is_dm: true,
                 mentions_bot: false,
                 is_bot: false,
+                connector_name: None,
             })
             .await
             .expect("send discord message");
@@ -13478,6 +13658,7 @@ spec:
                 is_dm: true,
                 mentions_bot: false,
                 is_bot: false,
+                connector_name: None,
             })
             .await
             .expect("send discord message");

--- a/rust/crates/sera-gateway/src/discord.rs
+++ b/rust/crates/sera-gateway/src/discord.rs
@@ -31,6 +31,13 @@ pub struct DiscordMessage {
     /// peer bots make it through with this flag set so the routing layer
     /// (`process_message`) can apply the configured peer-bot policy.
     pub is_bot: bool,
+    /// Manifest name of the [`DiscordConnector`] that produced this message.
+    /// Set by [`DiscordConnector`] as it dispatches into the shared mpsc;
+    /// `None` only for synthetic test fixtures. The routing layer uses this
+    /// to look up the *connector-specific* `peer_bots` allowlist rather than
+    /// taking the first parsed discord connector in manifests (sera-yeg.1
+    /// repair, Codex comment 3274130773).
+    pub connector_name: Option<String>,
 }
 
 /// Discord Gateway connector — connects via WebSocket, handles heartbeat,
@@ -38,6 +45,11 @@ pub struct DiscordMessage {
 pub struct DiscordConnector {
     token: String,
     agent_name: String,
+    /// Manifest name of the connector this instance was spawned for. Used to
+    /// stamp outgoing [`DiscordMessage`]s so the routing layer can look up
+    /// per-connector configuration (e.g. `peer_bots`) instead of folding
+    /// across all discord connectors.
+    connector_name: String,
     tx: mpsc::Sender<DiscordMessage>,
     /// Bot's own user ID, set on READY event.
     bot_user_id: std::sync::Mutex<Option<String>>,
@@ -348,6 +360,10 @@ pub fn parse_message_create(payload: &Value, bot_user_id: Option<&str>) -> Optio
         is_dm,
         mentions_bot,
         is_bot,
+        // Stamped by the dispatching `DiscordConnector` (which knows its
+        // own connector_name); the pure parser deliberately stays
+        // identity-agnostic so it remains unit-testable without one.
+        connector_name: None,
     })
 }
 
@@ -524,12 +540,14 @@ impl DiscordConnector {
     pub fn new(
         token: &str,
         agent_name: &str,
+        connector_name: &str,
         tx: mpsc::Sender<DiscordMessage>,
         shutting_down: Arc<AtomicBool>,
     ) -> Self {
         Self {
             token: token.to_owned(),
             agent_name: agent_name.to_owned(),
+            connector_name: connector_name.to_owned(),
             tx,
             bot_user_id: std::sync::Mutex::new(None),
             shutting_down,
@@ -965,10 +983,18 @@ impl DiscordConnector {
                         }
                         "MESSAGE_CREATE" => {
                             let bot_id = self.bot_user_id.lock().ok().and_then(|g| g.clone());
-                            if let Some(msg) = parse_message_create(payload, bot_id.as_deref())
-                                && let Err(e) = self.tx.send(msg).await
+                            if let Some(mut msg) = parse_message_create(payload, bot_id.as_deref())
                             {
-                                tracing::error!("Failed to dispatch Discord message: {e}");
+                                // Stamp the message with this connector's
+                                // manifest name so the routing layer applies
+                                // the *connector-specific* peer-bot policy
+                                // (sera-yeg.1 repair — Codex 3274130773).
+                                msg.connector_name = Some(self.connector_name.clone());
+                                if let Err(e) = self.tx.send(msg).await {
+                                    tracing::error!(
+                                        "Failed to dispatch Discord message: {e}"
+                                    );
+                                }
                             }
                         }
                         _ => {
@@ -1039,6 +1065,7 @@ mod tests {
             is_dm: false,
             mentions_bot: false,
             is_bot: false,
+            connector_name: None,
         };
         assert_eq!(msg.channel_id, "123456");
         assert_eq!(msg.user_id, "789");
@@ -1260,9 +1287,11 @@ mod tests {
     fn test_connector_new() {
         let (tx, _rx) = mpsc::channel(10);
         let shutting_down = Arc::new(AtomicBool::new(false));
-        let connector = DiscordConnector::new("token123", "my-agent", tx, shutting_down);
+        let connector =
+            DiscordConnector::new("token123", "my-agent", "discord-main", tx, shutting_down);
         assert_eq!(connector.token, "token123");
         assert_eq!(connector.agent_name, "my-agent");
+        assert_eq!(connector.connector_name, "discord-main");
     }
 
     // --- strip_mentions tests ---
@@ -1329,6 +1358,7 @@ mod tests {
         let connector = Arc::new(DiscordConnector::new(
             "fake-token",
             "test-agent",
+            "discord-test",
             tx,
             Arc::clone(&shutting_down),
         ));
@@ -1413,7 +1443,13 @@ mod tests {
     fn test_connector() -> (Arc<DiscordConnector>, mpsc::Receiver<DiscordMessage>) {
         let (tx, rx) = mpsc::channel(4);
         let shutting_down = Arc::new(AtomicBool::new(false));
-        let connector = Arc::new(DiscordConnector::new("token", "agent", tx, shutting_down));
+        let connector = Arc::new(DiscordConnector::new(
+            "token",
+            "agent",
+            "discord-test",
+            tx,
+            shutting_down,
+        ));
         (connector, rx)
     }
 

--- a/rust/crates/sera-gateway/src/discord.rs
+++ b/rust/crates/sera-gateway/src/discord.rs
@@ -21,12 +21,16 @@ pub struct DiscordMessage {
     pub user_id: String,
     pub username: String,
     pub content: String,
-    #[allow(dead_code)]
     pub message_id: String,
     /// Whether this message was a DM (not a guild channel).
     pub is_dm: bool,
     /// Whether the bot was mentioned in this message (for guild channels).
     pub mentions_bot: bool,
+    /// Whether the message author is itself a Discord bot. SERA's own bot
+    /// messages are always filtered upstream in [`parse_message_create`];
+    /// peer bots make it through with this flag set so the routing layer
+    /// (`process_message`) can apply the configured peer-bot policy.
+    pub is_bot: bool,
 }
 
 /// Discord Gateway connector — connects via WebSocket, handles heartbeat,
@@ -294,7 +298,9 @@ pub fn strip_mentions(content: &str) -> String {
 /// with `t == "MESSAGE_CREATE"`.
 ///
 /// Returns `None` if the payload is not a MESSAGE_CREATE dispatch, or if the
-/// message author is a bot.
+/// message author is SERA's own bot (loop-safety). Other bot authors are
+/// surfaced with `is_bot = true` so the routing layer can apply the
+/// configured peer-bot policy (sera-yeg.1).
 ///
 /// The `is_dm` and `mentions_bot` fields are set based on the raw payload data.
 pub fn parse_message_create(payload: &Value, bot_user_id: Option<&str>) -> Option<DiscordMessage> {
@@ -306,11 +312,18 @@ pub fn parse_message_create(payload: &Value, bot_user_id: Option<&str>) -> Optio
     }
     let d = payload.get("d")?;
     let author = d.get("author")?;
+    let author_id = author.get("id")?.as_str()?;
 
-    // Skip bot messages
-    if author.get("bot").and_then(Value::as_bool).unwrap_or(false) {
+    // Hard loop-safety: never surface SERA's own bot messages to the routing
+    // layer. This is the only filter applied here; unrelated bots and peer
+    // bots are surfaced with `is_bot = true` so policy can decide.
+    if let Some(self_id) = bot_user_id
+        && author_id == self_id
+    {
         return None;
     }
+
+    let is_bot = author.get("bot").and_then(Value::as_bool).unwrap_or(false);
 
     // Check if this is a DM (no guild_id) or mentions the bot
     let is_dm = d.get("guild_id").is_none();
@@ -328,13 +341,96 @@ pub fn parse_message_create(payload: &Value, bot_user_id: Option<&str>) -> Optio
 
     Some(DiscordMessage {
         channel_id: d.get("channel_id")?.as_str()?.to_owned(),
-        user_id: author.get("id")?.as_str()?.to_owned(),
+        user_id: author_id.to_owned(),
         username: author.get("username")?.as_str()?.to_owned(),
         content: strip_mentions(d.get("content")?.as_str()?),
         message_id: d.get("id")?.as_str()?.to_owned(),
         is_dm,
         mentions_bot,
+        is_bot,
     })
+}
+
+/// Routing decision for a Discord message authored by a bot.
+///
+/// Pure data — no I/O — so the policy is unit-testable without standing up
+/// a gateway. `decide_bot_policy` is the sole producer; `process_message`
+/// is the sole consumer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BotPolicyDecision {
+    /// Author is human or a configured peer bot with explicit handoff.
+    Accept,
+    /// Author is SERA's own bot. Defense-in-depth — `parse_message_create`
+    /// already drops these.
+    IgnoreSelf,
+    /// Author is a bot we don't recognize as a peer.
+    IgnoreUnrelated,
+    /// Author is a configured peer bot but the message lacks an explicit
+    /// handoff (DM or @-mention of SERA).
+    IgnoreNoHandoff,
+}
+
+impl BotPolicyDecision {
+    /// Human-readable tag for audit metadata.
+    pub fn audit_reason(self) -> &'static str {
+        match self {
+            BotPolicyDecision::Accept => "accept",
+            BotPolicyDecision::IgnoreSelf => "ignored_self_bot",
+            BotPolicyDecision::IgnoreUnrelated => "ignored_unrelated_bot",
+            BotPolicyDecision::IgnoreNoHandoff => "ignored_peer_bot_no_handoff",
+        }
+    }
+}
+
+/// Decide whether to accept a Discord message under the peer-bot policy.
+///
+/// Loop-safety contract (sera-yeg.1):
+/// * Human authors are always accepted.
+/// * SERA's own bot id is always ignored (already filtered upstream).
+/// * Other bot authors are accepted only if `author_id` or `username` matches
+///   an entry in `peer_bots` AND the message is an explicit handoff to SERA
+///   (DM or @-mention).
+pub fn decide_bot_policy(
+    is_bot: bool,
+    author_id: &str,
+    username: &str,
+    self_bot_id: Option<&str>,
+    is_explicit_handoff: bool,
+    peer_bots: &[String],
+) -> BotPolicyDecision {
+    if !is_bot {
+        return BotPolicyDecision::Accept;
+    }
+    if let Some(self_id) = self_bot_id
+        && author_id == self_id
+    {
+        return BotPolicyDecision::IgnoreSelf;
+    }
+    let is_peer = peer_bots
+        .iter()
+        .any(|p| !p.is_empty() && (p == author_id || p == username));
+    if !is_peer {
+        return BotPolicyDecision::IgnoreUnrelated;
+    }
+    if !is_explicit_handoff {
+        return BotPolicyDecision::IgnoreNoHandoff;
+    }
+    BotPolicyDecision::Accept
+}
+
+/// Build the REST URL for the Discord typing-indicator endpoint.
+/// Extracted for unit testability (no live Discord required).
+pub fn typing_indicator_url(channel_id: &str) -> String {
+    format!("{DISCORD_API_BASE}/channels/{channel_id}/typing")
+}
+
+/// Build the REST URL for adding/removing the bot's own reaction on a
+/// message. Discord expects the emoji URL-encoded (`%F0%9F%91%80` for `👀`).
+pub fn own_reaction_url(channel_id: &str, message_id: &str, emoji: &str) -> String {
+    let emoji_enc = urlencoding::encode(emoji);
+    format!(
+        "{DISCORD_API_BASE}/channels/{channel_id}/messages/{message_id}/reactions/{emoji_enc}/@me"
+    )
 }
 
 /// Extract the event name from a Dispatch payload (opcode 0).
@@ -526,6 +622,83 @@ impl DiscordConnector {
             anyhow::bail!("Discord API error {status}: {body}");
         }
         Ok(())
+    }
+
+    /// Trigger the Discord typing indicator on a channel.
+    ///
+    /// The indicator self-expires after ~10 seconds, so callers must
+    /// re-trigger periodically while processing. UX affordance only —
+    /// failures (missing permission, transport error) are returned to the
+    /// caller for low-noise logging and never propagated as turn failures
+    /// (sera-yeg.2).
+    pub async fn trigger_typing(&self, channel_id: &str) -> anyhow::Result<()> {
+        let url = typing_indicator_url(channel_id);
+        let client = reqwest::Client::new();
+        let resp = client
+            .post(&url)
+            .header("Authorization", format!("Bot {}", self.token))
+            .send()
+            .await?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            anyhow::bail!("Discord typing error {status}");
+        }
+        Ok(())
+    }
+
+    /// Add an emoji reaction (the bot's own) to a message.
+    ///
+    /// UX affordance only — failures are returned for low-noise logging by
+    /// the caller and never propagated as turn failures (sera-yeg.2).
+    pub async fn add_reaction(
+        &self,
+        channel_id: &str,
+        message_id: &str,
+        emoji: &str,
+    ) -> anyhow::Result<()> {
+        let url = own_reaction_url(channel_id, message_id, emoji);
+        let client = reqwest::Client::new();
+        let resp = client
+            .put(&url)
+            .header("Authorization", format!("Bot {}", self.token))
+            .header("Content-Length", "0")
+            .send()
+            .await?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            anyhow::bail!("Discord add_reaction error {status}");
+        }
+        Ok(())
+    }
+
+    /// Remove the bot's own reaction from a message.
+    ///
+    /// UX affordance only — failures are returned for low-noise logging by
+    /// the caller and never propagated as turn failures (sera-yeg.2).
+    pub async fn remove_own_reaction(
+        &self,
+        channel_id: &str,
+        message_id: &str,
+        emoji: &str,
+    ) -> anyhow::Result<()> {
+        let url = own_reaction_url(channel_id, message_id, emoji);
+        let client = reqwest::Client::new();
+        let resp = client
+            .delete(&url)
+            .header("Authorization", format!("Bot {}", self.token))
+            .send()
+            .await?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            anyhow::bail!("Discord remove_reaction error {status}");
+        }
+        Ok(())
+    }
+
+    /// The bot's own Discord user id, populated on the first READY dispatch.
+    /// `None` until the gateway has connected.
+    pub fn bot_user_id(&self) -> Option<String> {
+        self.bot_user_id.lock().ok().and_then(|g| g.clone())
     }
 
     // -----------------------------------------------------------------------
@@ -795,12 +968,14 @@ mod tests {
             message_id: "msg001".into(),
             is_dm: false,
             mentions_bot: false,
+            is_bot: false,
         };
         assert_eq!(msg.channel_id, "123456");
         assert_eq!(msg.user_id, "789");
         assert_eq!(msg.username, "testuser");
         assert_eq!(msg.content, "hello world");
         assert_eq!(msg.message_id, "msg001");
+        assert!(!msg.is_bot);
     }
 
     #[test]
@@ -870,7 +1045,8 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_message_create_bot_filtered() {
+    fn test_parse_message_create_self_bot_dropped() {
+        // SERA's own bot id is always dropped at parse time (loop safety).
         let payload = serde_json::json!({
             "op": 0,
             "t": "MESSAGE_CREATE",
@@ -878,15 +1054,43 @@ mod tests {
             "d": {
                 "id": "msg124",
                 "channel_id": "ch456",
-                "content": "I am a bot",
+                "content": "self echo",
                 "author": {
-                    "id": "bot001",
-                    "username": "botuser",
+                    "id": "self-bot",
+                    "username": "sera",
                     "bot": true
                 }
             }
         });
-        assert!(parse_message_create(&payload, None).is_none());
+        assert!(parse_message_create(&payload, Some("self-bot")).is_none());
+    }
+
+    #[test]
+    fn test_parse_message_create_peer_bot_surfaced() {
+        // Peer-bot messages survive parse with `is_bot = true` so the
+        // routing layer can apply the configured peer-bot policy
+        // (sera-yeg.1). The previous behavior of dropping all bots at
+        // parse time made the peer-bot policy impossible to implement.
+        let payload = serde_json::json!({
+            "op": 0,
+            "t": "MESSAGE_CREATE",
+            "s": 43,
+            "d": {
+                "id": "msg124",
+                "channel_id": "ch456",
+                "content": "I am a peer bot",
+                "author": {
+                    "id": "bot001",
+                    "username": "hermes",
+                    "bot": true
+                }
+            }
+        });
+        let msg = parse_message_create(&payload, Some("other-self-id"))
+            .expect("peer-bot messages should surface for policy");
+        assert!(msg.is_bot);
+        assert_eq!(msg.user_id, "bot001");
+        assert_eq!(msg.username, "hermes");
     }
 
     #[test]
@@ -1435,6 +1639,138 @@ mod tests {
         let evt = serde_json::json!({ "op": 0, "t": "GUILD_CREATE", "s": 17, "d": {} });
         assert_eq!(conn.handle_payload(&evt).await, None);
         assert_eq!(conn.test_last_sequence(), 17);
+    }
+
+    // -----------------------------------------------------------------------
+    // Peer-bot policy decisions (sera-yeg.1)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn bot_policy_human_always_accepted() {
+        assert_eq!(
+            decide_bot_policy(false, "user-1", "alice", Some("self"), false, &[]),
+            BotPolicyDecision::Accept,
+        );
+        // Even with no peer_bots configured, a human user is fine.
+        assert_eq!(
+            decide_bot_policy(false, "user-1", "alice", Some("self"), true, &[]),
+            BotPolicyDecision::Accept,
+        );
+    }
+
+    #[test]
+    fn bot_policy_self_bot_is_ignored() {
+        // Defense in depth: even if parse_message_create lets the self id
+        // through, the policy says ignore.
+        let peers: Vec<String> = vec!["self-id".into()];
+        assert_eq!(
+            decide_bot_policy(true, "self-id", "sera", Some("self-id"), true, &peers),
+            BotPolicyDecision::IgnoreSelf,
+        );
+    }
+
+    #[test]
+    fn bot_policy_unrelated_bot_is_ignored() {
+        let peers: Vec<String> = vec!["allowed-peer".into()];
+        assert_eq!(
+            decide_bot_policy(true, "stranger-bot", "stranger", Some("self"), true, &peers),
+            BotPolicyDecision::IgnoreUnrelated,
+        );
+        // Empty peer-bots list = strict default, all bots ignored.
+        assert_eq!(
+            decide_bot_policy(true, "any-bot", "any", Some("self"), true, &[]),
+            BotPolicyDecision::IgnoreUnrelated,
+        );
+    }
+
+    #[test]
+    fn bot_policy_peer_bot_without_handoff_is_ignored() {
+        let peers: Vec<String> = vec!["peer-1".into()];
+        assert_eq!(
+            decide_bot_policy(true, "peer-1", "hermes", Some("self"), false, &peers),
+            BotPolicyDecision::IgnoreNoHandoff,
+        );
+    }
+
+    #[test]
+    fn bot_policy_peer_bot_with_explicit_handoff_accepted() {
+        let peers: Vec<String> = vec!["peer-1".into()];
+        assert_eq!(
+            decide_bot_policy(true, "peer-1", "hermes", Some("self"), true, &peers),
+            BotPolicyDecision::Accept,
+        );
+    }
+
+    #[test]
+    fn bot_policy_peer_bot_match_by_username() {
+        // Operators may configure peer bots by friendly name (e.g.
+        // `@Sera 2.0` on the Hermes side); the policy matches either id
+        // or username so both work.
+        let peers: Vec<String> = vec!["Sera 2.0".into()];
+        assert_eq!(
+            decide_bot_policy(true, "12345", "Sera 2.0", Some("self"), true, &peers),
+            BotPolicyDecision::Accept,
+        );
+    }
+
+    #[test]
+    fn bot_policy_ignores_empty_string_peer_entries() {
+        // Empty strings in the peers list must not match anyone — guards
+        // against an operator typo collapsing the strict default.
+        let peers: Vec<String> = vec!["".into(), "real-peer".into()];
+        assert_eq!(
+            decide_bot_policy(true, "", "", Some("self"), true, &peers),
+            BotPolicyDecision::IgnoreUnrelated,
+        );
+        assert_eq!(
+            decide_bot_policy(true, "real-peer", "x", Some("self"), true, &peers),
+            BotPolicyDecision::Accept,
+        );
+    }
+
+    #[test]
+    fn bot_policy_audit_reasons_are_distinct() {
+        assert_eq!(BotPolicyDecision::Accept.audit_reason(), "accept");
+        assert_eq!(BotPolicyDecision::IgnoreSelf.audit_reason(), "ignored_self_bot");
+        assert_eq!(
+            BotPolicyDecision::IgnoreUnrelated.audit_reason(),
+            "ignored_unrelated_bot",
+        );
+        assert_eq!(
+            BotPolicyDecision::IgnoreNoHandoff.audit_reason(),
+            "ignored_peer_bot_no_handoff",
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // REST URL construction (sera-yeg.2)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn typing_indicator_url_shape() {
+        assert_eq!(
+            typing_indicator_url("ch-42"),
+            "https://discord.com/api/v10/channels/ch-42/typing",
+        );
+    }
+
+    #[test]
+    fn own_reaction_url_url_encodes_emoji() {
+        // `👀` is U+1F440 → UTF-8 `F0 9F 91 80` → percent-encoded
+        // `%F0%9F%91%80`. Without encoding, Discord rejects the route
+        // with 400 INVALID_FORM_BODY.
+        assert_eq!(
+            own_reaction_url("ch-1", "msg-1", "👀"),
+            "https://discord.com/api/v10/channels/ch-1/messages/msg-1/reactions/%F0%9F%91%80/@me",
+        );
+        assert_eq!(
+            own_reaction_url("ch-1", "msg-1", "✅"),
+            "https://discord.com/api/v10/channels/ch-1/messages/msg-1/reactions/%E2%9C%85/@me",
+        );
+        assert_eq!(
+            own_reaction_url("ch-1", "msg-1", "❌"),
+            "https://discord.com/api/v10/channels/ch-1/messages/msg-1/reactions/%E2%9D%8C/@me",
+        );
     }
 
     #[tokio::test]

--- a/rust/crates/sera-gateway/src/discord.rs
+++ b/rust/crates/sera-gateway/src/discord.rs
@@ -382,6 +382,76 @@ impl BotPolicyDecision {
     }
 }
 
+/// Top-level routing gate for an inbound Discord message. Composes the
+/// peer-bot policy with the human DM/mention filter so the gate order is
+/// expressed in one pure function instead of inline in `process_message`.
+///
+/// Rationale (sera-yeg.1 repair): the original `process_message` returned
+/// early on `!is_explicit_handoff` *before* running `decide_bot_policy`,
+/// which silently dropped unrelated bots in public channels and peer bots
+/// without handoff — including the audit log entry the spec requires.
+/// Routing now goes through this helper so bot-authored messages always
+/// run through the peer-bot policy (auditable) while human messages keep
+/// the cheap "not a DM, not mentioned → ignore" fast path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MessageGateDecision {
+    /// Message should proceed to the turn pipeline.
+    Accept,
+    /// Human author posting in a guild channel without @-mention — drop
+    /// silently (debug log only) to keep public channels low-noise.
+    IgnoreHumanNoHandoff,
+    /// Bot author was denied by the peer-bot policy; carries the reason so
+    /// the caller can audit-log it under `discord_message_ignored`.
+    IgnoreBot(BotPolicyDecision),
+}
+
+/// Decide whether to admit an inbound Discord message to the turn pipeline.
+///
+/// Order of gates (sera-yeg.1):
+/// * Bot authors always go through [`decide_bot_policy`] regardless of
+///   DM/mention status, so self bots, unrelated bots, and peer bots
+///   without explicit handoff all produce an [`IgnoreBot`] decision the
+///   caller must audit. This is what makes `ignored_peer_bot_no_handoff`
+///   and `ignored_unrelated_bot` actually appear in the live audit log
+///   instead of being dropped silently by the human-channel filter.
+/// * Human authors keep the original behavior: non-DM messages without an
+///   @-mention return [`IgnoreHumanNoHandoff`] (silent ignore, no audit
+///   row), everything else returns [`Accept`].
+///
+/// `is_explicit_handoff` must be `msg.is_dm || msg.mentions_bot` — the
+/// caller computes it once and passes it in.
+///
+/// [`IgnoreBot`]: MessageGateDecision::IgnoreBot
+/// [`IgnoreHumanNoHandoff`]: MessageGateDecision::IgnoreHumanNoHandoff
+/// [`Accept`]: MessageGateDecision::Accept
+pub fn gate_message(
+    is_bot: bool,
+    author_id: &str,
+    username: &str,
+    self_bot_id: Option<&str>,
+    is_explicit_handoff: bool,
+    peer_bots: &[String],
+) -> MessageGateDecision {
+    if is_bot {
+        let policy = decide_bot_policy(
+            true,
+            author_id,
+            username,
+            self_bot_id,
+            is_explicit_handoff,
+            peer_bots,
+        );
+        return match policy {
+            BotPolicyDecision::Accept => MessageGateDecision::Accept,
+            denied => MessageGateDecision::IgnoreBot(denied),
+        };
+    }
+    if !is_explicit_handoff {
+        return MessageGateDecision::IgnoreHumanNoHandoff;
+    }
+    MessageGateDecision::Accept
+}
+
 /// Decide whether to accept a Discord message under the peer-bot policy.
 ///
 /// Loop-safety contract (sera-yeg.1):
@@ -1740,6 +1810,103 @@ mod tests {
             BotPolicyDecision::IgnoreNoHandoff.audit_reason(),
             "ignored_peer_bot_no_handoff",
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Routing gate composition (sera-yeg.1 repair)
+    //
+    // These tests model the gate order in `process_message`: bots must run
+    // through the peer-bot policy *before* the generic human/public-channel
+    // filter, so unrelated bots and peer-without-handoff in public channels
+    // still produce auditable decisions.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn gate_human_dm_accepted() {
+        assert_eq!(
+            gate_message(false, "u1", "alice", Some("self"), true, &[]),
+            MessageGateDecision::Accept,
+        );
+    }
+
+    #[test]
+    fn gate_human_mention_accepted() {
+        // is_explicit_handoff carries either is_dm OR mentions_bot.
+        assert_eq!(
+            gate_message(false, "u1", "alice", Some("self"), true, &[]),
+            MessageGateDecision::Accept,
+        );
+    }
+
+    #[test]
+    fn gate_human_no_handoff_silently_ignored() {
+        // Public channel + no mention → silent ignore (no audit row).
+        // This preserves the original low-noise behavior for humans.
+        assert_eq!(
+            gate_message(false, "u1", "alice", Some("self"), false, &[]),
+            MessageGateDecision::IgnoreHumanNoHandoff,
+        );
+    }
+
+    #[test]
+    fn gate_self_bot_ignored_even_in_public_channel() {
+        // Loop safety: self bot id is hard-ignored regardless of channel
+        // context. Parse-time filter already drops these, but the gate
+        // is defense-in-depth and must still emit an auditable decision.
+        let peers: Vec<String> = vec!["self-id".into()];
+        assert_eq!(
+            gate_message(true, "self-id", "sera", Some("self-id"), false, &peers),
+            MessageGateDecision::IgnoreBot(BotPolicyDecision::IgnoreSelf),
+        );
+    }
+
+    #[test]
+    fn gate_unrelated_bot_in_public_channel_audited_not_silent() {
+        // BUG REPAIR: before this fix, an unrelated bot posting in a public
+        // channel (is_dm=false, mentions_bot=false) was silently dropped by
+        // the `!is_explicit_handoff` early return. It must now surface as
+        // IgnoreBot so the caller writes a `discord_message_ignored` audit
+        // row with reason `ignored_unrelated_bot`.
+        let peers: Vec<String> = vec!["allowed-peer".into()];
+        assert_eq!(
+            gate_message(true, "stranger", "stranger", Some("self"), false, &peers),
+            MessageGateDecision::IgnoreBot(BotPolicyDecision::IgnoreUnrelated),
+        );
+    }
+
+    #[test]
+    fn gate_peer_bot_without_handoff_in_public_channel_audited_not_silent() {
+        // BUG REPAIR: a configured peer bot that posts in a public channel
+        // without DM/mention used to disappear via the human early return.
+        // It must now surface as IgnoreBot with `IgnoreNoHandoff` so the
+        // caller audits the failure mode under
+        // `ignored_peer_bot_no_handoff`.
+        let peers: Vec<String> = vec!["peer-1".into()];
+        assert_eq!(
+            gate_message(true, "peer-1", "hermes", Some("self"), false, &peers),
+            MessageGateDecision::IgnoreBot(BotPolicyDecision::IgnoreNoHandoff),
+        );
+    }
+
+    #[test]
+    fn gate_peer_bot_with_explicit_handoff_accepted() {
+        let peers: Vec<String> = vec!["peer-1".into()];
+        assert_eq!(
+            gate_message(true, "peer-1", "hermes", Some("self"), true, &peers),
+            MessageGateDecision::Accept,
+        );
+    }
+
+    #[test]
+    fn gate_bot_runs_before_human_handoff_check() {
+        // Sanity: even though a bot author lacks is_explicit_handoff (i.e.
+        // would have been silently dropped by the old early return), the
+        // gate routes via bot policy first. The decision must be policy-
+        // driven (IgnoreUnrelated here), never the silent human path.
+        let peers: Vec<String> = vec![];
+        let d = gate_message(true, "x", "y", Some("self"), false, &peers);
+        assert!(matches!(d, MessageGateDecision::IgnoreBot(_)));
+        assert_ne!(d, MessageGateDecision::IgnoreHumanNoHandoff);
     }
 
     // -----------------------------------------------------------------------

--- a/rust/crates/sera-types/src/config_manifest.rs
+++ b/rust/crates/sera-types/src/config_manifest.rs
@@ -284,6 +284,16 @@ pub struct ConnectorSpec {
     pub token: Option<SecretRef>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub agent: Option<String>,
+    /// Peer bots that are allowed to hand off to SERA on this connector
+    /// (sera-yeg.1). Matched against the message author's Discord user id
+    /// OR username. Empty/absent = strict default (no peer bots accepted).
+    ///
+    /// Acceptance still requires the peer bot's message to be an explicit
+    /// handoff — either a DM to SERA or an @-mention of SERA in a guild
+    /// channel — so a chatty configured peer cannot create a feedback loop
+    /// by talking past SERA.
+    #[serde(default, alias = "peerBots", skip_serializing_if = "Vec::is_empty")]
+    pub peer_bots: Vec<String>,
 }
 
 /// A reference to a secret value, resolved at runtime.


### PR DESCRIPTION
## Summary

Implements the two SERA Discord collaboration improvements queued as
beads `sera-yeg.2` (UX feedback) and `sera-yeg.1` (peer-bot handoff).

## sera-yeg.2 — Discord feedback affordances

- Add `trigger_typing`, `add_reaction`, `remove_own_reaction` REST
  helpers on `DiscordConnector`.
- While processing an accepted Discord turn, emit the typing indicator
  (re-triggered every 8s) and the `👀` reaction; on success swap to
  `✅`, on failure / hook rejection swap to `❌`.
- All affordance failures degrade gracefully — logged at `debug`
  level only, never propagated as turn failures.
- URL construction is extracted (`typing_indicator_url`,
  `own_reaction_url`) and unit-tested without a live Discord.

## sera-yeg.1 — Guarded peer-bot handoff

- `parse_message_create` no longer drops all bot authors. SERA's own
  bot id remains a hard drop at parse time (loop safety); other bots
  surface with the new `DiscordMessage.is_bot` flag so the routing
  layer can apply policy.
- New `peer_bots` list on `ConnectorSpec` (with `peerBots` camelCase
  alias). Empty/absent = current strict default; configured ids or
  usernames pass when the message is an explicit handoff (DM or
  @-mention).
- Pure `decide_bot_policy` function returns
  `Accept` / `IgnoreSelf` / `IgnoreUnrelated` / `IgnoreNoHandoff` so
  the four required test cases (self bot, unrelated bot, peer + mention,
  peer without handoff) cover the policy without a live Discord.
- Accepted peer-bot turns are classified as `PrincipalKind::Agent`
  for downstream audit / routing visibility.
- Ignored bot messages are recorded with `kind=discord_message_ignored`
  in the audit table, including the policy reason, so operators can
  see when a peer-bot rule fired.

Source beads: `sera-yeg.2`, `sera-yeg.1`.
Idempotency key: `sera-discord-collab-yeg1-yeg2-20260520`.

## Test plan

- [x] `cargo check -p sera-gateway` — clean
- [x] `cargo clippy -p sera-gateway --bin sera-gateway -- -D warnings`
      — clean
- [x] `cargo test -p sera-gateway` — 735 pass, 3 ignored
      (after pre-building `sera-runtime` for the E2E discord round-trip)
- [x] `cargo test -p sera-config` — 148 pass
      (covers the new `peer_bots` YAML parsing)
- [x] `cargo test -p sera-types` — 454 pass
- [x] Manual review: typing/reaction REST URLs verified by unit test,
      Discord `bot=true` self drop verified, and lifecycle failure paths
      do not abort the turn (degraded logging only).
- [ ] Live Discord smoke (deferred — requires a real bot token / guild
      and is out of scope for a code-only PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)