### PR TITLE
feat(context): gateway ContextEnvelope assembly path + description-less skill preservation (sera-ibkr.3)

### DIFF
--- a/rust/crates/sera-gateway/src/bin/sera.rs
+++ b/rust/crates/sera-gateway/src/bin/sera.rs
@@ -46,6 +46,10 @@ use sera_memory::PgVectorStore;
 use sera_memory::SemanticMemoryStore;
 #[allow(unused_imports)]
 use sera_memory::{DEFAULT_SQLITE_VEC_DIMENSIONS, SqliteMemoryStore};
+use sera_runtime::context_engine::envelope::{
+    ContextEnvelopeBuilder, ContextSegment, PRIORITY_IMMUTABLE_ANCHOR, PRIORITY_SELF_INTROSPECTION,
+    PRIORITY_SEMANTIC_RECALL, PRIORITY_SKILL_INDEX, PRIORITY_SKILL_INJECTION,
+};
 use sera_runtime::skill_dispatch::SkillDispatchEngine;
 use sera_runtime::subagent::SubagentManager;
 // sera-uwk0: Mail gate ingress correlator (Design B — RFC 5322 headers +
@@ -84,6 +88,7 @@ use sera_types::config_manifest::{
 };
 use sera_types::event::IncomingEvent as DomainEvent;
 use sera_types::hook::{HookChain, HookContext, HookPoint, HookResult};
+use sera_types::memory::SegmentKind;
 use sera_types::principal::{PrincipalId, PrincipalKind, PrincipalRef};
 use sera_meta::constitutional::ConstitutionalRegistry;
 use sera_meta::artifact_pipeline::ArtifactPipeline;
@@ -4350,16 +4355,27 @@ async fn execute_turn(
     // keeps the synchronous behaviour.
     delta_tx: Option<tokio::sync::mpsc::Sender<String>>,
 ) -> MvsTurnResult {
-    let mut messages: Vec<serde_json::Value> = Vec::new();
+    // ── Context envelope (sera-ibkr.3): one ordered assembly path for the
+    // system-role context injected ahead of transcript replay. Segment order
+    // and per-segment message shape match the previous inline assembly
+    // exactly. `SERA_CONTEXT_BUDGET_CHARS` (unset = unlimited = live
+    // behaviour unchanged) enables whole-segment budget eviction; the
+    // persona immutable anchor is never evicted.
+    let budget_chars = std::env::var("SERA_CONTEXT_BUDGET_CHARS")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok());
+    let mut envelope = ContextEnvelopeBuilder::new(budget_chars);
 
-    // Add system message from persona if configured.
+    // Persona immutable anchor — priority 0, never evicted.
     if let Some(persona) = &agent_spec.persona
         && let Some(anchor) = &persona.immutable_anchor
     {
-        messages.push(serde_json::json!({
-            "role": "system",
-            "content": anchor,
-        }));
+        envelope.push(ContextSegment::new(
+            SegmentKind::Persona,
+            "persona.immutable_anchor",
+            anchor.clone(),
+            PRIORITY_IMMUTABLE_ANCHOR,
+        ));
     }
 
     // ── Skill dispatch: fire trigger-matched skills for this turn and
@@ -4378,10 +4394,12 @@ async fn execute_turn(
         if injection.trim().is_empty() {
             continue;
         }
-        messages.push(serde_json::json!({
-            "role": "system",
-            "content": injection,
-        }));
+        envelope.push(ContextSegment::new(
+            SegmentKind::Custom("skill_dispatch".into()),
+            "skill_dispatch",
+            injection,
+            PRIORITY_SKILL_INJECTION,
+        ));
     }
 
     // ── Skill index (Hermes parity, plan area B): inject a stable,
