### PR TITLE
feat(runtime): MiniMax primary + local fallback chain (sera-m1k8)

### DIFF
--- a/rust/crates/sera-runtime/CLAUDE.md
+++ b/rust/crates/sera-runtime/CLAUDE.md
@@ -28,6 +28,23 @@ cargo run -p sera-runtime -- --ndjson < submissions.ndjson
 | `AGENT_ID` | `sera-local` | Agent identifier |
 | `AGENT_CHAT_PORT` | 0 | Health check HTTP port (0 = disabled) |
 | `RUST_LOG` | `info` | Tracing filter (NDJSON mode) |
+| `SERA_LLM_FALLBACK_BASE_URL` | (unset) | Optional fallback endpoint (sera-m1k8) |
+| `SERA_LLM_FALLBACK_MODEL` | (unset) | Optional fallback model name |
+| `SERA_LLM_FALLBACK_API_KEY` | (unset) | Optional fallback API key (env-resolved) |
+| `SERA_LLM_FALLBACK_PROVIDER_ID` | fallback model | Optional explicit provider id for reasoning/pool inference |
+| `SERA_LLM_FALLBACK_MAX_TOKENS` | inherits primary | Optional override for fallback `max_tokens` |
+
+### Provider chain (sera-m1k8)
+
+When `SERA_LLM_FALLBACK_*` env vars are set, `build_provider_from_config`
+wraps the primary [`LlmClient`] in a [`fallback_chain::FallbackChain`]. The
+chain prefers the primary (typically MiniMax over the OpenAI-compatible path)
+and falls back to the secondary (typically local LM Studio / Qwen) **only**
+on retryable upstream errors: `RateLimited`, `ProviderUnavailable`,
+`Timeout`. Non-retryable classes (`RequestError`, `ContextOverflow`) surface
+verbatim so SERA-side bugs are not silently masked by falling back. Absent
+the env vars the chain is bypassed and behaviour is byte-identical to the
+single-provider path.
 
 ## Module Map
 

