### PR TITLE
fix(gateway): reverse Discord peer-mention handoff (sera-yeg.4)

### DIFF
--- a/rust/crates/sera-gateway/src/bin/sera.rs
+++ b/rust/crates/sera-gateway/src/bin/sera.rs
@@ -4930,10 +4930,43 @@ async fn process_message(state: &AppState, msg: &DiscordMessage) -> anyhow::Resu
         );
     }
 
+    // Build the peer-mention directory and runtime-visible content for this
+    // turn (sera-yeg.4). The directory carries inbound `<@id>` mentions that
+    // are allowlisted by the connector's `peer_bots` config — the only
+    // mentions safe to expose to the runtime or echo on outbound. When
+    // `raw_content` is empty (synthetic test fixtures), fall back to the
+    // pre-existing stripped `msg.content` so existing tests are unaffected.
+    let peer_directory = if msg.raw_content.is_empty() {
+        Vec::new()
+    } else {
+        crate::discord::peer_directory_from_mentions(
+            &msg.mentions,
+            self_bot_id.as_deref(),
+            &peer_bots,
+        )
+    };
+    let runtime_content = if msg.raw_content.is_empty() {
+        msg.content.clone()
+    } else {
+        crate::discord::normalize_content_for_runtime(
+            &msg.raw_content,
+            self_bot_id.as_deref(),
+            &peer_directory,
+        )
+    };
+
     // Run the inner turn pipeline. We wrap everything below in an async block
     // so the typing/reaction lifecycle finalizes consistently (✅ on success,
     // ❌ on failure) regardless of where the inner pipeline returns.
-    let outcome = process_message_inner(state, msg, is_explicit_handoff, principal_kind).await;
+    let outcome = process_message_inner(
+        state,
+        msg,
+        is_explicit_handoff,
+        principal_kind,
+        &runtime_content,
+        &peer_directory,
+    )
+    .await;
     if let Some(handle) = typing_task {
         handle.abort();
     }