@@ -4391,17 +4409,21 @@ async fn execute_turn(
     // replayed. Rebuilt each turn so skills created via `skill-manage` appear
     // without restart; only present when at least one skill is discoverable.
     if let Some(block) = skill_index_block().await {
-        messages.push(serde_json::json!({
-            "role": "system",
-            "content": block,
-        }));
+        envelope.push(ContextSegment::new(
+            SegmentKind::Custom("skill_index".into()),
+            "skill_index",
+            block,
+            PRIORITY_SKILL_INDEX,
+        ));
     }
 
     if self_introspection_requested(user_message) {
-        messages.push(serde_json::json!({
-            "role": "system",
-            "content": build_self_introspection_snapshot(agent_spec, agent_name, skill_engine),
-        }));
+        envelope.push(ContextSegment::new(
+            SegmentKind::Custom("self_introspection".into()),
+            "self_introspection",
+            build_self_introspection_snapshot(agent_spec, agent_name, skill_engine),
+            PRIORITY_SELF_INTROSPECTION,
+        ));
     }
 
     // ── Memory recall: text-only SemanticMemoryStore query. Best-effort —
@@ -4424,16 +4446,22 @@ async fn execute_turn(
                 .map(|h| format!("- {}", h.entry.content))
                 .collect::<Vec<_>>()
                 .join("\n");
-            messages.push(serde_json::json!({
-                "role": "system",
-                "content": format!("Relevant memories:\n{recalled}"),
-            }));
+            envelope.push(ContextSegment::new(
+                SegmentKind::Custom("semantic_recall".into()),
+                "semantic_recall",
+                format!("Relevant memories:\n{recalled}"),
+                PRIORITY_SEMANTIC_RECALL,
+            ));
         }
         Ok(_) => {}
         Err(e) => {
             tracing::warn!(error = %e, "semantic recall failed; continuing without memory");
         }
     }
+
+    let envelope = envelope.build();
+    envelope.introspect();
+    let mut messages = envelope.to_messages();
 
     // Add transcript history (including tool_calls and tool results), with
     // sera-xbmz invariant enforcement: drop `tool` role rows whose
@@ -12756,6 +12784,146 @@ spec:
                 snapshot.contains(needle),
                 "snapshot must contain {needle:?}; got:\n{snapshot}"
             );
+        }
+    }
+
+    /// sera-ibkr.3: envelope segment order — anchor first, all system messages
+    /// before the user turn, recall (when present) is the last system message.
+    #[tokio::test]
+    async fn execute_turn_orders_envelope_segments_before_transcript() {
+        struct RecordingTransport {
+            seen: Arc<std::sync::Mutex<Vec<Vec<serde_json::Value>>>>,
+        }
+
+        #[async_trait::async_trait]
+        impl AgentTurnTransport for RecordingTransport {
+            async fn send_turn(
+                &self,
+                messages: Vec<serde_json::Value>,
+                _session_key: &str,
+            ) -> anyhow::Result<TurnEvents> {
+                self.seen.lock().unwrap().push(messages);
+                Ok(TurnEvents {
+                    response: "ok".to_string(),
+                    ..TurnEvents::default()
+                })
+            }
+
+            async fn send_steer(
+                &self,
+                _items: Vec<serde_json::Value>,
+                _session_key: &str,
+            ) -> anyhow::Result<()> {
+                Ok(())
+            }
+
+            async fn shutdown(&self) -> anyhow::Result<()> {
+                Ok(())
+            }
+
+            async fn liveness_probe(&self) -> anyhow::Result<()> {
+                Ok(())
+            }
+        }
+
+        let seen = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let transport = RecordingTransport {
+            seen: Arc::clone(&seen),
+        };
+        let agent_spec = AgentSpec {
+            provider: "stub-provider".to_string(),
+            model: Some("stub-model".to_string()),
+            persona: Some(sera_types::config_manifest::PersonaSpec {
+                immutable_anchor: Some("You are a test anchor.".to_string()),
+                mutable_persona: None,
+                mutable_token_budget: None,
+            }),
+            tools: Some(AgentToolsSpec {
+                allow: vec!["bash".to_string()],
+            }),
+            workspace: Some("/workspace/test".to_string()),
+            policy_ref: None,
+            enforcement_mode: None,
+            approval_policy: None,
+            subagents_allowed: vec![],
+        };
+        let skill_engine = SkillDispatchEngine::new();
+        let semantic_store: Arc<dyn SemanticMemoryStore> = Arc::new(
+            SqliteMemoryStore::open_in_memory(None).expect("open in-memory semantic store"),
+        );
+        let cancel = CancellationToken::new();
+        let capability_registry = CapabilityRegistry::empty();
+
+        let result = execute_turn(
+            &agent_spec,
+            &[],
+            "hello",
+            &transport,
+            "ibkr3-order-test-session",
+            &skill_engine,
+            &semantic_store,
+            "sera",
+            &cancel,
+            &capability_registry,
+            None,
+        )
+        .await;
+
+        assert_eq!(result.reply, "ok");
+        let captured = seen.lock().unwrap();
+        let messages = captured.first().expect("transport should see one turn");
+
+        // First message must be role=system with the anchor content.
+        let first = messages.first().expect("at least one message");
+        assert_eq!(
+            first.get("role").and_then(|v| v.as_str()),
+            Some("system"),
+            "first message must be role=system (persona anchor)"
+        );
+        assert_eq!(
+            first.get("content").and_then(|v| v.as_str()),
+            Some("You are a test anchor."),
+            "first system message must be the persona immutable anchor"
+        );
+
+        // All system messages must precede the first non-system (user) message.
+        let first_user_pos = messages
+            .iter()
+            .position(|m| m.get("role").and_then(|v| v.as_str()) == Some("user"))
+            .expect("there must be a user message");
+        for (i, msg) in messages.iter().enumerate() {
+            if i >= first_user_pos {
+                break;
+            }
+            assert_eq!(
+                msg.get("role").and_then(|v| v.as_str()),
+                Some("system"),
+                "message at index {i} before the user turn must be role=system"
+            );
+        }
+
+        // If a recall segment is present it must be the last system message
+        // and start with "Relevant memories:".
+        let system_messages: Vec<&serde_json::Value> = messages
+            .iter()
+            .filter(|m| m.get("role").and_then(|v| v.as_str()) == Some("system"))
+            .collect();
+        if let Some(last_sys) = system_messages.last() {
+            let content = last_sys
+                .get("content")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            if content.starts_with("Relevant memories:") {
+                // Confirm it really is after all other system messages.
+                let last_sys_pos = messages
+                    .iter()
+                    .rposition(|m| m.get("role").and_then(|v| v.as_str()) == Some("system"))
+                    .unwrap();
+                assert!(
+                    last_sys_pos < first_user_pos,
+                    "recall segment must still precede the user turn"
+                );
+            }
         }
     }
 

