### PR TITLE
feat(skills,runtime): close Tier 1 self-improvement skill loop (sera-1cvw)

### DIFF
--- a/artifacts/reports/research/sera-1cvw-skill-loop-close-report.md
+++ b/artifacts/reports/research/sera-1cvw-skill-loop-close-report.md
@@ -1,0 +1,67 @@
+# sera-1cvw — Close Tier 1 Self-Improvement Skill Loop
+
+## Summary
+
+Closes the first end-to-end self-improvement loop: an agent can patch a skill via `skill-manage`, and a subsequent runtime turn auto-matches the patched skill via `TriggerDispatcher` with durable activity provenance and a governed apply boundary.
+
+## Changes
+
+### sera-skills crate
+
+| File | Change |
+|------|--------|
+| `src/knowledge_activity_log.rs` | `save_to_path()` / `load_from_path()` — atomic JSON persistence + reload, with rolling-window truncation on load. 5 new tests. |
+| `src/patch_policy.rs` | **New module.** `SkillPatchPolicy` trait + `Tier1SkillPatchPolicy` (allowed-root + body-budget) + `AllowAllPolicy` (test/open sandbox). 6 new tests. |
+| `src/lib.rs` | Export `patch_policy` module + re-export key types. |
+
+### sera-runtime crate
+
+| File | Change |
+|------|--------|
+| `src/tools/skill_management.rs` | `SkillManagementContext`: optional `log_path` + `patch_policy` fields, `with_log_persistence()`, `with_patch_policy()`, `persist_log()`. `patch_skill()`: Tier 1 policy gate before validation. Richer provenance metadata (`skill_name`, `patch_kind`, `diff_summary`, `root`, `body_bytes`, `after_hash`). `skill_management_context_from_env()`: wires `Tier1SkillPatchPolicy` + log persistence by default. 7 new tests. |
+| `src/skill_dispatch.rs` | `prepare_turn_context()` — integration seam combining `on_turn()` + `active_context_injections()` for turn-loop callers. |
+
+## Acceptance Criteria Verification
+
+| AC | Status | Evidence |
+|----|--------|----------|
+| 1. `skill-manage patch` validates/applies atomically | PASS | All 49 skill_management tests pass including version-mismatch, name-mismatch, path-traversal rejection tests |
+| 2. Turn auto-match via TriggerDispatcher | PASS | `fresh_engine_loads_patched_skill_and_fires_trigger` test: patch adds "welcome" trigger, fresh engine loads from disk and fires on "welcome aboard" |
+| 3. KnowledgeActivityLog persists to disk | PASS | `activity_log_persists_to_disk_and_survives_restart` test: session 1 creates + persists, session 2 loads + verifies entry |
+| 4. Fresh runtime loads patched skill | PASS | `fresh_engine_loads_patched_skill_and_fires_trigger` test: new `SkillDispatchEngine` loads via `load_dir()`, proves patched content is on disk |
+| 5. Tier 1 policy rejects out-of-bounds patches | PASS | `patch_rejected_by_policy_outside_root` + `patch_rejected_by_policy_over_budget` tests |
+| 6. Patch provenance audit-visible | PASS | `activity_log_provenance_has_required_fields` test: verifies skill_name, action, patch_kind, diff_summary, root, body_bytes, after_hash |
+| 7. Tests pass + cargo check | PASS | See below |
+| 8. PR opened against main | PASS | #1288 |
+
+## Tests/Checks Run
+
+| Command | Result |
+|---------|--------|
+| `cargo test --lib -p sera-skills` | **255 passed** (was 244; +11 new) |
+| `cargo test --lib -p sera-runtime -- skill_management` | **49 passed** (was 42; +7 new) |
+| `cargo test --lib -p sera-runtime -- skill_dispatch` | **9 passed** |
+| `cargo test -p sera-skills --test self_patch` | **13 passed** |
+| `cargo check -p sera-runtime -p sera-skills` | Clean, 0 errors, 0 warnings |
+
+## PR URL
+
+https://github.com/TKCen/sera/pull/1288
+
+## Remaining Gaps / Follow-up Beads
+
+1. **DefaultRuntime turn-loop wiring**: `prepare_turn_context()` seam exists but `DefaultRuntime` does not call it yet — the next step is adding the call in the runtime's turn orchestration before the think step.
+2. **Full sera-meta PolicyEngine integration**: The narrow `Tier1SkillPatchPolicy` is a focused interface; wiring the full `PolicyEngine` with `ChangeArtifact` + `EvolutionResult` pipeline is a follow-up.
+3. **OCSF audit event emission**: Provenance is captured in `KnowledgeActivityLog` entries; emitting structured OCSF events alongside is a follow-up.
+
+## Git Status
+
+```
+## omc/sera-1cvw-skill-loop-close...origin/omc/sera-1cvw-skill-loop-close
+```
+
+Clean — all changes committed and pushed.
+
+## Done Marker
+
+SERA_1CVW_SKILL_LOOP_CLOSE_DONE https://github.com/TKCen/sera/pull/1288

--- a/artifacts/reports/research/sera-1cvw-skill-loop-close-report.md
+++ b/artifacts/reports/research/sera-1cvw-skill-loop-close-report.md
@@ -86,6 +86,7 @@ Repair evidence:
 - `cargo clippy -p sera-runtime -p sera-gateway -p sera-skills -- -D warnings`: clean.
 - CI repair for `execute_turn_injects_truthful_self_introspection_snapshot`: `reload_registered_dirs()` now no-ops when no source directories are registered, preserving programmatically registered skills. Verified with `cargo test -p sera-gateway --bin sera-gateway execute_turn_injects_truthful_self_introspection_snapshot -- --nocapture`.
 - Codex follow-up for mixed disk/manual registries: reload now preserves programmatic registrations alongside scanned directories. Verified with `reload_preserves_manual_registrations_alongside_loaded_dirs`, the gateway introspection snapshot test, check, and scoped clippy.
+- Codex concurrent-reload follow-up: final registry swap now merges active names from both the pre-scan snapshot and the current registry while holding the mutex, preventing activations made during async disk scan from being lost. Verified with `restore_active_names_merges_snapshot_and_current_registry` plus focused gateway/check/clippy gates.
 
 ## Remaining Gaps / Follow-up Beads
 

--- a/artifacts/reports/research/sera-1cvw-skill-loop-close-report.md
+++ b/artifacts/reports/research/sera-1cvw-skill-loop-close-report.md
@@ -84,6 +84,7 @@ Repair evidence:
 - `cargo test --lib -p sera-skills trigger_dispatcher -- --nocapture`: 18 passed.
 - `cargo check -p sera-runtime -p sera-gateway -p sera-skills`: clean.
 - `cargo clippy -p sera-runtime -p sera-gateway -p sera-skills -- -D warnings`: clean.
+- CI repair for `execute_turn_injects_truthful_self_introspection_snapshot`: `reload_registered_dirs()` now no-ops when no source directories are registered, preserving programmatically registered skills. Verified with `cargo test -p sera-gateway --bin sera-gateway execute_turn_injects_truthful_self_introspection_snapshot -- --nocapture`.
 
 ## Remaining Gaps / Follow-up Beads
 

--- a/artifacts/reports/research/sera-1cvw-skill-loop-close-report.md
+++ b/artifacts/reports/research/sera-1cvw-skill-loop-close-report.md
@@ -87,6 +87,7 @@ Repair evidence:
 - CI repair for `execute_turn_injects_truthful_self_introspection_snapshot`: `reload_registered_dirs()` now no-ops when no source directories are registered, preserving programmatically registered skills. Verified with `cargo test -p sera-gateway --bin sera-gateway execute_turn_injects_truthful_self_introspection_snapshot -- --nocapture`.
 - Codex follow-up for mixed disk/manual registries: reload now preserves programmatic registrations alongside scanned directories. Verified with `reload_preserves_manual_registrations_alongside_loaded_dirs`, the gateway introspection snapshot test, check, and scoped clippy.
 - Codex concurrent-reload follow-up: final registry swap now merges active names from both the pre-scan snapshot and the current registry while holding the mutex, preventing activations made during async disk scan from being lost. Verified with `restore_active_names_merges_snapshot_and_current_registry` plus focused gateway/check/clippy gates.
+- Codex concurrent-register follow-up: final reload swap now also merges manual registrations added while async disk scan was in flight. Verified with `merge_current_manual_entries_preserves_registrations_added_during_reload` plus focused gateway/check/clippy gates.
 
 ## Remaining Gaps / Follow-up Beads
 

--- a/artifacts/reports/research/sera-1cvw-skill-loop-close-report.md
+++ b/artifacts/reports/research/sera-1cvw-skill-loop-close-report.md
@@ -88,6 +88,7 @@ Repair evidence:
 - Codex follow-up for mixed disk/manual registries: reload now preserves programmatic registrations alongside scanned directories. Verified with `reload_preserves_manual_registrations_alongside_loaded_dirs`, the gateway introspection snapshot test, check, and scoped clippy.
 - Codex concurrent-reload follow-up: final registry swap now merges active names from both the pre-scan snapshot and the current registry while holding the mutex, preventing activations made during async disk scan from being lost. Verified with `restore_active_names_merges_snapshot_and_current_registry` plus focused gateway/check/clippy gates.
 - Codex concurrent-register follow-up: final reload swap now also merges manual registrations added while async disk scan was in flight. Verified with `merge_current_manual_entries_preserves_registrations_added_during_reload` plus focused gateway/check/clippy gates.
+- Codex body-injection/same-name follow-up: runtime now stores loaded `SkillDefinition`s and injects active markdown bodies, and same-name manual registrations observed at swap time replace stale snapshots. Verified with `active_context_injections_include_loaded_markdown_body`, `merge_current_manual_entries_replaces_same_name_snapshot`, skill-management tests, gateway snapshot test, check, and scoped clippy.
 
 ## Remaining Gaps / Follow-up Beads
 

--- a/artifacts/reports/research/sera-1cvw-skill-loop-close-report.md
+++ b/artifacts/reports/research/sera-1cvw-skill-loop-close-report.md
@@ -66,9 +66,28 @@ Repair evidence:
 - `cargo test -p sera-skills --test self_patch`: 13 passed.
 - `cargo check -p sera-runtime -p sera-skills`: clean.
 
+## PR Review / CI Repair 2
+
+A second Codex review on `46e8196b` found that long-running gateway processes still used an in-memory skill registry loaded at startup. This left patched triggers invisible until restart. The repair adds:
+
+- `SkillDispatchEngine` source-dir tracking and `reload_registered_dirs()`;
+- `prepare_turn_context_refreshed()` for turn-loop callers;
+- gateway `execute_turn` wiring to refresh skill dispatch before injecting skill context, with warn-and-fallback behavior if reload fails;
+- regression tests proving patched markdown triggers are visible without process restart and active skills survive reload;
+- corrected markdown parser semantics: frontmatter `triggers` now stay as keyword triggers on the `SkillDefinition` while `SkillConfig::trigger` remains `Manual`, avoiding accidental fire-on-any-turn behavior.
+
+Repair evidence:
+
+- `cargo test --lib -p sera-runtime -- skill_dispatch -- --nocapture`: 11 passed.
+- `cargo test --lib -p sera-runtime -- skill_management::tests::fresh_engine_loads_patched_skill_and_fires_trigger -- --nocapture`: 1 passed.
+- `cargo test --lib -p sera-skills markdown::tests::parses_valid_frontmatter_and_body -- --nocapture`: 1 passed.
+- `cargo test --lib -p sera-skills trigger_dispatcher -- --nocapture`: 18 passed.
+- `cargo check -p sera-runtime -p sera-gateway -p sera-skills`: clean.
+- `cargo clippy -p sera-runtime -p sera-gateway -p sera-skills -- -D warnings`: clean.
+
 ## Remaining Gaps / Follow-up Beads
 
-1. **DefaultRuntime turn-loop wiring**: `prepare_turn_context()` seam exists but `DefaultRuntime` does not call it yet — the next step is adding the call in the runtime's turn orchestration before the think step.
+1. **DefaultRuntime turn-loop wiring**: gateway `execute_turn` now refreshes and prepares skill context before the think step; standalone `DefaultRuntime` integration remains a follow-up if/when it owns skill dispatch directly.
 2. **Full sera-meta PolicyEngine integration**: The narrow `Tier1SkillPatchPolicy` is a focused interface; wiring the full `PolicyEngine` with `ChangeArtifact` + `EvolutionResult` pipeline is a follow-up.
 3. **OCSF audit event emission**: Provenance is captured in `KnowledgeActivityLog` entries; emitting structured OCSF events alongside is a follow-up.
 

--- a/artifacts/reports/research/sera-1cvw-skill-loop-close-report.md
+++ b/artifacts/reports/research/sera-1cvw-skill-loop-close-report.md
@@ -71,14 +71,14 @@ Repair evidence:
 A second Codex review on `46e8196b` found that long-running gateway processes still used an in-memory skill registry loaded at startup. This left patched triggers invisible until restart. The repair adds:
 
 - `SkillDispatchEngine` source-dir tracking and `reload_registered_dirs()`;
-- `prepare_turn_context_refreshed()` for turn-loop callers;
-- gateway `execute_turn` wiring to refresh skill dispatch before injecting skill context, with warn-and-fallback behavior if reload fails;
-- regression tests proving patched markdown triggers are visible without process restart and active skills survive reload;
+- `prepare_turn_context()` as the refreshed async turn-loop seam, plus `prepare_loaded_turn_context()` as the explicit no-refresh fallback;
+- gateway `execute_turn` wiring to call the refreshed `prepare_turn_context()` before injecting skill context, with warn-and-fallback behavior if reload fails;
+- regression tests proving patched markdown triggers are visible through the default turn-context seam without process restart and active skills survive reload;
 - corrected markdown parser semantics: frontmatter `triggers` now stay as keyword triggers on the `SkillDefinition` while `SkillConfig::trigger` remains `Manual`, avoiding accidental fire-on-any-turn behavior.
 
 Repair evidence:
 
-- `cargo test --lib -p sera-runtime -- skill_dispatch -- --nocapture`: 11 passed.
+- `cargo test --lib -p sera-runtime -- skill_dispatch -- --nocapture`: 11 passed, including `prepare_turn_context_sees_patched_triggers_without_restart`.
 - `cargo test --lib -p sera-runtime -- skill_management::tests::fresh_engine_loads_patched_skill_and_fires_trigger -- --nocapture`: 1 passed.
 - `cargo test --lib -p sera-skills markdown::tests::parses_valid_frontmatter_and_body -- --nocapture`: 1 passed.
 - `cargo test --lib -p sera-skills trigger_dispatcher -- --nocapture`: 18 passed.

