### PR TITLE
docs(parity): Hermes parity matrix + Phase 0 baseline gate (sera-hermes-parity)

### DIFF
--- a/docs/internal/plans/hermes-parity-matrix.md
+++ b/docs/internal/plans/hermes-parity-matrix.md
@@ -1,0 +1,123 @@
+# SERA ↔ Hermes Parity Matrix
+
+> **Status:** Living document. Phase 0 artifact from the SERA ↔ Hermes parity
+> plan (`docs/internal/plans/SERA-HERMES-PARITY-DIFFERENTIATION-PLAN-2026-05-23.md`).
+> Public-safe: do not paste private chat content, credentials, home-network details, or local-only paths into this file.
+
+This matrix turns the parity plan from prose into a tracked acceptance list.
+Each row describes one parity surface, the Hermes-side benchmark, the
+current SERA path, the SERA target shape (including the differentiation
+hook that keeps SERA accountable rather than just convenient), the
+acceptance smoke / test, the bead that owns the work, and the matrix
+status.
+
+The reader of this matrix should be able to answer three questions:
+
+1. Which Hermes parity gaps still force Sera to fall back to Hermes today?
+2. Which SERA bead owns each open gap?
+3. Which live smoke proves the baseline is green?
+
+Status values:
+
+- `BASELINE` — wired and proven by the live baseline gate
+  (`rust/crates/sera-e2e-harness/tests/hermes_parity_baseline.rs`).
+- `IN_PROGRESS` — bead is open and active.
+- `GAP` — bead is open but unstarted, or no canonical bead yet.
+- `DIFF_PRESERVED` — SERA path already exceeds Hermes on the
+  differentiation axis (audit, policy, HITL, GoalRun).
+
+Priority follows the bead's priority (`P1` … `P3`); rows without an owning bead are tagged with a recommended priority.
+
+---
+
+## Live baseline gate
+
+The smallest acceptance bundle that proves SERA can host a turn at all:
+
+| Probe | Surface | Expectation |
+|---|---|---|
+| Readiness | `GET /api/health/ready` | HTTP 200 and `runtime_connected=true`. |
+| Authenticated chat nonce | `POST /api/chat` | HTTP 200 with `session_id` and a non-empty `response`, when an LLM is configured. |
+| Response sanitizer contract | `POST /api/chat` response body | `response` contains no `<think>` or `</think>` markers (raw chain-of-thought is never leaked to the operator). |
+| Skip contract | All probes | If gateway/runtime binaries or an LLM are not available, the gate skips cleanly with an explicit stderr line rather than failing. |
+
+Owning crate: `rust/crates/sera-e2e-harness`. Owning test:
+`tests/hermes_parity_baseline.rs` (gated behind `--features integration`).
+Owning report template: `docs/internal/sessions/hermes-parity-baseline-template.md`
+(template for operator-run live captures; the test itself is the canonical
+CI/regression gate). The `artifacts/` working directory is gitignored, so
+operator-run capture instances are kept out-of-tree by convention.
+
+---
+
+## Parity matrix
+
+Columns:
+
+- **Capability** — Hermes benchmark surface.
+- **SERA current path** — what exists in the workspace today, including the crate / module that owns it.
+- **SERA target path** — the parity-complete shape, including the differentiation hook (audit, policy, HITL, GoalRun, workflow, gateway-dispatch).
+- **Acceptance smoke** — the smallest live or test-suite probe that proves parity.
+- **Owner bead** — canonical bead anchor; create a new bead only when none exists.
+- **Status** / **Priority**.
+
+| # | Capability | SERA current path | SERA target path (with differentiation hook) | Acceptance smoke | Owner bead | Status | Priority |
+|---|---|---|---|---|---|---|---|
+| 1 | API chat intake (`/api/chat`) | `sera-gateway` chat handler (`crates/sera-gateway/src/bin/sera.rs::chat_handler`); session-scoped through gateway-owned SQLite. | Stable JSON contract (`session_id`, `response`, `usage`), SSE streaming events, `POST /api/chat/cancel`, response sanitizer applied before operator-visible bytes. **Differentiation:** gateway-owned session and audit, no runtime-side completion text reaching operator without sanitization. | `hermes_parity_baseline.rs::api_chat_nonce` — authenticated POST returns `session_id` + non-empty `response`. | `sera-duo3` (CI smoke pipeline), reinforced by `sera-yj18` (streaming tool-call edge cases). | BASELINE | P2 |
+| 2 | Discord intake / egress | `sera-gateway` Discord connector (`crates/sera-gateway/src/discord.rs`, `bin/sera.rs::handle_message`); peer-mention handoff already reversed and stdio transport recycled per readiness probe. | Reliable buffered ingress + typed reactions/typing + visible failure replies + audit per Discord turn. **Differentiation:** rate-limited, audit-logged, capability-policy-checked Discord turns rather than raw bot loops. | Discord smoke fixture pair under `sera-duo3` once `sera-yeg.2` / `sera-s77a` land; manual smoke covered in `docs/internal/sessions/hermes-parity-baseline-template.md`. | `sera-yeg.2` (typing/reactions), `sera-s77a` (buffering / rate-limit), `sera-duo3` (CI smoke). | IN_PROGRESS | P2 |
+| 3 | Provider / fallback conformance | `sera-runtime` OpenAI-compatible client + provider chain (MiniMax primary + local Qwen fallback) merged in #1272. | Ordered provider chain, typed failure classes, no silent fallback for policy/tool/schema errors, redaction of provider-internal errors before operator-facing output. **Differentiation:** routing is an accountable policy decision, not a config toggle. | `cargo test -p sera-runtime --lib provider_chain` + live MiniMax smoke documented in `docs/internal/sessions/hermes-parity-baseline-template.md`. | `sera-m1k8` (primary anchor) + `sera-yj18` (streaming tool-call edge cases). | IN_PROGRESS | P1 |
+| 4 | Response sanitization / strict output | `sera-runtime` think step sanitizes assistant-visible output (`crates/sera-runtime/src/turn.rs::think`) and bridges `reasoning_content`. | Hard contract: no `<think>` / `</think>` markers in operator-visible `response`; `reasoning_content` never bleeds into assistant text unless explicitly enabled. **Differentiation:** sanitizer is a contract enforced by the gateway boundary, not a hope. | `hermes_parity_baseline.rs::response_sanitizer_contract` — asserts no `<think>` / `</think>` markers in the operator-visible `response`. | `sera-yj18` (current streaming tool-call empty-content boundary that drove the sanitizer hardening). | BASELINE | P2 |
+| 5 | File / search / patch tools | `sera-tools` (`crates/sera-tools/src/mvs_tools.rs` + sibling tool modules); registered via the Tool trait. | Hermes-equivalent file / search / patch tools with mtime conflict checks, model-visible failure semantics, and gateway-dispatch authority. **Differentiation:** CapabilityPolicy + audit ledger per call. | New parity smoke under `sera-e2e-harness` once a tool-loop bead lands; tracked under `sera-tqzd` and `sera-q66q`. | `sera-tqzd` (failure surfacing), `sera-q66q` (audit ledger). New bead recommended for file/patch parity coverage. | GAP | P2 |
+| 6 | Terminal / process tools | `sera-tools` terminal/process tool surface (current MVS subset); sandbox policy partial. | Hermes-equivalent terminal/process tools with sandbox policy, approval gates, and timeout / process-tree containment. **Differentiation:** HITL approval + sandbox boundary + audit per process spawn. | Negative-test smoke for denied tool / sandbox violation under `sera-tqzd`; new bead recommended for the positive-path parity smoke. | `sera-tqzd` (failure surfacing) + new bead to be created for terminal-tool parity. | GAP | P2 |
+| 7 | Web / browser / MCP | MCP bridge scaffolding in `sera-tools` / `sera-runtime`; browser parity not yet wired. | Web search + browser + MCP bridge tools available with consistent failure semantics. **Differentiation:** egress policy + SSRF guardrails + audit. | Smoke that drives an MCP tool round-trip from `sera-runtime`; tracked under a new bead recommended below (no current anchor). | New bead recommended (working name: `sera-mcp-parity`). | GAP | P2 |
+| 8 | Memory / session search | Tier-1 MemoryBlock + Tier-2 semantic recall scaffolding in `sera-runtime/src/context_engine`; gateway-owned durable memory in `sera-db`. | Two-tier injection: compact MemoryBlock + on-demand semantic search tool; session transcript search; cross-session operator state with provenance. **Differentiation:** scoped retrieval + audit; memory writes governed (`sera-rj4z`). | Cross-session retrieval test under `sera-e2e-harness` once `sera-rj4z` lands. | `sera-rj4z` (vector semantic memory + cross-session continuity). | IN_PROGRESS | P2 |
+| 9 | Skills / procedure lifecycle | `sera-skills` crate covers discover / list / load. Profile-scoped availability and post-task suggestion partial. | Full discover / load / create / update / patch + profile-scoped availability + post-complex-task skill suggestion. **Differentiation:** skill writes are audited; skill changes are visible to HITL. | Smoke that loads a skill before a tool call and asserts the skill is recorded in audit; tracked under a new bead recommended below. | New bead recommended (working name: `sera-skills-parity`). | GAP | P3 |
+| 10 | Delegation / subagents | Subagent spawn/list/status scaffolding in `sera-runtime`; OMC / Claude / Codex / Hermes profiles can be launched. Pattern A vs Pattern B distinction not yet enforced. | BYOH harnesses available with Pattern A audit when possible and Pattern B explicitly labeled opaque; subagent spawn becomes a GoalRun step rather than a loose helper call. **Differentiation:** GoalRun accountability, not chat-style spawn. | Spawn → status → close-out smoke under `sera-e2e-harness` with audit assertion; tracked under a new bead. | New bead recommended (working name: `sera-delegation-goalrun`). | GAP | P2 |
+| 11 | Workflows / cron / webhooks | Workflow engine scaffolding in `sera-workflow`; cron/event/threshold/manual trigger work tracked in existing workflow beads. Webhook intake exists; sanitization layer (`sera-ctag`) not yet wired. | Cron / event / threshold / manual trigger + watchdog / no-agent script equivalent; webhook sanitization layer in front of prompt/context construction. **Differentiation:** workflow tasks are GoalRuns with stop conditions, evidence, and closeout. | Workflow trigger smoke + webhook sanitizer smoke under `sera-e2e-harness`. | `sera-ctag` (webhook sanitization), plus a new workflow-parity bead recommended for the GoalRun acceptance test. | GAP | P2 |
+| 12 | TUI / dashboard / control plane | `sera-tui` (`crates/sera-tui`) + dashboard surfaces exist; control-plane completeness partial. | Sessions + approvals + agents + workflow / GoalRun state + logs + health + provider/budget status + audit drilldown + approvals queue. **Differentiation:** operator console for accountable work, not a generic chat UI. | Manual TUI smoke + a non-interactive control-plane smoke under `sera-e2e-harness`; tracked under a new bead recommended below. | New bead recommended (working name: `sera-control-plane-parity`). | GAP | P3 |
+| 13 | Audit / HITL / policy | `sera-policy` scaffolding + audit log rows in SQLite. HITL approval surfaces partial; OCSF-shaped events not yet wired. | Immutable, OCSF-shaped audit ledger; HITL approval flows for write/execute/admin; CapabilityPolicy / PrincipalPolicy enforced before execution. **Differentiation:** this is the moat — do not trade it for short-term parity. | Append-only ledger smoke + HITL approval round-trip + policy-deny smoke under `sera-e2e-harness`. | `sera-q66q` (audit ledger), `sera-ctag` (sanitizer), `sera-tqzd` (failure visibility). New bead recommended for the HITL approval smoke. | IN_PROGRESS | P2 |
+
+---
+
+## Recommended new beads
+
+Where this matrix has no canonical anchor, file beads with concrete acceptance
+criteria rather than a single "parity epic". Suggested working names and
+acceptance criteria (file the canonical bead before doing implementation
+work):
+
+1. **`sera-tool-parity-file`** — File / search / patch tool parity smoke,
+   including mtime conflict and denied-write tests, plus audit assertion.
+2. **`sera-tool-parity-terminal`** — Terminal / process tool parity smoke,
+   including sandbox-deny + approval gate + timeout containment.
+3. **`sera-mcp-parity`** — Web / browser / MCP bridge tool round-trip smoke
+   with egress / SSRF guardrails.
+4. **`sera-skills-parity`** — Skill load-before-tool-call smoke with audit.
+5. **`sera-delegation-goalrun`** — Subagent spawn / status / close-out smoke
+   expressed as a GoalRun step.
+6. **`sera-workflow-parity`** — Cron / event / threshold trigger smoke +
+   webhook sanitizer integration (joins on `sera-ctag`).
+7. **`sera-control-plane-parity`** — TUI + dashboard control-plane smoke.
+8. **`sera-hitl-parity`** — HITL approval round-trip smoke (joins on
+   `sera-q66q`).
+
+These names are placeholders for the canonical beads; do not invent IDs in
+this matrix. Each row above will be updated to point at the canonical bead
+once filed.
+
+---
+
+## Update protocol
+
+1. When a row's owning bead changes status, update the matrix row in the
+   same PR (or follow-up PR) that changes the bead.
+2. When a new row is needed (a Hermes capability we previously missed),
+   add it under the same column shape; do not collapse it into an
+   existing row.
+3. Keep the matrix public-safe: redact private paths, secret names, and
+   operator chat content. The baseline live-smoke report
+   (`docs/internal/sessions/hermes-parity-baseline-template.md`) is the place for
+   operator-run capture details — even there, do not paste secrets.
+4. When a row reaches `BASELINE`, link it from the **Live baseline gate**
+   table at the top so future readers can see at a glance which probes
+   already cover it.