--- a/rust/crates/sera-gateway/src/skill_index.rs
+++ b/rust/crates/sera-gateway/src/skill_index.rs
@@ -141,13 +141,33 @@ mod tests {
     #[tokio::test]
     async fn unparseable_skills_are_skipped() {
         let dir = TempDir::new().unwrap();
-        // Missing required `description` frontmatter → parse error, skipped.
-        fs::write(dir.path().join("broken.md"), "---\nname: broken\n---\nbody\n").unwrap();
+        // Truly unparseable: missing required `name` frontmatter → parse error, skipped.
+        fs::write(
+            dir.path().join("broken.md"),
+            "---\ndescription: no name here\n---\nbody\n",
+        )
+        .unwrap();
         write_skill_md(&dir.path().join("ok.md"), "ok-skill", "works fine");
 
         let block = build_skill_index_context(dir.path()).await.unwrap();
         assert!(block.contains("- ok-skill: works fine"));
-        assert!(!block.contains("broken"));
+        // broken.md has no `name` so it is truly unparseable and must not appear.
+        assert!(!block.contains("no name here"));
+    }
+
+    #[tokio::test]
+    async fn description_less_skill_appears_in_index() {
+        let dir = TempDir::new().unwrap();
+        // Missing `description` must NOT exclude the skill from the gateway index.
+        fs::write(dir.path().join("nodesc.md"), "---\nname: nodesc\n---\nbody\n").unwrap();
+        write_skill_md(&dir.path().join("ok.md"), "ok-skill", "works fine");
+
+        let block = build_skill_index_context(dir.path()).await.unwrap();
+        assert!(
+            block.contains("- nodesc:"),
+            "description-less skill must appear in gateway index; block:\n{block}"
+        );
+        assert!(block.contains("- ok-skill: works fine"));
     }
 
     #[tokio::test]

--- a/rust/crates/sera-runtime/src/context_engine/envelope.rs
+++ b/rust/crates/sera-runtime/src/context_engine/envelope.rs
@@ -1,0 +1,321 @@
+//! Ordered context-envelope assembly (sera-ibkr.3).
+//!
+//! A single ordered assembly path for the system-role context messages the
+//! gateway injects ahead of transcript replay. Each injection becomes one
+//! [`ContextSegment`]; [`ContextEnvelope::to_messages`] renders them, in
+//! order, to one `{"role":"system","content":...}` value apiece — the same
+//! shape the gateway's `execute_turn` produced inline. Collapsing the
+//! segments into a single message would change live wire behaviour, so the
+//! renderer deliberately keeps them separate.
+//!
+//! ## Budget (sera-ibkr.3)
+//!
+//! A char-based cap mirrors the spirit of [`sera_types::memory::MemoryBlock`]
+//! priority eviction, but kept deliberately simple: whole-segment eviction,
+//! no partial truncation. `None` budget (the production default) is unlimited
+//! and leaves live behaviour byte-identical. On overflow the lowest-priority
+//! (highest `priority` value) evictable segments are dropped first; the
+//! persona immutable anchor (`priority == 0`) is **never** evicted. A drop
+//! sets the [`ContextEnvelope::pressure`] flag and emits a `warn!` event.
+
+use sera_types::memory::SegmentKind;
+
+/// Priority of the persona immutable anchor. `0` is never evicted, matching
+/// the Soul convention in [`sera_types::memory::MemoryBlock`].
+pub const PRIORITY_IMMUTABLE_ANCHOR: u8 = 0;
+/// Priority of a trigger-matched skill injection.
+pub const PRIORITY_SKILL_INJECTION: u8 = 3;
+/// Priority of the skill index block.
+pub const PRIORITY_SKILL_INDEX: u8 = 4;
+/// Priority of the self-introspection snapshot.
+pub const PRIORITY_SELF_INTROSPECTION: u8 = 5;
+/// Priority of semantic recall — the most evictable segment.
+pub const PRIORITY_SEMANTIC_RECALL: u8 = 6;
+
+/// A single unit of assembled context, rendered to one system message.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContextSegment {
+    /// What produced this segment. Reuses [`SegmentKind`]; uses
+    /// [`SegmentKind::Custom`] where no dedicated variant fits (skill index,
+    /// self-introspection).
+    pub kind: SegmentKind,
+    /// Provenance label, e.g. `"persona.immutable_anchor"`, `"skill_dispatch"`,
+    /// `"skill_index"`, `"self_introspection"`, `"semantic_recall"`.
+    pub source: String,
+    /// Rendered text injected as the system message content.
+    pub content: String,
+    /// Lower = more important. `0` is never evicted.
+    pub priority: u8,
+}
+
+impl ContextSegment {
+    /// Construct a segment with an explicit priority.
+    pub fn new(
+        kind: SegmentKind,
+        source: impl Into<String>,
+        content: impl Into<String>,
+        priority: u8,
+    ) -> Self {
+        Self {
+            kind,
+            source: source.into(),
+            content: content.into(),
+            priority,
+        }
+    }
+}
+
+/// An ordered collection of [`ContextSegment`]s with budget bookkeeping.
+#[derive(Debug, Clone)]
+pub struct ContextEnvelope {
+    segments: Vec<ContextSegment>,
+    /// `true` when budget pressure forced at least one eviction.
+    pub pressure: bool,
+}
+
+impl ContextEnvelope {
+    /// Borrow the retained segments in render order.
+    pub fn segments(&self) -> &[ContextSegment] {
+        &self.segments
+    }
+
+    /// Render each segment to one `{"role":"system","content":...}` value, in
+    /// order. Never collapses segments — one message per segment.
+    pub fn to_messages(&self) -> Vec<serde_json::Value> {
+        self.segments
+            .iter()
+            .map(|seg| {
+                serde_json::json!({
+                    "role": "system",
+                    "content": seg.content,
+                })
+            })
+            .collect()
+    }
+
+    /// Emit a structured introspection record of every retained segment plus
+    /// envelope totals. One `debug!` per segment, one summary line.
+    pub fn introspect(&self) {
+        for seg in &self.segments {
+            tracing::debug!(
+                kind = ?seg.kind,
+                source = %seg.source,
+                priority = seg.priority,
+                char_len = seg.content.chars().count(),
+                "context envelope segment"
+            );
+        }
+        tracing::debug!(
+            segments = self.segments.len(),
+            total_chars = self.total_chars(),
+            pressure = self.pressure,
+            "context envelope assembled"
+        );
+    }
+
+    /// Total characters across retained segment contents.
+    pub fn total_chars(&self) -> usize {
+        self.segments.iter().map(|s| s.content.chars().count()).sum()
+    }
+}
+
+/// Builds a [`ContextEnvelope`] by pushing segments in canonical order, then
+/// applying an optional char budget.
+#[derive(Debug, Default)]
+pub struct ContextEnvelopeBuilder {
+    segments: Vec<ContextSegment>,
+    budget_chars: Option<usize>,
+}
+
+impl ContextEnvelopeBuilder {
+    /// New builder with an optional char budget. `None` = unlimited =
+    /// live behaviour unchanged.
+    pub fn new(budget_chars: Option<usize>) -> Self {
+        Self {
+            segments: Vec::new(),
+            budget_chars,
+        }
+    }
+
+    /// Append a pre-built segment in canonical order.
+    pub fn push(&mut self, segment: ContextSegment) -> &mut Self {
+        self.segments.push(segment);
+        self
+    }
+
+    /// Finalise the envelope, applying budget eviction if a cap is set.
+    ///
+    /// Eviction drops whole segments by descending priority (most evictable
+    /// first), preserving input order among the survivors. `priority == 0`
+    /// (the persona immutable anchor) is never dropped, even when the budget
+    /// is smaller than the anchor itself.
+    pub fn build(self) -> ContextEnvelope {
+        let Self {
+            segments,
+            budget_chars,
+        } = self;
+
+        let Some(budget) = budget_chars.filter(|b| *b > 0) else {
+            // Unlimited (None / 0): no eviction, no pressure.
+            return ContextEnvelope {
+                segments,
+                pressure: false,
+            };
+        };
+
+        let total: usize = segments.iter().map(|s| s.content.chars().count()).sum();
+        if total <= budget {
+            return ContextEnvelope {
+                segments,
+                pressure: false,
+            };
+        }
+
+        // Over budget: evict whole segments, highest priority value first,
+        // never the immutable anchor. Among equal priorities, evict later
+        // (input-order) segments first so earlier context is preferentially
+        // retained.
+        let mut keep: Vec<bool> = vec![true; segments.len()];
+        let mut current = total;
+        let mut pressure = false;
+
+        // Eviction candidates: indices of non-anchor segments, ordered by
+        // (priority desc, index desc) so the most evictable goes first.
+        let mut candidates: Vec<usize> = segments
+            .iter()
+            .enumerate()
+            .filter(|(_, s)| s.priority != PRIORITY_IMMUTABLE_ANCHOR)
+            .map(|(i, _)| i)
+            .collect();
+        candidates.sort_by(|&a, &b| {
+            segments[b]
+                .priority
+                .cmp(&segments[a].priority)
+                .then(b.cmp(&a))
+        });
+
+        for idx in candidates {
+            if current <= budget {
+                break;
+            }
+            let seg = &segments[idx];
+            tracing::warn!(
+                kind = ?seg.kind,
+                source = %seg.source,
+                priority = seg.priority,
+                char_len = seg.content.chars().count(),
+                budget,
+                "context envelope budget pressure: evicting segment"
+            );
+            keep[idx] = false;
+            current -= seg.content.chars().count();
+            pressure = true;
+        }
+
+        let retained: Vec<ContextSegment> = segments
+            .into_iter()
+            .zip(keep)
+            .filter_map(|(seg, k)| k.then_some(seg))
+            .collect();
+
+        ContextEnvelope {
+            segments: retained,
+            pressure,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn seg(source: &str, content: &str, priority: u8) -> ContextSegment {
+        ContextSegment::new(SegmentKind::Custom(source.into()), source, content, priority)
+    }
+
+    #[test]
+    fn ordering_renders_messages_in_canonical_order() {
+        let mut b = ContextEnvelopeBuilder::new(None);
+        b.push(seg("persona.immutable_anchor", "anchor", PRIORITY_IMMUTABLE_ANCHOR))
+            .push(seg("skill_dispatch", "skill", PRIORITY_SKILL_INJECTION))
+            .push(seg("semantic_recall", "recall", PRIORITY_SEMANTIC_RECALL));
+        let env = b.build();
+        let msgs = env.to_messages();
+        assert_eq!(msgs.len(), 3);
+        assert_eq!(msgs[0]["content"], "anchor");
+        assert_eq!(msgs[1]["content"], "skill");
+        assert_eq!(msgs[2]["content"], "recall");
+        for m in &msgs {
+            assert_eq!(m["role"], "system");
+        }
+    }
+
+    #[test]
+    fn unlimited_budget_evicts_nothing() {
+        let mut b = ContextEnvelopeBuilder::new(None);
+        b.push(seg("a", "x".repeat(1000).as_str(), PRIORITY_SKILL_INJECTION))
+            .push(seg("semantic_recall", "y".repeat(1000).as_str(), PRIORITY_SEMANTIC_RECALL));
+        let env = b.build();
+        assert!(!env.pressure);
+        assert_eq!(env.segments().len(), 2);
+    }
+
+    #[test]
+    fn zero_budget_treated_as_unlimited() {
+        let mut b = ContextEnvelopeBuilder::new(Some(0));
+        b.push(seg("a", "hello", PRIORITY_SKILL_INJECTION));
+        let env = b.build();
+        assert!(!env.pressure);
+        assert_eq!(env.segments().len(), 1);
+    }
+
+    #[test]
+    fn small_budget_evicts_semantic_recall_first() {
+        // anchor(6) + skill_index(10) + recall(10) = 26 chars; budget 20.
+        let mut b = ContextEnvelopeBuilder::new(Some(20));
+        b.push(seg("persona.immutable_anchor", "anchor", PRIORITY_IMMUTABLE_ANCHOR))
+            .push(seg("skill_index", "skillindex", PRIORITY_SKILL_INDEX))
+            .push(seg("semantic_recall", "recalltext", PRIORITY_SEMANTIC_RECALL));
+        let env = b.build();
+        assert!(env.pressure);
+        // recall (most evictable) dropped; anchor + skill_index retained.
+        let sources: Vec<&str> = env.segments().iter().map(|s| s.source.as_str()).collect();
+        assert_eq!(sources, vec!["persona.immutable_anchor", "skill_index"]);
+    }
+
+    #[test]
+    fn eviction_order_recall_then_introspection_then_index() {
+        // All evictable segments large; only the anchor must survive.
+        let mut b = ContextEnvelopeBuilder::new(Some(6));
+        b.push(seg("persona.immutable_anchor", "anchor", PRIORITY_IMMUTABLE_ANCHOR))
+            .push(seg("skill_dispatch", "skilll", PRIORITY_SKILL_INJECTION))
+            .push(seg("skill_index", "indexx", PRIORITY_SKILL_INDEX))
+            .push(seg("self_introspection", "introo", PRIORITY_SELF_INTROSPECTION))
+            .push(seg("semantic_recall", "recall", PRIORITY_SEMANTIC_RECALL));
+        let env = b.build();
+        assert!(env.pressure);
+        let sources: Vec<&str> = env.segments().iter().map(|s| s.source.as_str()).collect();
+        assert_eq!(sources, vec!["persona.immutable_anchor"]);
+    }
+
+    #[test]
+    fn immutable_anchor_never_evicted_even_when_budget_smaller() {
+        // Budget 2, anchor alone is 6 chars — still retained.
+        let mut b = ContextEnvelopeBuilder::new(Some(2));
+        b.push(seg("persona.immutable_anchor", "anchor", PRIORITY_IMMUTABLE_ANCHOR))
+            .push(seg("semantic_recall", "recall", PRIORITY_SEMANTIC_RECALL));
+        let env = b.build();
+        assert!(env.pressure);
+        let sources: Vec<&str> = env.segments().iter().map(|s| s.source.as_str()).collect();
+        assert_eq!(sources, vec!["persona.immutable_anchor"]);
+    }
+
+    #[test]
+    fn total_chars_counts_retained_only() {
+        let mut b = ContextEnvelopeBuilder::new(Some(6));
+        b.push(seg("persona.immutable_anchor", "anchor", PRIORITY_IMMUTABLE_ANCHOR))
+            .push(seg("semantic_recall", "recall", PRIORITY_SEMANTIC_RECALL));
+        let env = b.build();
+        assert_eq!(env.total_chars(), 6);
+    }
+}

--- a/rust/crates/sera-runtime/src/context_engine/mod.rs
+++ b/rust/crates/sera-runtime/src/context_engine/mod.rs
@@ -1,6 +1,7 @@
 //! Context engine — pluggable context assembly and compaction.
 
 pub mod enricher;
+pub mod envelope;
 pub mod hybrid;
 pub mod kvcache;
 pub mod pipeline;
@@ -8,6 +9,11 @@ pub mod pipeline;
 pub use enricher::{
     ContextEnricher, ContextEnricherConfig, EnrichmentResult, MAX_RECALL_SEGMENTS,
     MEMORY_RECALL_PRIORITY,
+};
+pub use envelope::{
+    ContextEnvelope, ContextEnvelopeBuilder, ContextSegment, PRIORITY_IMMUTABLE_ANCHOR,
+    PRIORITY_SELF_INTROSPECTION, PRIORITY_SEMANTIC_RECALL, PRIORITY_SKILL_INDEX,
+    PRIORITY_SKILL_INJECTION,
 };
 
 use async_trait::async_trait;

--- a/rust/crates/sera-skills/src/discovery.rs
+++ b/rust/crates/sera-skills/src/discovery.rs
@@ -211,13 +211,38 @@ mod tests {
     #[tokio::test]
     async fn unparseable_file_is_skipped() {
         let dir = TempDir::new().unwrap();
-        // Missing required `description` → parse error, skipped.
-        fs::write(dir.path().join("broken.md"), "---\nname: broken\n---\nbody\n").unwrap();
+        // Truly unparseable: missing required `name` → parse error, skipped.
+        fs::write(dir.path().join("broken.md"), "---\ndescription: no name here\n---\nbody\n")
+            .unwrap();
         write_skill_md(&dir.path().join("ok.md"), "ok-skill", "works fine");
 
         let skills = discover_skills(dir.path()).await;
         let names: Vec<&str> = skills.iter().map(|(s, _)| s.name.as_str()).collect();
         assert!(names.contains(&"ok-skill"), "valid skill should be present");
-        assert!(!names.contains(&"broken"), "unparseable skill should be skipped");
+        // broken.md has no `name`, so it should still be skipped.
+        assert!(
+            !skills.iter().any(|(s, _)| s.description == "no name here"),
+            "truly unparseable skill should be skipped"
+        );
+    }
+
+    #[tokio::test]
+    async fn description_less_skill_is_preserved() {
+        let dir = TempDir::new().unwrap();
+        // Missing `description` must NOT drop the skill — description defaults to "".
+        fs::write(dir.path().join("nodesc.md"), "---\nname: nodesc\n---\nbody\n").unwrap();
+        write_skill_md(&dir.path().join("ok.md"), "ok-skill", "works fine");
+
+        let skills = discover_skills(dir.path()).await;
+        let names: Vec<&str> = skills.iter().map(|(s, _)| s.name.as_str()).collect();
+        assert!(
+            names.contains(&"nodesc"),
+            "description-less skill must be preserved, got: {names:?}"
+        );
+        let nodesc = skills.iter().find(|(s, _)| s.name == "nodesc").unwrap();
+        assert_eq!(
+            nodesc.0.description, "",
+            "missing description must default to empty string"
+        );
     }
 }

--- a/rust/crates/sera-skills/src/md_loader.rs
+++ b/rust/crates/sera-skills/src/md_loader.rs
@@ -255,9 +255,19 @@ pub fn parse_skill_md(raw: &str, source_path: Option<PathBuf>) -> Result<Skill, 
     let name = fm
         .name
         .ok_or_else(|| SkillsError::Format("SKILL.md frontmatter missing `name`".to_string()))?;
-    // `description` is optional — missing or absent defaults to empty string so
-    // description-less skills are preserved rather than dropped during discovery.
-    // Matches the `unwrap_or_default()` semantics in SkillDispatchEngine.
+    // `description` is optional — absent defaults to empty string so
+    // description-less skills are preserved rather than dropped during
+    // discovery. An explicitly provided empty/whitespace description is
+    // rejected, matching `parse_skill_markdown_str`: the dispatch parser
+    // refuses to register such a skill, so advertising it in discovery or
+    // the gateway index would list a skill that can never fire.
+    if let Some(ref desc) = fm.description
+        && desc.trim().is_empty()
+    {
+        return Err(SkillsError::Format(
+            "SKILL.md `description` must be non-empty when provided".to_string(),
+        ));
+    }
     let description = fm.description.unwrap_or_default();
 
     if name.trim().is_empty() {
@@ -385,11 +395,21 @@ mod tests {
     }
 
     #[test]
-    fn empty_description_allowed() {
-        // An explicit empty description is valid — description is optional.
+    fn explicit_empty_description_rejected() {
+        // An explicitly empty description is invalid — the dispatch parser
+        // (`parse_skill_markdown_str`) rejects it, so accepting it here would
+        // advertise a skill that can never fire.
         let raw = "---\nname: ok\ndescription: \"\"\n---\nbody\n";
-        let skill = parse_skill_md(raw, None).unwrap();
-        assert_eq!(skill.description, "");
+        let err = parse_skill_md(raw, None).unwrap_err();
+        assert!(matches!(err, SkillsError::Format(_)));
+    }
+
+    #[test]
+    fn explicit_whitespace_description_rejected() {
+        // Whitespace-only is treated the same as explicitly empty.
+        let raw = "---\nname: ok\ndescription: \"   \"\n---\nbody\n";
+        let err = parse_skill_md(raw, None).unwrap_err();
+        assert!(matches!(err, SkillsError::Format(_)));
     }
 
     #[test]

--- a/rust/crates/sera-skills/src/md_loader.rs
+++ b/rust/crates/sera-skills/src/md_loader.rs
@@ -255,18 +255,14 @@ pub fn parse_skill_md(raw: &str, source_path: Option<PathBuf>) -> Result<Skill, 
     let name = fm
         .name
         .ok_or_else(|| SkillsError::Format("SKILL.md frontmatter missing `name`".to_string()))?;
-    let description = fm.description.ok_or_else(|| {
-        SkillsError::Format("SKILL.md frontmatter missing `description`".to_string())
-    })?;
+    // `description` is optional — missing or absent defaults to empty string so
+    // description-less skills are preserved rather than dropped during discovery.
+    // Matches the `unwrap_or_default()` semantics in SkillDispatchEngine.
+    let description = fm.description.unwrap_or_default();
 
     if name.trim().is_empty() {
         return Err(SkillsError::Format(
             "SKILL.md `name` must not be empty".to_string(),
-        ));
-    }
-    if description.trim().is_empty() {
-        return Err(SkillsError::Format(
-            "SKILL.md `description` must not be empty".to_string(),
         ));
     }
 
@@ -373,13 +369,12 @@ mod tests {
     }
 
     #[test]
-    fn missing_description_errors() {
+    fn missing_description_defaults_to_empty() {
+        // `description` is optional — missing description must NOT drop the skill.
         let raw = "---\nname: x\n---\nbody\n";
-        let err = parse_skill_md(raw, None).unwrap_err();
-        match err {
-            SkillsError::Format(msg) => assert!(msg.contains("`description`")),
-            other => panic!("expected Format error, got {other:?}"),
-        }
+        let skill = parse_skill_md(raw, None).unwrap();
+        assert_eq!(skill.name, "x");
+        assert_eq!(skill.description, "");
     }
 
     #[test]
@@ -390,10 +385,11 @@ mod tests {
     }
 
     #[test]
-    fn empty_description_rejected() {
+    fn empty_description_allowed() {
+        // An explicit empty description is valid — description is optional.
         let raw = "---\nname: ok\ndescription: \"\"\n---\nbody\n";
-        let err = parse_skill_md(raw, None).unwrap_err();
-        assert!(matches!(err, SkillsError::Format(_)));
+        let skill = parse_skill_md(raw, None).unwrap();
+        assert_eq!(skill.description, "");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Two commits advancing the Hermes-parity ContextEngine lane (bead `sera-ibkr.3`):

1. **`a163a228` — PR #1300 P2 preflight fix**: discovery routed through `md_loader` where `description` was required, silently dropping older description-less AgentSkills markdown from `skill-list`/gateway index while `SkillDispatchEngine` treats description as optional. `parse_skill_md` now defaults description to empty string; truly unparseable skills (missing `name`) remain skipped. Regression tests at loader, discovery, and gateway skill-index levels.

2. **`6df3cad1` — ContextEnvelope assembly (sera-ibkr.3 slice)**: new `ContextEnvelope`/`ContextEnvelopeBuilder`/`ContextSegment` in `sera-runtime::context_engine::envelope`, wired into the gateway's `execute_turn` as the single ordered assembly path for pre-transcript system messages:
   persona `immutable_anchor` (priority 0, never evicted) → `skill_dispatch` injections → `skill_index` → `self_introspection` → `semantic_recall`.

## Behavior

- **Live behavior preserved**: one `{"role":"system"}` message per segment, identical order/content; with `SERA_CONTEXT_BUDGET_CHARS` unset (the default), `build()` short-circuits and the wire output is byte-identical to the previous inline assembly.
- **Budget pressure**: setting `SERA_CONTEXT_BUDGET_CHARS` enables whole-segment eviction by descending priority (later segments first among ties); eviction sets `pressure` and emits a `warn!`; the persona anchor is never evicted, even when the budget is smaller than the anchor.
- **Provenance**: every segment carries `SegmentKind` + source label + priority, introspectable via `envelope.introspect()` debug traces.

## Acceptance (sera-ibkr.3)

- ✅ One assembly path produces ordered context messages
- ✅ immutable_anchor and semantic recall behavior preserved (verified against removed inline code; reviewer confirmed byte-identical default path)
- ✅ Segment metadata/provenance logged/introspectable
- ✅ Budget pressure tested (7 envelope unit tests incl. eviction order, anchor protection, zero-budget-as-unlimited)

## Testing

- `cargo test -p sera-gateway -p sera-runtime` — **1636 passed, 3 ignored** (includes new `execute_turn_orders_envelope_segments_before_transcript` gateway test via `RecordingTransport`)
- `cargo clippy -p sera-gateway -p sera-runtime --all-targets -- -D warnings` — clean
- Independent code review (Opus reviewer): APPROVE, 0 P0/P1; the actionable P2 (re-export omitting `PRIORITY_*` constants) was fixed in-branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)