@@ -4965,11 +4998,19 @@ enum TurnOutcome {
 /// Inner pipeline for an accepted Discord turn. Extracted so
 /// `process_message` can finalize the UX-affordance lifecycle (typing /
 /// reaction) in one place regardless of where the pipeline returns.
+///
+/// `runtime_content` is the mention-normalized form of the inbound message
+/// (`<@self>` stripped, allowlisted peer `<@id>` rewritten to `@<handle>`,
+/// other mentions stripped) — what the LLM and transcript see. The reverse
+/// path: `peer_directory` rewrites `@<handle>` tokens back to `<@id>` on
+/// outbound so the reply actually pings the peer in Discord (sera-yeg.4).
 async fn process_message_inner(
     state: &AppState,
     msg: &DiscordMessage,
     _is_explicit_handoff: bool,
     principal_kind: PrincipalKind,
+    runtime_content: &str,
+    peer_directory: &[crate::discord::PeerMentionBinding],
 ) -> anyhow::Result<TurnOutcome> {
     // Load hook chains from manifests.
     let chains = state.manifests.read().unwrap().hook_chain_specs();
@@ -4992,7 +5033,7 @@ async fn process_message_inner(
     let pre_route_ctx = HookContext {
         point: HookPoint::PreRoute,
         event: Some(serde_json::json!({
-            "content": msg.content,
+            "content": runtime_content,
             "channel_id": msg.channel_id,
             "username": msg.username,
         })),
@@ -5082,14 +5123,14 @@ async fn process_message_inner(
             Err(e) => anyhow::bail!("DB error: {e}"),
         };
 
-        let _ = db.append_transcript(&session.id, "user", Some(&msg.content), None, None);
+        let _ = db.append_transcript(&session.id, "user", Some(runtime_content), None, None);
         let transcript = db
             .get_transcript_recent(&session.id, 20)
             .unwrap_or_default();
         (session, transcript)
     };
 
-    let domain_event = DomainEvent::message(&agent_name, &session_key, principal, &msg.content);
+    let domain_event = DomainEvent::message(&agent_name, &session_key, principal, runtime_content);
     tracing::debug!(event_id = %domain_event.id.0, "Created domain event for Discord message");
 
     let session_json = serde_json::json!({"id": session.id, "key": session_key});
@@ -5179,7 +5220,7 @@ async fn process_message_inner(
     let result = execute_turn(
         &agent_spec,
         &transcript,
-        &msg.content,
+        runtime_content,
         &*supervisor,
         &session_key,
         &state.skill_engine,
@@ -5192,11 +5233,19 @@ async fn process_message_inner(
     .await;
     state.deregister_cancellation_token(&session_key);
 
+    // Render the LLM reply so allowlisted `@<handle>` tokens become Discord
+    // `<@id>` mention tags. Reverse peer-mention handoff (sera-yeg.4):
+    // arbitrary user @-names pass through unchanged because they are not in
+    // `peer_directory`, preserving the loop-safety contract.
+    let reply_rendered = crate::discord::render_outbound_content(&result.reply, peer_directory);
+
     // Persist tool call events to transcript before the final response.
+    // Transcript stores the rendered reply (with `<@id>` tags) so future
+    // turn context sees what was actually sent to Discord.
     {
         let db = state.db.lock().await;
         persist_tool_events(&db, &session.id, &result.tool_events);
-        let _ = db.append_transcript(&session.id, "assistant", Some(&result.reply), None, None);
+        let _ = db.append_transcript(&session.id, "assistant", Some(&reply_rendered), None, None);
     }
 
     // Complete the run and drain any pending messages for this session.
@@ -5215,7 +5264,7 @@ async fn process_message_inner(
         principal: Some(principal_json),
         metadata: std::collections::HashMap::from([(
             "reply".to_string(),
-            serde_json::json!(result.reply),
+            serde_json::json!(reply_rendered),
         )]),
         change_artifact: None, // Populated by sera-meta when processing evolution ChangeArtifacts
     };
@@ -5232,9 +5281,11 @@ async fn process_message_inner(
         HookResult::Continue { .. } => {}
     }
 
-    // Send the reply back to Discord via the shared connector.
+    // Send the reply back to Discord via the shared connector. The rendered
+    // reply already has allowlisted `@<handle>` tokens rewritten to
+    // `<@id>` (sera-yeg.4 reverse handoff).
     if let Some(ref dc) = state.discord {
-        if let Err(e) = dc.send_message(&msg.channel_id, &result.reply).await {
+        if let Err(e) = dc.send_message(&msg.channel_id, &reply_rendered).await {
             tracing::error!(error = ?e, channel_id = %msg.channel_id, "Discord send_message failed");
         }
     } else {
@@ -5304,11 +5355,14 @@ async fn process_message_inner(
                 let mut lq = state.lane_queue.lock().await;
                 lq.complete_run(&session_key);
             }
-            // Send steering response to Discord if any.
-            if let Some(ref dc) = state.discord
-                && let Err(e) = dc.send_message(&msg.channel_id, &follow_up.reply).await
-            {
-                tracing::error!(error = ?e, channel_id = %msg.channel_id, "Discord send_message failed");
+            // Send steering response to Discord if any. Render allowlisted
+            // peer mentions (sera-yeg.4).
+            if let Some(ref dc) = state.discord {
+                let rendered =
+                    crate::discord::render_outbound_content(&follow_up.reply, peer_directory);
+                if let Err(e) = dc.send_message(&msg.channel_id, &rendered).await {
+                    tracing::error!(error = ?e, channel_id = %msg.channel_id, "Discord send_message failed");
+                }
             }
             continue;
         }
@@ -5346,11 +5400,20 @@ async fn process_message_inner(
         .await;
         state.deregister_cancellation_token(&session_key);
 
+        // Render the follow-up reply once: transcript and outbound both see
+        // the `@<handle>` → `<@id>` rewrite (sera-yeg.4).
+        let follow_up_rendered =
+            crate::discord::render_outbound_content(&follow_up.reply, peer_directory);
         {
             let db = state.db.lock().await;
             persist_tool_events(&db, &session.id, &follow_up.tool_events);
-            let _ =
-                db.append_transcript(&session.id, "assistant", Some(&follow_up.reply), None, None);
+            let _ = db.append_transcript(
+                &session.id,
+                "assistant",
+                Some(&follow_up_rendered),
+                None,
+                None,
+            );
         }
 
         // Complete run for this follow-up turn.
@@ -5361,7 +5424,7 @@ async fn process_message_inner(
 
         // Send the follow-up reply to Discord.
         if let Some(ref dc) = state.discord
-            && let Err(e) = dc.send_message(&msg.channel_id, &follow_up.reply).await
+            && let Err(e) = dc.send_message(&msg.channel_id, &follow_up_rendered).await
         {
             tracing::error!(error = ?e, channel_id = %msg.channel_id, "Discord send_message failed");
         }
@@ -9188,6 +9251,8 @@ spec:
             mentions_bot: false,
             is_bot: false,
             connector_name: None,
+            raw_content: String::new(),
+            mentions: Vec::new(),
         })
         .await
         .unwrap();
@@ -9254,6 +9319,8 @@ spec:
             mentions_bot: false,
             is_bot: true,
             connector_name: Some("discord-main".into()),
+            raw_content: String::new(),
+            mentions: Vec::new(),
         };
         process_message(&state, &msg).await.expect("process_message");
 
@@ -9293,6 +9360,8 @@ spec:
             mentions_bot: false,
             is_bot: true,
             connector_name: Some("discord-main".into()),
+            raw_content: String::new(),
+            mentions: Vec::new(),
         };
         process_message(&state, &msg).await.expect("process_message");
 
@@ -9328,6 +9397,8 @@ spec:
             mentions_bot: false,
             is_bot: false,
             connector_name: None,
+            raw_content: String::new(),
+            mentions: Vec::new(),
         };
         process_message(&state, &msg).await.expect("process_message");
 
@@ -9436,6 +9507,8 @@ spec:
             mentions_bot: false,
             is_bot: true,
             connector_name: Some("connector-b".into()),
+            raw_content: String::new(),
+            mentions: Vec::new(),
         };
         process_message(&state, &msg).await.expect("process_message");
 
@@ -9458,6 +9531,125 @@ spec:
         );
     }
 
+    /// Reverse peer-mention handoff (sera-yeg.4): an inbound message that
+    /// mentions both SERA (`<@self>`) and an allowlisted peer (`<@peer>`)
+    /// must reach the transcript with the peer reference preserved as
+    /// `@<handle>` text. The pre-yeg.4 strip_mentions pass deleted the
+    /// peer reference entirely, so SERA never saw what bot to ping in the
+    /// reply. After this fix the runtime view of the inbound carries the
+    /// handle and the routing layer keeps the binding for outbound
+    /// rendering.
+    #[tokio::test]
+    async fn process_message_preserves_allowlisted_peer_mention_in_transcript() {
+        let state = test_state_async().await;
+        inject_peer_bots(&state, &["Sera 2.0"]);
+
+        let msg = DiscordMessage {
+            channel_id: "ch_yeg4".into(),
+            user_id: "1000".into(),
+            username: "operator".into(),
+            content: String::new(),
+            message_id: "msg_yeg4_persist".into(),
+            is_dm: true,
+            mentions_bot: true,
+            is_bot: false,
+            connector_name: Some("discord-main".into()),
+            raw_content: "<@111> please tell <@222> reverse path works".into(),
+            mentions: vec![
+                crate::discord::DiscordMentionedUser {
+                    id: "111".into(),
+                    username: "Sera".into(),
+                },
+                crate::discord::DiscordMentionedUser {
+                    id: "222".into(),
+                    username: "Sera 2.0".into(),
+                },
+            ],
+        };
+        process_message(&state, &msg).await.expect("process_message");
+
+        let db = state.db.lock().await;
+        let session_key = "discord:sera:ch_yeg4";
+        let session = db
+            .get_session_by_key(session_key)
+            .unwrap()
+            .expect("session created");
+        let transcript = db.get_transcript(&session.id).unwrap();
+        // Discord parser strips `<@self>` (routing-only) but normalization
+        // rewrites the allowlisted `<@peer-2>` to `@Sera 2.0` so the
+        // runtime + transcript see the handle.
+        let user_row = transcript
+            .iter()
+            .find(|t| t.role == "user")
+            .expect("user transcript row");
+        let content = user_row.content.as_deref().expect("user content");
+        assert!(
+            content.contains("@Sera 2.0"),
+            "user transcript should preserve @Sera 2.0 mention; got {content:?}",
+        );
+        assert!(
+            !content.contains("<@self>") && !content.contains("<@peer-2>"),
+            "raw `<@id>` tags must not leak into transcript; got {content:?}",
+        );
+    }
+
+    /// Reverse peer-mention handoff arbitrary-mention guard (sera-yeg.4):
+    /// an inbound mention that is NOT in `peer_bots` must be stripped from
+    /// the runtime view so unconfigured users cannot turn SERA into a
+    /// mention-spam relay or smuggle prompt-injection via @-references.
+    #[tokio::test]
+    async fn process_message_drops_unallowlisted_inbound_mention() {
+        let state = test_state_async().await;
+        inject_peer_bots(&state, &["Sera 2.0"]);
+
+        let msg = DiscordMessage {
+            channel_id: "ch_yeg4_strip".into(),
+            user_id: "1000".into(),
+            username: "operator".into(),
+            content: String::new(),
+            message_id: "msg_yeg4_strip".into(),
+            is_dm: true,
+            mentions_bot: true,
+            is_bot: false,
+            connector_name: Some("discord-main".into()),
+            raw_content: "<@111> hi <@333> please".into(),
+            mentions: vec![
+                crate::discord::DiscordMentionedUser {
+                    id: "111".into(),
+                    username: "Sera".into(),
+                },
+                crate::discord::DiscordMentionedUser {
+                    id: "333".into(),
+                    username: "rando".into(),
+                },
+            ],
+        };
+        process_message(&state, &msg).await.expect("process_message");
+
+        let db = state.db.lock().await;
+        let session_key = "discord:sera:ch_yeg4_strip";
+        let session = db
+            .get_session_by_key(session_key)
+            .unwrap()
+            .expect("session created");
+        let transcript = db.get_transcript(&session.id).unwrap();
+        let user_row = transcript
+            .iter()
+            .find(|t| t.role == "user")
+            .expect("user transcript row");
+        let content = user_row.content.as_deref().expect("user content");
+        // Self stripped, unallowlisted user stripped — no `@rando`, no
+        // `<@id>` tags, just the residual text.
+        assert!(
+            !content.contains("rando") && !content.contains("<@"),
+            "unallowlisted mention must not appear in runtime view; got {content:?}",
+        );
+        assert!(
+            content.contains("hi") && content.contains("please"),
+            "non-mention text must survive normalization; got {content:?}",
+        );
+    }
+
     /// Symmetric integration regression: peer-B posting to connector-a
     /// must also be classified as unrelated, not as a recognized peer
     /// (sera-yeg.1 follow-up — Codex 3274130773).
@@ -9476,6 +9668,8 @@ spec:
             mentions_bot: false,
             is_bot: true,
             connector_name: Some("connector-a".into()),
+            raw_content: String::new(),
+            mentions: Vec::new(),
         };
         process_message(&state, &msg).await.expect("process_message");
 
@@ -13743,6 +13937,8 @@ spec:
                 mentions_bot: false,
                 is_bot: false,
                 connector_name: None,
+                raw_content: String::new(),
+                mentions: Vec::new(),
             })
             .await
             .expect("send discord message");
