### PR TITLE
feat(runtime,gateway): structured tool-failure visibility + OCSF audit (sera-tqzd, sera-q66q)

### DIFF
--- a/rust/crates/sera-gateway/src/agent_transport.rs
+++ b/rust/crates/sera-gateway/src/agent_transport.rs
@@ -16,6 +16,7 @@
 //! sense. The implementor is responsible only for the backend round-trip.
 
 use async_trait::async_trait;
+use sera_types::envelope::ToolCallStatus;
 use serde::Serialize;
 use serde_json::Value;
 use tokio::sync::mpsc::Sender;
@@ -34,6 +35,15 @@ pub enum ToolEvent {
     End {
         call_id: String,
         content: String,
+        /// Structured outcome forwarded from `EventMsg::ToolCallEnd::status`.
+        /// Defaults to `Success` so an older runtime that omits the wire
+        /// field still produces a sensible event for the audit emitter
+        /// (`sera-tqzd`, `sera-q66q`).
+        status: ToolCallStatus,
+        /// Canonical [`sera_types::tool::ToolError`] variant name when the
+        /// dispatch failed; `None` on success or when the runtime could not
+        /// classify the error.
+        error_class: Option<String>,
     },
 }
 

--- a/rust/crates/sera-gateway/src/bin/sera.rs
+++ b/rust/crates/sera-gateway/src/bin/sera.rs
@@ -614,6 +614,22 @@ impl StdioHarness {
                 }
                 "tool_call_end" => {
                     if let Some(msg) = event.get("msg") {
+                        // sera-tqzd / sera-q66q: the runtime sets `status` /
+                        // `error_class` on `EventMsg::ToolCallEnd` when
+                        // dispatch fails. Default to `Success` so older
+                        // runtimes (which never emit the fields) still
+                        // produce sensible audit rows.
+                        let status = match msg
+                            .get("status")
+                            .and_then(|v| v.as_str())
+                        {
+                            Some("failure") => sera_types::envelope::ToolCallStatus::Failure,
+                            _ => sera_types::envelope::ToolCallStatus::Success,
+                        };
+                        let error_class = msg
+                            .get("error_class")
+                            .and_then(|v| v.as_str())
+                            .map(|s| s.to_string());
                         result.tool_events.push(ToolEvent::End {
                             call_id: msg
                                 .get("call_id")
@@ -625,6 +641,8 @@ impl StdioHarness {
                                 .and_then(|v| v.as_str())
                                 .unwrap_or("")
                                 .to_string(),
+                            status,
+                            error_class,
                         });
                     }
                 }
@@ -4370,6 +4388,19 @@ async fn execute_turn(
                     capability_registry,
                 )
                 .await;
+                // sera-tqzd / sera-q66q: append one OCSF v1.7 API Activity
+                // audit entry per tool execution End event so success +
+                // failure are equally observable in the immutable ledger.
+                // Runs after `enforce_tool_events` so a runtime-blocked
+                // call (rewritten to `[sera-policy] denied …`) still
+                // produces a paired tool-execution failure row alongside
+                // the upstream policy-denial row from the Begin path.
+                emit_tool_execution_audit(
+                    agent_name,
+                    session_key,
+                    &filtered_events,
+                )
+                .await;
                 MvsTurnResult {
                     reply: events.response,
                     tool_events: filtered_events,
@@ -4453,6 +4484,166 @@ async fn enforce_tool_events(
         }
     }
     events
+}
+
+/// OCSF v1.7.0 class_uid for tool-execution audit entries (`sera-q66q`).
+///
+/// `3006` is "API Activity" — the closest OCSF class for "a tool / API call
+/// executed and reported a status". Pairs `activity_id=4` (Execute) with
+/// `status_id=1`/`status_id=2` (Success/Failure) so dashboards can split
+/// success and failure without parsing the human-readable detail.
+const TOOL_EXECUTION_OCSF_CLASS_UID: u32 = 3006;
+
+/// Cap on the per-row tool-result snippet stored in the audit payload. The
+/// hash-chain stores the entire payload as the body of a SQL row plus the
+/// SHA-256 — keeping the snippet short keeps row size bounded for high-volume
+/// tool loops while still leaving enough context to recognise the failure
+/// shape during closeout.
+const TOOL_EXEC_AUDIT_CONTENT_LIMIT: usize = 512;
+
+/// Build the OCSF payload for one tool execution. Pure (no I/O) so unit
+/// tests can assert the shape without touching the hash-chain backend
+/// (`sera-tqzd` / `sera-q66q` parity slice).
+///
+/// `content_snippet` is truncated to [`TOOL_EXEC_AUDIT_CONTENT_LIMIT`] so a
+/// runaway tool reply cannot bloat the audit ledger. The full body remains
+/// in the session transcript via `persist_tool_events`.
+fn make_tool_execution_audit_payload(
+    agent_name: &str,
+    session_key: &str,
+    call_id: &str,
+    tool_name: &str,
+    status: sera_types::envelope::ToolCallStatus,
+    error_class: Option<&str>,
+    content: &str,
+) -> serde_json::Value {
+    use sera_types::envelope::ToolCallStatus;
+
+    let status_id = match status {
+        ToolCallStatus::Success => 1,  // OCSF "Success"
+        ToolCallStatus::Failure => 2,  // OCSF "Failure"
+    };
+    let severity_id = match status {
+        ToolCallStatus::Success => 1,  // Informational
+        ToolCallStatus::Failure => 3,  // Medium — operator-actionable
+    };
+    let snippet: String = if content.len() > TOOL_EXEC_AUDIT_CONTENT_LIMIT {
+        let mut s = content[..TOOL_EXEC_AUDIT_CONTENT_LIMIT].to_string();
+        s.push_str("…[truncated]");
+        s
+    } else {
+        content.to_string()
+    };
+    serde_json::json!({
+        "activity_id": 4, // OCSF API Activity: "Execute"
+        "action_id": status.as_str(),
+        "category_uid": 3, // Application Activity
+        "class_uid": TOOL_EXECUTION_OCSF_CLASS_UID,
+        "severity_id": severity_id,
+        "status_id": status_id,
+        "status": match status {
+            ToolCallStatus::Success => "Success",
+            ToolCallStatus::Failure => "Failure",
+        },
+        "status_detail": error_class.unwrap_or(""),
+        "actor": { "user": { "name": agent_name } },
+        "api": {
+            "operation": tool_name,
+            "request": { "uid": call_id },
+        },
+        "resource": {
+            "name": tool_name,
+            "type": "tool",
+            "uid": session_key,
+        },
+        "unmapped": {
+            "result_snippet": snippet,
+            "error_class": error_class,
+        },
+    })
+}
+
+/// Emit one OCSF v1.7.0 API Activity (class_uid=3006) audit entry per
+/// `ToolEvent::End` observed for this turn (`sera-q66q` immutable ledger +
+/// `sera-tqzd` failure visibility).
+///
+/// Begin events provide the `tool` name that pairs with each End's
+/// `call_id`. If the runtime emits an End without a matching Begin
+/// (defensive guard against truncated streams), the entry still records
+/// `tool="(unknown)"` so the failure remains visible — silence is the
+/// failure mode this bead exists to prevent.
+///
+/// Best-effort: an uninitialised audit backend logs a debug line and
+/// continues; the gateway never fails a turn because of an audit-sink
+/// outage. The hash-chain is computed locally (genesis `prev_hash`) and
+/// the backend reorders/links entries on append.
+async fn emit_tool_execution_audit(
+    agent_name: &str,
+    session_key: &str,
+    events: &[ToolEvent],
+) {
+    use sera_telemetry::audit::{AuditEntry, audit_append};
+
+    let mut tool_for_call: std::collections::HashMap<&str, &str> =
+        std::collections::HashMap::new();
+    for event in events {
+        if let ToolEvent::Begin { call_id, tool, .. } = event {
+            tool_for_call.insert(call_id.as_str(), tool.as_str());
+        }
+    }
+
+    for event in events {
+        if let ToolEvent::End {
+            call_id,
+            content,
+            status,
+            error_class,
+        } = event
+        {
+            let tool_name = tool_for_call
+                .get(call_id.as_str())
+                .copied()
+                .unwrap_or("(unknown)");
+            let payload = make_tool_execution_audit_payload(
+                agent_name,
+                session_key,
+                call_id,
+                tool_name,
+                *status,
+                error_class.as_deref(),
+                content,
+            );
+            let this_hash = AuditEntry::compute_hash(
+                TOOL_EXECUTION_OCSF_CLASS_UID,
+                &payload,
+                &[0u8; 32],
+            );
+            let entry = AuditEntry {
+                ocsf_class_uid: TOOL_EXECUTION_OCSF_CLASS_UID,
+                payload,
+                prev_hash: [0u8; 32],
+                this_hash,
+                signature: None,
+            };
+            if let Err(e) = audit_append(entry).await {
+                tracing::debug!(
+                    error = %e,
+                    tool = %tool_name,
+                    call_id = %call_id,
+                    "audit backend unavailable for tool execution"
+                );
+            } else if *status == sera_types::envelope::ToolCallStatus::Failure {
+                tracing::warn!(
+                    agent = %agent_name,
+                    session_key = %session_key,
+                    tool = %tool_name,
+                    call_id = %call_id,
+                    error_class = error_class.as_deref().unwrap_or(""),
+                    "Tool execution recorded as failure (sera-tqzd)"
+                );
+            }
+        }
+    }
 }
 
 /// Emit an OCSF v1.7.0 Policy Activity (class_uid=6003, action_id=blocked)
