### PR TITLE
feat(skills): skill-loop convergence — canonical kebab-case surface + #1299 strengths (discovery, frontmatter compat, index block, properties fix)

### DIFF
--- a/docs/public/specs/SPEC-tools.md
+++ b/docs/public/specs/SPEC-tools.md
@@ -285,6 +285,12 @@ agents:
 > [!NOTE]
 > Progressive disclosure is most valuable in enterprise deployments with large MCP tool surfaces. Tier 1 deployments with <15 tools can use `strategy: "all"` without penalty.
 
+### 4.2 Agent-Visible Skill Tools
+
+The canonical agent-visible skill tool names are `skill-list`, `skill-view`, and `skill-manage` (kebab-case). They let an agent discover installed skills, read a skill's full SKILL.md, and create or patch a skill (governed by the Tier 1 patch policy and recorded in the skill activity log). The snake_case `skills_list` / `skill_view` surface from the B-area lane is superseded by these names.
+
+Skill discovery is shared through `sera_skills::discovery` — a single source of truth that scans `SKILL.md` files recursively to depth 3 plus flat top-level `*.md` files, dedups by skill name, and sorts deterministically. Both `skill-list` and the gateway skill index system-prompt block consume this module, so the index advertises only skills that `skill-view` can resolve (no advertised-but-unviewable skills).
+
 ---
 
 ## 5. Tool Profiles

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5235,6 +5235,7 @@ dependencies = [
  "sera-runtime",
  "sera-secrets",
  "sera-session",
+ "sera-skills",
  "sera-telemetry",
  "sera-testing",
  "sera-tools",

--- a/rust/crates/sera-gateway/Cargo.toml
+++ b/rust/crates/sera-gateway/Cargo.toml
@@ -23,6 +23,7 @@ sera-tools.workspace = true
 sera-config.workspace = true
 sera-errors.workspace = true
 sera-runtime.workspace = true
+sera-skills.workspace = true
 sera-hooks.workspace = true
 sera-hitl.workspace = true
 sera-workflow.workspace = true

--- a/rust/crates/sera-gateway/src/bin/sera.rs
+++ b/rust/crates/sera-gateway/src/bin/sera.rs
@@ -4309,6 +4309,19 @@ fn append_transcript_history_messages(
     }
 }
 
+/// Build the Hermes-parity skill index block (plan area B) for this turn.
+///
+/// Scanned fresh on every turn — deliberately NOT cached: `skill-manage` can
+/// create or patch skills at runtime, and a memoised block would advertise a
+/// stale index until restart while `skill-list` rescans live. The scan is a
+/// depth-3 walk of the skills directory (resolved from `SERA_SKILLS_DIR`,
+/// matching the `SkillDispatchEngine` boot default of `./skills`), which is
+/// negligible next to an LLM turn.
+async fn skill_index_block() -> Option<String> {
+    let skills_dir = std::env::var("SERA_SKILLS_DIR").unwrap_or_else(|_| "./skills".to_string());
+    sera_gateway::skill_index::build_skill_index_context(std::path::Path::new(&skills_dir)).await
+}
+
 /// Execute a turn by dispatching through the agent's [`AgentTurnTransport`].
 ///
 /// The gateway builds the conversation messages from the transcript and
@@ -4368,6 +4381,19 @@ async fn execute_turn(
         messages.push(serde_json::json!({
             "role": "system",
             "content": injection,
+        }));
+    }
+
+    // ── Skill index (Hermes parity, plan area B): inject a stable,
+    // descriptions-only listing of available skills with mandatory-load
+    // guidance. Placed alongside the trigger-matched skill injections so the
+    // agent sees what it can load via `skill-view` before the transcript is
+    // replayed. Rebuilt each turn so skills created via `skill-manage` appear
+    // without restart; only present when at least one skill is discoverable.
+    if let Some(block) = skill_index_block().await {
+        messages.push(serde_json::json!({
+            "role": "system",
+            "content": block,
         }));
     }
 

--- a/rust/crates/sera-gateway/src/lib.rs
+++ b/rust/crates/sera-gateway/src/lib.rs
@@ -28,6 +28,7 @@ pub mod scheduler;
 pub mod session_persist;
 pub mod session_store;
 pub mod signals;
+pub mod skill_index;
 pub mod transcript_persist;
 pub mod transport;
 pub mod workflow_store;