--- a/docs/internal/plans/hermes-parity-matrix.md
+++ b/docs/internal/plans/hermes-parity-matrix.md
@@ -37,7 +37,7 @@ The smallest acceptance bundle that proves SERA can host a turn at all:
 | Probe | Surface | Expectation |
 |---|---|---|
 | Readiness | `GET /api/health/ready` | HTTP 200 and `runtime_connected=true`. |
-| Authenticated chat nonce | `POST /api/chat` | HTTP 200 with `session_id` and a non-empty `response`, when an LLM is configured. |
+| Authenticated chat nonce | `POST /api/chat` | HTTP 200 with `session_id` and a non-empty `response` that echoes the per-test nonce (freshness guard against stale/canned replies). The request carries `Authorization: Bearer`; auth is only enforced under an auth-enabled harness profile, tracked as a follow-up. |
 | Response sanitizer contract | `POST /api/chat` response body | `response` contains no `<think>` or `</think>` markers (raw chain-of-thought is never leaked to the operator). |
 | Skip contract | All probes | If gateway/runtime binaries or an LLM are not available, the gate skips cleanly with an explicit stderr line rather than failing. |
 
@@ -63,7 +63,7 @@ Columns:
 
 | # | Capability | SERA current path | SERA target path (with differentiation hook) | Acceptance smoke | Owner bead | Status | Priority |
 |---|---|---|---|---|---|---|---|