@@ -4721,7 +4912,12 @@ fn persist_tool_events(db: &sera_db::sqlite::SqliteDb, session_id: &str, events:
                     None,
                 );
             }
-            ToolEvent::End { call_id, content } => {
+            ToolEvent::End {
+                call_id,
+                content,
+                status: _,
+                error_class: _,
+            } => {
                 let _ =
                     db.append_transcript(session_id, "tool", Some(content), None, Some(call_id));
             }
@@ -8505,6 +8701,163 @@ mod tests {
             "agent:sera-b",
         );
         assert_ne!(e1.this_hash, e2.this_hash);
+    }
+
+    // ── Tool-execution audit payload (sera-tqzd / sera-q66q) ───────────────
+    //
+    // Same testing posture as the external-agent-register helpers above:
+    // the pure builder is unit-tested, the async emission is best-effort
+    // against the global set-once backend and is not exercised here.
+
+    #[test]
+    fn tool_execution_audit_payload_success_shape() {
+        // Success path: status_id=1, severity=Informational, action_id="success".
+        // The OCSF envelope must carry the API Activity class so dashboards
+        // can split tool-call activity from policy denials.
+        let payload = make_tool_execution_audit_payload(
+            "agent-test",
+            "sess-123",
+            "call_ok_1",
+            "file-list",
+            sera_types::envelope::ToolCallStatus::Success,
+            None,
+            "12 entries",
+        );
+
+        assert_eq!(payload["class_uid"], TOOL_EXECUTION_OCSF_CLASS_UID);
+        assert_eq!(payload["class_uid"], 3006);
+        assert_eq!(payload["activity_id"], 4); // Execute
+        assert_eq!(payload["category_uid"], 3); // Application Activity
+        assert_eq!(payload["status_id"], 1);
+        assert_eq!(payload["status"], "Success");
+        assert_eq!(payload["severity_id"], 1);
+        assert_eq!(payload["action_id"], "success");
+        assert_eq!(payload["actor"]["user"]["name"], "agent-test");
+        assert_eq!(payload["api"]["operation"], "file-list");
+        assert_eq!(payload["api"]["request"]["uid"], "call_ok_1");
+        assert_eq!(payload["resource"]["name"], "file-list");
+        assert_eq!(payload["resource"]["type"], "tool");
+        assert_eq!(payload["resource"]["uid"], "sess-123");
+        assert_eq!(payload["status_detail"], "");
+        assert!(payload["unmapped"]["error_class"].is_null());
+        assert_eq!(payload["unmapped"]["result_snippet"], "12 entries");
+    }
+
+    #[test]
+    fn tool_execution_audit_payload_failure_carries_error_class() {
+        // Failure path: status_id=2, severity=Medium, action_id="failure"
+        // and the error_class string lands both in status_detail (operator
+        // surface) and in unmapped.error_class (machine surface).
+        let payload = make_tool_execution_audit_payload(
+            "agent-test",
+            "sess-fail-1",
+            "call_fail_1",
+            "shell-exec",
+            sera_types::envelope::ToolCallStatus::Failure,
+            Some("policy_denied"),
+            "[tool error: policy denied tool execution: denied for test]",
+        );
+
+        assert_eq!(payload["status_id"], 2);
+        assert_eq!(payload["status"], "Failure");
+        assert_eq!(payload["severity_id"], 3);
+        assert_eq!(payload["action_id"], "failure");
+        assert_eq!(payload["status_detail"], "policy_denied");
+        assert_eq!(payload["unmapped"]["error_class"], "policy_denied");
+        let snippet = payload["unmapped"]["result_snippet"]
+            .as_str()
+            .unwrap_or_default();
+        assert!(
+            snippet.contains("policy denied"),
+            "snippet must preserve the failure detail: {snippet}",
+        );
+    }
+
+    #[test]
+    fn tool_execution_audit_payload_truncates_long_snippet() {
+        // Bound the per-row body so a runaway tool reply cannot bloat the
+        // hash-chained ledger. The full content remains in the session
+        // transcript via `persist_tool_events`.
+        let big = "x".repeat(TOOL_EXEC_AUDIT_CONTENT_LIMIT + 100);
+        let payload = make_tool_execution_audit_payload(
+            "agent-test",
+            "sess-trunc",
+            "call_trunc",
+            "file-read",
+            sera_types::envelope::ToolCallStatus::Success,
+            None,
+            &big,
+        );
+        let snippet = payload["unmapped"]["result_snippet"]
+            .as_str()
+            .unwrap_or_default();
+        assert!(
+            snippet.ends_with("…[truncated]"),
+            "oversized snippet must be marked truncated: ends with {:?}",
+            &snippet[snippet.len().saturating_sub(20)..],
+        );
+        // The truncated body is bounded by the limit + the marker suffix.
+        assert!(snippet.len() <= TOOL_EXEC_AUDIT_CONTENT_LIMIT + 32);
+    }
+
+    #[test]
+    fn tool_execution_audit_payload_hash_is_well_formed() {
+        use sera_telemetry::audit::AuditEntry;
+
+        let payload = make_tool_execution_audit_payload(
+            "agent-test",
+            "sess-hash",
+            "call_hash",
+            "file-read",
+            sera_types::envelope::ToolCallStatus::Failure,
+            Some("timeout"),
+            "[tool error: tool execution timed out]",
+        );
+        // Genesis-style: prev_hash all-zeros, this_hash deterministic over the
+        // payload. The backend re-links to the chain tail on append, but the
+        // local computation must still be byte-stable for the M1 contract.
+        let this_hash = AuditEntry::compute_hash(
+            TOOL_EXECUTION_OCSF_CLASS_UID,
+            &payload,
+            &[0u8; 32],
+        );
+        let again = AuditEntry::compute_hash(
+            TOOL_EXECUTION_OCSF_CLASS_UID,
+            &payload,
+            &[0u8; 32],
+        );
+        assert_eq!(this_hash, again);
+        assert_ne!(this_hash, [0u8; 32]);
+    }
+
+    #[test]
+    fn tool_execution_audit_payload_distinguishes_status() {
+        // The success and failure variants over otherwise-identical inputs
+        // must differ in the hash so dashboards / closeout audits can't
+        // accidentally collapse them. Catches a future regression where
+        // status flips to a default that no longer reaches the payload.
+        let common = ("agent-test", "sess-x", "call_x", "tool-x", "result body");
+        let ok = make_tool_execution_audit_payload(
+            common.0,
+            common.1,
+            common.2,
+            common.3,
+            sera_types::envelope::ToolCallStatus::Success,
+            None,
+            common.4,
+        );
+        let bad = make_tool_execution_audit_payload(
+            common.0,
+            common.1,
+            common.2,
+            common.3,
+            sera_types::envelope::ToolCallStatus::Failure,
+            Some("execution_failed"),
+            common.4,
+        );
+        assert_ne!(ok["status_id"], bad["status_id"]);
+        assert_ne!(ok["severity_id"], bad["severity_id"]);
+        assert_ne!(ok["action_id"], bad["action_id"]);
     }
 
     #[tokio::test]