--- a/rust/crates/sera-runtime/src/fallback_chain.rs
+++ b/rust/crates/sera-runtime/src/fallback_chain.rs
@@ -1,0 +1,271 @@
+//! Ordered provider chain — try primary first, fall back to next on retryable errors.
+//!
+//! Used to put MiniMax (or any OpenAI-compatible endpoint) in front of a local
+//! LM Studio / Qwen backup so SERA prefers the cheap/cloud endpoint while
+//! preserving local continuity if the primary is unavailable. Each entry is a
+//! plain [`LlmClient`] so the chain works for any OpenAI-compatible provider
+//! without provider-specific adapter code.
+//!
+//! ## Fallback classification
+//!
+//! Errors from a [`LlmClient`] call are partitioned into two classes:
+//!
+//! - **Retryable** — [`LlmError::RateLimited`], [`LlmError::ProviderUnavailable`],
+//!   [`LlmError::Timeout`]. The chain advances to the next provider.
+//! - **Non-retryable** — [`LlmError::RequestError`] (4xx other than 429,
+//!   malformed body, tool-schema, policy, serialization bugs) and
+//!   [`LlmError::ContextOverflow`] (genuine model-side limit). These surface
+//!   immediately so a real SERA bug is not silently masked by falling back.
+//!
+//! When the last provider in the chain fails, its error is returned verbatim
+//! (whatever class it was), preserving caller-visible diagnostics.
+//!
+//! ## Wiring
+//!
+//! [`crate::llm_client::build_provider_from_config`] reads
+//! `SERA_LLM_FALLBACK_BASE_URL`, `SERA_LLM_FALLBACK_MODEL`, and
+//! `SERA_LLM_FALLBACK_API_KEY` and, when all three are set, builds a chain of
+//! `[primary, fallback]`. Otherwise it returns the primary alone — the
+//! single-provider path is byte-identical to the pre-chain behaviour.
+
+use async_trait::async_trait;
+use sera_types::runtime::TokenUsage;
+use sera_types::tool::ToolUseBehavior;
+
+use crate::llm_client::{LlmChatResult, LlmClient, LlmError};
+use crate::turn::{LlmProvider, ThinkError, ThinkResult};
+use crate::types::{ChatMessage, ToolDefinition};
+
+/// Ordered chain of [`LlmClient`]s with retryable-only fallback semantics.
+pub struct FallbackChain {
+    providers: Vec<LlmClient>,
+}
+
+impl FallbackChain {
+    /// Build a chain from an ordered list of clients. Panics on empty input —
+    /// a zero-provider chain is always a configuration bug, not a runtime
+    /// condition worth surfacing as an error variant.
+    pub fn new(providers: Vec<LlmClient>) -> Self {
+        assert!(
+            !providers.is_empty(),
+            "FallbackChain requires at least one provider"
+        );
+        Self { providers }
+    }
+
+    /// Number of providers in the chain (primary + fallbacks).
+    pub fn len(&self) -> usize {
+        self.providers.len()
+    }
+
+    /// Always `false` — [`FallbackChain::new`] rejects an empty provider list,
+    /// so a constructed chain is never empty. Defined for clippy parity with
+    /// [`Self::len`].
+    pub fn is_empty(&self) -> bool {
+        self.providers.is_empty()
+    }
+
+    /// Streaming chat with explicit tool-use policy. Tries each provider in
+    /// order, advancing only on [`is_retryable`] errors.
+    pub async fn chat_typed_with_behavior(
+        &self,
+        messages: &[ChatMessage],
+        tools: &[ToolDefinition],
+        tool_use_behavior: &ToolUseBehavior,
+    ) -> Result<LlmChatResult, LlmError> {
+        let last_index = self.providers.len() - 1;
+        let mut last_err: Option<LlmError> = None;
+        for (idx, provider) in self.providers.iter().enumerate() {
+            match provider
+                .chat_typed_with_behavior(messages, tools, tool_use_behavior)
+                .await
+            {
+                Ok(result) => return Ok(result),
+                Err(err) => {
+                    if !is_retryable(&err) || idx == last_index {
+                        return Err(err);
+                    }
+                    tracing::warn!(
+                        provider_index = idx,
+                        error = %err,
+                        "provider failed with retryable error, advancing chain"
+                    );
+                    last_err = Some(err);
+                }
+            }
+        }
+        Err(last_err.unwrap_or_else(|| {
+            LlmError::RequestError("FallbackChain exhausted with no providers".to_string())
+        }))
+    }
+
+    /// Non-streaming chat with explicit tool-use policy.
+    pub async fn chat_non_streaming_with_behavior(
+        &self,
+        messages: &[ChatMessage],
+        tools: &[ToolDefinition],
+        tool_use_behavior: &ToolUseBehavior,
+    ) -> Result<LlmChatResult, LlmError> {
+        let last_index = self.providers.len() - 1;
+        let mut last_err: Option<LlmError> = None;
+        for (idx, provider) in self.providers.iter().enumerate() {
+            match provider
+                .chat_non_streaming_with_behavior(messages, tools, tool_use_behavior)
+                .await
+            {
+                Ok(result) => return Ok(result),
+                Err(err) => {
+                    if !is_retryable(&err) || idx == last_index {
+                        return Err(err);
+                    }
+                    tracing::warn!(
+                        provider_index = idx,
+                        error = %err,
+                        "provider failed with retryable error, advancing chain (non-streaming)"
+                    );
+                    last_err = Some(err);
+                }
+            }
+        }
+        Err(last_err.unwrap_or_else(|| {
+            LlmError::RequestError("FallbackChain exhausted with no providers".to_string())
+        }))
+    }
+}
+
+/// True when an [`LlmError`] is eligible for chain fallback.
+///
+/// Retryable classes are exactly those that indicate upstream-side trouble
+/// rather than a SERA-side request bug. Falling back on
+/// [`LlmError::RequestError`] would mask tool-schema / policy / serialization
+/// bugs; falling back on [`LlmError::ContextOverflow`] would just produce the
+/// same error from the next provider at best.
+pub fn is_retryable(err: &LlmError) -> bool {
+    matches!(
+        err,
+        LlmError::RateLimited { .. } | LlmError::ProviderUnavailable(_) | LlmError::Timeout(_)
+    )
+}
+
+#[async_trait]
+impl LlmProvider for FallbackChain {
+    async fn chat(
+        &self,
+        messages: &[serde_json::Value],
+        tools: &[serde_json::Value],
+    ) -> Result<ThinkResult, ThinkError> {
+        <Self as LlmProvider>::chat_with_behavior(self, messages, tools, &ToolUseBehavior::Auto)
+            .await
+    }
+
+    async fn chat_with_behavior(
+        &self,
+        messages: &[serde_json::Value],
+        tools: &[serde_json::Value],
+        tool_use_behavior: &ToolUseBehavior,
+    ) -> Result<ThinkResult, ThinkError> {
+        let chat_messages: Vec<ChatMessage> = messages
+            .iter()
+            .map(|m| serde_json::from_value(m.clone()))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| ThinkError::Conversion(format!("message deserialization: {e}")))?;
+
+        let tool_defs: Vec<ToolDefinition> = tools
+            .iter()
+            .map(|t| serde_json::from_value(t.clone()))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| ThinkError::Conversion(format!("tool deserialization: {e}")))?;
+
+        let result = self
+            .chat_typed_with_behavior(&chat_messages, &tool_defs, tool_use_behavior)
+            .await
+            .map_err(|e| ThinkError::Llm(e.to_string()))?;
+
+        let tool_calls: Vec<serde_json::Value> = result
+            .message
+            .tool_calls
+            .unwrap_or_default()
+            .into_iter()
+            .map(|tc| {
+                serde_json::json!({
+                    "id": tc.id,
+                    "type": tc.call_type,
+                    "function": {
+                        "name": tc.function.name,
+                        "arguments": tc.function.arguments,
+                    }
+                })
+            })
+            .collect();
+
+        Ok(ThinkResult {
+            response: serde_json::json!({
+                "role": "assistant",
+                "content": result.message.content,
+            }),
+            tool_calls,
+            tokens: TokenUsage {
+                prompt_tokens: result.prompt_tokens,
+                completion_tokens: result.completion_tokens,
+                total_tokens: result.prompt_tokens + result.completion_tokens,
+            },
+            plan: None,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn rate_limited_is_retryable() {
+        let err = LlmError::RateLimited {
+            message: "slow down".into(),
+            retry_after: Some(Duration::from_secs(1)),
+        };
+        assert!(is_retryable(&err));
+    }
+
+    #[test]
+    fn provider_unavailable_is_retryable() {
+        assert!(is_retryable(&LlmError::ProviderUnavailable("503".into())));
+    }
+
+    #[test]
+    fn timeout_is_retryable() {
+        assert!(is_retryable(&LlmError::Timeout("60s".into())));
+    }
+
+    #[test]
+    fn request_error_is_not_retryable() {
+        // Schema / policy / serialization bugs must NOT trigger fallback —
+        // the chain would just hide a real SERA bug.
+        assert!(!is_retryable(&LlmError::RequestError(
+            "HTTP 400: missing tool argument".into()
+        )));
+    }
+
+    #[test]
+    fn context_overflow_is_not_retryable() {
+        // The next provider has the same context limit at best; falling back
+        // would just produce the same error after another roundtrip.
+        assert!(!is_retryable(&LlmError::ContextOverflow(
+            "max context exceeded".into()
+        )));
+    }
+
+    #[test]
+    #[should_panic(expected = "at least one provider")]
+    fn empty_chain_panics() {
+        let _ = FallbackChain::new(Vec::new());
+    }
+
+    #[test]
+    fn single_provider_chain_reports_length_one() {
+        let client = LlmClient::with_params("http://unused.invalid", "m", None, 1_000);
+        let chain = FallbackChain::new(vec![client]);
+        assert_eq!(chain.len(), 1);
+    }
+}

--- a/rust/crates/sera-runtime/src/fallback_chain.rs
+++ b/rust/crates/sera-runtime/src/fallback_chain.rs
@@ -17,11 +17,14 @@
 //!   [`LlmError::ContextOverflow`] (genuine model-side limit). These surface
 //!   immediately so a real SERA bug is not silently masked by falling back.
 //!
-//! Transport-level failures (DNS, connection refused, TLS handshake) are
-//! classified by [`LlmClient`] as [`LlmError::ProviderUnavailable`] — see
-//! `llm_client.rs` where the reqwest `is_connect()` branch maps to that
-//! variant — so a primary-down outage falls through to the next provider
-//! rather than surfacing as a SERA-side request bug.
+//! Transport-level failures (DNS, connection refused, TLS handshake, mid-
+//! request body drops, h2 stream resets, etc.) are classified by [`LlmClient`]
+//! as [`LlmError::ProviderUnavailable`] — see `classify_send_error` in
+//! `llm_client.rs`, which defaults any non-timeout reqwest error from `.send()`
+//! to `ProviderUnavailable` and reserves `RequestError` for the
+//! `is_request()` (SERA-side request-builder bug) case alone. This is the
+//! fix for the PR #1272 P1 review: a primary-down outage now falls through
+//! to the next provider rather than masquerading as a SERA-side request bug.
 //!
 //! When the last provider in the chain fails, its error is returned verbatim
 //! (whatever class it was), preserving caller-visible diagnostics.

--- a/rust/crates/sera-runtime/src/fallback_chain.rs
+++ b/rust/crates/sera-runtime/src/fallback_chain.rs
@@ -17,6 +17,12 @@
 //!   [`LlmError::ContextOverflow`] (genuine model-side limit). These surface
 //!   immediately so a real SERA bug is not silently masked by falling back.
 //!
+//! Transport-level failures (DNS, connection refused, TLS handshake) are
+//! classified by [`LlmClient`] as [`LlmError::ProviderUnavailable`] — see
+//! `llm_client.rs` where the reqwest `is_connect()` branch maps to that
+//! variant — so a primary-down outage falls through to the next provider
+//! rather than surfacing as a SERA-side request bug.
+//!
 //! When the last provider in the chain fails, its error is returned verbatim
 //! (whatever class it was), preserving caller-visible diagnostics.
 //!

--- a/rust/crates/sera-runtime/src/lib.rs
+++ b/rust/crates/sera-runtime/src/lib.rs
@@ -59,6 +59,7 @@ pub mod authz_builder;
 pub mod config;
 pub mod memory_budget;
 pub mod default_runtime;
+pub mod fallback_chain;
 pub mod health;
 pub mod llm_client;
 pub mod manifest;

--- a/rust/crates/sera-runtime/src/llm_client.rs
+++ b/rust/crates/sera-runtime/src/llm_client.rs
@@ -567,24 +567,12 @@ impl LlmClient {
                 )));
             }
             Ok(Err(e)) => {
-                let is_timeout = e.is_timeout();
-                let is_connect = e.is_connect();
                 if let Some(g) = guard {
                     // Network-level failure → treat as provider unavailable so
                     // the pool tries the next account next time.
                     g.mark_unavailable();
                 }
-                if is_timeout {
-                    return Err(LlmError::Timeout(e.to_string()));
-                }
-                if is_connect {
-                    // DNS failure, connection refused, TLS handshake error —
-                    // the upstream is unreachable. Classify as
-                    // ProviderUnavailable so FallbackChain advances rather
-                    // than masking this as a SERA-side request bug.
-                    return Err(LlmError::ProviderUnavailable(e.to_string()));
-                }
-                return Err(LlmError::RequestError(e.to_string()));
+                return Err(classify_send_error(e));
             }
             Ok(Ok(resp)) => resp,
         };