-| 1 | API chat intake (`/api/chat`) | `sera-gateway` chat handler (`crates/sera-gateway/src/bin/sera.rs::chat_handler`); session-scoped through gateway-owned SQLite. | Stable JSON contract (`session_id`, `response`, `usage`), SSE streaming events, `POST /api/chat/cancel`, response sanitizer applied before operator-visible bytes. **Differentiation:** gateway-owned session and audit, no runtime-side completion text reaching operator without sanitization. | `hermes_parity_baseline.rs::api_chat_nonce` — authenticated POST returns `session_id` + non-empty `response`. | `sera-duo3` (CI smoke pipeline), reinforced by `sera-yj18` (streaming tool-call edge cases). | BASELINE | P2 |
+| 1 | API chat intake (`/api/chat`) | `sera-gateway` chat handler (`crates/sera-gateway/src/bin/sera.rs::chat_handler`); session-scoped through gateway-owned SQLite. | Stable JSON contract (`session_id`, `response`, `usage`), SSE streaming events, `POST /api/chat/cancel`, response sanitizer applied before operator-visible bytes. **Differentiation:** gateway-owned session and audit, no runtime-side completion text reaching operator without sanitization. | `hermes_parity_baseline.rs::hermes_parity_baseline_gate` — POST with `Authorization: Bearer` returns `session_id` + a `response` that echoes the per-test nonce (freshness guard). Auth-enforced harness profile is a follow-up (see recommended new beads below). | `sera-duo3` (CI smoke pipeline), reinforced by `sera-yj18` (streaming tool-call edge cases). | BASELINE | P2 |
 | 2 | Discord intake / egress | `sera-gateway` Discord connector (`crates/sera-gateway/src/discord.rs`, `bin/sera.rs::handle_message`); peer-mention handoff already reversed and stdio transport recycled per readiness probe. | Reliable buffered ingress + typed reactions/typing + visible failure replies + audit per Discord turn. **Differentiation:** rate-limited, audit-logged, capability-policy-checked Discord turns rather than raw bot loops. | Discord smoke fixture pair under `sera-duo3` once `sera-yeg.2` / `sera-s77a` land; manual smoke covered in `docs/internal/sessions/hermes-parity-baseline-template.md`. | `sera-yeg.2` (typing/reactions), `sera-s77a` (buffering / rate-limit), `sera-duo3` (CI smoke). | IN_PROGRESS | P2 |
 | 3 | Provider / fallback conformance | `sera-runtime` OpenAI-compatible client + provider chain (MiniMax primary + local Qwen fallback) merged in #1272. | Ordered provider chain, typed failure classes, no silent fallback for policy/tool/schema errors, redaction of provider-internal errors before operator-facing output. **Differentiation:** routing is an accountable policy decision, not a config toggle. | `cargo test -p sera-runtime --lib provider_chain` + live MiniMax smoke documented in `docs/internal/sessions/hermes-parity-baseline-template.md`. | `sera-m1k8` (primary anchor) + `sera-yj18` (streaming tool-call edge cases). | IN_PROGRESS | P1 |
 | 4 | Response sanitization / strict output | `sera-runtime` think step sanitizes assistant-visible output (`crates/sera-runtime/src/turn.rs::think`) and bridges `reasoning_content`. | Hard contract: no `<think>` / `</think>` markers in operator-visible `response`; `reasoning_content` never bleeds into assistant text unless explicitly enabled. **Differentiation:** sanitizer is a contract enforced by the gateway boundary, not a hope. | `hermes_parity_baseline.rs::response_sanitizer_contract` — asserts no `<think>` / `</think>` markers in the operator-visible `response`. | `sera-yj18` (current streaming tool-call empty-content boundary that drove the sanitizer hardening). | BASELINE | P2 |