--- a/artifacts/reports/research/sera-1cvw-skill-loop-close-report.md
+++ b/artifacts/reports/research/sera-1cvw-skill-loop-close-report.md
@@ -85,6 +85,7 @@ Repair evidence:
 - `cargo check -p sera-runtime -p sera-gateway -p sera-skills`: clean.
 - `cargo clippy -p sera-runtime -p sera-gateway -p sera-skills -- -D warnings`: clean.
 - CI repair for `execute_turn_injects_truthful_self_introspection_snapshot`: `reload_registered_dirs()` now no-ops when no source directories are registered, preserving programmatically registered skills. Verified with `cargo test -p sera-gateway --bin sera-gateway execute_turn_injects_truthful_self_introspection_snapshot -- --nocapture`.
+- Codex follow-up for mixed disk/manual registries: reload now preserves programmatic registrations alongside scanned directories. Verified with `reload_preserves_manual_registrations_alongside_loaded_dirs`, the gateway introspection snapshot test, check, and scoped clippy.
 
 ## Remaining Gaps / Follow-up Beads
 

--- a/artifacts/reports/research/sera-1cvw-skill-loop-close-report.md
+++ b/artifacts/reports/research/sera-1cvw-skill-loop-close-report.md
@@ -11,14 +11,14 @@ Closes the first end-to-end self-improvement loop: an agent can patch a skill vi
 | File | Change |
 |------|--------|
 | `src/knowledge_activity_log.rs` | `save_to_path()` / `load_from_path()` — atomic JSON persistence + reload, with rolling-window truncation on load. 5 new tests. |
-| `src/patch_policy.rs` | **New module.** `SkillPatchPolicy` trait + `Tier1SkillPatchPolicy` (allowed-root + body-budget) + `AllowAllPolicy` (test/open sandbox). 6 new tests. |
+| `src/patch_policy.rs` | **New module.** `SkillPatchPolicy` trait + `Tier1SkillPatchPolicy` (allowed-root + resolved skill-path + body-budget) + `AllowAllPolicy` (test/open sandbox). 7 new tests including symlink-escape rejection. |
 | `src/lib.rs` | Export `patch_policy` module + re-export key types. |
 
 ### sera-runtime crate
 
 | File | Change |
 |------|--------|
-| `src/tools/skill_management.rs` | `SkillManagementContext`: optional `log_path` + `patch_policy` fields, `with_log_persistence()`, `with_patch_policy()`, `persist_log()`. `patch_skill()`: Tier 1 policy gate before validation. Richer provenance metadata (`skill_name`, `patch_kind`, `diff_summary`, `root`, `body_bytes`, `after_hash`). `skill_management_context_from_env()`: wires `Tier1SkillPatchPolicy` + log persistence by default. 7 new tests. |
+| `src/tools/skill_management.rs` | `SkillManagementContext`: optional `log_path` + `patch_policy` fields, `with_log_persistence()`, `with_patch_policy()`, `persist_log()`. `patch_skill()`: Tier 1 policy gate before validation using the resolved skill path, closing single-file symlink escape. Richer provenance metadata (`skill_name`, `patch_kind`, `diff_summary`, `root`, `body_bytes`, `after_hash`). `skill_management_context_from_env()`: wires `Tier1SkillPatchPolicy` + log persistence by default. 8 new tests. |
 | `src/skill_dispatch.rs` | `prepare_turn_context()` — integration seam combining `on_turn()` + `active_context_injections()` for turn-loop callers. |
 
 ## Acceptance Criteria Verification
@@ -29,7 +29,7 @@ Closes the first end-to-end self-improvement loop: an agent can patch a skill vi
 | 2. Turn auto-match via TriggerDispatcher | PASS | `fresh_engine_loads_patched_skill_and_fires_trigger` test: patch adds "welcome" trigger, fresh engine loads from disk and fires on "welcome aboard" |
 | 3. KnowledgeActivityLog persists to disk | PASS | `activity_log_persists_to_disk_and_survives_restart` test: session 1 creates + persists, session 2 loads + verifies entry |
 | 4. Fresh runtime loads patched skill | PASS | `fresh_engine_loads_patched_skill_and_fires_trigger` test: new `SkillDispatchEngine` loads via `load_dir()`, proves patched content is on disk |
-| 5. Tier 1 policy rejects out-of-bounds patches | PASS | `patch_rejected_by_policy_outside_root` + `patch_rejected_by_policy_over_budget` tests |
+| 5. Tier 1 policy rejects out-of-bounds patches | PASS | `patch_rejected_by_policy_outside_root`, `patch_rejected_by_policy_over_budget`, and `patch_rejected_when_single_file_skill_symlink_escapes_allowed_root` tests |
 | 6. Patch provenance audit-visible | PASS | `activity_log_provenance_has_required_fields` test: verifies skill_name, action, patch_kind, diff_summary, root, body_bytes, after_hash |
 | 7. Tests pass + cargo check | PASS | See below |
 | 8. PR opened against main | PASS | #1288 |
@@ -38,15 +38,33 @@ Closes the first end-to-end self-improvement loop: an agent can patch a skill vi
 
 | Command | Result |
 |---------|--------|
-| `cargo test --lib -p sera-skills` | **255 passed** (was 244; +11 new) |
-| `cargo test --lib -p sera-runtime -- skill_management` | **49 passed** (was 42; +7 new) |
+| `cargo test --lib -p sera-skills` | **256 passed** (was 244; +12 new) |
+| `cargo test --lib -p sera-runtime -- skill_management` | **50 passed** (was 42; +8 new) |
 | `cargo test --lib -p sera-runtime -- skill_dispatch` | **9 passed** |
 | `cargo test -p sera-skills --test self_patch` | **13 passed** |
 | `cargo check -p sera-runtime -p sera-skills` | Clean, 0 errors, 0 warnings |
+| `cargo clippy --workspace -- -D warnings` | Clean after CI repair |
 
 ## PR URL
 
 https://github.com/TKCen/sera/pull/1288
+
+## PR Review / CI Repair
+
+After PR #1288 opened, CI and automated review found two blockers:
+
+1. `validate-rust` failed clippy on `std::io::Error::new(ErrorKind::Other, e)`; fixed with `std::io::Error::other`.
+2. Codex identified a P1 symlink escape in the Tier 1 policy gate: a single-file skill inside an allowed root could be a symlink to a target outside the root. Fixed by passing the actual skill path into `SkillPatchPolicy`, canonicalizing the allowed root/root/path, requiring the resolved target to stay inside an allowed root, and adding unit + runtime regression tests.
+
+Repair evidence:
+
+- `cargo test --lib -p sera-skills patch_policy -- --nocapture`: 7 passed.
+- `cargo test --lib -p sera-runtime -- skill_management::tests::patch_rejected_when_single_file_skill_symlink_escapes_allowed_root skill_management::tests::patch_rejected_by_policy_outside_root --nocapture`: 2 passed.
+- `cargo clippy --workspace -- -D warnings`: clean.
+- `cargo test --lib -p sera-runtime -- skill_management`: 50 passed.
+- `cargo test --lib -p sera-skills`: 256 passed.
+- `cargo test -p sera-skills --test self_patch`: 13 passed.
+- `cargo check -p sera-runtime -p sera-skills`: clean.
 
 ## Remaining Gaps / Follow-up Beads
 