--- a/rust/crates/sera-gateway/src/bin/sera.rs
+++ b/rust/crates/sera-gateway/src/bin/sera.rs
@@ -4527,8 +4527,17 @@ fn make_tool_execution_audit_payload(
         ToolCallStatus::Success => 1,  // Informational
         ToolCallStatus::Failure => 3,  // Medium — operator-actionable
     };
+    // Truncate on a char boundary so a multi-byte UTF-8 codepoint (emoji,
+    // CJK, etc.) never panics audit-payload construction. Walks back from
+    // the byte limit until the prefix is a valid &str slice, then appends
+    // the truncation marker.
     let snippet: String = if content.len() > TOOL_EXEC_AUDIT_CONTENT_LIMIT {
-        let mut s = content[..TOOL_EXEC_AUDIT_CONTENT_LIMIT].to_string();
+        let mut cut = TOOL_EXEC_AUDIT_CONTENT_LIMIT;
+        while cut > 0 && !content.is_char_boundary(cut) {
+            cut -= 1;
+        }
+        let mut s = String::with_capacity(cut + 16);
+        s.push_str(&content[..cut]);
         s.push_str("…[truncated]");
         s
     } else {
@@ -8798,6 +8807,41 @@ mod tests {
         );
         // The truncated body is bounded by the limit + the marker suffix.
         assert!(snippet.len() <= TOOL_EXEC_AUDIT_CONTENT_LIMIT + 32);
+    }
+
+    #[test]
+    fn tool_execution_audit_payload_truncates_on_char_boundary() {
+        // Codex P1 review on PR #1284: a naive `content[..LIMIT]` truncation
+        // panics if the limit lands in the middle of a multi-byte UTF-8
+        // codepoint (emoji, CJK, accented Latin). Build a snippet that
+        // would have landed inside a 4-byte emoji at the byte limit and
+        // assert payload construction returns a valid UTF-8 snippet.
+        let pad = "a".repeat(TOOL_EXEC_AUDIT_CONTENT_LIMIT - 2);
+        let big = format!("{pad}🦀🦀🦀🦀");
+        // The 512th byte falls strictly inside a 🦀 (U+1F980, 4 UTF-8 bytes),
+        // so the byte-index slice would panic without the boundary walk.
+        assert!(!big.is_char_boundary(TOOL_EXEC_AUDIT_CONTENT_LIMIT));
+
+        let payload = make_tool_execution_audit_payload(
+            "agent-test",
+            "sess-utf8",
+            "call_utf8",
+            "file-read",
+            sera_types::envelope::ToolCallStatus::Success,
+            None,
+            &big,
+        );
+        let snippet = payload["unmapped"]["result_snippet"]
+            .as_str()
+            .expect("snippet must serialize");
+        assert!(
+            snippet.ends_with("…[truncated]"),
+            "boundary-safe truncation must still mark output: {snippet}",
+        );
+        // The truncated prefix must be valid UTF-8 — implicitly true because
+        // we built a String, but assert no zero-width replacement happened:
+        // the snippet must start with the original pad characters.
+        assert!(snippet.starts_with("aaaa"));
     }
 
     #[test]