@@ -100,6 +100,14 @@ work):
 7. **`sera-control-plane-parity`** — TUI + dashboard control-plane smoke.
 8. **`sera-hitl-parity`** — HITL approval round-trip smoke (joins on
    `sera-q66q`).
+9. **`sera-baseline-auth-enforced`** — extend the Phase 0 baseline gate
+   with an auth-enabled harness profile so Probe 2 enforces
+   `Authorization: Bearer` and a paired negative request asserts 401
+   without it. The current `hermes_parity_baseline_gate` already sends
+   the bearer header and is forward-fit, but autonomous-mode boot
+   (`InProcessGateway::start_local`) does not enforce auth, so the
+   gate verifies HTTP shape + sanitizer + freshness only, not the
+   auth-protected path.
 
 These names are placeholders for the canonical beads; do not invent IDs in
 this matrix. Each row above will be updated to point at the canonical bead

--- a/docs/internal/sessions/hermes-parity-baseline-template.md
+++ b/docs/internal/sessions/hermes-parity-baseline-template.md
@@ -1,0 +1,135 @@
+# Hermes Parity Baseline — Operator Live Smoke Report
+
+> Companion to:
+>
+> - `docs/internal/plans/SERA-HERMES-PARITY-DIFFERENTIATION-PLAN-2026-05-23.md` (plan)
+> - `docs/internal/plans/hermes-parity-matrix.md` (parity matrix)
+> - `rust/crates/sera-e2e-harness/tests/hermes_parity_baseline.rs` (CI/regression gate)
+>
+> **Public-safe.** Do not paste credentials, real Discord IDs, home-network details, or operator chat content into this file.
+
+The CI gate (`hermes_parity_baseline_gate`) covers the three core probes on a
+freshly booted gateway with a scripted mock LLM. This report is the place
+to capture an **operator-run live capture** against a real upstream
+(MiniMax / local Qwen) plus the optional Discord one-turn smoke — those
+probes need credentials and a live process, so they sit outside the
+automated test by design.
+
+Copy this template into a timestamped sibling file (e.g.
+`hermes-parity-baseline-2026-05-23.md`) before running, redacting any
+private values.
+
+---
+
+## Capture metadata
+
+| Field | Value |
+|---|---|
+| Capture date (UTC) | `YYYY-MM-DD HH:MM` |
+| Operator | redacted |
+| Branch / commit SHA | _e.g. `omc/hermes-parity-matrix-baseline @ <sha>`_ |
+| Gateway version / build | `cargo run -p sera-gateway -- --version` |
+| Runtime version / build | `cargo run -p sera-runtime -- --version` |
+| Provider chain | `minimax` primary, `local-qwen` fallback (redact endpoints) |
+
+---
+
+## Probe 1 — Readiness
+
+```bash
+curl -fsS "http://localhost:3001/api/health/ready" | jq .
+```
+
+| Expectation | Result |
+|---|---|
+| HTTP 200 | _PASS / FAIL_ |
+| `runtime_connected=true` | _PASS / FAIL_ |
+| `harness_ready=true` (if exposed) | _PASS / FAIL_ |
+
+Notes: _redact private IPs / hostnames; capture failure class verbatim if FAIL._
+
+---
+
+## Probe 2 — Authenticated `/api/chat` nonce
+
+```bash
+NONCE="nonce-$(date +%s%N)"
+curl -fsS -X POST "http://localhost:3001/api/chat" \
+  -H "Authorization: Bearer $SERA_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{\"agent\": \"sera\", \"message\": \"Reply with OK and the nonce $NONCE.\", \"stream\": false}" \
+  | jq '{session_id, response, usage}'
+```
+
+| Expectation | Result |
+|---|---|
+| HTTP 200 | _PASS / FAIL_ |
+| `session_id` present + non-empty | _PASS / FAIL_ |
+| `response` present + non-empty | _PASS / FAIL_ |
+| `usage` present (provider accounting) | _PASS / FAIL_ |
+
+Notes: _capture the `response` body in a redacted form (truncate to first 200 chars). Do not paste raw provider error bodies — extract failure class only._
+
+---
+
+## Probe 3 — Response sanitizer contract
+
+For the same chat call above, the operator-visible `response` MUST NOT
+contain raw chain-of-thought tags. Smoke check:
+
+```bash
+echo "$RESPONSE_BODY" | grep -iE '<think>|</think>' && echo "LEAK" || echo "CLEAN"
+```
+
+| Expectation | Result |
+|---|---|
+| No `<think>` marker in `response` | _PASS / FAIL_ |
+| No `</think>` marker in `response` | _PASS / FAIL_ |
+| No raw `reasoning_content` field bleed | _PASS / FAIL_ |
+
+Notes: _if leakage occurs, file under `sera-yj18` follow-up and link the capture._
+
+---
+
+## Optional Probe 4 — Discord one-turn smoke
+
+Only run when Discord credentials are available and the operator wants a
+live Discord regression. Do **not** paste the bot token, real channel IDs,
+or operator/peer Discord handles. Refer to the Discord-related beads
+(`sera-yeg.2`, `sera-s77a`) for the capability under test.
+
+| Expectation | Result |
+|---|---|
+| Mention is acked with `👀` reaction or typing indicator | _PASS / FAIL_ |
+| Final reply lands in the configured channel | _PASS / FAIL_ |
+| Reply contains no `<think>` markers | _PASS / FAIL_ |
+| On forced failure, `❌` reaction + actionable failure class | _PASS / FAIL_ |
+
+Notes: _redact every channel ID and handle; describe the channel by role
+(e.g. "private operator channel") only._
+
+---
+
+## Optional Probe 5 — Tool-failure visibility
+
+Trigger a controlled tool failure (e.g. read a nonexistent path through
+the file tool) and assert the failure surfaces to the operator with a
+typed failure class. Tracks `sera-tqzd`.
+
+| Expectation | Result |
+|---|---|
+| Operator-facing reply names a typed failure class | _PASS / FAIL_ |
+| Audit ledger row written for the failed tool call | _PASS / FAIL_ |
+| No silent "looks fine" reply when a tool failed | _PASS / FAIL_ |
+
+---
+
+## Overall verdict
+
+- **Baseline GREEN** when Probes 1–3 all pass on a fresh gateway boot.
+- **Baseline RED** when any of Probes 1–3 fail; file/update the owning
+  bead with the redacted evidence above before retrying.
+
+Source beads referenced from this capture: `sera-m1k8`, `sera-duo3`,
+`sera-q66q`, `sera-ctag`, `sera-s77a`, `sera-tqzd`, `sera-rj4z`,
+`sera-yeg.2`, `sera-yj18`.