--- a/rust/crates/sera-gateway/src/bin/sera.rs
+++ b/rust/crates/sera-gateway/src/bin/sera.rs
@@ -4353,8 +4353,15 @@ async fn execute_turn(
     // prepend their active `context_injection` strings as system messages.
     // Injected BEFORE transcript replay so the skill guidance frames the
     // history instead of being buried after it.
-    let _ = skill_engine.on_turn(user_message);
-    for injection in skill_engine.active_context_injections() {
+    let injections = match skill_engine.prepare_turn_context_refreshed(user_message).await {
+        Ok((_fired, injections)) => injections,
+        Err(e) => {
+            tracing::warn!(error = %e, "skill dispatch refresh failed; using current in-memory registry");
+            let (_fired, injections) = skill_engine.prepare_turn_context(user_message);
+            injections
+        }
+    };
+    for injection in injections {
         if injection.trim().is_empty() {
             continue;
         }

--- a/rust/crates/sera-gateway/src/bin/sera.rs
+++ b/rust/crates/sera-gateway/src/bin/sera.rs
@@ -4353,11 +4353,11 @@ async fn execute_turn(
     // prepend their active `context_injection` strings as system messages.
     // Injected BEFORE transcript replay so the skill guidance frames the
     // history instead of being buried after it.
-    let injections = match skill_engine.prepare_turn_context_refreshed(user_message).await {
+    let injections = match skill_engine.prepare_turn_context(user_message).await {
         Ok((_fired, injections)) => injections,
         Err(e) => {
             tracing::warn!(error = %e, "skill dispatch refresh failed; using current in-memory registry");
-            let (_fired, injections) = skill_engine.prepare_turn_context(user_message);
+            let (_fired, injections) = skill_engine.prepare_loaded_turn_context(user_message);
             injections
         }
     };

--- a/rust/crates/sera-runtime/src/skill_dispatch.rs
+++ b/rust/crates/sera-runtime/src/skill_dispatch.rs
@@ -125,6 +125,7 @@ impl SkillDispatchEngine {
             replacement.register_loaded(config, definition);
         }
         let mut g = self.inner.lock().expect("skill engine mutex poisoned");
+        merge_current_manual_entries(&mut replacement, &g.manual_entries);
         restore_active_names(&mut replacement, active_names, &g.registry);
         *g = replacement;
         Ok(count)
@@ -274,6 +275,24 @@ async fn collect_skill_dir(
 impl Default for SkillDispatchEngine {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+fn merge_current_manual_entries(
+    replacement: &mut Inner,
+    current_manual_entries: &[(SkillConfig, Option<SkillDefinition>)],
+) {
+    for (config, definition) in current_manual_entries {
+        if !replacement
+            .manual_entries
+            .iter()
+            .any(|(existing, _)| existing.name == config.name)
+        {
+            replacement
+                .manual_entries
+                .push((config.clone(), definition.clone()));
+        }
+        replacement.register_loaded(config.clone(), definition.clone());
     }
 }
 
@@ -578,6 +597,32 @@ mod tests {
             replacement.registry.active_skill_names(),
             vec!["current-active", "snapshot-active"],
         );
+    }
+
+
+    #[test]
+    fn merge_current_manual_entries_preserves_registrations_added_during_reload() {
+        let mut replacement = Inner::empty();
+        replacement.register_loaded(
+            cfg("disk", SkillTrigger::Event("disk".into()), Some("disk ctx")),
+            None,
+        );
+
+        let current_manual_entries = vec![(
+            cfg("manual-during-reload", SkillTrigger::Event("manual".into()), Some("manual ctx")),
+            None,
+        )];
+
+        merge_current_manual_entries(&mut replacement, &current_manual_entries);
+
+        assert!(replacement
+            .manual_entries
+            .iter()
+            .any(|(config, _)| config.name == "manual-during-reload"));
+        assert_eq!(replacement.dispatcher.dispatch("manual please").len(), 1);
+        replacement.registry.activate("manual-during-reload").unwrap();
+        assert_eq!(replacement.registry.active_skill_names(), vec!["manual-during-reload"]);
+        assert_eq!(replacement.registry.context_injections(), vec!["manual ctx"]);
     }
 
 }

--- a/rust/crates/sera-runtime/src/skill_dispatch.rs
+++ b/rust/crates/sera-runtime/src/skill_dispatch.rs
@@ -155,6 +155,19 @@ impl SkillDispatchEngine {
             .collect()
     }
 
+    /// Prepare skill context for a turn: dispatch triggers against the
+    /// user message content, activate matched skills, and return the
+    /// context injection strings to include in the system prompt.
+    ///
+    /// This is the integration seam for the turn loop: call this before the
+    /// think step and prepend/append the returned strings to the context
+    /// window. Returns `(newly_fired, injections)`.
+    pub fn prepare_turn_context(&self, turn_content: &str) -> (Vec<SkillMatch>, Vec<String>) {
+        let fired = self.on_turn(turn_content);
+        let injections = self.active_context_injections();
+        (fired, injections)
+    }
+
     /// Active skill names in deterministic order for self-introspection.
     pub fn active_skill_names(&self) -> Vec<String> {
         self.inner

--- a/rust/crates/sera-runtime/src/skill_dispatch.rs
+++ b/rust/crates/sera-runtime/src/skill_dispatch.rs
@@ -93,6 +93,10 @@ impl SkillDispatchEngine {
             )
         };
 
+        if source_dirs.is_empty() {
+            return Ok(self.registered_count());
+        }
+
         let mut loaded = Vec::new();
         for dir in &source_dirs {
             loaded.extend(collect_skill_dir(dir).await?);

--- a/rust/crates/sera-runtime/src/skill_dispatch.rs
+++ b/rust/crates/sera-runtime/src/skill_dispatch.rs
@@ -7,6 +7,7 @@
 //! [`SkillDispatchEngine::on_turn`] from the harness before the think step
 //! so activated skills contribute their `context_injection` to the prompt.
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
@@ -25,6 +26,7 @@ pub struct SkillDispatchEngine {
 struct Inner {
     dispatcher: TriggerDispatcher,
     registry: SkillRegistry,
+    definitions: HashMap<String, SkillDefinition>,
     source_dirs: Vec<PathBuf>,
     manual_entries: Vec<(SkillConfig, Option<SkillDefinition>)>,
 }
@@ -34,12 +36,18 @@ impl Inner {
         Self {
             dispatcher: TriggerDispatcher::new(),
             registry: SkillRegistry::new(),
+            definitions: HashMap::new(),
             source_dirs: Vec::new(),
             manual_entries: Vec::new(),
         }
     }
 
     fn register_loaded(&mut self, config: SkillConfig, definition: Option<SkillDefinition>) {
+        if let Some(definition) = &definition {
+            self.definitions.insert(config.name.clone(), definition.clone());
+        } else {
+            self.definitions.remove(&config.name);
+        }
         self.registry.register(config.clone());
         self.dispatcher.register(config, definition);
     }
@@ -155,13 +163,28 @@ impl SkillDispatchEngine {
     /// Returns the `context_injection` strings for every currently-active
     /// skill. Intended to be appended to the system prompt on every turn.
     pub fn active_context_injections(&self) -> Vec<String> {
-        self.inner
-            .lock()
-            .expect("skill engine mutex poisoned")
-            .registry
-            .context_injections()
+        let g = self.inner.lock().expect("skill engine mutex poisoned");
+        g.registry
+            .active_skill_names()
             .into_iter()
-            .map(String::from)
+            .flat_map(|name| {
+                let config_injection = g
+                    .registry
+                    .get_config(name)
+                    .and_then(|config| config.context_injection.as_deref());
+                let body_injection = g.definitions.get(name).and_then(|definition| {
+                    definition
+                        .body
+                        .as_deref()
+                        .map(str::trim)
+                        .filter(|body| !body.is_empty())
+                });
+                [config_injection, body_injection]
+                    .into_iter()
+                    .flatten()
+                    .map(String::from)
+                    .collect::<Vec<_>>()
+            })
             .collect()
     }
 
@@ -283,15 +306,12 @@ fn merge_current_manual_entries(
     current_manual_entries: &[(SkillConfig, Option<SkillDefinition>)],
 ) {
     for (config, definition) in current_manual_entries {
-        if !replacement
+        replacement
             .manual_entries
-            .iter()
-            .any(|(existing, _)| existing.name == config.name)
-        {
-            replacement
-                .manual_entries
-                .push((config.clone(), definition.clone()));
-        }
+            .retain(|(existing, _)| existing.name != config.name);
+        replacement
+            .manual_entries
+            .push((config.clone(), definition.clone()));
         replacement.register_loaded(config.clone(), definition.clone());
     }
 }
@@ -428,6 +448,24 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn active_context_injections_include_loaded_markdown_body() {
+        let tmp = tempfile::tempdir().unwrap();
+        tokio::fs::write(
+            tmp.path().join("hello.md"),
+            "---\nname: hello\nversion: 1.0.0\ntriggers:\n  - hi\n---\nmarkdown skill body\n",
+        )
+        .await
+        .unwrap();
+
+        let eng = SkillDispatchEngine::new();
+        eng.load_dir(tmp.path()).await.unwrap();
+        let (fired, injections) = eng.prepare_loaded_turn_context("hi there");
+
+        assert_eq!(fired.len(), 1);
+        assert_eq!(injections, vec!["markdown skill body"]);
+    }
+
+    #[tokio::test]
     async fn load_dir_reads_directory_style_skills() {
         let tmp = tempfile::tempdir().unwrap();
         let skill_dir = tmp.path().join("my-skill");
@@ -504,7 +542,7 @@ mod tests {
             .unwrap();
         assert_eq!(fired.len(), 1);
         assert_eq!(fired[0].name, "hello");
-        assert!(injections.is_empty());
+        assert_eq!(injections, vec!["new body"]);
     }
 
     #[tokio::test]
@@ -623,6 +661,28 @@ mod tests {
         replacement.registry.activate("manual-during-reload").unwrap();
         assert_eq!(replacement.registry.active_skill_names(), vec!["manual-during-reload"]);
         assert_eq!(replacement.registry.context_injections(), vec!["manual ctx"]);
+    }
+
+
+    #[test]
+    fn merge_current_manual_entries_replaces_same_name_snapshot() {
+        let mut replacement = Inner::empty();
+        replacement.manual_entries.push((
+            cfg("manual", SkillTrigger::Event("old".into()), Some("old ctx")),
+            None,
+        ));
+
+        let current_manual_entries = vec![(
+            cfg("manual", SkillTrigger::Event("new".into()), Some("new ctx")),
+            None,
+        )];
+
+        merge_current_manual_entries(&mut replacement, &current_manual_entries);
+
+        assert_eq!(replacement.manual_entries.len(), 1);
+        assert_eq!(replacement.manual_entries[0].0.context_injection.as_deref(), Some("new ctx"));
+        assert!(replacement.dispatcher.dispatch("old please").is_empty());
+        assert_eq!(replacement.dispatcher.dispatch("new please").len(), 1);
     }
 
 }

--- a/rust/crates/sera-runtime/src/skill_dispatch.rs
+++ b/rust/crates/sera-runtime/src/skill_dispatch.rs
@@ -124,11 +124,8 @@ impl SkillDispatchEngine {
         for (config, definition) in manual_entries {
             replacement.register_loaded(config, definition);
         }
-        for name in active_names {
-            let _ = replacement.registry.activate(&name);
-        }
-
         let mut g = self.inner.lock().expect("skill engine mutex poisoned");
+        restore_active_names(&mut replacement, active_names, &g.registry);
         *g = replacement;
         Ok(count)
     }
@@ -277,6 +274,25 @@ async fn collect_skill_dir(
 impl Default for SkillDispatchEngine {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+fn restore_active_names(
+    replacement: &mut Inner,
+    mut snapshotted_active_names: Vec<String>,
+    current_registry: &SkillRegistry,
+) {
+    snapshotted_active_names.extend(
+        current_registry
+            .active_skill_names()
+            .into_iter()
+            .map(String::from),
+    );
+    snapshotted_active_names.sort();
+    snapshotted_active_names.dedup();
+
+    for name in snapshotted_active_names {
+        let _ = replacement.registry.activate(&name);
     }
 }
 
@@ -529,6 +545,39 @@ mod tests {
         let fired_disk = eng.on_turn("disk please");
         assert_eq!(fired_disk.len(), 1);
         assert_eq!(fired_disk[0].name, "disk");
+    }
+
+
+    #[test]
+    fn restore_active_names_merges_snapshot_and_current_registry() {
+        let mut replacement = Inner::empty();
+        replacement.register_loaded(
+            cfg("snapshot-active", SkillTrigger::Event("snapshot".into()), Some("snapshot ctx")),
+            None,
+        );
+        replacement.register_loaded(
+            cfg("current-active", SkillTrigger::Event("current".into()), Some("current ctx")),
+            None,
+        );
+
+        let mut current = SkillRegistry::new();
+        current.register(cfg(
+            "current-active",
+            SkillTrigger::Event("current".into()),
+            Some("current ctx"),
+        ));
+        current.activate("current-active").unwrap();
+
+        restore_active_names(
+            &mut replacement,
+            vec!["snapshot-active".to_string()],
+            &current,
+        );
+
+        assert_eq!(
+            replacement.registry.active_skill_names(),
+            vec!["current-active", "snapshot-active"],
+        );
     }
 
 }

--- a/rust/crates/sera-runtime/src/skill_dispatch.rs
+++ b/rust/crates/sera-runtime/src/skill_dispatch.rs
@@ -26,6 +26,7 @@ struct Inner {
     dispatcher: TriggerDispatcher,
     registry: SkillRegistry,
     source_dirs: Vec<PathBuf>,
+    manual_entries: Vec<(SkillConfig, Option<SkillDefinition>)>,
 }
 
 impl Inner {
@@ -34,12 +35,19 @@ impl Inner {
             dispatcher: TriggerDispatcher::new(),
             registry: SkillRegistry::new(),
             source_dirs: Vec::new(),
+            manual_entries: Vec::new(),
         }
     }
 
-    fn register(&mut self, config: SkillConfig, definition: Option<SkillDefinition>) {
+    fn register_loaded(&mut self, config: SkillConfig, definition: Option<SkillDefinition>) {
         self.registry.register(config.clone());
         self.dispatcher.register(config, definition);
+    }
+
+    fn register_manual(&mut self, config: SkillConfig, definition: Option<SkillDefinition>) {
+        self.manual_entries.retain(|(existing, _)| existing.name != config.name);
+        self.manual_entries.push((config.clone(), definition.clone()));
+        self.register_loaded(config, definition);
     }
 }
 
@@ -56,7 +64,7 @@ impl SkillDispatchEngine {
     /// markdown frontmatter.
     pub fn register(&self, config: SkillConfig, definition: Option<SkillDefinition>) {
         let mut g = self.inner.lock().expect("skill engine mutex poisoned");
-        g.register(config, definition);
+        g.register_manual(config, definition);
     }
 
     /// Load every `*.md` skill file under `dir` (non-recursive) and register
@@ -71,7 +79,7 @@ impl SkillDispatchEngine {
             g.source_dirs.push(dir);
         }
         for (config, definition) in loaded {
-            g.register(config, Some(definition));
+            g.register_loaded(config, Some(definition));
         }
         Ok(count)
     }
@@ -81,10 +89,11 @@ impl SkillDispatchEngine {
     /// after reload remain active so updated context injections take effect
     /// without a process restart.
     pub async fn reload_registered_dirs(&self) -> Result<usize, SkillsError> {
-        let (source_dirs, active_names) = {
+        let (source_dirs, manual_entries, active_names) = {
             let g = self.inner.lock().expect("skill engine mutex poisoned");
             (
                 g.source_dirs.clone(),
+                g.manual_entries.clone(),
                 g.registry
                     .active_skill_names()
                     .into_iter()
@@ -105,8 +114,15 @@ impl SkillDispatchEngine {
 
         let mut replacement = Inner::empty();
         replacement.source_dirs = source_dirs;
+        replacement.manual_entries = manual_entries.clone();
         for (config, definition) in loaded {
-            replacement.register(config, Some(definition));
+            replacement.register_loaded(config, Some(definition));
+        }
+        // Preserve programmatic registrations across disk reloads. Register
+        // them after disk-loaded skills so embedders can intentionally
+        // override a scanned skill by name.
+        for (config, definition) in manual_entries {
+            replacement.register_loaded(config, definition);
         }
         for name in active_names {
             let _ = replacement.registry.activate(&name);
@@ -481,6 +497,38 @@ mod tests {
 
         eng.reload_registered_dirs().await.unwrap();
         assert_eq!(eng.active_skill_names(), vec!["helper"]);
+    }
+
+
+    #[tokio::test]
+    async fn reload_preserves_manual_registrations_alongside_loaded_dirs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("disk.md");
+        tokio::fs::write(
+            &path,
+            "---\nname: disk\nversion: 1.0.0\ntriggers:\n  - disk\n---\nbody\n",
+        )
+        .await
+        .unwrap();
+
+        let eng = SkillDispatchEngine::new();
+        eng.register(
+            cfg("manual", SkillTrigger::Event("manual".into()), Some("manual ctx")),
+            None,
+        );
+        eng.load_dir(tmp.path()).await.unwrap();
+
+        eng.reload_registered_dirs().await.unwrap();
+
+        let fired = eng.on_turn("manual please");
+        assert_eq!(fired.len(), 1);
+        assert_eq!(fired[0].name, "manual");
+        assert_eq!(eng.active_context_injections(), vec!["manual ctx"]);
+
+        eng.deactivate("manual");
+        let fired_disk = eng.on_turn("disk please");
+        assert_eq!(fired_disk.len(), 1);
+        assert_eq!(fired_disk[0].name, "disk");
     }
 
 }

--- a/rust/crates/sera-runtime/src/skill_dispatch.rs
+++ b/rust/crates/sera-runtime/src/skill_dispatch.rs
@@ -176,29 +176,26 @@ impl SkillDispatchEngine {
             .collect()
     }
 
-    /// Prepare skill context for a turn: dispatch triggers against the
-    /// user message content, activate matched skills, and return the
-    /// context injection strings to include in the system prompt.
-    ///
-    /// This is the integration seam for the turn loop: call this before the
-    /// think step and prepend/append the returned strings to the context
-    /// window. Returns `(newly_fired, injections)`.
-    pub fn prepare_turn_context(&self, turn_content: &str) -> (Vec<SkillMatch>, Vec<String>) {
+    /// Prepare skill context from the currently loaded in-memory registry
+    /// without reloading from disk. This is mainly a fallback/test helper;
+    /// long-running turn loops should call [`Self::prepare_turn_context`] so
+    /// `skill-manage patch` effects are visible without process restart.
+    pub fn prepare_loaded_turn_context(&self, turn_content: &str) -> (Vec<SkillMatch>, Vec<String>) {
         let fired = self.on_turn(turn_content);
         let injections = self.active_context_injections();
         (fired, injections)
     }
 
     /// Refresh registered skill directories from disk, then prepare skill
-    /// context for a turn. Use this in long-running harnesses so
-    /// `skill-manage patch` effects are visible on subsequent turns without
-    /// restarting the process.
-    pub async fn prepare_turn_context_refreshed(
+    /// context for a turn. This is the integration seam for long-running
+    /// harnesses: call before the think step and prepend/append returned
+    /// injections to the context window. Returns `(newly_fired, injections)`.
+    pub async fn prepare_turn_context(
         &self,
         turn_content: &str,
     ) -> Result<(Vec<SkillMatch>, Vec<String>), SkillsError> {
         self.reload_registered_dirs().await?;
-        Ok(self.prepare_turn_context(turn_content))
+        Ok(self.prepare_loaded_turn_context(turn_content))
     }
 
     /// Active skill names in deterministic order for self-introspection.
@@ -425,7 +422,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn refreshed_turn_context_sees_patched_triggers_without_restart() {
+    async fn prepare_turn_context_sees_patched_triggers_without_restart() {
         let tmp = tempfile::tempdir().unwrap();
         let path = tmp.path().join("hello.md");
         tokio::fs::write(
@@ -447,7 +444,7 @@ mod tests {
         .unwrap();
 
         let (fired, injections) = eng
-            .prepare_turn_context_refreshed("welcome aboard")
+            .prepare_turn_context("welcome aboard")
             .await
             .unwrap();
         assert_eq!(fired.len(), 1);
@@ -456,7 +453,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn reload_preserves_active_skill_with_updated_injection() {
+    async fn reload_preserves_active_skill() {
         let tmp = tempfile::tempdir().unwrap();
         let path = tmp.path().join("helper.md");
         tokio::fs::write(

--- a/rust/crates/sera-runtime/src/skill_dispatch.rs
+++ b/rust/crates/sera-runtime/src/skill_dispatch.rs
@@ -7,7 +7,7 @@
 //! [`SkillDispatchEngine::on_turn`] from the harness before the think step
 //! so activated skills contribute their `context_injection` to the prompt.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
 use sera_skills::{SkillsError, TriggerDispatcher, parse_skill_markdown_file};
@@ -25,16 +25,29 @@ pub struct SkillDispatchEngine {
 struct Inner {
     dispatcher: TriggerDispatcher,
     registry: SkillRegistry,
+    source_dirs: Vec<PathBuf>,
+}
+
+impl Inner {
+    fn empty() -> Self {
+        Self {
+            dispatcher: TriggerDispatcher::new(),
+            registry: SkillRegistry::new(),
+            source_dirs: Vec::new(),
+        }
+    }
+
+    fn register(&mut self, config: SkillConfig, definition: Option<SkillDefinition>) {
+        self.registry.register(config.clone());
+        self.dispatcher.register(config, definition);
+    }
 }
 
 impl SkillDispatchEngine {
     /// Construct an empty engine.
     pub fn new() -> Self {
         Self {
-            inner: Mutex::new(Inner {
-                dispatcher: TriggerDispatcher::new(),
-                registry: SkillRegistry::new(),
-            }),
+            inner: Mutex::new(Inner::empty()),
         }
     }
 
@@ -43,56 +56,60 @@ impl SkillDispatchEngine {
     /// markdown frontmatter.
     pub fn register(&self, config: SkillConfig, definition: Option<SkillDefinition>) {
         let mut g = self.inner.lock().expect("skill engine mutex poisoned");
-        g.registry.register(config.clone());
-        g.dispatcher.register(config, definition);
+        g.register(config, definition);
     }
 
     /// Load every `*.md` skill file under `dir` (non-recursive) and register
     /// it. Parse failures are logged and skipped so one bad file does not
     /// wedge the runtime.
     pub async fn load_dir(&self, dir: &Path) -> Result<usize, SkillsError> {
-        if !dir.exists() {
-            return Ok(0);
+        let loaded = collect_skill_dir(dir).await?;
+        let count = loaded.len();
+        let mut g = self.inner.lock().expect("skill engine mutex poisoned");
+        let dir = dir.to_path_buf();
+        if !g.source_dirs.iter().any(|existing| existing == &dir) {
+            g.source_dirs.push(dir);
         }
-        let mut count = 0usize;
-        let mut reader = tokio::fs::read_dir(dir).await?;
-        while let Some(entry) = reader.next_entry().await? {
-            let path = entry.path();
-            // Single-file: top-level *.md files
-            if path.is_file() && path.extension().is_some_and(|e| e == "md") {
-                match parse_skill_markdown_file(&path).await {
-                    Ok(parsed) => {
-                        self.register(parsed.config, Some(parsed.definition));
-                        count += 1;
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            path = %path.display(),
-                            error = %e,
-                            "skill_dispatch: failed to parse skill markdown, skipping"
-                        );
-                    }
-                }
-            // Directory-style: <name>/SKILL.md (created by skill-manage)
-            } else if path.is_dir() {
-                let skill_md = path.join("SKILL.md");
-                if skill_md.exists() {
-                    match parse_skill_markdown_file(&skill_md).await {
-                        Ok(parsed) => {
-                            self.register(parsed.config, Some(parsed.definition));
-                            count += 1;
-                        }
-                        Err(e) => {
-                            tracing::warn!(
-                                path = %skill_md.display(),
-                                error = %e,
-                                "skill_dispatch: failed to parse directory skill, skipping"
-                            );
-                        }
-                    }
-                }
-            }
+        for (config, definition) in loaded {
+            g.register(config, Some(definition));
         }
+        Ok(count)
+    }
+
+    /// Reload every previously loaded skill directory from disk and replace
+    /// the in-memory dispatcher/registry. Active skill names that still exist
+    /// after reload remain active so updated context injections take effect
+    /// without a process restart.
+    pub async fn reload_registered_dirs(&self) -> Result<usize, SkillsError> {
+        let (source_dirs, active_names) = {
+            let g = self.inner.lock().expect("skill engine mutex poisoned");
+            (
+                g.source_dirs.clone(),
+                g.registry
+                    .active_skill_names()
+                    .into_iter()
+                    .map(String::from)
+                    .collect::<Vec<_>>(),
+            )
+        };
+
+        let mut loaded = Vec::new();
+        for dir in &source_dirs {
+            loaded.extend(collect_skill_dir(dir).await?);
+        }
+        let count = loaded.len();
+
+        let mut replacement = Inner::empty();
+        replacement.source_dirs = source_dirs;
+        for (config, definition) in loaded {
+            replacement.register(config, Some(definition));
+        }
+        for name in active_names {
+            let _ = replacement.registry.activate(&name);
+        }
+
+        let mut g = self.inner.lock().expect("skill engine mutex poisoned");
+        *g = replacement;
         Ok(count)
     }
 
@@ -109,7 +126,11 @@ impl SkillDispatchEngine {
     /// of newly activated skills (skills already active are not re-fired).
     pub fn on_turn(&self, content: &str) -> Vec<SkillMatch> {
         let mut g = self.inner.lock().expect("skill engine mutex poisoned");
-        let Inner { dispatcher, registry } = &mut *g;
+        let Inner {
+            dispatcher,
+            registry,
+            ..
+        } = &mut *g;
         dispatcher.fire(content, registry)
     }
 
@@ -168,6 +189,18 @@ impl SkillDispatchEngine {
         (fired, injections)
     }
 
+    /// Refresh registered skill directories from disk, then prepare skill
+    /// context for a turn. Use this in long-running harnesses so
+    /// `skill-manage patch` effects are visible on subsequent turns without
+    /// restarting the process.
+    pub async fn prepare_turn_context_refreshed(
+        &self,
+        turn_content: &str,
+    ) -> Result<(Vec<SkillMatch>, Vec<String>), SkillsError> {
+        self.reload_registered_dirs().await?;
+        Ok(self.prepare_turn_context(turn_content))
+    }
+
     /// Active skill names in deterministic order for self-introspection.
     pub fn active_skill_names(&self) -> Vec<String> {
         self.inner
@@ -179,6 +212,49 @@ impl SkillDispatchEngine {
             .map(String::from)
             .collect()
     }
+}
+
+async fn collect_skill_dir(
+    dir: &Path,
+) -> Result<Vec<(SkillConfig, SkillDefinition)>, SkillsError> {
+    if !dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut loaded = Vec::new();
+    let mut reader = tokio::fs::read_dir(dir).await?;
+    while let Some(entry) = reader.next_entry().await? {
+        let path = entry.path();
+        // Single-file: top-level *.md files
+        if path.is_file() && path.extension().is_some_and(|e| e == "md") {
+            match parse_skill_markdown_file(&path).await {
+                Ok(parsed) => loaded.push((parsed.config, parsed.definition)),
+                Err(e) => {
+                    tracing::warn!(
+                        path = %path.display(),
+                        error = %e,
+                        "skill_dispatch: failed to parse skill markdown, skipping"
+                    );
+                }
+            }
+        // Directory-style: <name>/SKILL.md (created by skill-manage)
+        } else if path.is_dir() {
+            let skill_md = path.join("SKILL.md");
+            if skill_md.exists() {
+                match parse_skill_markdown_file(&skill_md).await {
+                    Ok(parsed) => loaded.push((parsed.config, parsed.definition)),
+                    Err(e) => {
+                        tracing::warn!(
+                            path = %skill_md.display(),
+                            error = %e,
+                            "skill_dispatch: failed to parse directory skill, skipping"
+                        );
+                    }
+                }
+            }
+        }
+    }
+    Ok(loaded)
 }
 
 impl Default for SkillDispatchEngine {
@@ -347,4 +423,63 @@ mod tests {
         assert_eq!(n, 1, "only the good file should register");
         assert_eq!(eng.registered_count(), 1);
     }
+
+    #[tokio::test]
+    async fn refreshed_turn_context_sees_patched_triggers_without_restart() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("hello.md");
+        tokio::fs::write(
+            &path,
+            "---\nname: hello\nversion: 1.0.0\ntriggers:\n  - hi\n---\nold body\n",
+        )
+        .await
+        .unwrap();
+
+        let eng = SkillDispatchEngine::new();
+        assert_eq!(eng.load_dir(tmp.path()).await.unwrap(), 1);
+        assert!(eng.on_turn("welcome aboard").is_empty());
+
+        tokio::fs::write(
+            &path,
+            "---\nname: hello\nversion: 1.0.0\ntriggers:\n  - welcome\n---\nnew body\n",
+        )
+        .await
+        .unwrap();
+
+        let (fired, injections) = eng
+            .prepare_turn_context_refreshed("welcome aboard")
+            .await
+            .unwrap();
+        assert_eq!(fired.len(), 1);
+        assert_eq!(fired[0].name, "hello");
+        assert!(injections.is_empty());
+    }
+
+    #[tokio::test]
+    async fn reload_preserves_active_skill_with_updated_injection() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("helper.md");
+        tokio::fs::write(
+            &path,
+            "---\nname: helper\nversion: 1.0.0\ntriggers:\n  - go\n---\nold body\n",
+        )
+        .await
+        .unwrap();
+
+        let eng = SkillDispatchEngine::new();
+        eng.load_dir(tmp.path()).await.unwrap();
+        assert_eq!(eng.on_turn("go now").len(), 1);
+        assert_eq!(eng.active_skill_names(), vec!["helper"]);
+
+        tokio::fs::write(
+            &path,
+            "---\nname: helper\nversion: 1.0.0\ntriggers:\n  - go\n---\nnew body\n",
+        )
+        .await
+        .unwrap();
+
+        eng.reload_registered_dirs().await.unwrap();
+        assert_eq!(eng.active_skill_names(), vec!["helper"]);
+    }
+
 }

--- a/rust/crates/sera-runtime/src/tools/skill_management.rs
+++ b/rust/crates/sera-runtime/src/tools/skill_management.rs
@@ -14,7 +14,9 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
-use sera_skills::knowledge_activity_log::{KnowledgeActivityEntry, KnowledgeActivityLog, KnowledgeOp};
+use sera_skills::knowledge_activity_log::{
+    KnowledgeActivityEntry, KnowledgeActivityLog, KnowledgeOp,
+};
 use sera_skills::parse_skill_markdown_str;
 use sera_skills::patch_policy::SkillPatchPolicy;
 use sera_skills::self_patch::{
@@ -88,12 +90,11 @@ impl SkillManagementContext {
 
     /// Persist the activity log to disk if a log path is configured.
     fn persist_log(&self) {
-        if let Some(ref path) = self.log_path {
-            if let Ok(log) = self.activity_log.lock() {
-                if let Err(e) = log.save_to_path(path) {
-                    tracing::warn!(path = %path.display(), error = %e, "failed to persist activity log");
-                }
-            }
+        if let Some(ref path) = self.log_path
+            && let Ok(log) = self.activity_log.lock()
+            && let Err(e) = log.save_to_path(path)
+        {
+            tracing::warn!(path = %path.display(), error = %e, "failed to persist activity log");
         }
     }
 }
@@ -218,7 +219,11 @@ struct SkillFrontmatter {
 async fn extract_skill_frontmatter(path: &Path) -> Option<SkillFrontmatter> {
     let content_path = if path.is_dir() {
         let skill_md = path.join("SKILL.md");
-        if skill_md.exists() { skill_md } else { return None }
+        if skill_md.exists() {
+            skill_md
+        } else {
+            return None;
+        }
     } else {
         path.to_path_buf()
     };
@@ -227,25 +232,42 @@ async fn extract_skill_frontmatter(path: &Path) -> Option<SkillFrontmatter> {
     let parsed = parse_skill_markdown_str(&content, content_path).ok()?;
     Some(SkillFrontmatter {
         name: parsed.config.name,
-        description: if parsed.config.description.is_empty() { None } else { Some(parsed.config.description) },
-        version: if parsed.config.version.is_empty() { None } else { Some(parsed.config.version) },
+        description: if parsed.config.description.is_empty() {
+            None
+        } else {
+            Some(parsed.config.description)
+        },
+        version: if parsed.config.version.is_empty() {
+            None
+        } else {
+            Some(parsed.config.version)
+        },
     })
 }
 
 /// Scan roots for a skill whose frontmatter `name` matches `target_name`.
 /// Returns the content file path and the root it was found in. Used as a
 /// fallback when path-based lookup fails (basename != frontmatter name).
-async fn find_by_frontmatter_name(roots: &[PathBuf], target_name: &str) -> Option<(PathBuf, PathBuf)> {
+async fn find_by_frontmatter_name(
+    roots: &[PathBuf],
+    target_name: &str,
+) -> Option<(PathBuf, PathBuf)> {
     for root in roots {
         if !root.exists() {
             continue;
         }
-        let Ok(mut reader) = tokio::fs::read_dir(root).await else { continue };
+        let Ok(mut reader) = tokio::fs::read_dir(root).await else {
+            continue;
+        };
         while let Ok(Some(entry)) = reader.next_entry().await {
             let path = entry.path();
             let content_path = if path.is_dir() {
                 let skill_md = path.join("SKILL.md");
-                if skill_md.exists() { skill_md } else { continue }
+                if skill_md.exists() {
+                    skill_md
+                } else {
+                    continue;
+                }
             } else if path.is_file() && path.extension().and_then(|e| e.to_str()) == Some("md") {
                 path.clone()
             } else {
@@ -407,9 +429,7 @@ impl Tool for SkillView {
 
             // Directory-style: <root>/<name>/SKILL.md
             let skill_md = skill_path.join("SKILL.md");
-            if skill_md.is_file()
-                && path_has_frontmatter_name(&skill_md, name).await
-            {
+            if skill_md.is_file() && path_has_frontmatter_name(&skill_md, name).await {
                 let content = tokio::fs::read_to_string(&skill_md)
                     .await
                     .map_err(|e| ToolError::ExecutionFailed(format!("read SKILL.md: {e}")))?;
@@ -425,9 +445,7 @@ impl Tool for SkillView {
 
             // Single-file: <root>/<name>.md
             let md_file = root.join(format!("{name}.md"));
-            if md_file.is_file()
-                && path_has_frontmatter_name(&md_file, name).await
-            {
+            if md_file.is_file() && path_has_frontmatter_name(&md_file, name).await {
                 let content = tokio::fs::read_to_string(&md_file)
                     .await
                     .map_err(|e| ToolError::ExecutionFailed(format!("read {name}.md: {e}")))?;
@@ -444,7 +462,9 @@ impl Tool for SkillView {
 
         // Fallback: scan roots for a skill whose frontmatter name matches
         // (handles basename != frontmatter name cases).
-        if let Some((content_path, root)) = find_by_frontmatter_name(&self.ctx.skill_roots, name).await {
+        if let Some((content_path, root)) =
+            find_by_frontmatter_name(&self.ctx.skill_roots, name).await
+        {
             let content = tokio::fs::read_to_string(&content_path)
                 .await
                 .map_err(|e| ToolError::ExecutionFailed(format!("read: {e}")))?;
@@ -519,7 +539,9 @@ impl Tool for SkillManage {
             "body".to_string(),
             ParameterSchema {
                 schema_type: "string".to_string(),
-                description: Some("Skill content (SKILL.md for create; new body for patch)".to_string()),
+                description: Some(
+                    "Skill content (SKILL.md for create; new body for patch)".to_string(),
+                ),
                 enum_values: None,
                 default: None,
             },
@@ -603,9 +625,7 @@ impl SkillManage {
 
         // Validate the body is parseable SKILL.md before persisting.
         let parsed = parse_skill_markdown_str(body, PathBuf::from(format!("{name}/SKILL.md")))
-            .map_err(|e| {
-                ToolError::InvalidInput(format!("invalid SKILL.md body: {e}"))
-            })?;
+            .map_err(|e| ToolError::InvalidInput(format!("invalid SKILL.md body: {e}")))?;
         if parsed.config.name != name {
             return Err(ToolError::InvalidInput(format!(
                 "frontmatter name '{}' does not match requested skill name '{name}'",
@@ -691,12 +711,19 @@ impl SkillManage {
 
         // ── Tier 1 policy gate ──────────────────────────────────────────
         if let Some(ref policy) = self.ctx.patch_policy {
-            policy.check_patch(name, &_root, body.len()).map_err(|rej| {
-                ToolError::ExecutionFailed(format!("patch policy rejected: {rej}"))
-            })?;
+            let skill_path = match &location {
+                SkillLocation::Directory(dir) => dir.as_path(),
+                SkillLocation::SingleFile(path) => path.as_path(),
+            };
+            policy
+                .check_patch(name, &_root, skill_path, body.len())
+                .map_err(|rej| {
+                    ToolError::ExecutionFailed(format!("patch policy rejected: {rej}"))
+                })?;
         }
 
-        if !matches!(&location, SkillLocation::Directory(_)) && patch_kind_str != "update_skill_md" {
+        if !matches!(&location, SkillLocation::Directory(_)) && patch_kind_str != "update_skill_md"
+        {
             return Err(ToolError::InvalidInput(format!(
                 "patch_kind '{patch_kind_str}' requires directory-style skill; '{name}' is a single-file skill"
             )));
@@ -714,11 +741,11 @@ impl SkillManage {
 
         let (patch_kind, payload) = match patch_kind_str {
             "update_skill_md" => {
-                let parsed = parse_skill_markdown_str(
-                    body,
-                    PathBuf::from(format!("{name}/SKILL.md")),
-                )
-                .map_err(|e| ToolError::InvalidInput(format!("invalid SKILL.md body: {e}")))?;
+                let parsed =
+                    parse_skill_markdown_str(body, PathBuf::from(format!("{name}/SKILL.md")))
+                        .map_err(|e| {
+                            ToolError::InvalidInput(format!("invalid SKILL.md body: {e}"))
+                        })?;
                 if parsed.config.name != name {
                     return Err(ToolError::InvalidInput(format!(
                         "frontmatter name '{}' does not match skill '{name}'",
@@ -792,18 +819,18 @@ impl SkillManage {
 
         match &location {
             SkillLocation::Directory(skill_dir) => {
-                let parent = skill_dir
-                    .parent()
-                    .ok_or_else(|| ToolError::ExecutionFailed("skill dir has no parent".to_string()))?;
+                let parent = skill_dir.parent().ok_or_else(|| {
+                    ToolError::ExecutionFailed("skill dir has no parent".to_string())
+                })?;
                 let applier = FsSelfPatchApplier::new(parent);
                 applier
                     .apply(validated)
                     .map_err(|e| ToolError::ExecutionFailed(format!("patch apply failed: {e}")))?;
             }
             SkillLocation::SingleFile(path) => {
-                tokio::fs::write(path, body)
-                    .await
-                    .map_err(|e| ToolError::ExecutionFailed(format!("write {}: {e}", path.display())))?;
+                tokio::fs::write(path, body).await.map_err(|e| {
+                    ToolError::ExecutionFailed(format!("write {}: {e}", path.display()))
+                })?;
             }
         }
 
@@ -856,14 +883,14 @@ impl SkillManage {
                 return Ok((SkillLocation::Directory(path), root.clone()));
             }
             let md_file = root.join(format!("{name}.md"));
-            if md_file.is_file()
-                && path_has_frontmatter_name(&md_file, name).await
-            {
+            if md_file.is_file() && path_has_frontmatter_name(&md_file, name).await {
                 return Ok((SkillLocation::SingleFile(md_file), root.clone()));
             }
         }
         // Fallback: scan for a skill whose frontmatter name matches.
-        if let Some((content_path, root)) = find_by_frontmatter_name(&self.ctx.skill_roots, name).await {
+        if let Some((content_path, root)) =
+            find_by_frontmatter_name(&self.ctx.skill_roots, name).await
+        {
             if content_path.file_name().and_then(|f| f.to_str()) == Some("SKILL.md")
                 && let Some(dir) = content_path.parent()
             {
@@ -1071,10 +1098,7 @@ mod tests {
         assert!(!parsed["truncated"].as_bool().unwrap());
 
         let skills = parsed["skills"].as_array().unwrap();
-        let names: Vec<&str> = skills
-            .iter()
-            .map(|s| s["name"].as_str().unwrap())
-            .collect();
+        let names: Vec<&str> = skills.iter().map(|s| s["name"].as_str().unwrap()).collect();
         assert!(names.contains(&"alpha"));
         assert!(names.contains(&"beta"));
     }
@@ -1082,8 +1106,18 @@ mod tests {
     #[tokio::test]
     async fn list_skills_with_query_filter() {
         let tmp = tempfile::tempdir().unwrap();
-        setup_skill_dir(tmp.path(), "code-review", &skill_body("code-review", "Reviews code")).await;
-        setup_skill_dir(tmp.path(), "deploy-helper", &skill_body("deploy-helper", "Deploys")).await;
+        setup_skill_dir(
+            tmp.path(),
+            "code-review",
+            &skill_body("code-review", "Reviews code"),
+        )
+        .await;
+        setup_skill_dir(
+            tmp.path(),
+            "deploy-helper",
+            &skill_body("deploy-helper", "Deploys"),
+        )
+        .await;
 
         let ctx = Arc::new(SkillManagementContext::new(vec![tmp.path().to_path_buf()]));
         let tool = SkillList::new(ctx);
@@ -1098,7 +1132,12 @@ mod tests {
     #[tokio::test]
     async fn list_skills_extracts_description() {
         let tmp = tempfile::tempdir().unwrap();
-        setup_skill_dir(tmp.path(), "test-skill", &skill_body("test-skill", "A test skill")).await;
+        setup_skill_dir(
+            tmp.path(),
+            "test-skill",
+            &skill_body("test-skill", "A test skill"),
+        )
+        .await;
 
         let ctx = Arc::new(SkillManagementContext::new(vec![tmp.path().to_path_buf()]));
         let tool = SkillList::new(ctx);
@@ -1153,7 +1192,12 @@ mod tests {
         assert!(!output.is_error);
         let parsed: serde_json::Value = serde_json::from_str(&output.content).unwrap();
         assert_eq!(parsed["name"], "single");
-        assert!(parsed["content"].as_str().unwrap().contains("Single file skill"));
+        assert!(
+            parsed["content"]
+                .as_str()
+                .unwrap()
+                .contains("Single file skill")
+        );
     }
 
     #[tokio::test]
@@ -1246,9 +1290,12 @@ mod tests {
     #[tokio::test]
     async fn create_rejects_collision_with_single_file_skill() {
         let tmp = tempfile::tempdir().unwrap();
-        tokio::fs::write(tmp.path().join("legacy.md"), &skill_body("legacy", "Legacy"))
-            .await
-            .unwrap();
+        tokio::fs::write(
+            tmp.path().join("legacy.md"),
+            &skill_body("legacy", "Legacy"),
+        )
+        .await
+        .unwrap();
 
         let ctx = Arc::new(SkillManagementContext::new(vec![tmp.path().to_path_buf()]));
         let tool = SkillManage::new(ctx);
@@ -1262,7 +1309,10 @@ mod tests {
         );
         let err = tool.execute(input, make_ctx()).await.unwrap_err();
         assert!(matches!(err, ToolError::ExecutionFailed(_)));
-        assert!(!tmp.path().join("legacy").exists(), "directory must not be created");
+        assert!(
+            !tmp.path().join("legacy").exists(),
+            "directory must not be created"
+        );
     }
 
     #[tokio::test]
@@ -1285,7 +1335,10 @@ mod tests {
         );
         let err = tool.execute(input, make_ctx()).await.unwrap_err();
         assert!(matches!(err, ToolError::ExecutionFailed(_)));
-        assert!(!tmp.path().join("foo").exists(), "directory must not be created");
+        assert!(
+            !tmp.path().join("foo").exists(),
+            "directory must not be created"
+        );
     }
 
     #[tokio::test]
@@ -1310,7 +1363,10 @@ mod tests {
         );
         let err = tool.execute(input, make_ctx()).await.unwrap_err();
         assert!(matches!(err, ToolError::ExecutionFailed(_)));
-        assert!(!tmp.path().join("bar").exists(), "directory must not be created");
+        assert!(
+            !tmp.path().join("bar").exists(),
+            "directory must not be created"
+        );
     }
 
     #[tokio::test]
@@ -1348,9 +1404,12 @@ mod tests {
         // old/ dir has SKILL.md with name: foo
         let legacy_dir = tmp.path().join("old");
         tokio::fs::create_dir_all(&legacy_dir).await.unwrap();
-        tokio::fs::write(legacy_dir.join("SKILL.md"), &skill_body("foo", "Real foo dir"))
-            .await
-            .unwrap();
+        tokio::fs::write(
+            legacy_dir.join("SKILL.md"),
+            &skill_body("foo", "Real foo dir"),
+        )
+        .await
+        .unwrap();
 
         let ctx = Arc::new(SkillManagementContext::new(vec![tmp.path().to_path_buf()]));
         let tool = SkillView::new(ctx);
@@ -1369,7 +1428,9 @@ mod tests {
         // Real skill directory
         setup_skill_dir(tmp.path(), "real", &skill_body("real", "Real skill")).await;
         // Non-skill directory (no SKILL.md)
-        tokio::fs::create_dir_all(tmp.path().join("stale-tmp")).await.unwrap();
+        tokio::fs::create_dir_all(tmp.path().join("stale-tmp"))
+            .await
+            .unwrap();
         tokio::fs::write(tmp.path().join("stale-tmp").join("junk.txt"), "junk")
             .await
             .unwrap();
@@ -1388,15 +1449,21 @@ mod tests {
     async fn list_includes_dot_and_underscore_prefixed_skills() {
         let tmp = tempfile::tempdir().unwrap();
         // .foo.md — hidden-prefix single file with valid frontmatter
-        tokio::fs::write(tmp.path().join(".foo.md"), &skill_body("dot-foo", "Dot foo"))
-            .await
-            .unwrap();
+        tokio::fs::write(
+            tmp.path().join(".foo.md"),
+            &skill_body("dot-foo", "Dot foo"),
+        )
+        .await
+        .unwrap();
         // _bar/ — underscore-prefix directory with valid SKILL.md
         let bar_dir = tmp.path().join("_bar");
         tokio::fs::create_dir_all(&bar_dir).await.unwrap();
-        tokio::fs::write(bar_dir.join("SKILL.md"), &skill_body("under-bar", "Under bar"))
-            .await
-            .unwrap();
+        tokio::fs::write(
+            bar_dir.join("SKILL.md"),
+            &skill_body("under-bar", "Under bar"),
+        )
+        .await
+        .unwrap();
 
         let ctx = Arc::new(SkillManagementContext::new(vec![tmp.path().to_path_buf()]));
         let tool = SkillList::new(ctx);
@@ -1410,8 +1477,14 @@ mod tests {
             .iter()
             .map(|s| s["name"].as_str().unwrap())
             .collect();
-        assert!(names.contains(&"dot-foo"), "dot-prefixed skill must appear: {names:?}");
-        assert!(names.contains(&"under-bar"), "underscore-prefixed skill must appear: {names:?}");
+        assert!(
+            names.contains(&"dot-foo"),
+            "dot-prefixed skill must appear: {names:?}"
+        );
+        assert!(
+            names.contains(&"under-bar"),
+            "underscore-prefixed skill must appear: {names:?}"
+        );
     }
 
     #[tokio::test]
@@ -1422,13 +1495,19 @@ mod tests {
             .await
             .unwrap();
         // README.md — no skill frontmatter name field
-        tokio::fs::write(tmp.path().join("README.md"), "# Project Readme\nNo frontmatter.")
-            .await
-            .unwrap();
+        tokio::fs::write(
+            tmp.path().join("README.md"),
+            "# Project Readme\nNo frontmatter.",
+        )
+        .await
+        .unwrap();
         // Malformed frontmatter — has --- but no name
-        tokio::fs::write(tmp.path().join("broken.md"), "---\ndescription: no name\n---\nbody")
-            .await
-            .unwrap();
+        tokio::fs::write(
+            tmp.path().join("broken.md"),
+            "---\ndescription: no name\n---\nbody",
+        )
+        .await
+        .unwrap();
 
         let ctx = Arc::new(SkillManagementContext::new(vec![tmp.path().to_path_buf()]));
         let tool = SkillList::new(ctx);
@@ -1658,9 +1737,12 @@ mod tests {
     #[tokio::test]
     async fn patch_single_file_rejects_add_knowledge() {
         let tmp = tempfile::tempdir().unwrap();
-        tokio::fs::write(tmp.path().join("simple.md"), &skill_body("simple", "Simple"))
-            .await
-            .unwrap();
+        tokio::fs::write(
+            tmp.path().join("simple.md"),
+            &skill_body("simple", "Simple"),
+        )
+        .await
+        .unwrap();
 
         let ctx = Arc::new(SkillManagementContext::new(vec![tmp.path().to_path_buf()]));
         let tool = SkillManage::new(ctx);
@@ -1777,7 +1859,10 @@ mod tests {
         unsafe { std::env::set_var("SERA_SKILLS_DIR", "/tmp/__sera_nonexistent_skills_dir__") };
         let ctx = skill_management_context_from_env();
         unsafe { std::env::remove_var("SERA_SKILLS_DIR") };
-        assert!(ctx.is_some(), "explicit SERA_SKILLS_DIR registers tools even if dir doesn't exist yet");
+        assert!(
+            ctx.is_some(),
+            "explicit SERA_SKILLS_DIR registers tools even if dir doesn't exist yet"
+        );
     }
 
     #[test]
@@ -1814,8 +1899,7 @@ mod tests {
             64 * 1024,
         );
         let ctx = Arc::new(
-            SkillManagementContext::new(vec![allowed_root])
-                .with_patch_policy(Box::new(policy)),
+            SkillManagementContext::new(vec![allowed_root]).with_patch_policy(Box::new(policy)),
         );
         let tool = SkillManage::new(ctx);
 
@@ -1834,10 +1918,65 @@ mod tests {
         match err {
             ToolError::ExecutionFailed(msg) => {
                 assert!(msg.contains("patch policy rejected"), "unexpected: {msg}");
-                assert!(msg.contains("not in the allowed roots"), "unexpected: {msg}");
+                assert!(
+                    msg.contains("not contained by an allowed Tier 1 root"),
+                    "unexpected: {msg}"
+                );
             }
             other => panic!("expected ExecutionFailed, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn patch_rejected_when_single_file_skill_symlink_escapes_allowed_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        let allowed_root = tmp.path().join("allowed");
+        let outside_root = tmp.path().join("outside");
+        tokio::fs::create_dir_all(&allowed_root).await.unwrap();
+        tokio::fs::create_dir_all(&outside_root).await.unwrap();
+
+        let outside_skill = outside_root.join("evil.md");
+        tokio::fs::write(&outside_skill, skill_body("evil", "outside target"))
+            .await
+            .unwrap();
+        let linked_skill = allowed_root.join("evil.md");
+        std::os::unix::fs::symlink(&outside_skill, &linked_skill).unwrap();
+
+        let policy = sera_skills::patch_policy::Tier1SkillPatchPolicy::new(
+            vec![allowed_root.clone()],
+            64 * 1024,
+        );
+        let ctx = Arc::new(
+            SkillManagementContext::new(vec![allowed_root]).with_patch_policy(Box::new(policy)),
+        );
+        let tool = SkillManage::new(ctx);
+
+        let input = make_input(
+            "skill-manage",
+            serde_json::json!({
+                "action": "patch",
+                "name": "evil",
+                "patch_kind": "update_skill_md",
+                "body": skill_body("evil", "should not escape"),
+                "base_version": "1.0.0",
+            }),
+        );
+        let err = tool.execute(input, make_ctx()).await.unwrap_err();
+        match err {
+            ToolError::ExecutionFailed(msg) => {
+                assert!(msg.contains("patch policy rejected"), "unexpected: {msg}");
+                assert!(
+                    msg.contains("not contained by an allowed Tier 1 root"),
+                    "unexpected: {msg}"
+                );
+            }
+            other => panic!("expected ExecutionFailed, got {other:?}"),
+        }
+
+        let outside_body = tokio::fs::read_to_string(&outside_skill).await.unwrap();
+        assert!(outside_body.contains("outside target"));
+        assert!(!outside_body.contains("should not escape"));
     }
 
     #[tokio::test]
@@ -1969,7 +2108,12 @@ mod tests {
         assert_eq!(meta["action"], "patch");
         assert_eq!(meta["skill_name"], "prov");
         assert_eq!(meta["patch_kind"], "update_skill_md");
-        assert!(meta["diff_summary"].as_str().unwrap().contains("UpdateSkillMd"));
+        assert!(
+            meta["diff_summary"]
+                .as_str()
+                .unwrap()
+                .contains("UpdateSkillMd")
+        );
         assert!(meta["root"].as_str().is_some());
         assert!(meta["after_hash"].as_str().is_some());
         assert!(meta["body_bytes"].as_u64().unwrap() > 0);

--- a/rust/crates/sera-runtime/src/tools/skill_management.rs
+++ b/rust/crates/sera-runtime/src/tools/skill_management.rs
@@ -16,6 +16,7 @@ use std::sync::{Arc, Mutex};
 use async_trait::async_trait;
 use sera_skills::knowledge_activity_log::{KnowledgeActivityEntry, KnowledgeActivityLog, KnowledgeOp};
 use sera_skills::parse_skill_markdown_str;
+use sera_skills::patch_policy::SkillPatchPolicy;
 use sera_skills::self_patch::{
     DefaultSelfPatchValidator, FsSelfPatchApplier, PatchKind, PatchPayload, SelfPatchApplier,
     SelfPatchValidator, SkillPatch,
@@ -36,9 +37,13 @@ pub struct SkillManagementContext {
     pub skill_roots: Vec<PathBuf>,
     /// Directory where new skills are written.
     pub write_root: PathBuf,
-    /// In-memory activity log recording create/patch operations.
-    /// Phase 2 adds persistence to disk/DB.
+    /// Activity log recording create/patch operations, persisted to `log_path`.
     pub activity_log: Mutex<KnowledgeActivityLog>,
+    /// When set, the activity log is persisted after each write operation.
+    pub log_path: Option<PathBuf>,
+    /// Tier 1 policy gate applied before every patch. When `None`, patches
+    /// are ungoverned (test/bootstrap mode only).
+    pub patch_policy: Option<Box<dyn SkillPatchPolicy>>,
 }
 
 impl SkillManagementContext {
@@ -51,12 +56,45 @@ impl SkillManagementContext {
             skill_roots,
             write_root,
             activity_log: Mutex::new(KnowledgeActivityLog::default()),
+            log_path: None,
+            patch_policy: None,
         }
     }
 
     pub fn with_write_root(mut self, root: PathBuf) -> Self {
         self.write_root = root;
         self
+    }
+
+    /// Enable durable activity log at `path`. If the file exists it is loaded;
+    /// otherwise a fresh log is created on the first write.
+    pub fn with_log_persistence(mut self, path: PathBuf) -> Self {
+        if let Ok(loaded) = KnowledgeActivityLog::load_from_path(
+            &path,
+            sera_skills::knowledge_activity_log::DEFAULT_MAX_ENTRIES,
+        ) {
+            self.activity_log = Mutex::new(loaded);
+        }
+        self.log_path = Some(path);
+        self
+    }
+
+    /// Attach a Tier 1 patch policy. When set, every `skill-manage patch`
+    /// call runs this check before validation.
+    pub fn with_patch_policy(mut self, policy: Box<dyn SkillPatchPolicy>) -> Self {
+        self.patch_policy = Some(policy);
+        self
+    }
+
+    /// Persist the activity log to disk if a log path is configured.
+    fn persist_log(&self) {
+        if let Some(ref path) = self.log_path {
+            if let Ok(log) = self.activity_log.lock() {
+                if let Err(e) = log.save_to_path(path) {
+                    tracing::warn!(path = %path.display(), error = %e, "failed to persist activity log");
+                }
+            }
+        }
     }
 }
 
@@ -619,10 +657,13 @@ impl SkillManage {
                 .with_page_id(name)
                 .with_metadata(serde_json::json!({
                     "action": "create",
+                    "skill_name": name,
+                    "root": self.ctx.write_root.display().to_string(),
                     "bytes": body.len(),
                 })),
             );
         }
+        self.ctx.persist_log();
 
         let output = serde_json::json!({
             "status": "created",
@@ -647,6 +688,13 @@ impl SkillManage {
             .as_str()
             .ok_or_else(|| ToolError::InvalidInput("missing 'body' for patch".to_string()))?;
         let (location, _root) = self.find_skill(name).await?;
+
+        // ── Tier 1 policy gate ──────────────────────────────────────────
+        if let Some(ref policy) = self.ctx.patch_policy {
+            policy.check_patch(name, &_root, body.len()).map_err(|rej| {
+                ToolError::ExecutionFailed(format!("patch policy rejected: {rej}"))
+            })?;
+        }
 
         if !matches!(&location, SkillLocation::Directory(_)) && patch_kind_str != "update_skill_md" {
             return Err(ToolError::InvalidInput(format!(
@@ -759,6 +807,14 @@ impl SkillManage {
             }
         }
 
+        // Compute before/after hash for provenance.
+        let after_hash = {
+            use std::hash::{Hash, Hasher};
+            let mut h = std::collections::hash_map::DefaultHasher::new();
+            body.hash(&mut h);
+            format!("{:016x}", h.finish())
+        };
+
         if let Ok(mut log) = self.ctx.activity_log.lock() {
             log.append(
                 KnowledgeActivityEntry::new(
@@ -769,10 +825,16 @@ impl SkillManage {
                 .with_page_id(name)
                 .with_metadata(serde_json::json!({
                     "action": "patch",
+                    "skill_name": name,
                     "patch_kind": patch_kind_str,
+                    "diff_summary": diff_summary,
+                    "root": _root.display().to_string(),
+                    "body_bytes": body.len(),
+                    "after_hash": after_hash,
                 })),
             );
         }
+        self.ctx.persist_log();
 
         let output = serde_json::json!({
             "status": "patched",
@@ -893,7 +955,16 @@ pub fn skill_management_context_from_env() -> Option<Arc<SkillManagementContext>
     };
     let path = PathBuf::from(&dir);
     if explicit || path.is_dir() {
-        Some(Arc::new(SkillManagementContext::new(vec![path])))
+        let roots = vec![path.clone()];
+        let log_path = path.join(".activity-log.json");
+        let policy = sera_skills::patch_policy::Tier1SkillPatchPolicy::new(
+            roots.clone(),
+            sera_skills::self_patch::MAX_SKILL_MD_BYTES,
+        );
+        let ctx = SkillManagementContext::new(roots)
+            .with_log_persistence(log_path)
+            .with_patch_policy(Box::new(policy));
+        Some(Arc::new(ctx))
     } else {
         None
     }
@@ -1729,41 +1800,211 @@ mod tests {
         assert_eq!(registry.list().len(), 14);
     }
 
-    // ── Dogfood scaffold ────────────────────────────────────────────────
+    // ── Policy gate ──────────────────────────────────────────────────────
 
-    /// Phase 2 expectation: a fresh session should use an improved skill
-    /// after a correction/background review loop updates it. This test
-    /// scaffolds the end-to-end flow without the background review trigger.
     #[tokio::test]
-    #[ignore = "Phase 2: requires background review loop + fresh session spawn"]
-    async fn dogfood_fresh_session_uses_improved_skill() {
+    async fn patch_rejected_by_policy_outside_root() {
         let tmp = tempfile::tempdir().unwrap();
+        let allowed_root = tmp.path().join("allowed");
+        tokio::fs::create_dir_all(&allowed_root).await.unwrap();
+        setup_skill_dir(&allowed_root, "target", &skill_body("target", "Target")).await;
+
+        let policy = sera_skills::patch_policy::Tier1SkillPatchPolicy::new(
+            vec![tmp.path().join("other-root")],
+            64 * 1024,
+        );
+        let ctx = Arc::new(
+            SkillManagementContext::new(vec![allowed_root])
+                .with_patch_policy(Box::new(policy)),
+        );
+        let tool = SkillManage::new(ctx);
+
+        let new_body = skill_body("target", "Patched");
+        let input = make_input(
+            "skill-manage",
+            serde_json::json!({
+                "action": "patch",
+                "name": "target",
+                "patch_kind": "update_skill_md",
+                "body": new_body,
+                "base_version": "1.0.0",
+            }),
+        );
+        let err = tool.execute(input, make_ctx()).await.unwrap_err();
+        match err {
+            ToolError::ExecutionFailed(msg) => {
+                assert!(msg.contains("patch policy rejected"), "unexpected: {msg}");
+                assert!(msg.contains("not in the allowed roots"), "unexpected: {msg}");
+            }
+            other => panic!("expected ExecutionFailed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn patch_rejected_by_policy_over_budget() {
+        let tmp = tempfile::tempdir().unwrap();
+        setup_skill_dir(tmp.path(), "target", &skill_body("target", "Target")).await;
+
+        let policy = sera_skills::patch_policy::Tier1SkillPatchPolicy::new(
+            vec![tmp.path().to_path_buf()],
+            50, // tiny budget
+        );
+        let ctx = Arc::new(
+            SkillManagementContext::new(vec![tmp.path().to_path_buf()])
+                .with_patch_policy(Box::new(policy)),
+        );
+        let tool = SkillManage::new(ctx);
+
+        let new_body = skill_body("target", "Patched content that exceeds the budget");
+        let input = make_input(
+            "skill-manage",
+            serde_json::json!({
+                "action": "patch",
+                "name": "target",
+                "patch_kind": "update_skill_md",
+                "body": new_body,
+                "base_version": "1.0.0",
+            }),
+        );
+        let err = tool.execute(input, make_ctx()).await.unwrap_err();
+        match err {
+            ToolError::ExecutionFailed(msg) => {
+                assert!(msg.contains("exceeds Tier 1 budget"), "unexpected: {msg}");
+            }
+            other => panic!("expected ExecutionFailed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn patch_allowed_by_policy_within_bounds() {
+        let tmp = tempfile::tempdir().unwrap();
+        setup_skill_dir(tmp.path(), "ok-skill", &skill_body("ok-skill", "OK")).await;
+
+        let policy = sera_skills::patch_policy::Tier1SkillPatchPolicy::new(
+            vec![tmp.path().to_path_buf()],
+            64 * 1024,
+        );
+        let ctx = Arc::new(
+            SkillManagementContext::new(vec![tmp.path().to_path_buf()])
+                .with_patch_policy(Box::new(policy)),
+        );
+        let tool = SkillManage::new(ctx);
+
+        let new_body = skill_body("ok-skill", "Patched and approved");
+        let input = make_input(
+            "skill-manage",
+            serde_json::json!({
+                "action": "patch",
+                "name": "ok-skill",
+                "patch_kind": "update_skill_md",
+                "body": new_body,
+                "base_version": "1.0.0",
+            }),
+        );
+        let output = tool.execute(input, make_ctx()).await.unwrap();
+        assert!(!output.is_error);
+    }
+
+    // ── Activity log persistence ───────────────────────────────────────
+
+    #[tokio::test]
+    async fn activity_log_persists_to_disk_and_survives_restart() {
+        let tmp = tempfile::tempdir().unwrap();
+        let log_path = tmp.path().join("activity.json");
+
+        // Session 1: create a skill, persist log.
+        {
+            let ctx = Arc::new(
+                SkillManagementContext::new(vec![tmp.path().to_path_buf()])
+                    .with_log_persistence(log_path.clone()),
+            );
+            let tool = SkillManage::new(Arc::clone(&ctx));
+            let body = skill_body("durable", "Durable skill");
+            let input = make_input(
+                "skill-manage",
+                serde_json::json!({"action": "create", "name": "durable", "body": body}),
+            );
+            tool.execute(input, make_ctx()).await.unwrap();
+        }
+
+        // Session 2: load log from disk, verify entry survived.
+        {
+            let ctx = Arc::new(
+                SkillManagementContext::new(vec![tmp.path().to_path_buf()])
+                    .with_log_persistence(log_path.clone()),
+            );
+            let log = ctx.activity_log.lock().unwrap();
+            assert_eq!(log.len(), 1, "persisted entry must survive process restart");
+            let entry = log.iter().next().unwrap();
+            assert_eq!(entry.op, KnowledgeOp::Store);
+            assert!(entry.summary.contains("durable"));
+        }
+    }
+
+    #[tokio::test]
+    async fn activity_log_provenance_has_required_fields() {
+        let tmp = tempfile::tempdir().unwrap();
+        setup_skill_dir(tmp.path(), "prov", &skill_body("prov", "V1")).await;
+
+        let ctx = Arc::new(SkillManagementContext::new(vec![tmp.path().to_path_buf()]));
+        let tool = SkillManage::new(Arc::clone(&ctx));
+
+        let new_body = skill_body("prov", "V2 improved");
+        let input = make_input(
+            "skill-manage",
+            serde_json::json!({
+                "action": "patch",
+                "name": "prov",
+                "patch_kind": "update_skill_md",
+                "body": new_body,
+                "base_version": "1.0.0",
+            }),
+        );
+        tool.execute(input, make_ctx()).await.unwrap();
+
+        let log = ctx.activity_log.lock().unwrap();
+        assert_eq!(log.len(), 1);
+        let entry = log.iter().next().unwrap();
+        let meta = entry.metadata.as_ref().unwrap();
+        assert_eq!(meta["action"], "patch");
+        assert_eq!(meta["skill_name"], "prov");
+        assert_eq!(meta["patch_kind"], "update_skill_md");
+        assert!(meta["diff_summary"].as_str().unwrap().contains("UpdateSkillMd"));
+        assert!(meta["root"].as_str().is_some());
+        assert!(meta["after_hash"].as_str().is_some());
+        assert!(meta["body_bytes"].as_u64().unwrap() > 0);
+    }
+
+    // ── Fresh-load proof (end-to-end skill loop) ───────────────────────
+
+    #[tokio::test]
+    async fn fresh_engine_loads_patched_skill_and_fires_trigger() {
+        let tmp = tempfile::tempdir().unwrap();
+
+        // 1. Create a skill with triggers via skill-manage.
         let ctx = Arc::new(SkillManagementContext::new(vec![tmp.path().to_path_buf()]));
         let manage = SkillManage::new(Arc::clone(&ctx));
-        let view = SkillView::new(Arc::clone(&ctx));
-
-        // 1. Create initial skill
-        let v1 = skill_body("greeting", "Says hello");
+        let v1 = "---\nname: greet\nversion: 1.0.0\ndescription: Greeting\ntriggers:\n  - hello\n---\n\nSay hi.\n";
         manage
             .execute(
                 make_input(
                     "skill-manage",
-                    serde_json::json!({"action": "create", "name": "greeting", "body": v1}),
+                    serde_json::json!({"action": "create", "name": "greet", "body": v1}),
                 ),
                 make_ctx(),
             )
             .await
             .unwrap();
 
-        // 2. Simulate correction: patch the skill with improved content
-        let v2 = skill_body("greeting", "Says hello warmly with context");
+        // 2. Patch the skill with updated content and a new trigger.
+        let v2 = "---\nname: greet\nversion: 1.0.0\ndescription: Greeting improved\ntriggers:\n  - hello\n  - welcome\n---\n\nSay hello warmly with context.\n";
         manage
             .execute(
                 make_input(
                     "skill-manage",
                     serde_json::json!({
                         "action": "patch",
-                        "name": "greeting",
+                        "name": "greet",
                         "patch_kind": "update_skill_md",
                         "body": v2,
                         "base_version": "1.0.0",
@@ -1774,22 +2015,56 @@ mod tests {
             .await
             .unwrap();
 
-        // 3. Verify the updated skill is visible (simulates fresh session load)
-        let output = view
-            .execute(
-                make_input("skill-view", serde_json::json!({"name": "greeting"})),
-                make_ctx(),
-            )
+        // 3. Simulate fresh runtime session: new SkillDispatchEngine loads from disk.
+        let engine = crate::skill_dispatch::SkillDispatchEngine::new();
+        let loaded = engine.load_dir(tmp.path()).await.unwrap();
+        assert_eq!(loaded, 1, "fresh engine must load the patched skill");
+
+        // 4. Trigger fires on the new keyword added by the patch.
+        let (fired, injections) = engine.prepare_turn_context("welcome aboard");
+        assert_eq!(fired.len(), 1);
+        assert_eq!(fired[0].name, "greet");
+        // The skill has no context_injection field, so injections from the
+        // body are empty, but the skill IS active.
+        let _ = injections;
+
+        // 5. Verify the original trigger still works.
+        engine.deactivate("greet");
+        let (fired2, _) = engine.prepare_turn_context("hello there");
+        assert_eq!(fired2.len(), 1);
+        assert_eq!(fired2[0].name, "greet");
+
+        // 6. Verify the updated body is on disk (content proof).
+        let content = tokio::fs::read_to_string(tmp.path().join("greet").join("SKILL.md"))
             .await
             .unwrap();
-        let parsed: serde_json::Value = serde_json::from_str(&output.content).unwrap();
-        let content = parsed["content"].as_str().unwrap();
         assert!(
             content.contains("warmly with context"),
-            "fresh session should see the improved skill"
+            "patched content must be on disk for fresh sessions"
         );
+    }
 
-        // Phase 2 TODO: spawn a fresh DefaultRuntime session, load skills,
-        // and verify the agent's behaviour reflects the updated skill content.
+    // ── Turn context integration ───────────────────────────────────────
+
+    #[test]
+    fn prepare_turn_context_returns_fired_and_injections() {
+        let eng = crate::skill_dispatch::SkillDispatchEngine::new();
+        use sera_types::skill::{SkillConfig, SkillMode, SkillTrigger};
+        let cfg = SkillConfig {
+            name: "helper".into(),
+            version: "1.0.0".into(),
+            description: "test".into(),
+            mode: SkillMode::OnDemand,
+            trigger: SkillTrigger::Event("assist".into()),
+            tools: vec![],
+            context_injection: Some("You are a helpful assistant.".into()),
+            config: serde_json::json!({}),
+        };
+        eng.register(cfg, None);
+
+        let (fired, injections) = eng.prepare_turn_context("please assist me");
+        assert_eq!(fired.len(), 1);
+        assert_eq!(fired[0].name, "helper");
+        assert_eq!(injections, vec!["You are a helpful assistant."]);
     }
 }

--- a/rust/crates/sera-runtime/src/tools/skill_management.rs
+++ b/rust/crates/sera-runtime/src/tools/skill_management.rs
@@ -2165,7 +2165,7 @@ mod tests {
         assert_eq!(loaded, 1, "fresh engine must load the patched skill");
 
         // 4. Trigger fires on the new keyword added by the patch.
-        let (fired, injections) = engine.prepare_turn_context("welcome aboard");
+        let (fired, injections) = engine.prepare_turn_context("welcome aboard").await.unwrap();
         assert_eq!(fired.len(), 1);
         assert_eq!(fired[0].name, "greet");
         // The skill has no context_injection field, so injections from the
@@ -2174,7 +2174,7 @@ mod tests {
 
         // 5. Verify the original trigger still works.
         engine.deactivate("greet");
-        let (fired2, _) = engine.prepare_turn_context("hello there");
+        let (fired2, _) = engine.prepare_turn_context("hello there").await.unwrap();
         assert_eq!(fired2.len(), 1);
         assert_eq!(fired2[0].name, "greet");
 
@@ -2190,8 +2190,8 @@ mod tests {
 
     // ── Turn context integration ───────────────────────────────────────
 
-    #[test]
-    fn prepare_turn_context_returns_fired_and_injections() {
+    #[tokio::test]
+    async fn prepare_turn_context_returns_fired_and_injections() {
         let eng = crate::skill_dispatch::SkillDispatchEngine::new();
         use sera_types::skill::{SkillConfig, SkillMode, SkillTrigger};
         let cfg = SkillConfig {
@@ -2206,7 +2206,7 @@ mod tests {
         };
         eng.register(cfg, None);
 
-        let (fired, injections) = eng.prepare_turn_context("please assist me");
+        let (fired, injections) = eng.prepare_loaded_turn_context("please assist me");
         assert_eq!(fired.len(), 1);
         assert_eq!(fired[0].name, "helper");
         assert_eq!(injections, vec!["You are a helpful assistant."]);

--- a/rust/crates/sera-skills/src/knowledge_activity_log.rs
+++ b/rust/crates/sera-skills/src/knowledge_activity_log.rs
@@ -15,6 +15,7 @@
 //! Inspired by Karpathy's LLM `wiki log.md` concept.
 
 use std::fmt;
+use std::path::Path;
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -286,6 +287,40 @@ impl KnowledgeActivityLog {
     /// Iterate over all entries in chronological order (oldest first).
     pub fn iter(&self) -> impl Iterator<Item = &KnowledgeActivityEntry> {
         self.entries.iter()
+    }
+}
+
+impl KnowledgeActivityLog {
+    /// Persist the log as JSON to `path` (atomic write via temp file + rename).
+    pub fn save_to_path(&self, path: &Path) -> std::io::Result<()> {
+        let json = serde_json::to_string(self)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let tmp = path.with_extension("tmp");
+        std::fs::write(&tmp, &json)?;
+        std::fs::rename(&tmp, path)?;
+        Ok(())
+    }
+
+    /// Load a log from a JSON file. Returns a fresh empty log if the file
+    /// does not exist. `max_entries` overrides the persisted capacity so the
+    /// caller controls the rolling window.
+    pub fn load_from_path(path: &Path, max_entries: usize) -> std::io::Result<Self> {
+        assert!(max_entries > 0, "max_entries must be > 0");
+        if !path.exists() {
+            return Ok(Self::new(max_entries));
+        }
+        let json = std::fs::read_to_string(path)?;
+        let mut log: Self = serde_json::from_str(&json)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+        log.max_entries = max_entries;
+        // Truncate if loaded log exceeds the new max.
+        while log.entries.len() > log.max_entries {
+            log.entries.remove(0);
+        }
+        Ok(log)
     }
 }
 
@@ -650,5 +685,86 @@ mod tests {
         let log = KnowledgeActivityLog::default();
         assert_eq!(log.max_entries(), DEFAULT_MAX_ENTRIES);
         assert!(log.is_empty());
+    }
+
+    // --- persistence ---
+
+    #[test]
+    fn save_and_load_round_trip() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("activity.json");
+
+        let mut log = KnowledgeActivityLog::new(10);
+        log.append(make_entry(KnowledgeOp::Store, "agent-1", "created skill"));
+        log.append(
+            make_entry(KnowledgeOp::Update, "agent-1", "patched skill")
+                .with_page_id("my-skill")
+                .with_metadata(serde_json::json!({"patch_kind": "update_skill_md"})),
+        );
+        log.save_to_path(&path).unwrap();
+
+        let loaded = KnowledgeActivityLog::load_from_path(&path, 10).unwrap();
+        assert_eq!(loaded.len(), 2);
+        let entries: Vec<_> = loaded.iter().collect();
+        assert_eq!(entries[0].op, KnowledgeOp::Store);
+        assert_eq!(entries[0].summary, "created skill");
+        assert_eq!(entries[1].op, KnowledgeOp::Update);
+        assert_eq!(entries[1].page_id.as_deref(), Some("my-skill"));
+        assert!(entries[1].metadata.is_some());
+    }
+
+    #[test]
+    fn load_missing_file_returns_fresh_log() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("does-not-exist.json");
+        let log = KnowledgeActivityLog::load_from_path(&path, 5).unwrap();
+        assert!(log.is_empty());
+        assert_eq!(log.max_entries(), 5);
+    }
+
+    #[test]
+    fn load_truncates_when_max_entries_shrinks() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("activity.json");
+
+        let mut log = KnowledgeActivityLog::new(10);
+        for i in 0..8 {
+            log.append(make_entry(KnowledgeOp::Store, "s", &format!("e{i}")));
+        }
+        log.save_to_path(&path).unwrap();
+
+        let loaded = KnowledgeActivityLog::load_from_path(&path, 3).unwrap();
+        assert_eq!(loaded.len(), 3);
+        assert_eq!(loaded.max_entries(), 3);
+        let entries: Vec<_> = loaded.iter().collect();
+        assert_eq!(entries[0].summary, "e5");
+        assert_eq!(entries[2].summary, "e7");
+    }
+
+    #[test]
+    fn save_creates_parent_directories() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("nested").join("deep").join("activity.json");
+        let log = KnowledgeActivityLog::new(5);
+        log.save_to_path(&path).unwrap();
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn save_is_atomic_via_rename() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("activity.json");
+        let mut log = KnowledgeActivityLog::new(5);
+        log.append(make_entry(KnowledgeOp::Store, "s", "first"));
+        log.save_to_path(&path).unwrap();
+
+        // Overwrite with new data
+        log.append(make_entry(KnowledgeOp::Update, "s", "second"));
+        log.save_to_path(&path).unwrap();
+
+        let loaded = KnowledgeActivityLog::load_from_path(&path, 5).unwrap();
+        assert_eq!(loaded.len(), 2);
+        // No .tmp file left behind
+        assert!(!tmp.path().join("activity.tmp").exists());
     }
 }

--- a/rust/crates/sera-skills/src/knowledge_activity_log.rs
+++ b/rust/crates/sera-skills/src/knowledge_activity_log.rs
@@ -77,11 +77,7 @@ pub struct KnowledgeActivityEntry {
 
 impl KnowledgeActivityEntry {
     /// Create a new entry with the current UTC timestamp.
-    pub fn new(
-        op: KnowledgeOp,
-        scope: impl Into<String>,
-        summary: impl Into<String>,
-    ) -> Self {
+    pub fn new(op: KnowledgeOp, scope: impl Into<String>, summary: impl Into<String>) -> Self {
         Self {
             timestamp: Utc::now(),
             op,
@@ -293,8 +289,7 @@ impl KnowledgeActivityLog {
 impl KnowledgeActivityLog {
     /// Persist the log as JSON to `path` (atomic write via temp file + rename).
     pub fn save_to_path(&self, path: &Path) -> std::io::Result<()> {
-        let json = serde_json::to_string(self)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+        let json = serde_json::to_string(self).map_err(std::io::Error::other)?;
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;
         }
@@ -410,16 +405,14 @@ mod tests {
 
     #[test]
     fn entry_with_page_id() {
-        let e = make_entry(KnowledgeOp::Update, "agent-1", "updated")
-            .with_page_id("page-42");
+        let e = make_entry(KnowledgeOp::Update, "agent-1", "updated").with_page_id("page-42");
         assert_eq!(e.page_id.as_deref(), Some("page-42"));
     }
 
     #[test]
     fn entry_with_metadata() {
         let meta = serde_json::json!({"lines_changed": 10});
-        let e = make_entry(KnowledgeOp::Update, "agent-1", "updated")
-            .with_metadata(meta.clone());
+        let e = make_entry(KnowledgeOp::Update, "agent-1", "updated").with_metadata(meta.clone());
         assert_eq!(e.metadata, Some(meta));
     }
 
@@ -578,12 +571,8 @@ mod tests {
     #[test]
     fn query_by_page_id() {
         let mut log = KnowledgeActivityLog::new(10);
-        log.append(
-            make_entry(KnowledgeOp::Update, "s", "a").with_page_id("page-1"),
-        );
-        log.append(
-            make_entry(KnowledgeOp::Update, "s", "b").with_page_id("page-2"),
-        );
+        log.append(make_entry(KnowledgeOp::Update, "s", "a").with_page_id("page-1"));
+        log.append(make_entry(KnowledgeOp::Update, "s", "b").with_page_id("page-2"));
         log.append(make_entry(KnowledgeOp::Update, "s", "c")); // no page_id
 
         let results = log.query(&ActivityLogFilter::new().with_page_id("page-1"));
@@ -657,9 +646,7 @@ mod tests {
     #[test]
     fn log_serde_roundtrip_json() {
         let mut log = KnowledgeActivityLog::new(5);
-        log.append(
-            make_entry(KnowledgeOp::Store, "agent-1", "hello").with_page_id("p1"),
-        );
+        log.append(make_entry(KnowledgeOp::Store, "agent-1", "hello").with_page_id("p1"));
         log.append(make_entry(KnowledgeOp::Lint, "agent-1", "lint ok"));
         let json = serde_json::to_string(&log).unwrap();
         let parsed: KnowledgeActivityLog = serde_json::from_str(&json).unwrap();

--- a/rust/crates/sera-skills/src/lib.rs
+++ b/rust/crates/sera-skills/src/lib.rs
@@ -36,6 +36,7 @@ pub mod sources;
 pub mod resolver;
 pub mod lockfile;
 pub mod cli;
+pub mod patch_policy;
 pub mod trigger_dispatcher;
 
 pub use error::SkillsError;
@@ -62,4 +63,5 @@ pub use source::{ResolvedSkill, SkillSearchHit, SkillSource};
 pub use sources::{FileSystemSource, OciSkillPuller, PluginSource, RegistrySource};
 pub use resolver::{ResolvedSkillBundle, SkillResolver, SkillResolverBuilder};
 pub use lockfile::{LockReconciliation, SkillLockEntry, SkillLockFile, LOCKFILE_SCHEMA_VERSION};
+pub use patch_policy::{AllowAllPolicy, PatchRejection, SkillPatchPolicy, Tier1SkillPatchPolicy};
 pub use trigger_dispatcher::{MatchReason, SkillMatch, TriggerDispatcher};

--- a/rust/crates/sera-skills/src/markdown.rs
+++ b/rust/crates/sera-skills/src/markdown.rs
@@ -354,14 +354,13 @@ pub fn parse_skill_markdown_str(
 
     // Derive a SkillConfig. Defaults for markdown skills:
     //   mode    = OnDemand (activation decided at runtime)
-    //   trigger = Always if any keyword triggers are declared, else Manual
+    //   trigger = Manual; frontmatter `triggers` live on the definition and
+    //             TriggerDispatcher matches them as keywords. Mapping keyword
+    //             skills to Always would make every triggered markdown skill
+    //             fire on any non-empty turn.
     //   tools   = frontmatter tools
     //   context_injection = None (body lives on the definition)
-    let trigger = if fm.triggers.is_empty() {
-        SkillTrigger::Manual
-    } else {
-        SkillTrigger::Always
-    };
+    let trigger = SkillTrigger::Manual;
 
     let config = SkillConfig {
         name: fm.name.clone(),
@@ -446,7 +445,7 @@ You are a senior code reviewer. When activated, you systematically examine code.
         // Derived config.
         assert_eq!(parsed.config.name, "code-review");
         assert_eq!(parsed.config.mode, SkillMode::OnDemand);
-        assert_eq!(parsed.config.trigger, SkillTrigger::Always);
+        assert_eq!(parsed.config.trigger, SkillTrigger::Manual);
         assert_eq!(parsed.config.tools, vec!["read_file", "search_code"]);
     }
 

--- a/rust/crates/sera-skills/src/patch_policy.rs
+++ b/rust/crates/sera-skills/src/patch_policy.rs
@@ -1,0 +1,148 @@
+//! Narrow policy interface for governing skill patch operations.
+//!
+//! [`SkillPatchPolicy`] is the Tier 1 boundary check that runs before
+//! `SelfPatchValidator`. Full `sera-meta::PolicyEngine` integration is a
+//! follow-up; this trait is the seam for that wiring.
+
+use std::path::{Path, PathBuf};
+
+/// Why a patch was rejected by policy.
+#[derive(Debug, Clone)]
+pub struct PatchRejection {
+    pub reason: String,
+}
+
+impl std::fmt::Display for PatchRejection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.reason)
+    }
+}
+
+/// Policy gate for skill patch operations.
+pub trait SkillPatchPolicy: Send + Sync {
+    fn check_patch(
+        &self,
+        skill_name: &str,
+        skill_root: &Path,
+        body_bytes: usize,
+    ) -> Result<(), PatchRejection>;
+}
+
+/// Default Tier 1 policy: restricts patches to allowed skill roots and
+/// enforces a per-patch body budget.
+pub struct Tier1SkillPatchPolicy {
+    allowed_roots: Vec<PathBuf>,
+    max_body_bytes: usize,
+}
+
+impl Tier1SkillPatchPolicy {
+    pub fn new(allowed_roots: Vec<PathBuf>, max_body_bytes: usize) -> Self {
+        Self {
+            allowed_roots,
+            max_body_bytes,
+        }
+    }
+}
+
+impl SkillPatchPolicy for Tier1SkillPatchPolicy {
+    fn check_patch(
+        &self,
+        _skill_name: &str,
+        skill_root: &Path,
+        body_bytes: usize,
+    ) -> Result<(), PatchRejection> {
+        let root_ok = self.allowed_roots.iter().any(|allowed| {
+            skill_root.starts_with(allowed) || skill_root == allowed
+        });
+        if !root_ok {
+            return Err(PatchRejection {
+                reason: format!(
+                    "skill root '{}' is not in the allowed roots for Tier 1 patches",
+                    skill_root.display()
+                ),
+            });
+        }
+        if body_bytes > self.max_body_bytes {
+            return Err(PatchRejection {
+                reason: format!(
+                    "patch body {} bytes exceeds Tier 1 budget of {} bytes",
+                    body_bytes, self.max_body_bytes
+                ),
+            });
+        }
+        Ok(())
+    }
+}
+
+/// Permissive policy that approves every patch (for tests or open sandboxes).
+pub struct AllowAllPolicy;
+
+impl SkillPatchPolicy for AllowAllPolicy {
+    fn check_patch(&self, _: &str, _: &Path, _: usize) -> Result<(), PatchRejection> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tier1_allows_patch_within_root_and_budget() {
+        let policy = Tier1SkillPatchPolicy::new(
+            vec![PathBuf::from("/skills")],
+            64 * 1024,
+        );
+        assert!(policy.check_patch("my-skill", Path::new("/skills"), 100).is_ok());
+        assert!(policy.check_patch("my-skill", Path::new("/skills/sub"), 100).is_ok());
+    }
+
+    #[test]
+    fn tier1_rejects_outside_allowed_root() {
+        let policy = Tier1SkillPatchPolicy::new(
+            vec![PathBuf::from("/skills")],
+            64 * 1024,
+        );
+        let err = policy
+            .check_patch("evil", Path::new("/etc"), 10)
+            .unwrap_err();
+        assert!(err.reason.contains("not in the allowed roots"));
+    }
+
+    #[test]
+    fn tier1_rejects_over_budget() {
+        let policy = Tier1SkillPatchPolicy::new(
+            vec![PathBuf::from("/skills")],
+            1024,
+        );
+        let err = policy
+            .check_patch("big", Path::new("/skills"), 2048)
+            .unwrap_err();
+        assert!(err.reason.contains("exceeds Tier 1 budget"));
+    }
+
+    #[test]
+    fn tier1_multiple_roots() {
+        let policy = Tier1SkillPatchPolicy::new(
+            vec![PathBuf::from("/a"), PathBuf::from("/b")],
+            64 * 1024,
+        );
+        assert!(policy.check_patch("s", Path::new("/a"), 10).is_ok());
+        assert!(policy.check_patch("s", Path::new("/b"), 10).is_ok());
+        assert!(policy.check_patch("s", Path::new("/c"), 10).is_err());
+    }
+
+    #[test]
+    fn allow_all_always_permits() {
+        let policy = AllowAllPolicy;
+        assert!(policy.check_patch("x", Path::new("/anywhere"), 999_999).is_ok());
+    }
+
+    #[test]
+    fn rejection_display() {
+        let r = PatchRejection {
+            reason: "too big".into(),
+        };
+        assert_eq!(r.to_string(), "too big");
+    }
+}

--- a/rust/crates/sera-skills/src/patch_policy.rs
+++ b/rust/crates/sera-skills/src/patch_policy.rs
@@ -24,6 +24,7 @@ pub trait SkillPatchPolicy: Send + Sync {
         &self,
         skill_name: &str,
         skill_root: &Path,
+        skill_path: &Path,
         body_bytes: usize,
     ) -> Result<(), PatchRejection>;
 }
@@ -49,16 +50,20 @@ impl SkillPatchPolicy for Tier1SkillPatchPolicy {
         &self,
         _skill_name: &str,
         skill_root: &Path,
+        skill_path: &Path,
         body_bytes: usize,
     ) -> Result<(), PatchRejection> {
+        let skill_root = canonical_or_original(skill_root);
+        let skill_path = canonical_or_original(skill_path);
         let root_ok = self.allowed_roots.iter().any(|allowed| {
-            skill_root.starts_with(allowed) || skill_root == allowed
+            let allowed = canonical_or_original(allowed);
+            skill_root.starts_with(&allowed) && skill_path.starts_with(&allowed)
         });
         if !root_ok {
             return Err(PatchRejection {
                 reason: format!(
-                    "skill root '{}' is not in the allowed roots for Tier 1 patches",
-                    skill_root.display()
+                    "skill path '{}' is not contained by an allowed Tier 1 root",
+                    skill_path.display()
                 ),
             });
         }
@@ -74,11 +79,15 @@ impl SkillPatchPolicy for Tier1SkillPatchPolicy {
     }
 }
 
+fn canonical_or_original(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
 /// Permissive policy that approves every patch (for tests or open sandboxes).
 pub struct AllowAllPolicy;
 
 impl SkillPatchPolicy for AllowAllPolicy {
-    fn check_patch(&self, _: &str, _: &Path, _: usize) -> Result<(), PatchRejection> {
+    fn check_patch(&self, _: &str, _: &Path, _: &Path, _: usize) -> Result<(), PatchRejection> {
         Ok(())
     }
 }
@@ -89,53 +98,107 @@ mod tests {
 
     #[test]
     fn tier1_allows_patch_within_root_and_budget() {
-        let policy = Tier1SkillPatchPolicy::new(
-            vec![PathBuf::from("/skills")],
-            64 * 1024,
+        let policy = Tier1SkillPatchPolicy::new(vec![PathBuf::from("/skills")], 64 * 1024);
+        assert!(
+            policy
+                .check_patch(
+                    "my-skill",
+                    Path::new("/skills"),
+                    Path::new("/skills/my-skill"),
+                    100
+                )
+                .is_ok()
         );
-        assert!(policy.check_patch("my-skill", Path::new("/skills"), 100).is_ok());
-        assert!(policy.check_patch("my-skill", Path::new("/skills/sub"), 100).is_ok());
+        assert!(
+            policy
+                .check_patch(
+                    "my-skill",
+                    Path::new("/skills/sub"),
+                    Path::new("/skills/sub/my-skill"),
+                    100
+                )
+                .is_ok()
+        );
     }
 
     #[test]
     fn tier1_rejects_outside_allowed_root() {
-        let policy = Tier1SkillPatchPolicy::new(
-            vec![PathBuf::from("/skills")],
-            64 * 1024,
-        );
+        let policy = Tier1SkillPatchPolicy::new(vec![PathBuf::from("/skills")], 64 * 1024);
         let err = policy
-            .check_patch("evil", Path::new("/etc"), 10)
+            .check_patch("evil", Path::new("/etc"), Path::new("/etc/evil"), 10)
             .unwrap_err();
-        assert!(err.reason.contains("not in the allowed roots"));
+        assert!(
+            err.reason
+                .contains("not contained by an allowed Tier 1 root")
+        );
     }
 
     #[test]
     fn tier1_rejects_over_budget() {
-        let policy = Tier1SkillPatchPolicy::new(
-            vec![PathBuf::from("/skills")],
-            1024,
-        );
+        let policy = Tier1SkillPatchPolicy::new(vec![PathBuf::from("/skills")], 1024);
         let err = policy
-            .check_patch("big", Path::new("/skills"), 2048)
+            .check_patch("big", Path::new("/skills"), Path::new("/skills/big"), 2048)
             .unwrap_err();
         assert!(err.reason.contains("exceeds Tier 1 budget"));
     }
 
     #[test]
     fn tier1_multiple_roots() {
-        let policy = Tier1SkillPatchPolicy::new(
-            vec![PathBuf::from("/a"), PathBuf::from("/b")],
-            64 * 1024,
+        let policy =
+            Tier1SkillPatchPolicy::new(vec![PathBuf::from("/a"), PathBuf::from("/b")], 64 * 1024);
+        assert!(
+            policy
+                .check_patch("s", Path::new("/a"), Path::new("/a/s"), 10)
+                .is_ok()
         );
-        assert!(policy.check_patch("s", Path::new("/a"), 10).is_ok());
-        assert!(policy.check_patch("s", Path::new("/b"), 10).is_ok());
-        assert!(policy.check_patch("s", Path::new("/c"), 10).is_err());
+        assert!(
+            policy
+                .check_patch("s", Path::new("/b"), Path::new("/b/s"), 10)
+                .is_ok()
+        );
+        assert!(
+            policy
+                .check_patch("s", Path::new("/c"), Path::new("/c/s"), 10)
+                .is_err()
+        );
     }
 
     #[test]
     fn allow_all_always_permits() {
         let policy = AllowAllPolicy;
-        assert!(policy.check_patch("x", Path::new("/anywhere"), 999_999).is_ok());
+        assert!(
+            policy
+                .check_patch(
+                    "x",
+                    Path::new("/anywhere"),
+                    Path::new("/anywhere/x"),
+                    999_999
+                )
+                .is_ok()
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn tier1_rejects_symlink_escape_from_allowed_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        let allowed = tmp.path().join("allowed");
+        let outside = tmp.path().join("outside");
+        std::fs::create_dir_all(&allowed).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        let outside_skill = outside.join("evil.md");
+        std::fs::write(&outside_skill, "---\nname: evil\nversion: 1.0.0\n---\n").unwrap();
+        let linked_skill = allowed.join("evil.md");
+        std::os::unix::fs::symlink(&outside_skill, &linked_skill).unwrap();
+
+        let policy = Tier1SkillPatchPolicy::new(vec![allowed.clone()], 64 * 1024);
+        let err = policy
+            .check_patch("evil", &allowed, &linked_skill, 10)
+            .unwrap_err();
+        assert!(
+            err.reason
+                .contains("not contained by an allowed Tier 1 root")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Durable activity log**: `KnowledgeActivityLog` gains `save_to_path`/`load_from_path` — append-only entries persist to disk via atomic write and reload after process restart.
- **Governed apply (Tier 1 policy)**: New `SkillPatchPolicy` trait with `Tier1SkillPatchPolicy` (allowed-root + body-budget check) gates every `skill-manage patch` call before validation. `skill_management_context_from_env` wires the policy by default.
- **Turn-context integration seam**: `SkillDispatchEngine::prepare_turn_context()` combines trigger dispatch + context injection retrieval in a single call for turn-loop callers. A patched skill is auto-matchable on the next turn without a manual `skill-view`.
- **Richer patch provenance**: Activity log entries now carry `skill_name`, `patch_kind`, `diff_summary`, `root`, `body_bytes`, and `after_hash` — sufficient to reconstruct any patch operation.
- **Fresh-load proof**: Integration test creates a skill, patches it, then instantiates a fresh `SkillDispatchEngine` that loads from disk and proves the patched trigger fires.

## Files changed

| File | Change |
|------|--------|
| `sera-skills/src/knowledge_activity_log.rs` | `save_to_path`/`load_from_path` + 5 persistence tests |
| `sera-skills/src/patch_policy.rs` | New: `SkillPatchPolicy` trait, `Tier1SkillPatchPolicy`, `AllowAllPolicy` + 6 tests |
| `sera-skills/src/lib.rs` | Export new module + types |
| `sera-runtime/src/tools/skill_management.rs` | Policy gate, persistence wiring, provenance enrichment, `context_from_env` default policy + 7 new tests |
| `sera-runtime/src/skill_dispatch.rs` | `prepare_turn_context()` integration seam |

## Test plan

- [x] `cargo test --lib -p sera-skills` — **255 passed** (was 244)
- [x] `cargo test --lib -p sera-runtime -- skill_management` — **49 passed** (was 42)
- [x] `cargo test --lib -p sera-runtime -- skill_dispatch` — **9 passed**
- [x] `cargo test -p sera-skills --test self_patch` — **13 passed**
- [x] `cargo check -p sera-runtime -p sera-skills` — clean, 0 warnings

## Follow-up

- Wire `prepare_turn_context()` into `DefaultRuntime` turn loop (currently the seam exists but the runtime doesn't call it)
- Richer `sera-meta::PolicyEngine` integration replacing the narrow `Tier1SkillPatchPolicy`
- OCSF audit event emission alongside the `KnowledgeActivityLog` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)