--- a/rust/crates/sera-gateway/src/embedded_transport.rs
+++ b/rust/crates/sera-gateway/src/embedded_transport.rs
@@ -42,6 +42,7 @@ use serde_json::Value;
 use tokio::sync::Mutex;
 
 use sera_runtime::default_runtime::DefaultRuntime;
+use sera_types::envelope::read_tool_status_markers;
 use sera_types::principal::Principal;
 use sera_types::runtime::{AgentRuntime, TurnContext, TurnOutcome};
 use sera_types::tool::ToolDefinition;
@@ -387,7 +388,13 @@ fn project_tool_events(transcript: &[Value]) -> Vec<ToolEvent> {
                 .and_then(|c| c.as_str())
                 .unwrap_or("")
                 .to_string();
-            events.push(ToolEvent::End { call_id, content });
+            let (status, error_class) = read_tool_status_markers(msg);
+            events.push(ToolEvent::End {
+                call_id,
+                content,
+                status,
+                error_class,
+            });
         }
     }
     events
@@ -406,6 +413,7 @@ mod tests {
     use super::*;
     use sera_runtime::context_engine::pipeline::ContextPipeline;
     use sera_runtime::turn::{LlmProvider, ThinkError, ThinkResult};
+    use sera_types::envelope::ToolCallStatus;
 
     /// Minimal `LlmProvider` that returns a fixed assistant reply with a
     /// canned token count. Used to exercise the embedded transport without
@@ -746,9 +754,11 @@ mod tests {
             other => panic!("expected Begin, got {other:?}"),
         }
         match &events[1] {
-            ToolEvent::End { call_id, content } => {
+            ToolEvent::End { call_id, content, status, error_class } => {
                 assert_eq!(call_id, "call_1");
                 assert_eq!(content, "ok");
+                assert_eq!(*status, ToolCallStatus::Success);
+                assert!(error_class.is_none());
             }
             other => panic!("expected End, got {other:?}"),
         }

--- a/rust/crates/sera-runtime/src/stdio.rs
+++ b/rust/crates/sera-runtime/src/stdio.rs
@@ -365,6 +365,12 @@ async fn emit_tool_events_from_transcript(
                 .and_then(|c| c.as_str())
                 .unwrap_or("")
                 .to_string();
+            // sera-tqzd: lift the structured failure marker the `act()` step
+            // stamps onto a failed tool result so the wire `ToolCallEnd`
+            // carries a typed `status` + `error_class`. Backward-compatible:
+            // a transcript without the markers stays Success/None.
+            let (status, error_class) =
+                sera_types::envelope::read_tool_status_markers(msg);
             emit(
                 stdout,
                 Event {
@@ -374,6 +380,8 @@ async fn emit_tool_events_from_transcript(
                         turn_id,
                         call_id,
                         result: result_content,
+                        status,
+                        error_class,
                     },
                     trace: Default::default(),
                     timestamp: chrono::Utc::now(),

--- a/rust/crates/sera-runtime/src/turn.rs
+++ b/rust/crates/sera-runtime/src/turn.rs
@@ -559,10 +559,18 @@ pub async fn act(
                         let tool_call_id = tc.get("id")
                             .and_then(|id| id.as_str())
                             .unwrap_or("unknown");
+                        // sera-tqzd: stamp the structured failure markers
+                        // alongside the human-readable `content` string so
+                        // the downstream wire path (`stdio::emit_tool_events_from_transcript`)
+                        // can lift them onto `EventMsg::ToolCallEnd::{status,error_class}`
+                        // without re-parsing the error text. The marker keys
+                        // are documented on `sera_types::envelope`.
                         results.push(serde_json::json!({
                             "tool_call_id": tool_call_id,
                             "role": "tool",
                             "content": format!("[tool error: {e}]"),
+                            sera_types::envelope::TOOL_STATUS_MARKER: "failure",
+                            sera_types::envelope::TOOL_ERROR_CLASS_MARKER: e.class_name(),
                         }));
                     }
                 }
@@ -1891,6 +1899,170 @@ mod tests {
         let result = act(&mut ctx, &think_result, None).await;
         match result {
             ActResult::ToolResults(_) => {} // Expected — no approval needed
+            other => panic!("expected ToolResults, got {:?}", other),
+        }
+    }
+
+    // ── sera-tqzd: failure markers on tool result messages ───────────────────
+
+    /// Dispatcher that always returns a fixed `ToolError` variant. Used to
+    /// prove that `act()` stamps `_sera_status` + `_sera_error_class` onto
+    /// the tool result message when dispatch fails, without depending on the
+    /// real tool registry.
+    struct AlwaysFailDispatcher {
+        err: ToolError,
+    }
+
+    #[async_trait]
+    impl ToolDispatcher for AlwaysFailDispatcher {
+        async fn dispatch(
+            &self,
+            _tool_call: &serde_json::Value,
+            _ctx: &ToolContext,
+        ) -> Result<serde_json::Value, ToolError> {
+            Err(self.err.clone())
+        }
+    }
+
+    #[tokio::test]
+    async fn act_marks_dispatch_failure_with_status_and_error_class() {
+        // sera-tqzd: when the dispatcher returns an error, the tool result
+        // message put into `ActResult::ToolResults` must carry the
+        // `_sera_status: "failure"` / `_sera_error_class: "<variant>"`
+        // markers so the runtime's NDJSON emitter can lift them onto the
+        // wire `EventMsg::ToolCallEnd`. The human-readable `content` keeps
+        // its `[tool error: …]` shape so the LLM still sees the message.
+        let mut ctx = make_turn_ctx(vec![]);
+        let dispatcher = AlwaysFailDispatcher {
+            err: ToolError::PolicyDenied("denied for test".to_string()),
+        };
+        let think_result = ThinkResult {
+            response: serde_json::json!({"role": "assistant", "content": "trying"}),
+            tool_calls: vec![serde_json::json!({
+                "id": "call_fail_1",
+                "type": "function",
+                "function": { "name": "shell-exec", "arguments": "{}" }
+            })],
+            tokens: TokenUsage::default(),
+            plan: None,
+        };
+        let result = act(&mut ctx, &think_result, Some(&dispatcher)).await;
+        match result {
+            ActResult::ToolResults(results) => {
+                assert_eq!(results.len(), 1);
+                let r = &results[0];
+                assert_eq!(r.get("tool_call_id").and_then(|v| v.as_str()), Some("call_fail_1"));
+                assert_eq!(r.get("role").and_then(|v| v.as_str()), Some("tool"));
+                let content = r.get("content").and_then(|v| v.as_str()).unwrap_or_default();
+                assert!(
+                    content.starts_with("[tool error: "),
+                    "content must keep the human-readable prefix: {content}",
+                );
+                assert_eq!(
+                    r.get(sera_types::envelope::TOOL_STATUS_MARKER)
+                        .and_then(|v| v.as_str()),
+                    Some("failure"),
+                    "_sera_status marker must record failure: {r}",
+                );
+                assert_eq!(
+                    r.get(sera_types::envelope::TOOL_ERROR_CLASS_MARKER)
+                        .and_then(|v| v.as_str()),
+                    Some("policy_denied"),
+                    "_sera_error_class must record the canonical ToolError variant: {r}",
+                );
+            }
+            other => panic!("expected ToolResults, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn act_propagates_error_class_for_each_variant() {
+        // Smoke that every ToolError variant maps to a stable class name in
+        // the failure marker — guards against future variants being silently
+        // bucketed under a wrong class by the dispatcher path.
+        let cases: &[(ToolError, &str)] = &[
+            (ToolError::NotFound("x".into()), "not_found"),
+            (ToolError::Unauthorized("x".into()), "unauthorized"),
+            (ToolError::ExecutionFailed("x".into()), "execution_failed"),
+            (ToolError::Timeout, "timeout"),
+            (ToolError::InvalidInput("x".into()), "invalid_input"),
+            (ToolError::PolicyDenied("x".into()), "policy_denied"),
+            (ToolError::InvalidArguments("x".into()), "invalid_arguments"),
+            (
+                ToolError::AbortedByHook {
+                    reason: "x".into(),
+                },
+                "aborted_by_hook",
+            ),
+            (
+                ToolError::PermissionDenied {
+                    reason: "x".into(),
+                },
+                "permission_denied",
+            ),
+        ];
+        for (err, expected_class) in cases {
+            assert_eq!(
+                err.class_name(),
+                *expected_class,
+                "ToolError::class_name() must map {:?} → {}",
+                err,
+                expected_class,
+            );
+
+            let mut ctx = make_turn_ctx(vec![]);
+            let dispatcher = AlwaysFailDispatcher { err: err.clone() };
+            let think_result = ThinkResult {
+                response: serde_json::json!({"role": "assistant", "content": "trying"}),
+                tool_calls: vec![serde_json::json!({
+                    "id": "call_variant",
+                    "type": "function",
+                    "function": { "name": "any-tool", "arguments": "{}" }
+                })],
+                tokens: TokenUsage::default(),
+                plan: None,
+            };
+            let result = act(&mut ctx, &think_result, Some(&dispatcher)).await;
+            match result {
+                ActResult::ToolResults(results) => {
+                    assert_eq!(
+                        results[0]
+                            .get(sera_types::envelope::TOOL_ERROR_CLASS_MARKER)
+                            .and_then(|v| v.as_str()),
+                        Some(*expected_class),
+                    );
+                }
+                other => panic!("expected ToolResults for {:?}, got {:?}", err, other),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn act_does_not_mark_success_path() {
+        // The success path must not carry the failure markers — the wire
+        // ToolCallEnd defaults to Success, so adding markers here would be a
+        // soft regression.
+        let mut ctx = make_turn_ctx(vec![]);
+        let dispatcher = StaticRiskDispatcher::new(&[
+            ("file-list", sera_types::tool::RiskLevel::Read),
+        ]);
+        let think_result = ThinkResult {
+            response: serde_json::json!({"role": "assistant", "content": "listing"}),
+            tool_calls: vec![serde_json::json!({
+                "id": "call_ok_1",
+                "type": "function",
+                "function": { "name": "file-list", "arguments": "{}" }
+            })],
+            tokens: TokenUsage::default(),
+            plan: None,
+        };
+        let result = act(&mut ctx, &think_result, Some(&dispatcher)).await;
+        match result {
+            ActResult::ToolResults(results) => {
+                let r = &results[0];
+                assert!(r.get(sera_types::envelope::TOOL_STATUS_MARKER).is_none());
+                assert!(r.get(sera_types::envelope::TOOL_ERROR_CLASS_MARKER).is_none());
+            }
             other => panic!("expected ToolResults, got {:?}", other),
         }
     }

--- a/rust/crates/sera-types/src/envelope.rs
+++ b/rust/crates/sera-types/src/envelope.rs
@@ -231,6 +231,20 @@ pub enum EventMsg {
         turn_id: Uuid,
         call_id: String,
         result: String,
+        /// Structured outcome of the tool execution. Defaults to `Success`
+        /// so older runtimes that do not set the field still deserialize.
+        /// Set by the runtime via [`sera-tqzd`] when `ToolDispatcher::dispatch`
+        /// returns an error, so failures are never reduced to an opaque
+        /// content string at the operator/audit boundary.
+        #[serde(default)]
+        status: ToolCallStatus,
+        /// Canonical [`ToolError`](crate::tool::ToolError) variant name when
+        /// `status == Failure` (e.g. `"policy_denied"`, `"execution_failed"`).
+        /// `None` on success or when the runtime cannot classify the error.
+        /// Used by the gateway audit ledger ([`sera-q66q`]) so a closeout
+        /// reader can filter on failure class without reparsing free text.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        error_class: Option<String>,
     },
     HitlRequest {
         approval_id: Uuid,
@@ -275,6 +289,66 @@ pub enum EventMsg {
         code: String,
         message: String,
     },
+}
+
+/// Outcome of a tool execution surfaced on [`EventMsg::ToolCallEnd`].
+///
+/// Lives alongside the wire envelope so both the runtime emitter and the
+/// gateway consumer share the same enum. `Success` is the serde default so
+/// older runtime builds — which never set the field — keep parsing.
+///
+/// Anchors: `sera-tqzd` (failure must be operator-visible) and `sera-q66q`
+/// (audit ledger entry per execution).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ToolCallStatus {
+    #[default]
+    Success,
+    Failure,
+}
+
+impl ToolCallStatus {
+    /// Stable lowercase tag — used by the gateway audit payload so dashboards
+    /// can filter without recomputing the enum case.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Success => "success",
+            Self::Failure => "failure",
+        }
+    }
+}
+
+/// JSON field on a transcript `tool` message that flags a failed dispatch
+/// (`"success"` / `"failure"`). Underscore-prefixed so the field is treated
+/// as runtime/gateway metadata rather than an OpenAI tool-message contract
+/// field. Older builds that never see it default to [`ToolCallStatus::Success`].
+pub const TOOL_STATUS_MARKER: &str = "_sera_status";
+
+/// JSON field on a transcript `tool` message carrying the canonical
+/// [`crate::tool::ToolError::class_name`] when [`TOOL_STATUS_MARKER`] is
+/// `"failure"`. Absent on success.
+pub const TOOL_ERROR_CLASS_MARKER: &str = "_sera_error_class";
+
+/// Parse the failure markers off a transcript `tool` message, returning
+/// `(status, error_class)`. Missing / malformed markers degrade to
+/// `(Success, None)` so the helper is safe on any tool-result JSON shape.
+///
+/// Single source of truth shared between the runtime's NDJSON emitter
+/// ([`sera-runtime`]) and the gateway's embedded-transport projection
+/// ([`sera-gateway`]) — keeps the wire / projection paths from drifting.
+pub fn read_tool_status_markers(msg: &serde_json::Value) -> (ToolCallStatus, Option<String>) {
+    let status = match msg.get(TOOL_STATUS_MARKER).and_then(|v| v.as_str()) {
+        Some("failure") => ToolCallStatus::Failure,
+        Some("success") | None => ToolCallStatus::Success,
+        // Unknown future strings are treated as success to preserve the
+        // forward-compat default; the wire field always wins if set.
+        Some(_) => ToolCallStatus::Success,
+    };
+    let error_class = msg
+        .get(TOOL_ERROR_CLASS_MARKER)
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+    (status, error_class)
 }
 
 /// W3C trace context for distributed tracing.
@@ -712,5 +786,103 @@ mod tests {
         }))
         .unwrap();
         assert!(matches!(plugin, RegisterOp::Plugin { .. }));
+    }
+
+    // ── ToolCallStatus + marker reader (sera-tqzd / sera-q66q) ────────────────
+
+    #[test]
+    fn tool_call_status_default_is_success() {
+        // Wire-default must be Success so old runtimes that never set the
+        // field don't get reclassified as failures.
+        assert_eq!(ToolCallStatus::default(), ToolCallStatus::Success);
+    }
+
+    #[test]
+    fn tool_call_status_serializes_snake_case() {
+        let success = serde_json::to_value(ToolCallStatus::Success).unwrap();
+        let failure = serde_json::to_value(ToolCallStatus::Failure).unwrap();
+        assert_eq!(success, serde_json::Value::String("success".into()));
+        assert_eq!(failure, serde_json::Value::String("failure".into()));
+    }
+
+    #[test]
+    fn read_tool_status_markers_defaults_to_success() {
+        let msg = serde_json::json!({
+            "role": "tool",
+            "tool_call_id": "c1",
+            "content": "ok",
+        });
+        let (status, class) = read_tool_status_markers(&msg);
+        assert_eq!(status, ToolCallStatus::Success);
+        assert!(class.is_none());
+    }
+
+    #[test]
+    fn read_tool_status_markers_recognises_failure() {
+        let msg = serde_json::json!({
+            "role": "tool",
+            "tool_call_id": "c2",
+            "content": "[tool error: …]",
+            TOOL_STATUS_MARKER: "failure",
+            TOOL_ERROR_CLASS_MARKER: "policy_denied",
+        });
+        let (status, class) = read_tool_status_markers(&msg);
+        assert_eq!(status, ToolCallStatus::Failure);
+        assert_eq!(class.as_deref(), Some("policy_denied"));
+    }
+
+    #[test]
+    fn read_tool_status_markers_ignores_unknown_status() {
+        // Forward-compat: unknown status values fall back to Success rather
+        // than synthesising a phantom failure. The wire field always wins
+        // when set to a known value.
+        let msg = serde_json::json!({
+            "role": "tool",
+            TOOL_STATUS_MARKER: "weird_future_state",
+        });
+        let (status, class) = read_tool_status_markers(&msg);
+        assert_eq!(status, ToolCallStatus::Success);
+        assert!(class.is_none());
+    }
+
+    #[test]
+    fn tool_call_end_with_status_round_trips() {
+        // Forward-compat: a runtime that emits the new fields must
+        // round-trip through serde, and an older runtime that omits them
+        // must deserialize with the Success default.
+        let new = EventMsg::ToolCallEnd {
+            turn_id: uuid::Uuid::nil(),
+            call_id: "c3".into(),
+            result: "[tool error: timeout]".into(),
+            status: ToolCallStatus::Failure,
+            error_class: Some("timeout".into()),
+        };
+        let json = serde_json::to_value(&new).unwrap();
+        assert_eq!(json["status"], serde_json::Value::String("failure".into()));
+        assert_eq!(json["error_class"], serde_json::Value::String("timeout".into()));
+        let parsed: EventMsg = serde_json::from_value(json).unwrap();
+        match parsed {
+            EventMsg::ToolCallEnd { status, error_class, .. } => {
+                assert_eq!(status, ToolCallStatus::Failure);
+                assert_eq!(error_class.as_deref(), Some("timeout"));
+            }
+            other => panic!("expected ToolCallEnd, got {:?}", other),
+        }
+
+        // Older wire shape — no status / error_class — must default to Success.
+        let legacy = serde_json::json!({
+            "type": "tool_call_end",
+            "turn_id": uuid::Uuid::nil(),
+            "call_id": "c4",
+            "result": "ok",
+        });
+        let parsed: EventMsg = serde_json::from_value(legacy).unwrap();
+        match parsed {
+            EventMsg::ToolCallEnd { status, error_class, .. } => {
+                assert_eq!(status, ToolCallStatus::Success);
+                assert!(error_class.is_none());
+            }
+            other => panic!("expected ToolCallEnd, got {:?}", other),
+        }
     }
 }

--- a/rust/crates/sera-types/src/tool.rs
+++ b/rust/crates/sera-types/src/tool.rs
@@ -480,6 +480,29 @@ pub enum ToolError {
     PermissionDenied { reason: String },
 }
 
+impl ToolError {
+    /// Stable snake_case class name for audit / wire propagation.
+    ///
+    /// Used by the runtime to fill `EventMsg::ToolCallEnd::error_class` when
+    /// dispatch fails (`sera-tqzd`), and by the gateway's OCSF audit emitter
+    /// (`sera-q66q`) to filter failures by class without reparsing `Display`.
+    /// The mapping is intentionally lossy: `Display`/`Debug` carry the
+    /// human-readable detail, while this returns only the discriminant.
+    pub fn class_name(&self) -> &'static str {
+        match self {
+            ToolError::NotFound(_) => "not_found",
+            ToolError::Unauthorized(_) => "unauthorized",
+            ToolError::ExecutionFailed(_) => "execution_failed",
+            ToolError::Timeout => "timeout",
+            ToolError::InvalidInput(_) => "invalid_input",
+            ToolError::PolicyDenied(_) => "policy_denied",
+            ToolError::InvalidArguments(_) => "invalid_arguments",
+            ToolError::AbortedByHook { .. } => "aborted_by_hook",
+            ToolError::PermissionDenied { .. } => "permission_denied",
+        }
+    }
+}
+
 impl From<ToolError> for sera_errors::SeraError {
     fn from(err: ToolError) -> Self {
         use sera_errors::SeraErrorCode;


### PR DESCRIPTION
## Summary

Narrow Hermes-parity slice closing the silent-failure gap on tool execution. Tool / provider failures now reach the operator and the immutable audit trail in a structured shape — they can no longer be reduced to an opaque content blob. Two source beads land together because tool-failure surfacing (`sera-tqzd`) and the per-execution audit-ledger entry (`sera-q66q`) share the same wire change.

Parent task: `t_3047993b` (parity smoke slice, merged in #1276 / #1277).
Parity matrix anchors: row 5 (file/search/patch tool parity) failure-surfacing axis; row 13 (audit / HITL / policy) immutable-ledger axis. `docs/internal/plans/hermes-parity-matrix.md`.

## What lands

- `sera-types/src/envelope.rs` — `EventMsg::ToolCallEnd` gains `#[serde(default)]` `status: ToolCallStatus` (`Success` / `Failure`) and `error_class: Option<String>`. Older runtimes parse unchanged; the default classification stays `Success`. New `TOOL_STATUS_MARKER` / `TOOL_ERROR_CLASS_MARKER` constants and a `read_tool_status_markers` helper are the single source of truth shared with the gateway's in-process projection.
- `sera-types/src/tool.rs` — `ToolError::class_name()` returns a stable snake_case discriminant tag (`policy_denied`, `execution_failed`, `timeout`, …) used by the runtime to fill the wire field without re-parsing `Display`.
- `sera-runtime/src/turn.rs::act` — on a dispatcher error, stamps `_sera_status` + `_sera_error_class` markers onto the tool-result transcript message alongside the existing `[tool error: …]` content. The success path is unchanged, so the default wire shape stays Success.
- `sera-runtime/src/stdio.rs::emit_tool_events_from_transcript` — lifts the markers into `EventMsg::ToolCallEnd::{status, error_class}` so the NDJSON wire carries structured failure data.
- `sera-gateway/src/agent_transport.rs::ToolEvent::End` + `sera-gateway/src/embedded_transport.rs::project_tool_events` — gain the same `status` / `error_class` fields so the stdio and embedded transports converge on the typed shape.
- `sera-gateway/src/bin/sera.rs` — the `tool_call_end` parser reads the new fields; a new `emit_tool_execution_audit` appends one OCSF v1.7 API Activity (class_uid=3006, activity_id=4 Execute) audit entry per `ToolEvent::End` into the hash-chained ledger via `audit_append`. Status, severity, `status_detail`, snippet, and `unmapped.error_class` are populated structurally so closeout dashboards can split success / failure without reparsing free text. Snippet is truncated at 512 bytes so high-volume tool loops cannot bloat the per-row body. Best-effort emission: an uninitialised backend logs a debug line and continues (same posture as `emit_policy_denial_audit`). Wired into the chat handler after `enforce_tool_events`, so a runtime-blocked tool produces a paired execution-Failure row alongside the Begin-side policy-denial row.

## Why this closes the bead acceptance

- **`sera-tqzd`** — silent failure on the covered path is now impossible: every `ToolError` variant maps to a stable class name that travels Runtime → Gateway as structured fields on `EventMsg::ToolCallEnd`, surfaces in the operator-visible `ToolEvent::End`, and writes a Failure-tagged audit row.
- **`sera-q66q`** — the gateway emits exactly one OCSF audit entry per tool execution End event. The payload is deterministic (covered by a hash-determinism test) and the success / failure paths produce distinct hashes so the chain cannot collapse them.

The slice is intentionally smaller than the full bead scope. Both beads also call for closeout dashboards / TUI surfaces that consume the new fields; those follow-ups stay on the beads.

## Tests

- `sera-types` (`envelope.rs`): 5 new — `ToolCallStatus` serde defaults, marker reader success / failure / forward-compat-unknown, wire-shape round-trip with and without the new fields.
- `sera-runtime` (`turn.rs`): 3 new — failure markers stamped on the `Err` path, every `ToolError` variant maps to its stable class name, success path carries no markers.
- `sera-gateway` (`bin/sera.rs`): 5 new — pure payload tests for success shape, failure carrying `error_class`, snippet truncation, hash determinism, and status-driven hash divergence so success and failure cannot collapse in the chain.
- `sera-gateway` (`embedded_transport.rs`): existing projection test updated to assert the new `End` fields default to `Success` / `None`.

## Test plan

- [x] `cargo check --workspace` — clean.
- [x] `cargo clippy -p sera-types -p sera-runtime -p sera-gateway -- -D warnings` — clean.
- [x] `cargo test -p sera-types --lib` — 432 passed.
- [x] `cargo test -p sera-runtime --lib` — 601 passed.
- [x] `cargo test -p sera-gateway --lib` — 234 passed.
- [x] `cargo test -p sera-gateway --bin sera-gateway` — 465 passed (full bin suite after building `sera-runtime` prerequisite).
- [ ] CI green on the same gates above.