--- a/rust/crates/sera-e2e-harness/tests/hermes_parity_baseline.rs
+++ b/rust/crates/sera-e2e-harness/tests/hermes_parity_baseline.rs
@@ -91,22 +91,20 @@ async fn hermes_parity_baseline_gate() -> Result<()> {
     };
 
     // ── 2. Boot the gateway child process ──
-    let gateway = match InProcessGateway::start_local(
+    //
+    // Once we are past the binary-located + LLM-resolved gates above,
+    // the environment is capable of running this test, and a boot
+    // failure here is a real parity regression (panic, config drift,
+    // runtime wiring break, port collision). Propagate the error so
+    // CI fails loudly instead of skipping. The "expected on stripped
+    // CI environments" path is handled by the two skips above.
+    let gateway = InProcessGateway::start_local(
         &gateway_bin_path,
         &runtime_bin_path,
         &llm_base_url,
     )
     .await
-    {
-        Ok(g) => g,
-        Err(e) => {
-            eprintln!(
-                "{SKIP_TAG} SKIP: gateway failed to boot ({e}). Expected on \
-                 stripped CI environments; see crate-level docs."
-            );
-            return Ok(());
-        }
-    };
+    .context("gateway failed to boot — baseline parity regression")?;
 
     let http = reqwest::Client::builder()
         .timeout(Duration::from_secs(15))
@@ -146,9 +144,21 @@ async fn hermes_parity_baseline_gate() -> Result<()> {
     // equality is intentionally not asserted — provider/runtime wiring
     // may legitimately rephrase — but the response shape (session_id
     // present, response field present) must hold.
+    //
+    // The request carries an `Authorization: Bearer …` header matching
+    // the development bootstrap key documented in the top-level
+    // CLAUDE.md. The harness boots in autonomous mode where auth is
+    // not enforced, so this header is decorative for the local skip
+    // path; once auth-enabled harness profiles land, the same call
+    // gates correctly against the principal middleware without test
+    // edits. `SERA_E2E_BEARER_TOKEN` can override the bootstrap value
+    // for operator-run captures against a non-autonomous gateway.
+    let bearer_token = std::env::var("SERA_E2E_BEARER_TOKEN")
+        .unwrap_or_else(|_| "sera_bootstrap_dev_123".to_string());
     let nonce = short_nonce();
     let chat: serde_json::Value = http
         .post(format!("{}/api/chat", gateway.base_url))
+        .bearer_auth(&bearer_token)
         .json(&json!({
             "agent": "sera",
             "message": format!("Reply with the word OK and the nonce {nonce}."),

--- a/rust/crates/sera-e2e-harness/tests/hermes_parity_baseline.rs
+++ b/rust/crates/sera-e2e-harness/tests/hermes_parity_baseline.rs
@@ -179,20 +179,20 @@ async fn hermes_parity_baseline_gate() -> Result<()> {
         .with_context(|| format!("chat response missing response: {chat:?}"))?
         .to_owned();
 
-    // When using the wiremock LLM, the scripted reply will land in
-    // `response`. With a real upstream LLM, `response` is whatever the
-    // provider returned. An empty body for a configured LLM is treated
-    // as a soft signal here rather than a hard fail — the existing
-    // `local_profile_turn.rs` documents that runtimes can legitimately
-    // short-circuit a turn (authz rejection, over-budget, tool-dispatch
-    // loop) without that being a parity break on its own.
-    if response_text.is_empty() {
-        eprintln!(
-            "{SKIP_TAG} SOFT: chat response was empty (provider chain may have \
-             swallowed the reply); baseline sanitizer contract holds trivially. \
-             Inspect /api/sessions/{session_id}/transcript for runtime evidence."
-        );
-    }
+    // The parity baseline requires a non-empty operator-visible reply.
+    // An empty `response` makes Probe 3 (sanitizer contract) vacuous —
+    // a leak would be hidden because there is nothing to scan — and the
+    // matrix explicitly defines this row as "session_id + non-empty
+    // response". Hard-fail here so a provider/runtime regression that
+    // swallows the reply cannot ship as a green baseline. The session
+    // hint in the message points at `/api/sessions/<id>/transcript` so
+    // an operator can pull runtime evidence without re-running.
+    assert!(
+        !response_text.is_empty(),
+        "baseline gate: /api/chat returned empty response — Probe 2 \
+         requires non-empty operator-visible text. Inspect \
+         /api/sessions/{session_id}/transcript for runtime evidence."
+    );
 
     // ── Probe 3: response sanitizer contract ──
     //

--- a/rust/crates/sera-e2e-harness/tests/hermes_parity_baseline.rs
+++ b/rust/crates/sera-e2e-harness/tests/hermes_parity_baseline.rs
@@ -25,7 +25,7 @@ use anyhow::{Context, Result};
 use serde_json::json;
 
 use sera_e2e_harness::binaries::{gateway_bin, runtime_bin};
-use sera_e2e_harness::mock_llm::start_mock_llm;
+use sera_e2e_harness::mock_llm::start_mock_llm_with_reply;
 use sera_e2e_harness::InProcessGateway;
 
 const SKIP_TAG: &str = "[hermes-parity-baseline]";
@@ -69,15 +69,22 @@ async fn hermes_parity_baseline_gate() -> Result<()> {
         }
     };
 
+    // Generate the freshness nonce up front so the mock LLM (when used)
+    // can be scripted to echo it back. A real upstream LLM is asked to
+    // echo it via the prompt. Either way Probe 2 then asserts the
+    // returned `response` contains this exact nonce, so a stale/canned
+    // reply cannot pass the gate.
+    let nonce = short_nonce();
+
     // ── 1. Resolve an LLM endpoint (operator-supplied or local mock) ──
     //
-    // `start_mock_llm` returns `(url, server)` and the caller must keep
-    // `server` alive for the duration of the test — dropping it tears
-    // down the wiremock listener. The `_mock_handle` binding here is
-    // exactly that lifetime anchor; it is intentionally unused.
+    // The wiremock variant returns `(url, server)` and the caller must
+    // keep `server` alive for the duration of the test — dropping it
+    // tears down the listener. `_mock_handle` is that lifetime anchor.
+    let mock_reply = format!("OK {nonce}");
     let (llm_base_url, _mock_handle) = match std::env::var("SERA_E2E_LLM_BASE_URL") {
         Ok(url) if !url.trim().is_empty() => (url, None),
-        _ => match start_mock_llm().await {
+        _ => match start_mock_llm_with_reply(&mock_reply).await {
             Ok((url, server)) => (url, Some(server)),
             Err(e) => {
                 eprintln!(
@@ -155,7 +162,6 @@ async fn hermes_parity_baseline_gate() -> Result<()> {
     // for operator-run captures against a non-autonomous gateway.
     let bearer_token = std::env::var("SERA_E2E_BEARER_TOKEN")
         .unwrap_or_else(|_| "sera_bootstrap_dev_123".to_string());
-    let nonce = short_nonce();
     let chat: serde_json::Value = http
         .post(format!("{}/api/chat", gateway.base_url))
         .bearer_auth(&bearer_token)
@@ -201,6 +207,21 @@ async fn hermes_parity_baseline_gate() -> Result<()> {
         !response_text.is_empty(),
         "baseline gate: /api/chat returned empty response — Probe 2 \
          requires non-empty operator-visible text. Inspect \
+         /api/sessions/{session_id}/transcript for runtime evidence."
+    );
+
+    // Freshness check: the response must contain the per-test nonce.
+    // With the wiremock fallback the mock was scripted to embed `nonce`
+    // in its reply, so the full gateway → runtime → mock chain is
+    // verified. With a real upstream LLM the prompt explicitly asks
+    // for the nonce to be echoed; a stale or canned response (e.g. a
+    // cached "Pong" frame from a previous session, the historical bug
+    // that drove `sera-yeg.3`) cannot satisfy this assertion.
+    assert!(
+        response_text.contains(&nonce),
+        "baseline gate: /api/chat response did not echo nonce \
+         {nonce:?} — Probe 2 requires per-request freshness. \
+         Got response: {response_text:?}. Inspect \
          /api/sessions/{session_id}/transcript for runtime evidence."
     );
 

--- a/rust/crates/sera-e2e-harness/tests/hermes_parity_baseline.rs
+++ b/rust/crates/sera-e2e-harness/tests/hermes_parity_baseline.rs
@@ -1,0 +1,231 @@
+//! Phase 0 Hermes parity baseline gate.
+//!
+//! Companion test to `docs/internal/plans/hermes-parity-matrix.md`. This is
+//! the smallest live-baseline bundle that proves SERA can host a turn at
+//! all, with three probes:
+//!
+//! 1. `GET /api/health/ready` returns 200 with `runtime_connected=true`.
+//! 2. Authenticated `POST /api/chat` returns 200 with a `session_id` and a
+//!    non-empty `response` for a nonce prompt.
+//! 3. The operator-visible `response` body contains no `<think>` /
+//!    `</think>` markers — the response sanitizer must not leak raw
+//!    chain-of-thought to the operator.
+//!
+//! Skip contract mirrors `local_profile_turn.rs`: if the gateway or
+//! runtime binaries cannot be located, or if a mock LLM cannot be
+//! started and `SERA_E2E_LLM_BASE_URL` is unset, the test prints an
+//! explicit skip line to stderr and returns `Ok(())` rather than
+//! failing.
+
+#![cfg(feature = "integration")]
+
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use serde_json::json;
+
+use sera_e2e_harness::binaries::{gateway_bin, runtime_bin};
+use sera_e2e_harness::mock_llm::start_mock_llm;
+use sera_e2e_harness::InProcessGateway;
+
+const SKIP_TAG: &str = "[hermes-parity-baseline]";
+
+/// The Hermes parity baseline gate.
+///
+/// One test = three probes against a single freshly booted gateway.
+/// Each probe asserts a single contract and produces a clear failure
+/// message; the test does *not* gate parity for any deeper Hermes
+/// capability (tools, memory, delegation, …) — those rows in the
+/// parity matrix get their own gates as they land.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn hermes_parity_baseline_gate() -> Result<()> {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_env("SERA_E2E_LOG")
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn")),
+        )
+        .with_test_writer()
+        .try_init();
+
+    // ── 0. Locate the gateway + runtime binaries ──
+    let gateway_bin_path = match gateway_bin() {
+        Some(p) => p,
+        None => {
+            eprintln!(
+                "{SKIP_TAG} SKIP: sera-gateway binary not found next to the \
+                 test binary. Run `cargo build -p sera-gateway` first."
+            );
+            return Ok(());
+        }
+    };
+    let runtime_bin_path = match runtime_bin() {
+        Some(p) => p,
+        None => {
+            eprintln!(
+                "{SKIP_TAG} SKIP: sera-runtime binary not found next to the \
+                 test binary. Run `cargo build -p sera-runtime` first."
+            );
+            return Ok(());
+        }
+    };
+
+    // ── 1. Resolve an LLM endpoint (operator-supplied or local mock) ──
+    //
+    // `start_mock_llm` returns `(url, server)` and the caller must keep
+    // `server` alive for the duration of the test — dropping it tears
+    // down the wiremock listener. The `_mock_handle` binding here is
+    // exactly that lifetime anchor; it is intentionally unused.
+    let (llm_base_url, _mock_handle) = match std::env::var("SERA_E2E_LLM_BASE_URL") {
+        Ok(url) if !url.trim().is_empty() => (url, None),
+        _ => match start_mock_llm().await {
+            Ok((url, server)) => (url, Some(server)),
+            Err(e) => {
+                eprintln!(
+                    "{SKIP_TAG} SKIP: could not start local mock LLM and \
+                     SERA_E2E_LLM_BASE_URL is unset ({e}). Baseline gate \
+                     needs either a real LLM or a wiremock bind."
+                );
+                return Ok(());
+            }
+        },
+    };
+
+    // ── 2. Boot the gateway child process ──
+    let gateway = match InProcessGateway::start_local(
+        &gateway_bin_path,
+        &runtime_bin_path,
+        &llm_base_url,
+    )
+    .await
+    {
+        Ok(g) => g,
+        Err(e) => {
+            eprintln!(
+                "{SKIP_TAG} SKIP: gateway failed to boot ({e}). Expected on \
+                 stripped CI environments; see crate-level docs."
+            );
+            return Ok(());
+        }
+    };
+
+    let http = reqwest::Client::builder()
+        .timeout(Duration::from_secs(15))
+        .build()
+        .context("building baseline HTTP client")?;
+
+    // ── Probe 1: /api/health/ready ──
+    //
+    // The gateway distinguishes "process up" (`/api/health`) from
+    // "runtime usable" (`/api/health/ready`), and the parity baseline
+    // requires the runtime probe to be green — `runtime_connected=true`.
+    let ready: serde_json::Value = http
+        .get(format!("{}/api/health/ready", gateway.base_url))
+        .send()
+        .await
+        .context("readiness probe send")?
+        .error_for_status()
+        .context("readiness probe HTTP status")?
+        .json()
+        .await
+        .context("readiness probe JSON parse")?;
+    let runtime_connected = ready
+        .get("runtime_connected")
+        .and_then(|v| v.as_bool())
+        .with_context(|| {
+            format!("readiness response missing runtime_connected bool: {ready:?}")
+        })?;
+    assert!(
+        runtime_connected,
+        "baseline gate requires runtime_connected=true on /api/health/ready, got {ready:?}"
+    );
+
+    // ── Probe 2: authenticated /api/chat nonce ──
+    //
+    // We embed a short non-cryptographic nonce in the prompt so a fresh
+    // session cannot be satisfied by a stale cached reply. Content
+    // equality is intentionally not asserted — provider/runtime wiring
+    // may legitimately rephrase — but the response shape (session_id
+    // present, response field present) must hold.
+    let nonce = short_nonce();
+    let chat: serde_json::Value = http
+        .post(format!("{}/api/chat", gateway.base_url))
+        .json(&json!({
+            "agent": "sera",
+            "message": format!("Reply with the word OK and the nonce {nonce}."),
+            "stream": false,
+        }))
+        .send()
+        .await
+        .context("chat nonce send")?
+        .error_for_status()
+        .context("chat nonce HTTP status")?
+        .json()
+        .await
+        .context("chat nonce JSON parse")?;
+
+    let session_id = chat
+        .get("session_id")
+        .and_then(|v| v.as_str())
+        .with_context(|| format!("chat response missing session_id: {chat:?}"))?
+        .to_owned();
+    assert!(
+        !session_id.is_empty(),
+        "baseline gate requires a non-empty session_id, got {chat:?}"
+    );
+
+    let response_text = chat
+        .get("response")
+        .and_then(|v| v.as_str())
+        .with_context(|| format!("chat response missing response: {chat:?}"))?
+        .to_owned();
+
+    // When using the wiremock LLM, the scripted reply will land in
+    // `response`. With a real upstream LLM, `response` is whatever the
+    // provider returned. An empty body for a configured LLM is treated
+    // as a soft signal here rather than a hard fail — the existing
+    // `local_profile_turn.rs` documents that runtimes can legitimately
+    // short-circuit a turn (authz rejection, over-budget, tool-dispatch
+    // loop) without that being a parity break on its own.
+    if response_text.is_empty() {
+        eprintln!(
+            "{SKIP_TAG} SOFT: chat response was empty (provider chain may have \
+             swallowed the reply); baseline sanitizer contract holds trivially. \
+             Inspect /api/sessions/{session_id}/transcript for runtime evidence."
+        );
+    }
+
+    // ── Probe 3: response sanitizer contract ──
+    //
+    // Operator-visible `response` must never contain raw chain-of-thought
+    // tags. Reasoning models (Qwen, DeepSeek-R1, GLM-4.6, …) emit
+    // `<think>` / `</think>` blocks; SERA's runtime sanitizer is
+    // responsible for stripping them before the gateway returns the
+    // reply. We check both opening and closing markers — a truncated
+    // stream could leak only one.
+    let lc = response_text.to_ascii_lowercase();
+    assert!(
+        !lc.contains("<think>"),
+        "baseline gate: operator-visible response leaked `<think>` marker: \
+         {response_text:?}"
+    );
+    assert!(
+        !lc.contains("</think>"),
+        "baseline gate: operator-visible response leaked `</think>` marker: \
+         {response_text:?}"
+    );
+
+    gateway.shutdown().await.context("graceful gateway shutdown")?;
+    Ok(())
+}
+
+/// Tiny non-cryptographic nonce — process pid + nanoseconds is enough to
+/// keep prompts unique across reruns of this test in the same CI job.
+/// We deliberately avoid pulling in `rand` for one number.
+fn short_nonce() -> String {
+    let pid = std::process::id();
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.subsec_nanos())
+        .unwrap_or(0);
+    format!("{pid:x}{nanos:x}")
+}


### PR DESCRIPTION
## Summary

- Add `docs/internal/plans/hermes-parity-matrix.md` — 13-row tracked parity matrix covering API chat, Discord, provider/fallback, response sanitization, file/search/patch tools, terminal/process tools, web/browser/MCP, memory/session search, skills, delegation, workflows/cron/webhooks, TUI/dashboard, and audit/HITL/policy. Each row links to a canonical bead (`sera-m1k8`, `sera-duo3`, `sera-q66q`, `sera-ctag`, `sera-s77a`, `sera-tqzd`, `sera-rj4z`, `sera-yeg.2`, `sera-yj18`), with status, priority, acceptance smoke, and the SERA differentiation hook (audit / policy / HITL / GoalRun).
- Add `rust/crates/sera-e2e-harness/tests/hermes_parity_baseline.rs` (gated behind `--features integration`) — Phase 0 live baseline gate that probes `/api/health/ready`, authenticated `/api/chat` with a nonce, and asserts no `<think>` / `</think>` leakage in the operator-visible response. Skip contract matches `local_profile_turn.rs` so the gate is green in CI environments without an LLM or pre-built binaries.
- Add `docs/internal/sessions/hermes-parity-baseline-template.md` — operator-run live capture template. `artifacts/` is gitignored, so live captures stay out-of-tree by convention.

## Acceptance the matrix answers

1. **Which Hermes parity gaps still force fallback to Hermes?** See the `GAP` and `IN_PROGRESS` rows in the matrix.
2. **Which SERA bead owns each gap?** Each row names its owning bead anchor; recommended new beads (no canonical ID yet) are listed at the bottom of the matrix.
3. **Which live smoke proves the baseline?** `hermes_parity_baseline_gate` in `rust/crates/sera-e2e-harness/tests/hermes_parity_baseline.rs`, covering readiness, `/api/chat` nonce, and sanitizer contract.

## Verification

- `cargo check -p sera-e2e-harness --tests --features integration` — clean.
- `cargo clippy -p sera-e2e-harness --tests --features integration -- -D warnings` — clean.
- Matrix smoke: 13 rows present (`awk '/^\| [0-9]+ \|/{c++} END{print c}'` → 13); all 9 known bead anchors referenced.

## Source

Source plan: `origin/plan/hermes-parity-differentiation:docs/internal/plans/SERA-HERMES-PARITY-DIFFERENTIATION-PLAN-2026-05-23.md`.
Source beads: `sera-m1k8`, `sera-duo3`, `sera-q66q`, `sera-ctag`, `sera-s77a`, `sera-tqzd`, `sera-rj4z`, `sera-yeg.2`, `sera-yj18`.
Kanban task: `t_8bf1ec84`.

## Test plan

- [ ] CI green on the new test compile (`cargo check`, `cargo clippy`).
- [ ] (Optional, operator-run) follow `docs/internal/sessions/hermes-parity-baseline-template.md` against a live MiniMax + local Qwen stack and capture a timestamped report under the gitignored `artifacts/` tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)