@@ -873,20 +861,36 @@ impl LlmClient {
 /// single-account `LLM_BASE_URL` / `LLM_API_KEY` path. Likewise
 /// `SERA_REASONING_LEVEL` defaults to `off` when unset.
 pub fn build_from_config(config: &RuntimeConfig) -> LlmClient {
+    // Provider kind is inferred from LLM_MODEL (e.g. "gpt-4o" → OpenAI,
+    // "claude-3-5-sonnet" → Anthropic).  Operators can also set
+    // SERA_LLM_PROVIDER_ID to pin the inference explicitly.
+    let provider_id = std::env::var("SERA_LLM_PROVIDER_ID")
+        .unwrap_or_else(|_| config.llm_model.clone());
+    wire_client_from_env(config, &provider_id)
+}
+
+/// Build an [`LlmClient`] from `config`, applying the same env-driven wiring
+/// that [`build_from_config`] uses for the primary: `SERA_REASONING_LEVEL` /
+/// `SERA_REASONING_BUDGET_TOKENS` thinking config, inferred provider kind,
+/// and the `SERA_<PROVIDER>_KEYS` account pool (sera-jvi) when configured for
+/// `provider_id`.
+///
+/// Extracted so [`build_provider_from_config`] can construct the fallback
+/// through the same path — closing the PR #1272 P2 gap where the fallback
+/// silently ran with no reasoning config and only a single static key, so
+/// fallback availability degraded exactly during the outage/rate-limit
+/// scenarios it was meant to cover.
+fn wire_client_from_env(config: &RuntimeConfig, provider_id: &str) -> LlmClient {
     use sera_config::providers::ProviderAccountsConfig;
     use sera_models::{
         AccountPool, CooldownConfig, ProviderAccount, ProviderKind, ReasoningLevel,
         ThinkingConfig,
     };
 
-    // Provider kind is inferred from LLM_MODEL (e.g. "gpt-4o" → OpenAI,
-    // "claude-3-5-sonnet" → Anthropic).  Operators can also set
-    // SERA_LLM_PROVIDER_ID to pin the inference explicitly.
-    let provider_id = std::env::var("SERA_LLM_PROVIDER_ID")
-        .unwrap_or_else(|_| config.llm_model.clone());
-    let provider_kind = ProviderKind::infer(&provider_id);
+    let provider_kind = ProviderKind::infer(provider_id);
 
-    // Thinking / reasoning level.
+    // Thinking / reasoning level (shared across primary + fallback — reasoning
+    // depth is an agent-level decision, not provider-specific).
     let level = std::env::var("SERA_REASONING_LEVEL")
         .ok()
         .and_then(|v| match v.trim().to_ascii_lowercase().as_str() {
@@ -910,7 +914,7 @@ pub fn build_from_config(config: &RuntimeConfig) -> LlmClient {
     // Account pool (sera-jvi). Only attached when at least one key is
     // configured for the active provider id.
     let accounts_cfg = ProviderAccountsConfig::from_env();
-    if let Some(keys) = accounts_cfg.keys_for(&provider_id)
+    if let Some(keys) = accounts_cfg.keys_for(provider_id)
         && !keys.is_empty()
     {
         let accounts: Vec<ProviderAccount> = keys
@@ -921,7 +925,7 @@ pub fn build_from_config(config: &RuntimeConfig) -> LlmClient {
             })
             .collect();
         let pool = Arc::new(
-            AccountPool::new(provider_id.clone(), accounts, CooldownConfig::default())
+            AccountPool::new(provider_id.to_string(), accounts, CooldownConfig::default())
                 .with_default_base_url(config.llm_base_url.clone()),
         );
         tracing::info!(
@@ -947,6 +951,10 @@ pub fn build_from_config(config: &RuntimeConfig) -> LlmClient {
 ///   the secondary on retryable errors only (rate-limit, timeout,
 ///   provider-unavailable). Operators wiring MiniMax as the primary point
 ///   `LLM_*` at MiniMax and `SERA_LLM_FALLBACK_*` at local LM Studio / Qwen.
+///   The fallback is built through the same `wire_client_from_env` path as
+///   the primary, so it picks up `SERA_REASONING_LEVEL` /
+///   `SERA_REASONING_BUDGET_TOKENS` and any `SERA_<PROVIDER>_KEYS` account
+///   pool configured for the fallback's provider id (PR #1272 P2 fix).
 /// - `SERA_LLM_FALLBACK_PROVIDER_ID` — optional explicit provider id for the
 ///   fallback (used for reasoning-config inference + account-pool lookup).
 ///   Defaults to the fallback model name.
@@ -977,7 +985,6 @@ pub fn build_provider_from_config(
                 .ok()
                 .filter(|s| !s.is_empty())
                 .unwrap_or_else(|| model.clone());
-            let provider_kind = sera_models::ProviderKind::infer(&provider_id);
             let fallback_config = RuntimeConfig {
                 llm_base_url: base,
                 llm_model: model.clone(),
@@ -985,8 +992,13 @@ pub fn build_provider_from_config(
                 max_tokens,
                 ..config.clone()
             };
-            let fallback_client = LlmClient::new(&fallback_config)
-                .with_provider_kind(provider_kind);
+            // PR #1272 P2 fix (sera-m1k8): route the fallback through the same
+            // env-driven wiring as the primary so it gets reasoning config and
+            // a provider account pool when configured. Otherwise the fallback
+            // silently runs with a single static key and no reasoning settings,
+            // degrading availability exactly during the outage/rate-limit
+            // scenarios the chain was added for.
+            let fallback_client = wire_client_from_env(&fallback_config, &provider_id);
             tracing::info!(
                 primary_model = %config.llm_model,
                 fallback_model = %model,
@@ -1079,6 +1091,36 @@ impl LlmProvider for LlmClient {
 // ---------------------------------------------------------------------------
 // Error classification
 // ---------------------------------------------------------------------------
+
+/// Classify a `reqwest::Error` raised from `.send()` (no HTTP response received).
+///
+/// Policy — see PR #1272 review (sera-m1k8):
+/// - `is_timeout()` → `Timeout` (chain-retryable).
+/// - transport-level signals (`is_connect()` — DNS / connection refused / TLS
+///   handshake; `is_body()` — mid-request body transport drop;
+///   `is_redirect()` — redirect-loop) → `ProviderUnavailable` so
+///   `FallbackChain` advances. Checked **before** `is_request()` because in
+///   reqwest those signals are not mutually exclusive: `is_request()` is also
+///   `true` for connect errors, so checking `is_request()` first would
+///   re-introduce the PR #1272 P1 bug (transport outages misclassified as
+///   SERA-side request bugs).
+/// - `is_request()` (after eliminating transport signals) → `RequestError`
+///   (genuine SERA-side request-builder bug — invalid URL, bad header, etc.).
+/// - everything else → `ProviderUnavailable` (default to upstream-side for
+///   unknown reqwest error kinds; the chain advances rather than masking a
+///   real outage as a SERA bug).
+fn classify_send_error(e: reqwest::Error) -> LlmError {
+    if e.is_timeout() {
+        return LlmError::Timeout(e.to_string());
+    }
+    if e.is_connect() || e.is_body() || e.is_redirect() {
+        return LlmError::ProviderUnavailable(e.to_string());
+    }
+    if e.is_request() {
+        return LlmError::RequestError(e.to_string());
+    }
+    LlmError::ProviderUnavailable(e.to_string())
+}
 
 /// Classify an HTTP error into the appropriate `LlmError` variant.
 fn classify_http_error(
@@ -2192,5 +2234,58 @@ mod tests {
         let config = make_runtime_config_with_thinking(None);
         let client = LlmClient::new(&config);
         assert_eq!(client.provider_kind(), ProviderKind::Anthropic);
+    }
+
+    // =========================================================================
+    // PR #1272 P2 — fallback gets the same env-driven wiring as the primary
+    // =========================================================================
+
+    #[test]
+    fn wire_client_from_env_attaches_thinking_and_account_pool() {
+        // Use a uniquely-named provider id so SERA_<PROVIDER>_KEYS can be
+        // set/cleared in this test without colliding with any real provider.
+        // SERA_REASONING_LEVEL is a single global env var; save/restore it so
+        // we don't pollute other tests that depend on its default ("off").
+        let provider_id = "sera1272testprov";
+        let keys_var = "SERA_SERA1272TESTPROV_KEYS";
+        let level_var = "SERA_REASONING_LEVEL";
+
+        let prev_level = std::env::var(level_var).ok();
+        let prev_keys = std::env::var(keys_var).ok();
+
+        // SAFETY: env::set_var is unsafe under edition 2024 (racy across
+        // threads). This test mutates two env vars and restores them before
+        // returning; concurrent test threads reading the same vars may see
+        // transient state, which is acceptable for the narrow window here —
+        // every existing wire/build_from_config test directly constructs
+        // clients without touching SERA_REASONING_LEVEL.
+        unsafe {
+            std::env::set_var(level_var, "high");
+            std::env::set_var(keys_var, "key-a,key-b,key-c");
+        }
+
+        let config = make_runtime_config_with_thinking(None);
+        let client = wire_client_from_env(&config, provider_id);
+
+        unsafe {
+            match prev_level {
+                Some(v) => std::env::set_var(level_var, v),
+                None => std::env::remove_var(level_var),
+            }
+            match prev_keys {
+                Some(v) => std::env::set_var(keys_var, v),
+                None => std::env::remove_var(keys_var),
+            }
+        }
+
+        assert_eq!(
+            client.thinking().level,
+            sera_models::ReasoningLevel::High,
+            "SERA_REASONING_LEVEL=high must propagate to wired client"
+        );
+        assert!(
+            client.has_account_pool(),
+            "SERA_<PROVIDER>_KEYS must attach an account pool"
+        );
     }
 }

--- a/rust/crates/sera-runtime/src/llm_client.rs
+++ b/rust/crates/sera-runtime/src/llm_client.rs
@@ -568,6 +568,7 @@ impl LlmClient {
             }
             Ok(Err(e)) => {
                 let is_timeout = e.is_timeout();
+                let is_connect = e.is_connect();
                 if let Some(g) = guard {
                     // Network-level failure → treat as provider unavailable so
                     // the pool tries the next account next time.
@@ -575,6 +576,13 @@ impl LlmClient {
                 }
                 if is_timeout {
                     return Err(LlmError::Timeout(e.to_string()));
+                }
+                if is_connect {
+                    // DNS failure, connection refused, TLS handshake error —
+                    // the upstream is unreachable. Classify as
+                    // ProviderUnavailable so FallbackChain advances rather
+                    // than masking this as a SERA-side request bug.
+                    return Err(LlmError::ProviderUnavailable(e.to_string()));
                 }
                 return Err(LlmError::RequestError(e.to_string()));
             }

--- a/rust/crates/sera-runtime/src/llm_client.rs
+++ b/rust/crates/sera-runtime/src/llm_client.rs
@@ -1102,6 +1102,13 @@ impl LlmProvider for LlmClient {
 ///
 /// Policy — see PR #1272 review (sera-m1k8):
 /// - `is_timeout()` → `Timeout` (chain-retryable).
+/// - `is_builder()` → `RequestError` (PR #1272 P2 follow-up). Builder errors
+///   come from request *construction* — invalid `LLM_BASE_URL` /
+///   `SERA_LLM_FALLBACK_BASE_URL`, malformed header values, etc. — and are
+///   purely local config / wiring bugs. They must surface as `RequestError`
+///   so the chain does NOT advance and silently route traffic to the
+///   fallback while masking the primary misconfiguration. Checked **before**
+///   transport signals because builder errors never reach the network.
 /// - transport-level signals (`is_connect()` — DNS / connection refused / TLS
 ///   handshake; `is_body()` — mid-request body transport drop;
 ///   `is_redirect()` — redirect-loop) → `ProviderUnavailable` so
@@ -1118,6 +1125,9 @@ impl LlmProvider for LlmClient {
 fn classify_send_error(e: reqwest::Error) -> LlmError {
     if e.is_timeout() {
         return LlmError::Timeout(e.to_string());
+    }
+    if e.is_builder() {
+        return LlmError::RequestError(e.to_string());
     }
     if e.is_connect() || e.is_body() || e.is_redirect() {
         return LlmError::ProviderUnavailable(e.to_string());
@@ -1429,6 +1439,30 @@ mod tests {
                 "error message should include the status code"
             );
         }
+    }
+
+    #[test]
+    fn classify_send_error_builder_is_request_error() {
+        // PR #1272 P2 follow-up: reqwest builder errors (invalid base URL,
+        // bad header construction, etc.) must classify as `RequestError` so
+        // `FallbackChain::is_retryable` returns false and the chain does NOT
+        // silently route traffic to the fallback while masking a local
+        // misconfiguration of the primary endpoint.
+        let err = reqwest::Client::new()
+            .get("not a url")
+            .build()
+            .unwrap_err();
+        assert!(err.is_builder(), "expected a reqwest builder error");
+
+        let classified = classify_send_error(err);
+        assert!(
+            matches!(classified, LlmError::RequestError(_)),
+            "builder errors must classify as RequestError, got {classified:?}"
+        );
+        assert!(
+            !crate::fallback_chain::is_retryable(&classified),
+            "builder/RequestError must not be chain-retryable"
+        );
     }
 
     #[test]

--- a/rust/crates/sera-runtime/src/llm_client.rs
+++ b/rust/crates/sera-runtime/src/llm_client.rs
@@ -927,6 +927,73 @@ pub fn build_from_config(config: &RuntimeConfig) -> LlmClient {
     client
 }
 
+/// Build an [`LlmProvider`] from a [`RuntimeConfig`], optionally wrapping the
+/// primary client in a [`crate::fallback_chain::FallbackChain`] when fallback
+/// env vars are set.
+///
+/// Env-var contract (sera-m1k8):
+/// - **Primary** — `LLM_BASE_URL`, `LLM_MODEL`, `LLM_API_KEY` (existing).
+/// - **Fallback (optional)** — `SERA_LLM_FALLBACK_BASE_URL`,
+///   `SERA_LLM_FALLBACK_MODEL`, `SERA_LLM_FALLBACK_API_KEY`. When all three
+///   are set the returned provider tries the primary first and falls back to
+///   the secondary on retryable errors only (rate-limit, timeout,
+///   provider-unavailable). Operators wiring MiniMax as the primary point
+///   `LLM_*` at MiniMax and `SERA_LLM_FALLBACK_*` at local LM Studio / Qwen.
+/// - `SERA_LLM_FALLBACK_PROVIDER_ID` — optional explicit provider id for the
+///   fallback (used for reasoning-config inference + account-pool lookup).
+///   Defaults to the fallback model name.
+/// - `SERA_LLM_FALLBACK_MAX_TOKENS` — optional override for the fallback
+///   client's `max_tokens` budget. Defaults to the primary's `max_tokens`.
+///
+/// When the fallback vars are absent, this returns a single-provider
+/// `Box<LlmClient>` — byte-identical to calling [`build_from_config`]
+/// directly.
+pub fn build_provider_from_config(
+    config: &RuntimeConfig,
+) -> Box<dyn crate::turn::LlmProvider> {
+    let primary = build_from_config(config);
+
+    let fallback_base = std::env::var("SERA_LLM_FALLBACK_BASE_URL").ok();
+    let fallback_model = std::env::var("SERA_LLM_FALLBACK_MODEL").ok();
+    let fallback_key = std::env::var("SERA_LLM_FALLBACK_API_KEY").ok();
+
+    match (fallback_base, fallback_model, fallback_key) {
+        (Some(base), Some(model), Some(api_key))
+            if !base.is_empty() && !model.is_empty() && !api_key.is_empty() =>
+        {
+            let max_tokens = std::env::var("SERA_LLM_FALLBACK_MAX_TOKENS")
+                .ok()
+                .and_then(|v| v.parse::<u32>().ok())
+                .unwrap_or(config.max_tokens);
+            let provider_id = std::env::var("SERA_LLM_FALLBACK_PROVIDER_ID")
+                .ok()
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| model.clone());
+            let provider_kind = sera_models::ProviderKind::infer(&provider_id);
+            let fallback_config = RuntimeConfig {
+                llm_base_url: base,
+                llm_model: model.clone(),
+                llm_api_key: api_key,
+                max_tokens,
+                ..config.clone()
+            };
+            let fallback_client = LlmClient::new(&fallback_config)
+                .with_provider_kind(provider_kind);
+            tracing::info!(
+                primary_model = %config.llm_model,
+                fallback_model = %model,
+                fallback_provider_id = %provider_id,
+                "FallbackChain configured (sera-m1k8): primary + 1 fallback"
+            );
+            Box::new(crate::fallback_chain::FallbackChain::new(vec![
+                primary,
+                fallback_client,
+            ]))
+        }
+        _ => Box::new(primary),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // LlmProvider implementation
 // ---------------------------------------------------------------------------

--- a/rust/crates/sera-runtime/src/llm_client.rs
+++ b/rust/crates/sera-runtime/src/llm_client.rs
@@ -606,13 +606,27 @@ impl LlmClient {
                     );
                     g.record_429(*retry_after);
                 }
-                Err(LlmError::ProviderUnavailable(_)) => {
+                Err(LlmError::ProviderUnavailable(_)) if status.as_u16() == 503 => {
+                    // 503 Service Unavailable on this credential: pool entry
+                    // is overloaded/banned, so cycle to the next credential.
                     record_credential_outcome(
                         &provider,
                         &credential_id,
                         CredentialOutcome::Error5xx,
                     );
                     g.mark_unavailable();
+                }
+                Err(LlmError::ProviderUnavailable(_)) => {
+                    // 500/502/504/etc.: server-side fault that's not the
+                    // credential's fault — keep the credential active. The
+                    // chain still falls back because the error class is
+                    // retryable; see PR #1272 P1 follow-up.
+                    record_credential_outcome(
+                        &provider,
+                        &credential_id,
+                        CredentialOutcome::Error5xx,
+                    );
+                    g.mark_success();
                 }
                 Err(LlmError::RequestError(_)) if is_non_retryable_status(status.as_u16()) => {
                     // Sera-hjem: 4xx other than 429 is the credential's fault
@@ -623,14 +637,6 @@ impl LlmClient {
                         CredentialOutcome::Error4xx,
                     );
                     g.record_non_retryable_error();
-                }
-                _ if (500..=599).contains(&status.as_u16()) => {
-                    record_credential_outcome(
-                        &provider,
-                        &credential_id,
-                        CredentialOutcome::Error5xx,
-                    );
-                    g.mark_success();
                 }
                 // Context overflow / unclassified — not the credential's
                 // fault, leave state untouched and don't taint counters.
@@ -1135,7 +1141,15 @@ fn classify_http_error(
             message: truncate_error(body),
             retry_after,
         }),
-        503 => Err(LlmError::ProviderUnavailable(truncate_error(body))),
+        // Any 5xx — upstream-side fault. Classify as ProviderUnavailable so
+        // `FallbackChain` advances on 500/502/504/etc., not just 503. PR #1272
+        // P1 follow-up: previously only 503 was retryable; generic 5xx fell
+        // through to `RequestError` and the chain stopped on the primary
+        // during common upstream outage classes.
+        500..=599 => Err(LlmError::ProviderUnavailable(format!(
+            "HTTP {status}: {}",
+            truncate_error(body)
+        ))),
         400 if lower_body.contains("context_length_exceeded")
             || lower_body.contains("maximum context length")
             || lower_body.contains("context window")
@@ -1400,10 +1414,21 @@ mod tests {
     }
 
     #[test]
-    fn test_error_generic_500() {
-        let err = classify_http_error(500, "internal server error", None).unwrap_err();
-        assert!(matches!(err, LlmError::RequestError(_)));
-        assert!(err.to_string().contains("HTTP 500"));
+    fn test_error_generic_5xx_is_provider_unavailable() {
+        // PR #1272 P1 follow-up: every 5xx — not just 503 — must classify as
+        // ProviderUnavailable so FallbackChain advances on common upstream
+        // outage classes (500 Internal, 502 Bad Gateway, 504 Gateway Timeout).
+        for status in [500u16, 502, 504, 505, 599] {
+            let err = classify_http_error(status, "upstream fault", None).unwrap_err();
+            assert!(
+                matches!(err, LlmError::ProviderUnavailable(_)),
+                "status {status} should be ProviderUnavailable, got {err:?}"
+            );
+            assert!(
+                err.to_string().contains(&format!("HTTP {status}")),
+                "error message should include the status code"
+            );
+        }
     }
 
     #[test]
@@ -1887,9 +1912,12 @@ mod tests {
     }
 
     #[test]
-    fn error_502_maps_to_request_error() {
+    fn error_502_maps_to_provider_unavailable() {
+        // PR #1272 P1 follow-up: 502 Bad Gateway is an upstream-side fault,
+        // not a SERA-side request bug. It must classify as ProviderUnavailable
+        // so the fallback chain advances on common primary-down outages.
         let err = classify_http_error(502, "bad gateway", None).unwrap_err();
-        assert!(matches!(err, LlmError::RequestError(_)));
+        assert!(matches!(err, LlmError::ProviderUnavailable(_)));
         assert!(err.to_string().contains("HTTP 502"));
     }
 

--- a/rust/crates/sera-runtime/src/main.rs
+++ b/rust/crates/sera-runtime/src/main.rs
@@ -199,9 +199,11 @@ async fn main() -> anyhow::Result<()> {
     let permissive_gate = resolve_allow_missing_gate();
 
     let context_engine = Box::new(ContextPipeline::new());
-    let llm_client = Box::new(llm_client::build_from_config(&config));
+    // sera-m1k8: returns either a single LlmClient or a FallbackChain wrapping
+    // primary + fallback when SERA_LLM_FALLBACK_* env vars are set.
+    let llm_provider = llm_client::build_provider_from_config(&config);
     let runtime = DefaultRuntime::new(context_engine)
-        .with_llm(llm_client)
+        .with_llm(llm_provider)
         .with_tool_dispatcher(Box::new(dispatcher))
         .with_authz_provider(authz_provider)
         .with_allow_missing_constitutional_gate(permissive_gate);

--- a/rust/crates/sera-runtime/tests/fallback_chain_integration.rs
+++ b/rust/crates/sera-runtime/tests/fallback_chain_integration.rs
@@ -236,6 +236,45 @@ async fn primary_timeout_falls_back_to_local() {
     assert_eq!(result.message.content.as_deref(), Some("from-local"));
 }
 
+#[tokio::test]
+async fn primary_connect_refused_falls_back_to_local() {
+    // Regression for PR #1272 review: when the primary is unreachable at the
+    // transport layer (DNS failure, connection refused, TLS handshake), the
+    // reqwest error must be classified as ProviderUnavailable so the chain
+    // advances. Previously these surfaced as RequestError and the fallback
+    // never got a chance — every primary-outage looked like a SERA bug.
+    //
+    // We synthesise "connection refused" by binding a TCP listener, capturing
+    // its port, then dropping the listener so the port is free again. The
+    // chance of another process racing in on that exact port within the test
+    // window is negligible on a CI host.
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind probe socket");
+    let dead_port = listener
+        .local_addr()
+        .expect("probe socket has local addr")
+        .port();
+    drop(listener);
+
+    let fallback = healthy_server("from-local").await;
+
+    let primary_client = LlmClient::with_params(
+        &format!("http://127.0.0.1:{dead_port}"),
+        "minimax-m2.1",
+        Some("sk-mm"),
+        5_000,
+    );
+    let fallback_client =
+        LlmClient::with_params(&fallback.uri(), "qwen-local", Some("local"), 5_000);
+
+    let chain = FallbackChain::new(vec![primary_client, fallback_client]);
+    let result = chain
+        .chat_non_streaming_with_behavior(&[user_msg("hi")], &[], &ToolUseBehavior::Auto)
+        .await
+        .expect("fallback should succeed after primary connect refused");
+
+    assert_eq!(result.message.content.as_deref(), Some("from-local"));
+}
+
 // ---------------------------------------------------------------------------
 // Non-retryable: must NOT fall back (would mask real SERA bugs)
 // ---------------------------------------------------------------------------

--- a/rust/crates/sera-runtime/tests/fallback_chain_integration.rs
+++ b/rust/crates/sera-runtime/tests/fallback_chain_integration.rs
@@ -1,0 +1,365 @@
+//! Integration tests for [`sera_runtime::fallback_chain::FallbackChain`].
+//!
+//! Covers the sera-m1k8 acceptance criteria: MiniMax-style primary +
+//! local-style fallback behaviour using wiremock servers as stand-ins for any
+//! OpenAI-compatible endpoint. Tests assert both fallback (on retryable
+//! upstream errors) and non-fallback (on request-bug / context-overflow
+//! classes that should not be silently masked).
+
+use sera_runtime::fallback_chain::FallbackChain;
+use sera_runtime::llm_client::{LlmClient, LlmError};
+use sera_runtime::types::{ChatMessage, FunctionDefinition, ToolDefinition};
+use sera_types::tool::ToolUseBehavior;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn user_msg(content: &str) -> ChatMessage {
+    ChatMessage {
+        role: "user".to_string(),
+        content: Some(content.to_string()),
+        tool_calls: None,
+        tool_call_id: None,
+        name: None,
+    }
+}
+
+fn make_tool(name: &str) -> ToolDefinition {
+    ToolDefinition {
+        tool_type: "function".to_string(),
+        function: FunctionDefinition {
+            name: name.to_string(),
+            description: format!("Tool {name}"),
+            parameters: serde_json::json!({"type":"object","properties":{}}),
+        },
+    }
+}
+
+fn chat_response_body(content: &str) -> serde_json::Value {
+    serde_json::json!({
+        "id": "cmpl-1",
+        "object": "chat.completion",
+        "created": 0,
+        "model": "m",
+        "choices": [{
+            "index": 0,
+            "message": {"role": "assistant", "content": content},
+            "finish_reason": "stop"
+        }],
+        "usage": {"prompt_tokens": 5, "completion_tokens": 2, "total_tokens": 7}
+    })
+}
+
+fn tool_call_response_body() -> serde_json::Value {
+    serde_json::json!({
+        "id": "cmpl-tc",
+        "object": "chat.completion",
+        "created": 0,
+        "model": "m",
+        "choices": [{
+            "index": 0,
+            "message": {
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": "call_xyz",
+                    "type": "function",
+                    "function": {"name": "shell_exec", "arguments": "{\"command\":\"ls\"}"}
+                }]
+            },
+            "finish_reason": "tool_calls"
+        }],
+        "usage": {"prompt_tokens": 8, "completion_tokens": 3, "total_tokens": 11}
+    })
+}
+
+async fn healthy_server(content: &str) -> MockServer {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(chat_response_body(content)))
+        .mount(&server)
+        .await;
+    server
+}
+
+async fn rate_limited_server() -> MockServer {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(429)
+                .set_body_string(r#"{"error":{"message":"rate limit"}}"#),
+        )
+        .mount(&server)
+        .await;
+    server
+}
+
+async fn unavailable_server() -> MockServer {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(503)
+                .set_body_string(r#"{"error":{"message":"upstream down"}}"#),
+        )
+        .mount(&server)
+        .await;
+    server
+}
+
+async fn bad_request_server() -> MockServer {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(400)
+                .set_body_string(r#"{"error":{"message":"invalid tool schema"}}"#),
+        )
+        .mount(&server)
+        .await;
+    server
+}
+
+async fn context_overflow_server() -> MockServer {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(400).set_body_string(
+            r#"{"error":{"code":"context_length_exceeded","message":"maximum context length is 8192 tokens"}}"#,
+        ))
+        .mount(&server)
+        .await;
+    server
+}
+
+async fn tool_call_server() -> MockServer {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(tool_call_response_body()))
+        .mount(&server)
+        .await;
+    server
+}
+
+// ---------------------------------------------------------------------------
+// Primary-success path: no fallback consumed
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn primary_success_does_not_touch_fallback() {
+    // Primary returns 200 immediately. Fallback points at an invalid host so
+    // any accidental fallback call would surface as a network error.
+    let primary = healthy_server("from-minimax").await;
+
+    let primary_client = LlmClient::with_params(&primary.uri(), "minimax-m2.1", Some("sk-mm"), 5_000);
+    let fallback_client =
+        LlmClient::with_params("http://unreachable.invalid:1", "qwen-local", Some("local"), 5_000);
+
+    let chain = FallbackChain::new(vec![primary_client, fallback_client]);
+    let result = chain
+        .chat_non_streaming_with_behavior(&[user_msg("hi")], &[], &ToolUseBehavior::Auto)
+        .await
+        .expect("primary should succeed");
+
+    assert_eq!(result.message.role, "assistant");
+    assert_eq!(result.message.content.as_deref(), Some("from-minimax"));
+    assert_eq!(result.prompt_tokens, 5);
+    assert_eq!(result.completion_tokens, 2);
+}
+
+// ---------------------------------------------------------------------------
+// Retryable-error fallback paths
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn primary_rate_limited_falls_back_to_local() {
+    let primary = rate_limited_server().await;
+    let fallback = healthy_server("from-local").await;
+
+    let primary_client = LlmClient::with_params(&primary.uri(), "minimax-m2.1", Some("sk-mm"), 5_000);
+    let fallback_client = LlmClient::with_params(&fallback.uri(), "qwen-local", Some("local"), 5_000);
+
+    let chain = FallbackChain::new(vec![primary_client, fallback_client]);
+    let result = chain
+        .chat_non_streaming_with_behavior(&[user_msg("hi")], &[], &ToolUseBehavior::Auto)
+        .await
+        .expect("fallback should succeed after primary 429");
+
+    assert_eq!(result.message.content.as_deref(), Some("from-local"));
+}
+
+#[tokio::test]
+async fn primary_unavailable_falls_back_to_local() {
+    let primary = unavailable_server().await;
+    let fallback = healthy_server("from-local").await;
+
+    let primary_client = LlmClient::with_params(&primary.uri(), "minimax-m2.1", Some("sk-mm"), 5_000);
+    let fallback_client = LlmClient::with_params(&fallback.uri(), "qwen-local", Some("local"), 5_000);
+
+    let chain = FallbackChain::new(vec![primary_client, fallback_client]);
+    let result = chain
+        .chat_non_streaming_with_behavior(&[user_msg("hi")], &[], &ToolUseBehavior::Auto)
+        .await
+        .expect("fallback should succeed after primary 503");
+
+    assert_eq!(result.message.content.as_deref(), Some("from-local"));
+}
+
+#[tokio::test]
+async fn primary_timeout_falls_back_to_local() {
+    // Force a per-request timeout by setting timeout_ms very low and making
+    // the primary delay longer than that.
+    let primary = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(chat_response_body("late"))
+                .set_delay(std::time::Duration::from_secs(2)),
+        )
+        .mount(&primary)
+        .await;
+    let fallback = healthy_server("from-local").await;
+
+    // 100ms timeout → primary will always trip outer timeout before responding.
+    let primary_client = LlmClient::with_params(&primary.uri(), "minimax-m2.1", Some("sk-mm"), 100);
+    let fallback_client = LlmClient::with_params(&fallback.uri(), "qwen-local", Some("local"), 5_000);
+
+    let chain = FallbackChain::new(vec![primary_client, fallback_client]);
+    let result = chain
+        .chat_non_streaming_with_behavior(&[user_msg("hi")], &[], &ToolUseBehavior::Auto)
+        .await
+        .expect("fallback should succeed after primary timeout");
+
+    assert_eq!(result.message.content.as_deref(), Some("from-local"));
+}
+
+// ---------------------------------------------------------------------------
+// Non-retryable: must NOT fall back (would mask real SERA bugs)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn primary_request_error_does_not_fall_back() {
+    let primary = bad_request_server().await;
+    // Fallback is healthy; if the chain incorrectly fell back, we'd see the
+    // local response instead of the schema-bug error. This is exactly the
+    // class of failure the operator wants surfaced loudly.
+    let fallback = healthy_server("from-local").await;
+
+    let primary_client = LlmClient::with_params(&primary.uri(), "minimax-m2.1", Some("sk-mm"), 5_000);
+    let fallback_client = LlmClient::with_params(&fallback.uri(), "qwen-local", Some("local"), 5_000);
+
+    let chain = FallbackChain::new(vec![primary_client, fallback_client]);
+    match chain
+        .chat_non_streaming_with_behavior(&[user_msg("hi")], &[], &ToolUseBehavior::Auto)
+        .await
+    {
+        Err(LlmError::RequestError(msg)) => {
+            assert!(
+                msg.contains("HTTP 400") || msg.contains("invalid tool schema"),
+                "expected request error from primary, got: {msg}"
+            );
+        }
+        Err(other) => panic!("expected RequestError, got {other:?}"),
+        Ok(_) => panic!("request-bug class must surface, not fall back"),
+    }
+}
+
+#[tokio::test]
+async fn primary_context_overflow_does_not_fall_back() {
+    let primary = context_overflow_server().await;
+    let fallback = healthy_server("from-local").await;
+
+    let primary_client = LlmClient::with_params(&primary.uri(), "minimax-m2.1", Some("sk-mm"), 5_000);
+    let fallback_client = LlmClient::with_params(&fallback.uri(), "qwen-local", Some("local"), 5_000);
+
+    let chain = FallbackChain::new(vec![primary_client, fallback_client]);
+    match chain
+        .chat_non_streaming_with_behavior(&[user_msg("hi")], &[], &ToolUseBehavior::Auto)
+        .await
+    {
+        Err(LlmError::ContextOverflow(_)) => {}
+        Err(other) => panic!("expected ContextOverflow, got {other:?}"),
+        Ok(_) => panic!("context overflow must surface, not fall back"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Chain exhaustion: every provider failed → surface the last error
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn chain_exhausted_returns_final_error() {
+    let primary = rate_limited_server().await;
+    let fallback = unavailable_server().await;
+
+    let primary_client = LlmClient::with_params(&primary.uri(), "minimax-m2.1", Some("sk-mm"), 5_000);
+    let fallback_client = LlmClient::with_params(&fallback.uri(), "qwen-local", Some("local"), 5_000);
+
+    let chain = FallbackChain::new(vec![primary_client, fallback_client]);
+    match chain
+        .chat_non_streaming_with_behavior(&[user_msg("hi")], &[], &ToolUseBehavior::Auto)
+        .await
+    {
+        // The last provider returned 503 → ProviderUnavailable.
+        Err(LlmError::ProviderUnavailable(_)) => {}
+        Err(other) => panic!("expected ProviderUnavailable, got {other:?}"),
+        Ok(_) => panic!("both providers failed; chain must surface an error"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tool-call semantics preserved through the chain
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn tool_calls_preserved_through_fallback() {
+    // Primary unavailable; fallback returns a tool_calls response. The chain
+    // must propagate the tool_calls intact (empty content + valid tool_calls).
+    let primary = unavailable_server().await;
+    let fallback = tool_call_server().await;
+
+    let primary_client = LlmClient::with_params(&primary.uri(), "minimax-m2.1", Some("sk-mm"), 5_000);
+    let fallback_client = LlmClient::with_params(&fallback.uri(), "qwen-local", Some("local"), 5_000);
+
+    let chain = FallbackChain::new(vec![primary_client, fallback_client]);
+    let result = chain
+        .chat_non_streaming_with_behavior(
+            &[user_msg("run ls")],
+            &[make_tool("shell_exec")],
+            &ToolUseBehavior::Auto,
+        )
+        .await
+        .expect("fallback should return tool_calls response");
+
+    assert!(result.message.content.is_none(), "content should be null when tool_calls present");
+    let tool_calls = result
+        .message
+        .tool_calls
+        .expect("tool_calls must be preserved");
+    assert_eq!(tool_calls.len(), 1);
+    assert_eq!(tool_calls[0].id, "call_xyz");
+    assert_eq!(tool_calls[0].function.name, "shell_exec");
+}
+
+// ---------------------------------------------------------------------------
+// Single-provider chain behaves identically to a direct LlmClient call
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn single_provider_chain_propagates_errors_verbatim() {
+    let server = bad_request_server().await;
+    let client = LlmClient::with_params(&server.uri(), "minimax-m2.1", Some("sk-mm"), 5_000);
+
+    let chain = FallbackChain::new(vec![client]);
+    match chain
+        .chat_non_streaming_with_behavior(&[user_msg("hi")], &[], &ToolUseBehavior::Auto)
+        .await
+    {
+        Err(LlmError::RequestError(_)) => {}
+        Err(other) => panic!("expected RequestError, got {other:?}"),
+        Ok(_) => panic!("single-provider chain must propagate errors verbatim"),
+    }
+}

--- a/rust/crates/sera-runtime/tests/fallback_chain_integration.rs
+++ b/rust/crates/sera-runtime/tests/fallback_chain_integration.rs
@@ -108,6 +108,19 @@ async fn unavailable_server() -> MockServer {
     server
 }
 
+async fn server_with_status(status: u16) -> MockServer {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(status)
+                .set_body_string(r#"{"error":{"message":"upstream fault"}}"#),
+        )
+        .mount(&server)
+        .await;
+    server
+}
+
 async fn bad_request_server() -> MockServer {
     let server = MockServer::start().await;
     Mock::given(method("POST"))
@@ -205,6 +218,36 @@ async fn primary_unavailable_falls_back_to_local() {
         .expect("fallback should succeed after primary 503");
 
     assert_eq!(result.message.content.as_deref(), Some("from-local"));
+}
+
+#[tokio::test]
+async fn primary_generic_5xx_falls_back_to_local() {
+    // Regression for PR #1272 review (current P1): the original classifier
+    // only routed 503 to ProviderUnavailable. 500 Internal Server Error,
+    // 502 Bad Gateway, and 504 Gateway Timeout — the most common primary-
+    // down classes — fell through to RequestError, so the chain stopped
+    // on the primary and never tried the fallback. Cover the canonical set.
+    for status in [500u16, 502, 504] {
+        let primary = server_with_status(status).await;
+        let fallback = healthy_server("from-local").await;
+
+        let primary_client =
+            LlmClient::with_params(&primary.uri(), "minimax-m2.1", Some("sk-mm"), 5_000);
+        let fallback_client =
+            LlmClient::with_params(&fallback.uri(), "qwen-local", Some("local"), 5_000);
+
+        let chain = FallbackChain::new(vec![primary_client, fallback_client]);
+        let result = chain
+            .chat_non_streaming_with_behavior(&[user_msg("hi")], &[], &ToolUseBehavior::Auto)
+            .await
+            .unwrap_or_else(|e| panic!("fallback should succeed after primary {status}: {e:?}"));
+
+        assert_eq!(
+            result.message.content.as_deref(),
+            Some("from-local"),
+            "status {status} should advance the chain to the fallback",
+        );
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Adds `FallbackChain` around the existing OpenAI-compatible `LlmClient` so SERA prefers MiniMax (or any OpenAI-compatible primary) and falls back to local LM Studio / Qwen only on retryable upstream errors.
- Fallback class: `RateLimited`, `ProviderUnavailable`, `Timeout`. Non-fallback: `RequestError`, `ContextOverflow` (surfacing schema/policy/serialization bugs and real model limits verbatim).
- Wiring is opt-in via `SERA_LLM_FALLBACK_BASE_URL` / `_MODEL` / `_API_KEY` (+ optional `_PROVIDER_ID`, `_MAX_TOKENS`). When unset, behaviour is byte-identical to the prior single-provider path.

## Behaviour

```
LLM_BASE_URL=https://api.minimax.example/v1
LLM_MODEL=minimax-m2.1
LLM_API_KEY=$MINIMAX_API_KEY                   # operator-resolved secret
SERA_LLM_FALLBACK_BASE_URL=http://host.docker.internal:1234/v1
SERA_LLM_FALLBACK_MODEL=qwen3.5-35b-a3b
SERA_LLM_FALLBACK_API_KEY=lm-studio
```

`build_provider_from_config` returns a `Box<dyn LlmProvider>` of either:
- a plain `LlmClient` (no fallback env) — unchanged behaviour, or
- a `FallbackChain([primary, fallback])` (fallback env present).

Streaming, tool-call semantics, empty-content+tool_calls guard, usage accounting, redacted audit/log output, and account-pool plumbing on the primary client are preserved.

## Test plan

- [x] `cargo test -p sera-runtime --lib fallback_chain` → 7 passed
- [x] `cargo test -p sera-runtime --test fallback_chain_integration` → 9 passed (primary success / 429 / 503 / timeout / 400-schema / context-overflow / chain-exhausted / tool-calls / single-provider passthrough)
- [x] `cargo test -p sera-runtime --test account_pool_integration --test mock_lm_studio_test` → 6 passed (no regressions in existing LLM wiring tests)
- [x] `cargo test -p sera-runtime --lib llm_client` → 71 passed
- [x] `cargo check -p sera-runtime --tests` → clean
- [x] `cargo clippy -p sera-runtime --tests --lib --bins` → clean for new code (one pre-existing stdio.rs warning unrelated to this change, left untouched per surgical-changes rule)
- [ ] Live MiniMax smoke — credentials not available in this lane; live test deferred to operator once `MINIMAX_API_KEY` is wired through the deployment

## No secrets

No real API keys appear in code, tests, logs, audit output, or this PR text. Tests use stub strings (`sk-mm`, `local`) against wiremock servers.

Source bead: `sera-m1k8`.