@@ -13967,6 +14163,8 @@ spec:
                 mentions_bot: false,
                 is_bot: false,
                 connector_name: None,
+                raw_content: String::new(),
+                mentions: Vec::new(),
             })
             .await
             .expect("send discord message");

--- a/rust/crates/sera-gateway/src/discord.rs
+++ b/rust/crates/sera-gateway/src/discord.rs
@@ -14,12 +14,42 @@ use tokio_tungstenite::tungstenite::Message;
 // Public types
 // ---------------------------------------------------------------------------
 
+/// One user mentioned in an inbound Discord MESSAGE_CREATE payload. Captured
+/// verbatim from the raw `d.mentions` array so the routing layer can decide
+/// which mentions are safe to expose to the runtime / echo on outbound (the
+/// connector-specific `peer_bots` allowlist filters this list — arbitrary
+/// user mentions are never preserved past that filter). See sera-yeg.4.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiscordMentionedUser {
+    pub id: String,
+    pub username: String,
+}
+
+/// A peer-bot binding observed in an inbound message and confirmed against
+/// the connector's `peer_bots` allowlist. The runtime sees the message with
+/// `<@id>` tags rewritten to `@<handle>` text tokens; outbound replies that
+/// reference the same `@<handle>` are rewritten back to `<@id>` so Discord
+/// renders an actual mention. This is the data carrier for the reverse
+/// peer-mention handoff path (sera-yeg.4).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PeerMentionBinding {
+    /// Discord user id (used to render `<@id>` outbound mention tags).
+    pub user_id: String,
+    /// Configured peer-bot handle (the form runtime/LLM transcript sees).
+    pub handle: String,
+}
+
 /// Message received from Discord, ready for the gateway event queue.
 #[derive(Debug, Clone)]
 pub struct DiscordMessage {
     pub channel_id: String,
     pub user_id: String,
     pub username: String,
+    /// Mention-stripped content (legacy field, kept for back-compat with the
+    /// pre-sera-yeg.4 routing layer and tests that synthesize messages
+    /// without filling `raw_content`). When `raw_content` is non-empty the
+    /// routing layer prefers it so the configured peer-bot allowlist can
+    /// drive normalization (`normalize_content_for_runtime`).
     pub content: String,
     pub message_id: String,
     /// Whether this message was a DM (not a guild channel).
@@ -38,6 +68,17 @@ pub struct DiscordMessage {
     /// taking the first parsed discord connector in manifests (sera-yeg.1
     /// repair, Codex comment 3274130773).
     pub connector_name: Option<String>,
+    /// Raw message content as received from Discord, with `<@id>` mention
+    /// tags intact. `Some` for messages produced by [`parse_message_create`];
+    /// synthetic test fixtures may leave this empty, in which case the
+    /// routing layer falls back to `content`.
+    pub raw_content: String,
+    /// Users mentioned in the raw payload (one entry per `d.mentions`
+    /// element). Empty when no `<@id>` tags were resolved by Discord. The
+    /// routing layer filters this through the connector's `peer_bots`
+    /// allowlist before exposing any mention to the runtime / echoing it on
+    /// outbound replies (sera-yeg.4).
+    pub mentions: Vec<DiscordMentionedUser>,
 }
 
 /// Discord Gateway connector — connects via WebSocket, handles heartbeat,
@@ -306,6 +347,95 @@ pub fn strip_mentions(content: &str) -> String {
     stripped.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
+/// Compiled regex matching Discord user mention tags, capturing the numeric
+/// id. Shared by [`normalize_content_for_runtime`] so allow- vs deny-list
+/// decisions key off the same parse the rest of the connector uses.
+fn mention_tag_re() -> &'static regex::Regex {
+    use std::sync::LazyLock;
+    static RE: LazyLock<regex::Regex> =
+        LazyLock::new(|| regex::Regex::new(r"<@!?(\d+)>").expect("valid regex"));
+    &RE
+}
+
+/// Filter the inbound `mentions` array through the connector's `peer_bots`
+/// allowlist (matched by id OR username, same as [`decide_bot_policy`]).
+/// SERA's own bot id is excluded so the self mention used for routing never
+/// leaks into the runtime view (sera-yeg.4).
+///
+/// Returns the bindings the routing layer can safely expose to the runtime
+/// and use to render outbound mention tags. Empty when nothing matched.
+pub fn peer_directory_from_mentions(
+    mentions: &[DiscordMentionedUser],
+    self_bot_id: Option<&str>,
+    peer_bots: &[String],
+) -> Vec<PeerMentionBinding> {
+    mentions
+        .iter()
+        .filter(|m| match self_bot_id {
+            Some(sid) => m.id != sid,
+            None => true,
+        })
+        .filter(|m| {
+            peer_bots
+                .iter()
+                .any(|p| !p.is_empty() && (p == &m.id || p == &m.username))
+        })
+        .map(|m| PeerMentionBinding {
+            user_id: m.id.clone(),
+            handle: m.username.clone(),
+        })
+        .collect()
+}
+
+/// Build the runtime-visible content from raw Discord text:
+/// * `<@self_bot_id>` (and `<@!self_bot_id>`) → stripped — the self mention
+///   is used for inbound routing only and must not appear in transcript.
+/// * `<@peer_id>` where `peer_id` is in `peer_directory` → replaced with
+///   `@<handle>` so the LLM sees the peer reference as plain text.
+/// * Every other `<@id>` tag → stripped. Arbitrary user mentions must never
+///   reach the runtime: that would enable mention-spam / prompt-injection
+///   for any guild member that happens to ping SERA.
+///
+/// Whitespace is collapsed and trimmed to match [`strip_mentions`].
+pub fn normalize_content_for_runtime(
+    raw: &str,
+    self_bot_id: Option<&str>,
+    peer_directory: &[PeerMentionBinding],
+) -> String {
+    let replaced = mention_tag_re().replace_all(raw, |caps: &regex::Captures<'_>| {
+        let id = &caps[1];
+        if let Some(sid) = self_bot_id
+            && id == sid
+        {
+            return String::new();
+        }
+        if let Some(binding) = peer_directory.iter().find(|b| b.user_id == id) {
+            return format!("@{}", binding.handle);
+        }
+        String::new()
+    });
+    replaced.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// Render an outbound Discord message by substituting `@<handle>` tokens
+/// with `<@user_id>` for each entry in `peer_directory`. Other text passes
+/// through unchanged so arbitrary user-supplied `@names` cannot become
+/// outbound pings — only allowlisted peer-bot handles get rewritten.
+///
+/// Longer handles are processed first so `@Sera 2.0` is preferred over
+/// `@Sera` when both appear in the directory (sera-yeg.4 acceptance #2).
+pub fn render_outbound_content(content: &str, peer_directory: &[PeerMentionBinding]) -> String {
+    let mut entries: Vec<&PeerMentionBinding> = peer_directory.iter().collect();
+    entries.sort_by_key(|b| std::cmp::Reverse(b.handle.len()));
+    let mut out = content.to_owned();
+    for binding in entries {
+        let needle = format!("@{}", binding.handle);
+        let replacement = format!("<@{}>", binding.user_id);
+        out = out.replace(&needle, &replacement);
+    }
+    out
+}
+
 /// Try to extract a `DiscordMessage` from a Dispatch (opcode 0) payload
 /// with `t == "MESSAGE_CREATE"`.
 ///
@@ -339,23 +469,31 @@ pub fn parse_message_create(payload: &Value, bot_user_id: Option<&str>) -> Optio
 
     // Check if this is a DM (no guild_id) or mentions the bot
     let is_dm = d.get("guild_id").is_none();
-    let mentions_bot = if let Some(bot_id) = bot_user_id {
-        d.get("mentions")
-            .and_then(|m| m.as_array())
-            .map(|arr| {
-                arr.iter()
-                    .any(|u| u.get("id").and_then(Value::as_str) == Some(bot_id))
-            })
-            .unwrap_or(false)
-    } else {
-        false
+    let mentions: Vec<DiscordMentionedUser> = d
+        .get("mentions")
+        .and_then(|m| m.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|u| {
+                    let id = u.get("id")?.as_str()?.to_owned();
+                    let username = u.get("username")?.as_str()?.to_owned();
+                    Some(DiscordMentionedUser { id, username })
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    let mentions_bot = match bot_user_id {
+        Some(bot_id) => mentions.iter().any(|m| m.id == bot_id),
+        None => false,
     };
+
+    let raw_content = d.get("content")?.as_str()?.to_owned();
 
     Some(DiscordMessage {
         channel_id: d.get("channel_id")?.as_str()?.to_owned(),
         user_id: author_id.to_owned(),
         username: author.get("username")?.as_str()?.to_owned(),
-        content: strip_mentions(d.get("content")?.as_str()?),
+        content: strip_mentions(&raw_content),
         message_id: d.get("id")?.as_str()?.to_owned(),
         is_dm,
         mentions_bot,
@@ -364,6 +502,8 @@ pub fn parse_message_create(payload: &Value, bot_user_id: Option<&str>) -> Optio
         // own connector_name); the pure parser deliberately stays
         // identity-agnostic so it remains unit-testable without one.
         connector_name: None,
+        raw_content,
+        mentions,
     })
 }
 
@@ -1066,6 +1206,8 @@ mod tests {
             mentions_bot: false,
             is_bot: false,
             connector_name: None,
+            raw_content: "hello world".into(),
+            mentions: Vec::new(),
         };
         assert_eq!(msg.channel_id, "123456");
         assert_eq!(msg.user_id, "789");
@@ -2007,5 +2149,249 @@ mod tests {
         assert!(conn.test_session_id().is_none());
         assert!(conn.test_resume_gateway_url().is_none());
         assert_eq!(conn.test_last_sequence(), -1);
+    }
+
+    // -----------------------------------------------------------------------
+    // Reverse peer-mention handoff (sera-yeg.4)
+    //
+    // Inbound: configured non-self peer mentions are preserved as
+    // `@<handle>` text so the runtime sees the reference; SERA's own self
+    // mention is stripped (used only for routing); arbitrary user mentions
+    // are stripped so they can't leak into the runtime or be echoed.
+    //
+    // Outbound: when SERA's reply contains `@<peer-handle>` for a binding
+    // captured on the inbound, it is rewritten to `<@id>` so Discord
+    // renders an actual mention (the reverse handoff goal).
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn parse_message_create_captures_raw_content_and_mentions() {
+        let payload = serde_json::json!({
+            "op": 0,
+            "t": "MESSAGE_CREATE",
+            "s": 60,
+            "d": {
+                "id": "msg-yeg4-1",
+                "channel_id": "ch-yeg4",
+                "content": "<@111> please ping <@222> for me",
+                "mentions": [
+                    {"id": "111", "username": "Sera"},
+                    {"id": "222", "username": "Sera 2.0"}
+                ],
+                "author": {
+                    "id": "user-yeg4",
+                    "username": "operator",
+                    "bot": false
+                }
+            }
+        });
+        let msg = parse_message_create(&payload, Some("111")).expect("parse");
+        // raw_content keeps mention tags intact for downstream normalization.
+        assert_eq!(msg.raw_content, "<@111> please ping <@222> for me");
+        // Legacy `content` is still the strip_mentions output (back-compat).
+        assert_eq!(msg.content, "please ping for me");
+        assert_eq!(msg.mentions.len(), 2);
+        assert_eq!(
+            msg.mentions[0],
+            DiscordMentionedUser {
+                id: "111".into(),
+                username: "Sera".into()
+            }
+        );
+        assert_eq!(
+            msg.mentions[1],
+            DiscordMentionedUser {
+                id: "222".into(),
+                username: "Sera 2.0".into()
+            }
+        );
+        // Self mention drives the mentions_bot routing flag.
+        assert!(msg.mentions_bot);
+    }
+
+    #[test]
+    fn peer_directory_filters_through_allowlist_and_drops_self() {
+        let mentions = vec![
+            DiscordMentionedUser {
+                id: "111".into(),
+                username: "Sera".into(),
+            },
+            DiscordMentionedUser {
+                id: "222".into(),
+                username: "Sera 2.0".into(),
+            },
+            DiscordMentionedUser {
+                id: "333".into(),
+                username: "random-user".into(),
+            },
+        ];
+        // peer_bots configured by username; self id is "111".
+        let peers: Vec<String> = vec!["Sera 2.0".into()];
+        let dir = peer_directory_from_mentions(&mentions, Some("111"), &peers);
+        // Self ("111") and the unallowlisted random user ("333") are dropped.
+        assert_eq!(
+            dir,
+            vec![PeerMentionBinding {
+                user_id: "222".into(),
+                handle: "Sera 2.0".into(),
+            }],
+        );
+    }
+
+    #[test]
+    fn peer_directory_matches_by_id_or_username() {
+        // peer_bots can list either the Discord user id (stable across
+        // username changes) OR the human-friendly username; both must
+        // resolve into a binding.
+        let mentions = vec![
+            DiscordMentionedUser {
+                id: "by-id".into(),
+                username: "Friendly".into(),
+            },
+            DiscordMentionedUser {
+                id: "by-name".into(),
+                username: "Hermes 2.0".into(),
+            },
+        ];
+        let peers: Vec<String> = vec!["by-id".into(), "Hermes 2.0".into()];
+        let dir = peer_directory_from_mentions(&mentions, None, &peers);
+        assert_eq!(dir.len(), 2);
+        assert!(dir.iter().any(|b| b.user_id == "by-id"));
+        assert!(dir.iter().any(|b| b.user_id == "by-name"));
+    }
+
+    #[test]
+    fn peer_directory_empty_when_no_peer_bots_configured() {
+        // Strict default: with peer_bots empty, no inbound mention is
+        // surfaced — even bots are anonymized away.
+        let mentions = vec![DiscordMentionedUser {
+            id: "222".into(),
+            username: "Sera 2.0".into(),
+        }];
+        let dir = peer_directory_from_mentions(&mentions, Some("self"), &[]);
+        assert!(dir.is_empty());
+    }
+
+    #[test]
+    fn normalize_content_strips_self_and_unknown_keeps_peer() {
+        let dir = vec![PeerMentionBinding {
+            user_id: "222".into(),
+            handle: "Sera 2.0".into(),
+        }];
+        // Self <@111>: stripped. Peer <@222>: replaced with @Sera 2.0.
+        // Unknown <@333>: stripped (arbitrary mention spam guard).
+        let raw = "<@111> hi <@222> and <@333> please";
+        let runtime = normalize_content_for_runtime(raw, Some("111"), &dir);
+        assert_eq!(runtime, "hi @Sera 2.0 and please");
+    }
+
+    #[test]
+    fn normalize_content_handles_nickname_form() {
+        // Discord uses `<@!id>` when the mention targets a member with a
+        // server nickname. Must be treated identically to `<@id>`.
+        let dir = vec![PeerMentionBinding {
+            user_id: "222".into(),
+            handle: "Sera 2.0".into(),
+        }];
+        let runtime = normalize_content_for_runtime("<@!222> ping", None, &dir);
+        assert_eq!(runtime, "@Sera 2.0 ping");
+    }
+
+    #[test]
+    fn normalize_content_strips_all_when_no_directory() {
+        // No peer directory and no self id: behave like strip_mentions —
+        // every mention tag is removed so nothing leaks to runtime.
+        let runtime = normalize_content_for_runtime("<@111> <@222> raw", None, &[]);
+        assert_eq!(runtime, "raw");
+    }
+
+    #[test]
+    fn render_outbound_substitutes_only_allowlisted_handles() {
+        let dir = vec![PeerMentionBinding {
+            user_id: "222".into(),
+            handle: "Sera 2.0".into(),
+        }];
+        // The allowlisted handle is rewritten; @stranger is left as plain
+        // text so it cannot become an outbound ping.
+        let out = render_outbound_content("hello @Sera 2.0 and @stranger", &dir);
+        assert_eq!(out, "hello <@222> and @stranger");
+    }
+
+    #[test]
+    fn render_outbound_prefers_longer_handle_on_overlap() {
+        // Two peers, one a prefix of the other. The longer handle must win
+        // so `@Sera 2.0` doesn't collapse to `<@sera_id> 2.0`.
+        let dir = vec![
+            PeerMentionBinding {
+                user_id: "AAA".into(),
+                handle: "Sera".into(),
+            },
+            PeerMentionBinding {
+                user_id: "BBB".into(),
+                handle: "Sera 2.0".into(),
+            },
+        ];
+        let out = render_outbound_content("@Sera 2.0 and @Sera", &dir);
+        assert_eq!(out, "<@BBB> and <@AAA>");
+    }
+
+    #[test]
+    fn render_outbound_noop_when_directory_empty() {
+        // No allowlisted peers -> reply passes through untouched. This is
+        // the loop-safety contract for the common case (human user, no
+        // reverse handoff): nothing in the reply gets turned into a ping.
+        assert_eq!(
+            render_outbound_content("@Sera 2.0 hi", &[]),
+            "@Sera 2.0 hi",
+        );
+    }
+
+    #[test]
+    fn render_outbound_does_not_introduce_self_ping() {
+        // SERA's own bot id is not in any peer_directory (peer_directory
+        // strips self at construction). If the LLM ever produces `@sera`
+        // text, the renderer must leave it alone — preventing accidental
+        // self-pings that could trip loop-safety telemetry.
+        let dir = vec![PeerMentionBinding {
+            user_id: "222".into(),
+            handle: "Sera 2.0".into(),
+        }];
+        let out = render_outbound_content("@sera will think about it", &dir);
+        assert_eq!(out, "@sera will think about it");
+    }
+
+    #[test]
+    fn reverse_handoff_round_trip_inbound_to_outbound() {
+        // End-to-end on the pure layer: inbound MESSAGE_CREATE mentioning
+        // both @Sera (self) and @Sera 2.0 (allowlisted peer). After
+        // normalization the runtime sees the peer reference as plain text.
+        // The LLM echoes that reference into its reply. The outbound
+        // renderer turns it back into a Discord `<@id>` tag — closing the
+        // reverse-mention loop without disabling any loop guard.
+        let payload = serde_json::json!({
+            "op": 0,
+            "t": "MESSAGE_CREATE",
+            "s": 70,
+            "d": {
+                "id": "msg-yeg4-rt",
+                "channel_id": "ch-yeg4-rt",
+                "content": "<@111> tell <@222> that the reverse path works",
+                "mentions": [
+                    {"id": "111", "username": "Sera"},
+                    {"id": "222", "username": "Sera 2.0"}
+                ],
+                "author": {"id": "user-rt", "username": "operator", "bot": false}
+            }
+        });
+        let msg = parse_message_create(&payload, Some("111")).expect("parse");
+        let peers: Vec<String> = vec!["Sera 2.0".into()];
+        let dir = peer_directory_from_mentions(&msg.mentions, Some("111"), &peers);
+        let runtime = normalize_content_for_runtime(&msg.raw_content, Some("111"), &dir);
+        assert_eq!(runtime, "tell @Sera 2.0 that the reverse path works");
+
+        // Simulated LLM reply that echoes the peer handle.
+        let reply = "@Sera 2.0 acknowledged: reverse path works";
+        let outbound = render_outbound_content(reply, &dir);
+        assert_eq!(outbound, "<@222> acknowledged: reverse path works");
     }
 }


### PR DESCRIPTION
## Summary
- SERA's Discord adapter can now produce outbound messages that actually mention an allowlisted peer bot (e.g. an operator-side `@Sera 2.0`) so the peer is pulled back into the thread.
- Inbound `<@id>` mention tags from configured peers are preserved through normalization as `@<handle>` text so the runtime sees the peer reference; arbitrary user mentions are still stripped.
- Outbound replies are rendered through an allowlist-only substitution: only handles in the connector's `peer_bots` get rewritten to `<@id>`, everything else passes through as plain text.

## Why
The forward path (peer bot pings SERA, SERA accepts the turn) shipped in #1267. The reverse path was missing: `strip_mentions()` deleted every `<@id>` tag at parse time, so when an inbound message asked SERA to ping back, the runtime never saw which bot to address and the reply went out without any mention. SERA could not deliberately re-engage the peer.

## Approach
- **Inbound parse**: `parse_message_create` now records `raw_content` and the `mentions` array (id + username for each `<@id>` Discord resolved).
- **Routing**: `process_message` builds a `peer_directory` by filtering the inbound mentions through the connector-specific `peer_bots` allowlist (id OR username match, self id excluded), then derives `runtime_content` via `normalize_content_for_runtime` — self mention stripped, allowlisted peer `<@id>` rewritten to `@<handle>`, all other `<@id>` tags stripped.
- **Outbound**: every `send_message` call site renders the reply through `render_outbound_content`, which substitutes `@<handle>` for `<@id>` only for entries in `peer_directory`. Longer handles win on overlap so `@Sera 2.0` does not collapse to `<@id> 2.0`. The persisted assistant transcript stores the rendered form.

## Loop-safety contracts preserved
- SERA's own bot id is still hard-ignored at parse time and policy time.
- Unrelated bots still flow through the existing peer-bot policy (`gate_message` / `decide_bot_policy`).
- Empty `peer_bots` means strict default: nothing surfaced inbound, nothing rendered outbound.
- Arbitrary user `@names` in an LLM reply pass through untouched — they cannot become Discord pings.

## Tests
- `discord.rs` adds eleven unit tests covering raw-content capture, allowlist filtering, normalization (self / peer / unknown / nickname forms), outbound substitution (allowlisted-only, longest match wins, empty-directory no-op, no self-ping), and a parser -> normalize -> render round trip.
- `bin/sera.rs` adds two integration tests on `process_message`: transcript preserves allowlisted peer reference; unallowlisted mentions stripped before runtime sees them.
- `cargo check -p sera-gateway` clean; `cargo clippy -p sera-gateway --bin sera-gateway -- -D warnings` clean; `cargo test -p sera-gateway` library suite 214 / 214 passing, binary suite 367 / 369 passing (2 pre-existing failures are `production_e2e` tests that require a built `sera-runtime` binary as a runtime prereq, unrelated to this change).

## Test plan
- [x] Unit tests for pure parsing, normalization, and outbound rendering
- [x] Integration tests confirming the runtime transcript carries the normalized peer mention and unallowlisted mentions are stripped
- [x] `cargo clippy -- -D warnings` clean for `sera-gateway` binary
- [ ] Live controlled smoke (operator-side step): with a configured peer bot mention (e.g. `peer_bots: ["Sera 2.0"]`), verify that an explicit reverse-handoff prompt produces a SERA reply mentioning the configured peer in Discord and the peer observes the ping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)