--- a/rust/crates/sera-gateway/src/skill_index.rs
+++ b/rust/crates/sera-gateway/src/skill_index.rs
@@ -1,0 +1,193 @@
+//! Skill index system-prompt block (Hermes parity, plan area B).
+//!
+//! Hermes injects a stable system-prompt block that lists the skills available
+//! in the runtime — descriptions only — with mandatory-load guidance: if a
+//! skill matches the task, the agent MUST load its full instructions before
+//! answering. SERA mirrors that contract here: scan the skills directory, parse
+//! each SKILL.md (and legacy flat `*.md`) via [`sera_skills::md_loader`], and
+//! render a descriptions-only block that points the agent at the `skill-view`
+//! and `skill-list` tools.
+//!
+//! The block is intentionally body-free: it advertises availability, not
+//! contents. The agent pulls full instructions on demand through `skill-view`.
+
+use std::path::Path;
+
+use sera_skills::discovery::discover_skills;
+
+/// Soft cap on the rendered block size. When the listing would exceed this,
+/// the tail is truncated and replaced with a `…and N more` pointer line.
+const MAX_BLOCK_CHARS: usize = 4000;
+
+/// Maximum length of a single skill description in the rendered block.
+/// Longer descriptions are clamped with a trailing `…`.
+const MAX_DESC_CHARS: usize = 200;
+
+/// Build the Hermes-parity skill index system-prompt block.
+///
+/// Discovers skills via [`discover_skills`] (the shared single source of truth
+/// for both layouts and name de-duplication). Returns `None` when the directory
+/// is missing/empty or no skill parses successfully. Otherwise renders a
+/// descriptions-only block sorted by skill name and capped at
+/// [`MAX_BLOCK_CHARS`].
+pub async fn build_skill_index_context(skills_dir: &Path) -> Option<String> {
+    let skills = discover_skills(skills_dir).await;
+    if skills.is_empty() {
+        return None;
+    }
+
+    // discover_skills already sorts by name and dedups; map to (name, desc).
+    let entries: Vec<(String, String)> = skills
+        .into_iter()
+        .map(|(skill, _)| (skill.name, skill.description))
+        .collect();
+
+    Some(render_block(&entries))
+}
+
+/// Sanitise a description for single-line rendering: collapse any `\n`/`\r`
+/// into a space and clamp to [`MAX_DESC_CHARS`] (appending `…` when clamped).
+fn sanitize_description(description: &str) -> String {
+    let single_line: String = description
+        .chars()
+        .map(|c| if c == '\n' || c == '\r' { ' ' } else { c })
+        .collect();
+    if single_line.chars().count() > MAX_DESC_CHARS {
+        let clamped: String = single_line.chars().take(MAX_DESC_CHARS).collect();
+        format!("{clamped}…")
+    } else {
+        single_line
+    }
+}
+
+/// Render the descriptions-only block, truncating the list to stay under
+/// [`MAX_BLOCK_CHARS`] with a `…and N more` pointer when necessary.
+fn render_block(entries: &[(String, String)]) -> String {
+    let header = "## Skills (mandatory)\n\
+        The following skills are available in this runtime. Before answering, check whether one matches the task. If a skill matches, you MUST load its full instructions with the `skill-view` tool (pass its name); err on the side of loading. Use `skill-list` to re-check availability.\n\n";
+
+    let mut block = String::from(header);
+    for (idx, (name, description)) in entries.iter().enumerate() {
+        let line = format!("- {name}: {}\n", sanitize_description(description));
+        let remaining = entries.len() - idx;
+        // Reserve room for a possible `…and N more` line so the cap holds even
+        // after truncation.
+        let pointer = format!("…and {remaining} more (use skill-list)\n");
+        if block.len() + line.len() + pointer.len() > MAX_BLOCK_CHARS && idx > 0 {
+            block.push_str(&pointer);
+            return block;
+        }
+        block.push_str(&line);
+    }
+    block
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn write_skill_md(path: &Path, name: &str, description: &str) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(
+            path,
+            format!("---\nname: {name}\ndescription: {description}\n---\n\nbody for {name}\n"),
+        )
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn renders_names_and_descriptions_from_both_layouts() {
+        let dir = TempDir::new().unwrap();
+        // Nested SKILL.md layout.
+        write_skill_md(
+            &dir.path().join("invoices/SKILL.md"),
+            "lookup-invoice",
+            "Find an invoice by id",
+        );
+        // Legacy flat layout.
+        write_skill_md(&dir.path().join("greet.md"), "greeter", "Say hello");
+
+        let block = build_skill_index_context(dir.path()).await.unwrap();
+
+        assert!(block.contains("## Skills (mandatory)"));
+        assert!(block.contains("skill-view"));
+        assert!(block.contains("- greeter: Say hello"));
+        assert!(block.contains("- lookup-invoice: Find an invoice by id"));
+        // Body must not leak.
+        assert!(!block.contains("body for"));
+        // Sorted by name: greeter before lookup-invoice.
+        let g = block.find("greeter").unwrap();
+        let l = block.find("lookup-invoice").unwrap();
+        assert!(g < l);
+    }
+
+    #[tokio::test]
+    async fn missing_dir_returns_none() {
+        let dir = TempDir::new().unwrap();
+        let missing = dir.path().join("does-not-exist");
+        assert!(build_skill_index_context(&missing).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn empty_dir_returns_none() {
+        let dir = TempDir::new().unwrap();
+        assert!(build_skill_index_context(dir.path()).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn unparseable_skills_are_skipped() {
+        let dir = TempDir::new().unwrap();
+        // Missing required `description` frontmatter → parse error, skipped.
+        fs::write(dir.path().join("broken.md"), "---\nname: broken\n---\nbody\n").unwrap();
+        write_skill_md(&dir.path().join("ok.md"), "ok-skill", "works fine");
+
+        let block = build_skill_index_context(dir.path()).await.unwrap();
+        assert!(block.contains("- ok-skill: works fine"));
+        assert!(!block.contains("broken"));
+    }
+
+    #[tokio::test]
+    async fn multiline_description_renders_on_one_line() {
+        let dir = TempDir::new().unwrap();
+        // A description spanning multiple lines (CRLF + LF) in the YAML.
+        fs::write(
+            dir.path().join("multi.md"),
+            "---\nname: multi\ndescription: \"line one\\nline two\\r\\nline three\"\n---\n\nbody\n",
+        )
+        .unwrap();
+
+        let block = build_skill_index_context(dir.path()).await.unwrap();
+
+        // The skill line must contain all three fragments but no embedded newline.
+        let line = block
+            .lines()
+            .find(|l| l.starts_with("- multi:"))
+            .expect("multi skill line present");
+        assert!(line.contains("line one"));
+        assert!(line.contains("line two"));
+        assert!(line.contains("line three"));
+        assert!(!line.contains('\r'), "carriage return must be sanitised");
+    }
+
+    #[tokio::test]
+    async fn caps_block_with_pointer_when_many_skills() {
+        let dir = TempDir::new().unwrap();
+        // Many skills with long descriptions to blow past the cap.
+        let long_desc = "x".repeat(200);
+        for i in 0..100 {
+            write_skill_md(
+                &dir.path().join(format!("skill{i:03}.md")),
+                &format!("skill{i:03}"),
+                &long_desc,
+            );
+        }
+
+        let block = build_skill_index_context(dir.path()).await.unwrap();
+        assert!(block.len() <= MAX_BLOCK_CHARS, "block len = {}", block.len());
+        assert!(block.contains("more (use skill-list)"));
+    }
+}

--- a/rust/crates/sera-runtime/src/tools/skill_management.rs
+++ b/rust/crates/sera-runtime/src/tools/skill_management.rs
@@ -163,43 +163,35 @@ async fn discover_skills(roots: &[PathBuf], query: Option<&str>) -> Vec<SkillLis
         if !root.exists() {
             continue;
         }
-        let Ok(mut reader) = tokio::fs::read_dir(root).await else {
-            continue;
-        };
-        while let Ok(Some(entry)) = reader.next_entry().await {
+
+        // Route through the shared recursive discovery so skill-list advertises
+        // exactly the skills the gateway index and skill-view can resolve
+        // (Hermes-layout SKILL.md to depth 3 + flat top-level *.md). The shared
+        // module already dedups by name within a root; we dedup across roots
+        // (first root wins) to preserve the existing collision semantics.
+        for (skill, _path) in sera_skills::discovery::discover_skills(root).await {
             if entries.len() >= MAX_LIST_ENTRIES {
                 break;
             }
-            let path = entry.path();
 
-            // Candidate detection aligned with SkillDispatchEngine::load_dir:
-            // top-level *.md file OR directory containing SKILL.md.
-            let is_candidate = (path.is_dir() && path.join("SKILL.md").exists())
-                || (path.is_file() && path.extension().and_then(|e| e.to_str()) == Some("md"));
-            if !is_candidate {
-                continue;
-            }
-
-            // Parse frontmatter to get the authoritative name the runtime
-            // loader registers, not the path-derived basename.
-            let Some(fm) = extract_skill_frontmatter(&path).await else {
-                continue;
-            };
-
-            if !seen_names.insert(fm.name.clone()) {
+            if !seen_names.insert(skill.name.clone()) {
                 continue;
             }
 
             if let Some(q) = query
-                && !fm.name.contains(q)
+                && !skill.name.contains(q)
             {
                 continue;
             }
 
             entries.push(SkillListEntry {
-                name: fm.name,
-                description: fm.description,
-                version: fm.version,
+                name: skill.name,
+                description: if skill.description.is_empty() {
+                    None
+                } else {
+                    Some(skill.description)
+                },
+                version: skill.version,
                 source: root.display().to_string(),
             });
         }
@@ -207,47 +199,12 @@ async fn discover_skills(roots: &[PathBuf], query: Option<&str>) -> Vec<SkillLis
     entries
 }
 
-struct SkillFrontmatter {
-    name: String,
-    description: Option<String>,
-    version: Option<String>,
-}
-
-/// Parse skill frontmatter using the same parser as `SkillDispatchEngine::load_dir`.
-/// Returns `None` if the file is missing, unparseable, or has an invalid name —
-/// so `skill-list` only advertises skills the runtime actually loads.
-async fn extract_skill_frontmatter(path: &Path) -> Option<SkillFrontmatter> {
-    let content_path = if path.is_dir() {
-        let skill_md = path.join("SKILL.md");
-        if skill_md.exists() {
-            skill_md
-        } else {
-            return None;
-        }
-    } else {
-        path.to_path_buf()
-    };
-
-    let content = tokio::fs::read_to_string(&content_path).await.ok()?;
-    let parsed = parse_skill_markdown_str(&content, content_path).ok()?;
-    Some(SkillFrontmatter {
-        name: parsed.config.name,
-        description: if parsed.config.description.is_empty() {
-            None
-        } else {
-            Some(parsed.config.description)
-        },
-        version: if parsed.config.version.is_empty() {
-            None
-        } else {
-            Some(parsed.config.version)
-        },
-    })
-}
-
 /// Scan roots for a skill whose frontmatter `name` matches `target_name`.
 /// Returns the content file path and the root it was found in. Used as a
 /// fallback when path-based lookup fails (basename != frontmatter name).
+///
+/// Uses the shared recursive discovery so any skill `skill-list` advertises is
+/// also viewable (the advertised-but-unviewable invariant).
 async fn find_by_frontmatter_name(
     roots: &[PathBuf],
     target_name: &str,
@@ -256,28 +213,9 @@ async fn find_by_frontmatter_name(
         if !root.exists() {
             continue;
         }
-        let Ok(mut reader) = tokio::fs::read_dir(root).await else {
-            continue;
-        };
-        while let Ok(Some(entry)) = reader.next_entry().await {
-            let path = entry.path();
-            let content_path = if path.is_dir() {
-                let skill_md = path.join("SKILL.md");
-                if skill_md.exists() {
-                    skill_md
-                } else {
-                    continue;
-                }
-            } else if path.is_file() && path.extension().and_then(|e| e.to_str()) == Some("md") {
-                path.clone()
-            } else {
-                continue;
-            };
-            if let Ok(content) = tokio::fs::read_to_string(&content_path).await
-                && let Ok(parsed) = parse_skill_markdown_str(&content, content_path.clone())
-                && parsed.config.name == target_name
-            {
-                return Some((content_path, root.clone()));
+        for (skill, path) in sera_skills::discovery::discover_skills(root).await {
+            if skill.name == target_name {
+                return Some((path, root.clone()));
             }
         }
     }
@@ -1218,6 +1156,65 @@ mod tests {
         let input = make_input("skill-view", serde_json::json!({"name": "../escape"}));
         let err = tool.execute(input, make_ctx()).await.unwrap_err();
         assert!(matches!(err, ToolError::InvalidInput(_)));
+    }
+
+    #[tokio::test]
+    async fn nested_hermes_skill_is_listed_and_viewable() {
+        // A Hermes-layout skill nested at depth 2 (group/research/SKILL.md)
+        // must be advertised by skill-list AND resolvable by skill-view — the
+        // advertised-but-unviewable invariant. Both route through the shared
+        // recursive discovery module.
+        let tmp = tempfile::tempdir().unwrap();
+        let nested = tmp.path().join("group").join("research");
+        tokio::fs::create_dir_all(&nested).await.unwrap();
+        tokio::fs::write(
+            nested.join("SKILL.md"),
+            &skill_body("research", "Nested research skill"),
+        )
+        .await
+        .unwrap();
+
+        let ctx = Arc::new(SkillManagementContext::new(vec![tmp.path().to_path_buf()]));
+
+        // skill-list advertises it.
+        let list = SkillList::new(Arc::clone(&ctx));
+        let list_out = list
+            .execute(
+                make_input("skill-list", serde_json::json!({})),
+                make_ctx(),
+            )
+            .await
+            .unwrap();
+        let list_parsed: serde_json::Value = serde_json::from_str(&list_out.content).unwrap();
+        let names: Vec<&str> = list_parsed["skills"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|s| s["name"].as_str().unwrap())
+            .collect();
+        assert!(
+            names.contains(&"research"),
+            "nested skill must be listed: {names:?}"
+        );
+
+        // skill-view resolves it (via the recursive fallback).
+        let view = SkillView::new(ctx);
+        let view_out = view
+            .execute(
+                make_input("skill-view", serde_json::json!({"name": "research"})),
+                make_ctx(),
+            )
+            .await
+            .unwrap();
+        assert!(!view_out.is_error);
+        let view_parsed: serde_json::Value = serde_json::from_str(&view_out.content).unwrap();
+        assert_eq!(view_parsed["name"], "research");
+        assert!(
+            view_parsed["content"]
+                .as_str()
+                .unwrap()
+                .contains("Nested research skill")
+        );
     }
 
     // ── SkillManage: create ─────────────────────────────────────────────

--- a/rust/crates/sera-skills/src/discovery.rs
+++ b/rust/crates/sera-skills/src/discovery.rs
@@ -1,0 +1,223 @@
+//! Skill discovery — single source of truth for locating SKILL.md files.
+//!
+//! Shared by the gateway's system-prompt index block and the resident
+//! `skills_list` / `skill_view` tools. Divergence here previously let the
+//! index advertise skills the tools couldn't resolve (the index scanned
+//! recursively and deduped by name, while the tools scanned one level and
+//! didn't), so name collisions returned arbitrary bodies. Both call sites now
+//! route through [`discover_skills`].
+//!
+//! Two layouts are supported:
+//! - **Hermes layout**: `SKILL.md` files found recursively up to [`MAX_DEPTH`].
+//! - **Flat layout**: top-level `*.md` files directly under the skills dir
+//!   (case-insensitive `md` extension).
+
+use std::path::{Path, PathBuf};
+
+use tracing::warn;
+
+use crate::md_loader::{load_skill_md, Skill};
+
+/// Maximum directory recursion depth when scanning for `SKILL.md` files.
+pub const MAX_DEPTH: usize = 3;
+
+/// Discover all skills under `skills_dir`.
+///
+/// Collects (a) `SKILL.md` files recursively up to [`MAX_DEPTH`] and (b)
+/// top-level `*.md` files (legacy flat layout). File paths are de-duplicated
+/// first (a top-level `SKILL.md` matches both scans). Each file is parsed via
+/// [`load_skill_md`]; parse failures emit a `warn!` and are skipped.
+///
+/// Results are sorted by `(name, path)` for determinism, then de-duplicated by
+/// name keeping the **first** entry — each collision emits a `warn!` naming
+/// both paths.
+///
+/// Returns `Vec<(Skill, skill_file_path)>`.
+pub async fn discover_skills(skills_dir: &Path) -> Vec<(Skill, PathBuf)> {
+    let mut paths: Vec<PathBuf> = Vec::new();
+    collect_skill_md(skills_dir, 0, &mut paths);
+    collect_flat_md(skills_dir, &mut paths);
+
+    // De-duplicate file paths (a top-level file literally named SKILL.md
+    // matches both scans).
+    paths.sort();
+    paths.dedup();
+
+    let mut results: Vec<(Skill, PathBuf)> = Vec::new();
+    for path in paths {
+        match load_skill_md(&path).await {
+            Ok(skill) => results.push((skill, path)),
+            Err(err) => warn!(
+                path = %path.display(),
+                error = %err,
+                "skill discovery: skipping unparseable skill"
+            ),
+        }
+    }
+
+    // Sort by (name, path) for deterministic collision resolution.
+    results.sort_by(|(a, ap), (b, bp)| a.name.cmp(&b.name).then_with(|| ap.cmp(bp)));
+
+    // De-duplicate by name, keeping the first entry; warn on each collision.
+    let mut deduped: Vec<(Skill, PathBuf)> = Vec::with_capacity(results.len());
+    for (skill, path) in results {
+        if let Some((kept, kept_path)) = deduped.last()
+            && kept.name == skill.name
+        {
+            warn!(
+                name = %skill.name,
+                kept = %kept_path.display(),
+                dropped = %path.display(),
+                "skill discovery: duplicate skill name, keeping first"
+            );
+            continue;
+        }
+        deduped.push((skill, path));
+    }
+
+    deduped
+}
+
+/// Recursively collect `SKILL.md` files under `dir` up to [`MAX_DEPTH`].
+fn collect_skill_md(dir: &Path, depth: usize, out: &mut Vec<PathBuf>) {
+    if depth > MAX_DEPTH {
+        return;
+    }
+    let Ok(read_dir) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in read_dir.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_skill_md(&path, depth + 1, out);
+        } else if path.file_name().and_then(|n| n.to_str()) == Some("SKILL.md") {
+            out.push(path);
+        }
+    }
+}
+
+/// Collect top-level `*.md` files directly under `dir` (legacy flat layout).
+fn collect_flat_md(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(read_dir) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in read_dir.flatten() {
+        let path = entry.path();
+        if path.is_file()
+            && path
+                .extension()
+                .and_then(|e| e.to_str())
+                .is_some_and(|e| e.eq_ignore_ascii_case("md"))
+        {
+            out.push(path);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn write_skill_md(path: &Path, name: &str, description: &str) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(
+            path,
+            format!("---\nname: {name}\ndescription: {description}\n---\n\nbody for {name}\n"),
+        )
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn finds_hermes_and_flat_layouts() {
+        let dir = TempDir::new().unwrap();
+        write_skill_md(
+            &dir.path().join("invoices/SKILL.md"),
+            "lookup-invoice",
+            "Find an invoice by id",
+        );
+        write_skill_md(&dir.path().join("greet.md"), "greeter", "Say hello");
+
+        let skills = discover_skills(dir.path()).await;
+        let names: Vec<&str> = skills.iter().map(|(s, _)| s.name.as_str()).collect();
+        assert!(names.contains(&"lookup-invoice"), "missing hermes skill");
+        assert!(names.contains(&"greeter"), "missing flat skill");
+        // Sorted by name: greeter < lookup-invoice.
+        assert_eq!(names, vec!["greeter", "lookup-invoice"]);
+    }
+
+    #[tokio::test]
+    async fn depth_two_nested_skill_is_found() {
+        let dir = TempDir::new().unwrap();
+        // group/research/SKILL.md — depth 2 (group=1, research=2), within MAX_DEPTH.
+        write_skill_md(
+            &dir.path().join("group/research/SKILL.md"),
+            "research",
+            "Nested research skill",
+        );
+
+        let skills = discover_skills(dir.path()).await;
+        let names: Vec<&str> = skills.iter().map(|(s, _)| s.name.as_str()).collect();
+        assert!(names.contains(&"research"), "depth-2 nested skill not found");
+    }
+
+    #[tokio::test]
+    async fn depth_beyond_max_is_not_found() {
+        let dir = TempDir::new().unwrap();
+        // a/b/c/d/SKILL.md — SKILL.md sits at depth 4, beyond MAX_DEPTH=3.
+        write_skill_md(
+            &dir.path().join("a/b/c/d/SKILL.md"),
+            "too-deep",
+            "Should not be discovered",
+        );
+
+        let skills = discover_skills(dir.path()).await;
+        let names: Vec<&str> = skills.iter().map(|(s, _)| s.name.as_str()).collect();
+        assert!(
+            !names.contains(&"too-deep"),
+            "skill beyond MAX_DEPTH should not be found, got: {names:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn name_collision_yields_one_deterministic_entry() {
+        let dir = TempDir::new().unwrap();
+        // Both resolve to name `foo`: a flat `foo.md` and a `foo/SKILL.md`.
+        write_skill_md(&dir.path().join("foo.md"), "foo", "flat foo");
+        write_skill_md(&dir.path().join("foo/SKILL.md"), "foo", "hermes foo");
+
+        let skills = discover_skills(dir.path()).await;
+        let foos: Vec<&(Skill, PathBuf)> =
+            skills.iter().filter(|(s, _)| s.name == "foo").collect();
+        assert_eq!(foos.len(), 1, "collision should yield exactly one entry");
+
+        // Determinism: sorted by (name, path), first path wins. `Path` ordering
+        // compares component-by-component, so `<dir>/foo/SKILL.md` vs
+        // `<dir>/foo.md` is decided by the first differing component: the dir
+        // component `foo` is a prefix of the file component `foo.md`, so `foo`
+        // sorts first and `foo/SKILL.md` is kept every run.
+        let kept = &foos[0].1;
+        assert_eq!(
+            kept,
+            &dir.path().join("foo").join("SKILL.md"),
+            "collision must deterministically keep foo/SKILL.md"
+        );
+        assert_eq!(foos[0].0.description, "hermes foo");
+    }
+
+    #[tokio::test]
+    async fn unparseable_file_is_skipped() {
+        let dir = TempDir::new().unwrap();
+        // Missing required `description` → parse error, skipped.
+        fs::write(dir.path().join("broken.md"), "---\nname: broken\n---\nbody\n").unwrap();
+        write_skill_md(&dir.path().join("ok.md"), "ok-skill", "works fine");
+
+        let skills = discover_skills(dir.path()).await;
+        let names: Vec<&str> = skills.iter().map(|(s, _)| s.name.as_str()).collect();
+        assert!(names.contains(&"ok-skill"), "valid skill should be present");
+        assert!(!names.contains(&"broken"), "unparseable skill should be skipped");
+    }
+}

--- a/rust/crates/sera-skills/src/lib.rs
+++ b/rust/crates/sera-skills/src/lib.rs
@@ -23,6 +23,7 @@ pub mod error;
 pub mod self_patch;
 pub mod loader;
 pub mod md_loader;
+pub mod discovery;
 pub mod skill_pack;
 pub mod bundle;
 pub mod markdown;

--- a/rust/crates/sera-skills/src/md_loader.rs
+++ b/rust/crates/sera-skills/src/md_loader.rs
@@ -49,12 +49,28 @@ pub const DEFAULT_TIER: u8 = 1;
 
 /// Recognised frontmatter keys. Anything outside this set is logged and
 /// dropped so legacy / experimental fields don't cause loads to fail.
-const KNOWN_KEYS: &[&str] = &["name", "description", "inputs", "tier"];
+const KNOWN_KEYS: &[&str] = &[
+    "name",
+    "description",
+    "inputs",
+    "tier",
+    // Hermes-compatible extension fields.
+    "version",
+    "platforms",
+    "environments",
+    "requires_toolsets",
+    "requires_tools",
+    "metadata",
+    "fallback_for_platforms",
+    "fallback_for_environments",
+];
 
 /// A parsed SKILL.md file.
 ///
 /// Carries the four load-bearing fields plus the raw markdown body, which
-/// downstream code injects into the agent prompt.
+/// downstream code injects into the agent prompt. Hermes-compatible extension
+/// fields are optional and default to empty / `None` so existing skills that
+/// omit them continue to parse identically.
 #[derive(Debug, Clone)]
 pub struct Skill {
     /// Stable identifier for the skill; matches the file's `name` field.
@@ -71,6 +87,51 @@ pub struct Skill {
     pub body: String,
     /// Absolute path the skill was loaded from, when known.
     pub source_path: Option<PathBuf>,
+
+    // --- Hermes-compatible extension fields ---
+    /// Semantic version string (e.g. `"1.2.0"`). Hermes uses string versions.
+    pub version: Option<String>,
+    /// Platform identifiers this skill targets (e.g. `["linux", "darwin"]`).
+    /// Empty means "all platforms".
+    pub platforms: Vec<String>,
+    /// Runtime environment tags (e.g. `["docker"]`).
+    pub environments: Vec<String>,
+    /// Named toolsets required by this skill (e.g. `["terminal", "web"]`).
+    pub requires_toolsets: Vec<String>,
+    /// Individual tool names required by this skill.
+    pub requires_tools: Vec<String>,
+    /// Platforms this skill acts as a fallback for.
+    pub fallback_for_platforms: Vec<String>,
+    /// Environments this skill acts as a fallback for.
+    pub fallback_for_environments: Vec<String>,
+    /// Raw metadata blob. Hermes nests its own data under the `hermes` key
+    /// inside this map.
+    pub metadata: Option<serde_yaml::Value>,
+}
+
+impl Skill {
+    /// Returns the `metadata.hermes` sub-value if present.
+    ///
+    /// Hermes stores tags, related skills, and config under a `hermes`
+    /// namespace inside the top-level `metadata` mapping. This helper avoids
+    /// manual YAML navigation at every call site.
+    pub fn hermes_metadata(&self) -> Option<&serde_yaml::Value> {
+        self.metadata
+            .as_ref()
+            .and_then(|m| m.get("hermes"))
+    }
+
+    /// Returns `true` when this skill applies to the given `platform`.
+    ///
+    /// A skill with an empty `platforms` list is treated as a wildcard —
+    /// it applies to every platform. The comparison is case-insensitive.
+    pub fn matches_platform(&self, platform: &str) -> bool {
+        self.platforms.is_empty()
+            || self
+                .platforms
+                .iter()
+                .any(|p| p.eq_ignore_ascii_case(platform))
+    }
 }
 
 /// Intermediate frontmatter shape. Mirrors the public SKILL.md schema.
@@ -84,6 +145,23 @@ struct Frontmatter {
     inputs: HashMap<String, String>,
     #[serde(default)]
     tier: Option<u8>,
+    // Hermes-compatible extension fields.
+    #[serde(default)]
+    version: Option<String>,
+    #[serde(default)]
+    platforms: Vec<String>,
+    #[serde(default)]
+    environments: Vec<String>,
+    #[serde(default)]
+    requires_toolsets: Vec<String>,
+    #[serde(default)]
+    requires_tools: Vec<String>,
+    #[serde(default)]
+    fallback_for_platforms: Vec<String>,
+    #[serde(default)]
+    fallback_for_environments: Vec<String>,
+    #[serde(default)]
+    metadata: Option<serde_yaml::Value>,
 }
 
 /// Split raw SKILL.md text at the leading `---` fences.
@@ -206,6 +284,14 @@ pub fn parse_skill_md(raw: &str, source_path: Option<PathBuf>) -> Result<Skill, 
         tier,
         body,
         source_path,
+        version: fm.version,
+        platforms: fm.platforms,
+        environments: fm.environments,
+        requires_toolsets: fm.requires_toolsets,
+        requires_tools: fm.requires_tools,
+        fallback_for_platforms: fm.fallback_for_platforms,
+        fallback_for_environments: fm.fallback_for_environments,
+        metadata: fm.metadata,
     })
 }
 
@@ -396,5 +482,109 @@ mod tests {
         let path = dir.path().join("does-not-exist.md");
         let err = load_skill_md(&path).await.unwrap_err();
         assert!(matches!(err, SkillsError::Io(_)));
+    }
+
+    #[test]
+    fn parses_hermes_skill_frontmatter_fields() {
+        let raw = "\
+---
+name: research-web
+description: Search the web and synthesise a cited report
+version: \"1.2.0\"
+platforms:
+  - linux
+  - darwin
+environments:
+  - docker
+requires_toolsets:
+  - terminal
+  - web
+metadata:
+  hermes:
+    tags:
+      - research
+    related_skills:
+      - other-skill
+    config:
+      foo: bar
+---
+
+# Behaviour
+Search and report.
+";
+        let skill = parse_skill_md(raw, None).unwrap();
+        assert_eq!(skill.name, "research-web");
+        assert_eq!(skill.description, "Search the web and synthesise a cited report");
+        assert_eq!(skill.version.as_deref(), Some("1.2.0"));
+        assert_eq!(skill.platforms, vec!["linux", "darwin"]);
+        assert_eq!(skill.environments, vec!["docker"]);
+        assert_eq!(skill.requires_toolsets, vec!["terminal", "web"]);
+        assert!(skill.requires_tools.is_empty());
+
+        let hermes = skill.hermes_metadata().expect("hermes metadata present");
+        let tags = hermes.get("tags").and_then(|v| v.as_sequence()).expect("tags list");
+        assert_eq!(tags.len(), 1);
+        assert_eq!(tags[0].as_str(), Some("research"));
+
+        let related = hermes
+            .get("related_skills")
+            .and_then(|v| v.as_sequence())
+            .expect("related_skills list");
+        assert_eq!(related[0].as_str(), Some("other-skill"));
+
+        let foo = hermes
+            .get("config")
+            .and_then(|v| v.get("foo"))
+            .and_then(|v| v.as_str());
+        assert_eq!(foo, Some("bar"));
+    }
+
+    #[test]
+    fn legacy_minimal_skill_still_parses() {
+        // A bare 2-field skill (no tier, no new Hermes fields) must parse
+        // identically to before this extension.
+        let raw = "---\nname: minimal\ndescription: just the basics\n---\nbody\n";
+        let skill = parse_skill_md(raw, None).unwrap();
+        assert_eq!(skill.name, "minimal");
+        assert_eq!(skill.description, "just the basics");
+        assert_eq!(skill.tier, DEFAULT_TIER);
+        assert!(skill.version.is_none());
+        assert!(skill.platforms.is_empty());
+        assert!(skill.environments.is_empty());
+        assert!(skill.requires_toolsets.is_empty());
+        assert!(skill.requires_tools.is_empty());
+        assert!(skill.fallback_for_platforms.is_empty());
+        assert!(skill.fallback_for_environments.is_empty());
+        assert!(skill.metadata.is_none());
+    }
+
+    #[test]
+    fn matches_platform_empty_is_wildcard() {
+        let raw = "---\nname: x\ndescription: y\n---\nbody\n";
+        let skill = parse_skill_md(raw, None).unwrap();
+        assert!(skill.platforms.is_empty());
+        assert!(skill.matches_platform("linux"));
+        assert!(skill.matches_platform("windows"));
+        assert!(skill.matches_platform("anything"));
+    }
+
+    #[test]
+    fn matches_platform_mismatch() {
+        let raw = "\
+---
+name: x
+description: y
+platforms:
+  - linux
+  - darwin
+---
+body
+";
+        let skill = parse_skill_md(raw, None).unwrap();
+        assert!(skill.matches_platform("linux"));
+        assert!(skill.matches_platform("Linux")); // case-insensitive
+        assert!(skill.matches_platform("Darwin"));
+        assert!(!skill.matches_platform("windows"));
+        assert!(!skill.matches_platform("freebsd"));
     }
 }

--- a/rust/crates/sera-types/src/tool.rs
+++ b/rust/crates/sera-types/src/tool.rs
@@ -29,7 +29,10 @@ pub struct FunctionDefinition {
 pub struct FunctionParameters {
     #[serde(rename = "type")]
     pub schema_type: String,
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    // Always serialized (even when empty): OpenAI-compatible backends such as
+    // LM Studio reject a function schema whose `parameters.properties` is
+    // missing, so a no-argument tool must emit `"properties": {}`.
+    #[serde(default)]
     pub properties: HashMap<String, ParameterSchema>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub required: Vec<String>,
@@ -1052,6 +1055,21 @@ mod tests {
         let json = serde_json::to_string(&schema).unwrap();
         let parsed: ToolSchema = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.parameters.schema_type, "object");
+    }
+
+    /// A no-argument tool (e.g. `skills_list`) must still serialize
+    /// `"properties": {}` — LM Studio's OpenAI-compat endpoint returns
+    /// HTTP 400 (`invalid_type` on `function.parameters.properties`) when
+    /// the key is absent.
+    #[test]
+    fn empty_function_parameters_serialize_properties_key() {
+        let params = FunctionParameters {
+            schema_type: "object".to_string(),
+            properties: HashMap::new(),
+            required: vec![],
+        };
+        let value = serde_json::to_value(&params).unwrap();
+        assert_eq!(value["properties"], serde_json::json!({}));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Resolves the **#1288 (main) vs #1299** skill-loop architecture divergence with one convergence slice from fresh `origin/main`.

**Decision:** canonical agent-visible skill tools are main's kebab-case `skill-list` / `skill-view` / `skill-manage` (merged, governed: patch policy, activity log, safe-path validation, write path). PR #1299's snake_case `skills_list`/`skill_view` tool surface is superseded; its four real strengths are adopted here:

- **`sera-types`**: `FunctionParameters.properties` always serializes (`{}` when empty) + regression test — ports `ed1ef984` from #1299. Main carried the latent bug: LM Studio returns HTTP 400 for a no-arg tool schema missing `properties` (found in B.4 live smoke).
- **`sera-skills/discovery.rs` (new)**: shared recursive discovery (Hermes `SKILL.md` layout to depth 3 + legacy flat top-level `*.md`, deterministic name dedup, warn-and-skip parse failures) — single source of truth.
- **`sera-skills/md_loader.rs`**: Hermes SKILL.md frontmatter extension fields (`version`, `platforms`, `environments`, `requires_toolsets`, `requires_tools`, `metadata.hermes`, fallbacks) with backward-compatible defaults; `hermes_metadata()` / `matches_platform()` helpers.
- **`sera-gateway/skill_index.rs` (new)**: Hermes-parity mandatory-load, descriptions-only skill index system-prompt block (4000-char cap), wired per turn in `execute_turn`. Deliberately **not cached** so skills created via `skill-manage` appear without restart. References the canonical kebab-case tools.
- **`skill_management.rs`**: `skill-list` and `skill-view`'s fallback resolution rerouted through shared discovery → nested Hermes-layout skills are listed *and* viewable (advertised-but-unviewable invariant test added). Write path + governance untouched.
- **SPEC-tools §4.2**: normative note fixing canonical tool names so future lanes don't fork the surface again.

## Verification

- `cargo test -p sera-types -p sera-skills -p sera-runtime`: **1476 passed, 1 ignored**
- `cargo test -p sera-gateway skill_index`: **6/6 passed**
- `cargo clippy -p sera-types -p sera-skills -p sera-runtime -p sera-gateway -- -D warnings`: clean
  (note: `--all-targets` clippy has pre-existing `await_holding_lock` failures on main in `constitutional_config.rs` and the SSE body-stream path — untouched by this diff)
- Independent code review: APPROVED
- Live smoke: not repeated — B.4's live smoke (PR #1299) already proved the adopted mechanics end-to-end against LM Studio; the delta here is name mapping + discovery routing, covered by the new tests. Re-smoking would require rebuilding the operator's live container from an unmerged branch and rewriting the live `sera.yaml` allowlist.

## Relationship to PR #1299

Supersedes #1299's tool surface; adopts its discovery/frontmatter/index/serialization contributions onto main's governed surface. Recommend closing #1299 after this merges (its MiniMax `llm_client.rs` WIP is separable and stays on that branch).

Closes sera-88ap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)