### PR TITLE
feat(context): optional token budget for ContextEnvelope assembly (sera-ibkr.3)

### DIFF
--- a/rust/crates/sera-gateway/src/bin/sera.rs
+++ b/rust/crates/sera-gateway/src/bin/sera.rs
@@ -4659,13 +4659,19 @@ async fn execute_turn(
     // ── Context envelope (sera-ibkr.3): one ordered assembly path for the
     // system-role context injected ahead of transcript replay. Segment order
     // and per-segment message shape match the previous inline assembly
-    // exactly. `SERA_CONTEXT_BUDGET_CHARS` (unset = unlimited = live
-    // behaviour unchanged) enables whole-segment budget eviction; the
-    // persona immutable anchor is never evicted.
-    let budget_chars = std::env::var("SERA_CONTEXT_BUDGET_CHARS")
-        .ok()
-        .and_then(|v| v.parse::<usize>().ok());
-    let mut envelope = ContextEnvelopeBuilder::new(budget_chars);
+    // exactly. `SERA_CONTEXT_BUDGET_CHARS` and `SERA_CONTEXT_BUDGET_TOKENS`
+    // (both unset = unlimited = live behaviour unchanged) enable whole-segment
+    // budget eviction; the two compose as a union constraint and the persona
+    // immutable anchor is never evicted.
+    let budget_chars = parse_context_budget(
+        "SERA_CONTEXT_BUDGET_CHARS",
+        std::env::var("SERA_CONTEXT_BUDGET_CHARS").ok(),
+    );
+    let budget_tokens = parse_context_budget(
+        "SERA_CONTEXT_BUDGET_TOKENS",
+        std::env::var("SERA_CONTEXT_BUDGET_TOKENS").ok(),
+    );
+    let mut envelope = ContextEnvelopeBuilder::new(budget_chars).with_budget_tokens(budget_tokens);
 
     // Persona immutable anchor — priority 0, never evicted.
     if let Some(persona) = &agent_spec.persona
@@ -4808,7 +4814,14 @@ async fn execute_turn(
     // audit entry naming each dropped segment. Best-effort — never fails the
     // turn.
     if envelope.pressure {
-        emit_context_pressure_audit(agent_name, session_key, budget_chars, &envelope).await;
+        emit_context_pressure_audit(
+            agent_name,
+            session_key,
+            budget_chars,
+            budget_tokens,
+            &envelope,
+        )
+        .await;
     }
     let mut messages = envelope.to_messages();
 
@@ -5153,11 +5166,35 @@ async fn emit_tool_execution_audit(
     }
 }
 
+/// Parse an optional context-budget env value (sera-ibkr.3). Unset, empty,
+/// unparseable, or nonpositive values fail closed to `None` = budget disabled.
+///
+/// Kept pure (takes the raw `Option<String>` rather than reading the env)
+/// so unit tests can exercise it without env mutation, which is racy under
+/// parallel tests. Backward-compat note for chars: routing the chars var
+/// through here keeps observable behaviour identical (an unparseable or zero
+/// value already disabled the budget) and only adds a `warn!`.
+fn parse_context_budget(var_name: &str, raw: Option<String>) -> Option<usize> {
+    let raw = raw?;
+    match raw.parse::<usize>() {
+        Ok(n) if n > 0 => Some(n),
+        _ => {
+            tracing::warn!(
+                var = var_name,
+                value = %raw,
+                "invalid context budget value; disabling this budget"
+            );
+            None
+        }
+    }
+}
+
 /// OCSF class for a context-budget eviction audit entry (sera-ibkr.3).
 ///
 /// `6003` is "Policy Activity". A budget eviction is enforcement of a
-/// configured resource policy (`SERA_CONTEXT_BUDGET_CHARS`) — segments are
-/// dropped to satisfy a cap — so it mirrors the denial precedent
+/// configured resource policy (`SERA_CONTEXT_BUDGET_CHARS` /
+/// `SERA_CONTEXT_BUDGET_TOKENS`) — segments are dropped to satisfy a cap —
+/// so it mirrors the denial precedent
 /// (`emit_policy_denial_audit`) rather than the `3006` API Activity class
 /// used for tool execution. We pair it with `action_id="evicted"` so
 /// dashboards can distinguish a budget eviction from an outright `blocked`
@@ -5168,13 +5205,18 @@ const CONTEXT_PRESSURE_OCSF_CLASS_UID: u32 = 6003;
 /// event. Pure (no I/O) so unit tests can assert the shape without touching
 /// the hash-chain backend, mirroring [`make_tool_execution_audit_payload`].
 ///
-/// The payload names the agent/session, the configured char budget, the
-/// retained segment count + total chars, and one entry per evicted segment
-/// (`source`, `kind`, `priority`, `char_len`) in eviction order.
+/// The payload names the agent/session, the configured char/token budgets, the
+/// retained segment count + total chars (+ total tokens when a token budget is
+/// active), and one entry per evicted segment (`source`, `kind`, `priority`,
+/// `char_len`, `token_len`) in eviction order. `policy.name` distinguishes the
+/// active budget(s): `context_budget_chars`, `context_budget_tokens`, or
+/// `context_budget` when both are configured. Segment content is never
+/// included.
 fn make_context_pressure_audit_payload(
     agent_name: &str,
     session_key: &str,
     budget_chars: Option<usize>,
+    budget_tokens: Option<usize>,
     envelope: &sera_runtime::context_engine::envelope::ContextEnvelope,
 ) -> serde_json::Value {
     let evicted: Vec<serde_json::Value> = envelope
@@ -5186,9 +5228,22 @@ fn make_context_pressure_audit_payload(
                 "kind": format!("{:?}", e.kind),
                 "priority": e.priority,
                 "char_len": e.char_len,
+                "token_len": e.token_len,
             })
         })
         .collect();
+    // Name the policy by which budget(s) are configured. Preserves the
+    // historical "context_budget_chars" value for the char-only path. The
+    // no-budget arm is unreachable in production (this audit is only emitted
+    // under `envelope.pressure`, which requires an active budget), but is kept
+    // total with a distinct value so it can never masquerade as the
+    // both-active "context_budget" record if a future caller drops the gate.
+    let policy_name = match (budget_chars.is_some(), budget_tokens.is_some()) {
+        (true, true) => "context_budget",
+        (false, true) => "context_budget_tokens",
+        (true, false) => "context_budget_chars",
+        (false, false) => "context_budget_none",
+    };
     serde_json::json!({
         "activity_id": 1, // OCSF Policy Activity — enforcement action taken
         "action_id": "evicted",
@@ -5196,7 +5251,7 @@ fn make_context_pressure_audit_payload(
         "class_uid": CONTEXT_PRESSURE_OCSF_CLASS_UID,
         "severity_id": 3, // Medium — operator-actionable budget pressure
         "actor": { "user": { "name": agent_name } },
-        "policy": { "name": "context_budget_chars" },
+        "policy": { "name": policy_name },
         "resource": {
             "name": agent_name,
             "type": "context_envelope",
@@ -5206,8 +5261,10 @@ fn make_context_pressure_audit_payload(
         "status_detail": "context envelope budget pressure",
         "unmapped": {
             "budget_chars": budget_chars,
+            "budget_tokens": budget_tokens,
             "retained_segments": envelope.segments().len(),
             "retained_chars": envelope.total_chars(),
+            "retained_tokens": envelope.total_tokens(),
             "evicted_count": envelope.evicted().len(),
             "evicted": evicted,
         },
@@ -5223,12 +5280,18 @@ async fn emit_context_pressure_audit(
     agent_name: &str,
     session_key: &str,
     budget_chars: Option<usize>,
+    budget_tokens: Option<usize>,
     envelope: &sera_runtime::context_engine::envelope::ContextEnvelope,
 ) {
     use sera_telemetry::audit::{AuditEntry, audit_append};
 
-    let payload =
-        make_context_pressure_audit_payload(agent_name, session_key, budget_chars, envelope);
+    let payload = make_context_pressure_audit_payload(
+        agent_name,
+        session_key,
+        budget_chars,
+        budget_tokens,
+        envelope,
+    );
     let this_hash =
         AuditEntry::compute_hash(CONTEXT_PRESSURE_OCSF_CLASS_UID, &payload, &[0u8; 32]);
     let entry = AuditEntry {
@@ -13503,6 +13566,7 @@ spec:
             "sera",
             "ibkr3-pressure-session",
             Some(12),
+            None,
             &envelope,
         );
 
@@ -13513,6 +13577,10 @@ spec:
         assert_eq!(payload["unmapped"]["budget_chars"], 12);
         assert_eq!(payload["unmapped"]["retained_segments"], 1);
         assert_eq!(payload["unmapped"]["evicted_count"], 2);
+        // Char-only path: token fields are null and policy names chars only.
+        assert!(payload["unmapped"]["budget_tokens"].is_null());
+        assert!(payload["unmapped"]["retained_tokens"].is_null());
+        assert_eq!(payload["policy"]["name"], "context_budget_chars");
 
         let evicted = payload["unmapped"]["evicted"]
             .as_array()
@@ -13522,15 +13590,195 @@ spec:
         assert_eq!(evicted[0]["source"], "semantic_recall");
         assert_eq!(evicted[0]["priority"], PRIORITY_SEMANTIC_RECALL);
         assert_eq!(evicted[0]["char_len"], 10);
+        assert!(evicted[0]["token_len"].is_null());
         assert_eq!(evicted[1]["source"], "skill_index");
         assert_eq!(evicted[1]["priority"], PRIORITY_SKILL_INDEX);
         assert_eq!(evicted[1]["char_len"], 10);
+        assert!(evicted[1]["token_len"].is_null());
         // The retained anchor must never appear in the eviction record.
         assert!(
             evicted
                 .iter()
                 .all(|e| e["source"] != "persona.immutable_anchor")
         );
+    }
+
+    /// sera-ibkr.3: token-only pressure payload. Uses
+    /// `estimate_text_tokens` to derive a budget that admits only the anchor,
+    /// then asserts the token fields are populated and chars null.
+    #[test]
+    fn make_context_pressure_audit_payload_token_only() {
+        use sera_runtime::context_engine::envelope::{
+            ContextEnvelopeBuilder, ContextSegment, PRIORITY_IMMUTABLE_ANCHOR,
+            PRIORITY_SEMANTIC_RECALL,
+        };
+        use sera_runtime::context_engine::estimate_text_tokens;
+
+        let anchor = "anchor text";
+        let recall = "a semantic recall segment that should be evicted under token pressure";
+        let budget = estimate_text_tokens(anchor) + estimate_text_tokens(recall) - 1;
+
+        let mut b = ContextEnvelopeBuilder::new(None).with_budget_tokens(Some(budget));
+        b.push(ContextSegment::new(
+            SegmentKind::Persona,
+            "persona.immutable_anchor",
+            anchor,
+            PRIORITY_IMMUTABLE_ANCHOR,
+        ))
+        .push(ContextSegment::new(
+            SegmentKind::Custom("semantic_recall".into()),
+            "semantic_recall",
+            recall,
+            PRIORITY_SEMANTIC_RECALL,
+        ));
+        let envelope = b.build();
+        assert!(envelope.pressure, "token budget must force eviction");
+
+        let payload = make_context_pressure_audit_payload(
+            "sera",
+            "ibkr3-token-session",
+            None,
+            Some(budget),
+            &envelope,
+        );
+
+        assert_eq!(payload["policy"]["name"], "context_budget_tokens");
+        assert!(payload["unmapped"]["budget_chars"].is_null());
+        assert_eq!(payload["unmapped"]["budget_tokens"], budget);
+        let retained_tokens = payload["unmapped"]["retained_tokens"]
+            .as_u64()
+            .expect("retained_tokens must be a number under a token budget");
+        assert!(retained_tokens <= budget as u64);
+
+        let evicted = payload["unmapped"]["evicted"]
+            .as_array()
+            .expect("evicted must be an array");
+        assert_eq!(evicted.len(), 1);
+        // Evicted entry carries numeric token_len and char_len, and exposes
+        // exactly the five provenance keys — never any segment content.
+        let entry = &evicted[0];
+        assert!(entry["token_len"].as_u64().is_some());
+        assert!(entry["char_len"].as_u64().is_some());
+        let obj = entry.as_object().expect("evicted entry must be an object");
+        let mut keys: Vec<&str> = obj.keys().map(|k| k.as_str()).collect();
+        keys.sort_unstable();
+        assert_eq!(keys, vec!["char_len", "kind", "priority", "source", "token_len"]);
+    }
+
+    /// sera-ibkr.3: both budgets configured → `policy.name == "context_budget"`.
+    #[test]
+    fn make_context_pressure_audit_payload_both_budgets() {
+        use sera_runtime::context_engine::envelope::{
+            ContextEnvelopeBuilder, ContextSegment, PRIORITY_IMMUTABLE_ANCHOR,
+            PRIORITY_SEMANTIC_RECALL,
+        };
+
+        // anchor(6) + recall(10) = 16; char budget 12 evicts recall.
+        let mut b = ContextEnvelopeBuilder::new(Some(12)).with_budget_tokens(Some(4096));
+        b.push(ContextSegment::new(
+            SegmentKind::Persona,
+            "persona.immutable_anchor",
+            "anchor",
+            PRIORITY_IMMUTABLE_ANCHOR,
+        ))
+        .push(ContextSegment::new(
+            SegmentKind::Custom("semantic_recall".into()),
+            "semantic_recall",
+            "recalltext",
+            PRIORITY_SEMANTIC_RECALL,
+        ));
+        let envelope = b.build();
+        assert!(envelope.pressure);
+
+        let payload = make_context_pressure_audit_payload(
+            "sera",
+            "ibkr3-both-session",
+            Some(12),
+            Some(4096),
+            &envelope,
+        );
+        assert_eq!(payload["policy"]["name"], "context_budget");
+        assert_eq!(payload["unmapped"]["budget_chars"], 12);
+        assert_eq!(payload["unmapped"]["budget_tokens"], 4096);
+    }
+
+    /// sera-ibkr.3: `parse_context_budget` fails closed for unset, empty,
+    /// unparseable, and nonpositive values; accepts positive integers.
+    #[test]
+    fn parse_context_budget_fails_closed() {
+        assert_eq!(parse_context_budget("V", None), None);
+        assert_eq!(parse_context_budget("V", Some("abc".into())), None);
+        assert_eq!(parse_context_budget("V", Some("0".into())), None);
+        assert_eq!(parse_context_budget("V", Some("-5".into())), None);
+        assert_eq!(parse_context_budget("V", Some("".into())), None);
+        assert_eq!(parse_context_budget("V", Some("4096".into())), Some(4096));
+    }
+
+    /// sera-ibkr.3: a generous token budget preserves segment structure —
+    /// each context source stays its own segment and renders to one system
+    /// message (the token budget never appends to user content). Mirrors the
+    /// envelope-order tests that use `ContextEnvelopeBuilder::new(None)`.
+    #[test]
+    fn token_budget_preserves_segment_structure() {
+        use sera_runtime::context_engine::envelope::{
+            ContextEnvelopeBuilder, ContextSegment, PRIORITY_IDENTITY_MEMORY,
+            PRIORITY_IMMUTABLE_ANCHOR, PRIORITY_SEMANTIC_RECALL, PRIORITY_SKILL_INDEX,
+        };
+
+        let mut b = ContextEnvelopeBuilder::new(None).with_budget_tokens(Some(100_000));
+        b.push(ContextSegment::new(
+            SegmentKind::Soul,
+            "identity_memory.soul",
+            "I am the soul.",
+            PRIORITY_IMMUTABLE_ANCHOR,
+        ))
+        .push(ContextSegment::new(
+            SegmentKind::Custom("identity_memory.durable_memory".into()),
+            "identity_memory.durable_memory",
+            "durable memory content",
+            PRIORITY_IDENTITY_MEMORY,
+        ))
+        .push(ContextSegment::new(
+            SegmentKind::Custom("skill_index".into()),
+            "skill_index",
+            "skill index block",
+            PRIORITY_SKILL_INDEX,
+        ))
+        .push(ContextSegment::new(
+            SegmentKind::Custom("semantic_recall".into()),
+            "semantic_recall",
+            "semantic recall content",
+            PRIORITY_SEMANTIC_RECALL,
+        ))
+        .push(ContextSegment::new(
+            SegmentKind::MemoryRecall("semantic_prefetch".into()),
+            "memory.hindsight.prefetch",
+            "prefetched recall content",
+            PRIORITY_SEMANTIC_RECALL,
+        ));
+        let envelope = b.build();
+
+        assert!(!envelope.pressure, "generous token budget must not evict");
+        let sources: Vec<&str> = envelope
+            .segments()
+            .iter()
+            .map(|s| s.source.as_str())
+            .collect();
+        assert_eq!(
+            sources,
+            vec![
+                "identity_memory.soul",
+                "identity_memory.durable_memory",
+                "skill_index",
+                "semantic_recall",
+                "memory.hindsight.prefetch",
+            ]
+        );
+        // One system message per segment — token budget never collapses or
+        // appends to user content.
+        let msgs = envelope.to_messages();
+        assert_eq!(msgs.len(), 5);
+        assert!(msgs.iter().all(|m| m["role"] == "system"));
     }
 
     // ── Memory prefetch segment (sera-ibkr.3) ───────────────────────────────

--- a/rust/crates/sera-runtime/src/context_engine/envelope.rs
+++ b/rust/crates/sera-runtime/src/context_engine/envelope.rs
@@ -17,8 +17,19 @@
 //! (highest `priority` value) evictable segments are dropped first; the
 //! persona immutable anchor (`priority == 0`) is **never** evicted. A drop
 //! sets the [`ContextEnvelope::pressure`] flag and emits a `warn!` event.
+//!
+//! An optional **token budget** ([`ContextEnvelopeBuilder::with_budget_tokens`])
+//! sits alongside the char budget. When configured it estimates each segment's
+//! tokens via [`crate::context_engine::estimate_text_tokens`] (`cl100k_base`,
+//! budgeting only) and evicts in the **same** (priority desc, index desc) order
+//! until both active budgets are satisfied. The two budgets compose as a union
+//! constraint: eviction continues while either cap is exceeded, and each evicted
+//! segment is recorded exactly once. A `None`/zero token budget is disabled,
+//! leaving char-only behaviour byte-identical (no token estimation performed).
 
 use sera_types::memory::SegmentKind;
+
+use crate::context_engine::estimate_text_tokens;
 
 /// Priority of the persona immutable anchor. `0` is never evicted, matching
 /// the Soul convention in [`sera_types::memory::MemoryBlock`].
@@ -86,6 +97,10 @@ pub struct EvictedSegment {
     pub priority: u8,
     /// Character length of the dropped segment content.
     pub char_len: usize,
+    /// Estimated token length of the dropped segment content. `Some` only when
+    /// a token budget was configured — tokens are estimated only under an active
+    /// token budget, since estimation isn't free.
+    pub token_len: Option<usize>,
 }
 
 /// An ordered collection of [`ContextSegment`]s with budget bookkeeping.
@@ -97,6 +112,10 @@ pub struct ContextEnvelope {
     evicted: Vec<EvictedSegment>,
     /// `true` when budget pressure forced at least one eviction.
     pub pressure: bool,
+    /// Sum of retained segments' estimated tokens, computed during `build`
+    /// **only** when a token budget was configured. `None` when the token
+    /// budget is disabled (no estimation was performed).
+    total_tokens: Option<usize>,
 }
 
 impl ContextEnvelope {
@@ -140,6 +159,7 @@ impl ContextEnvelope {
         tracing::debug!(
             segments = self.segments.len(),
             total_chars = self.total_chars(),
+            total_tokens = ?self.total_tokens(),
             pressure = self.pressure,
             "context envelope assembled"
         );
@@ -149,6 +169,13 @@ impl ContextEnvelope {
     pub fn total_chars(&self) -> usize {
         self.segments.iter().map(|s| s.content.chars().count()).sum()
     }
+
+    /// Sum of retained segments' estimated tokens, available **only** when a
+    /// token budget was configured at build time. `None` when the token budget
+    /// is disabled — no estimation was performed.
+    pub fn total_tokens(&self) -> Option<usize> {
+        self.total_tokens
+    }
 }
 
 /// Builds a [`ContextEnvelope`] by pushing segments in canonical order, then
@@ -157,6 +184,9 @@ impl ContextEnvelope {
 pub struct ContextEnvelopeBuilder {
     segments: Vec<ContextSegment>,
     budget_chars: Option<usize>,
+    /// Optional token cap, composed as a union with the char budget. `None`
+    /// (default) = disabled = no token estimation performed.
+    budget_tokens: Option<usize>,
 }
 
 impl ContextEnvelopeBuilder {
@@ -166,7 +196,17 @@ impl ContextEnvelopeBuilder {
         Self {
             segments: Vec::new(),
             budget_chars,
+            budget_tokens: None,
         }
+    }
+
+    /// Configure an optional token budget (sera-ibkr.3). `None`/zero =
+    /// disabled = char-only behaviour byte-identical (no token estimation).
+    /// Composes with the char budget as a union constraint: eviction continues
+    /// while either active cap is exceeded.
+    pub fn with_budget_tokens(mut self, budget_tokens: Option<usize>) -> Self {
+        self.budget_tokens = budget_tokens;
+        self
     }
 
     /// Append a pre-built segment in canonical order.
@@ -185,23 +225,47 @@ impl ContextEnvelopeBuilder {
         let Self {
             segments,
             budget_chars,
+            budget_tokens,
         } = self;
 
-        let Some(budget) = budget_chars.filter(|b| *b > 0) else {
-            // Unlimited (None / 0): no eviction, no pressure.
+        // Effective budgets: zero/None disables that constraint (mirrors the
+        // historical char-budget semantics exactly).
+        let char_budget = budget_chars.filter(|b| *b > 0);
+        let token_budget = budget_tokens.filter(|b| *b > 0);
+
+        // Per-segment char lengths (always cheap) and token estimates (only
+        // when a token budget is active — estimation isn't free).
+        let char_lens: Vec<usize> = segments.iter().map(|s| s.content.chars().count()).collect();
+        let token_lens: Option<Vec<usize>> = token_budget
+            .map(|_| segments.iter().map(|s| estimate_text_tokens(&s.content)).collect());
+
+        if char_budget.is_none() && token_budget.is_none() {
+            // Both constraints disabled: no eviction, no pressure, and no token
+            // total (none was estimated).
             return ContextEnvelope {
                 segments,
                 evicted: Vec::new(),
                 pressure: false,
+                total_tokens: None,
             };
+        }
+
+        let mut current_chars: usize = char_lens.iter().sum();
+        let mut current_tokens: usize = token_lens.as_ref().map_or(0, |t| t.iter().sum());
+
+        // Union constraint: over budget when either active cap is exceeded.
+        let over_budget = |chars: usize, tokens: usize| -> bool {
+            char_budget.is_some_and(|b| chars > b) || token_budget.is_some_and(|b| tokens > b)
         };
 
-        let total: usize = segments.iter().map(|s| s.content.chars().count()).sum();
-        if total <= budget {
+        if !over_budget(current_chars, current_tokens) {
+            // Within all active budgets: no eviction. Token total is still
+            // reported when a token budget was configured.
             return ContextEnvelope {
                 segments,
                 evicted: Vec::new(),
                 pressure: false,
+                total_tokens: token_budget.map(|_| current_tokens),
             };
         }
 
@@ -210,7 +274,6 @@ impl ContextEnvelopeBuilder {
         // (input-order) segments first so earlier context is preferentially
         // retained.
         let mut keep: Vec<bool> = vec![true; segments.len()];
-        let mut current = total;
         let mut pressure = false;
         let mut evicted: Vec<EvictedSegment> = Vec::new();
 
@@ -230,17 +293,20 @@ impl ContextEnvelopeBuilder {
         });
 
         for idx in candidates {
-            if current <= budget {
+            if !over_budget(current_chars, current_tokens) {
                 break;
             }
             let seg = &segments[idx];
-            let char_len = seg.content.chars().count();
+            let char_len = char_lens[idx];
+            let token_len = token_lens.as_ref().map(|t| t[idx]);
             tracing::warn!(
                 kind = ?seg.kind,
                 source = %seg.source,
                 priority = seg.priority,
                 char_len,
-                budget,
+                budget = ?char_budget,
+                token_len = ?token_len,
+                budget_tokens = ?token_budget,
                 "context envelope budget pressure: evicting segment"
             );
             evicted.push(EvictedSegment {
@@ -248,9 +314,15 @@ impl ContextEnvelopeBuilder {
                 source: seg.source.clone(),
                 priority: seg.priority,
                 char_len,
+                token_len,
             });
             keep[idx] = false;
-            current -= char_len;
+            // saturating_sub for defence in depth: each candidate index is
+            // visited at most once today, so plain subtraction never underflows,
+            // but this keeps the running totals sound if candidate construction
+            // ever changes.
+            current_chars = current_chars.saturating_sub(char_len);
+            current_tokens = current_tokens.saturating_sub(token_len.unwrap_or(0));
             pressure = true;
         }
 
@@ -264,6 +336,7 @@ impl ContextEnvelopeBuilder {
             segments: retained,
             evicted,
             pressure,
+            total_tokens: token_budget.map(|_| current_tokens),
         }
     }
 }
@@ -501,5 +574,167 @@ mod tests {
             .push(seg("semantic_recall", "recall", PRIORITY_SEMANTIC_RECALL));
         let env = b.build();
         assert_eq!(env.total_chars(), 6);
+    }
+
+    // ── Token budget (sera-ibkr.3) ──────────────────────────────────────────
+
+    #[test]
+    fn token_only_pressure_evicts_most_evictable() {
+        // Chars unlimited; token budget set just below the two-segment sum so
+        // the most-evictable (recall) is dropped.
+        let anchor = "anchor text";
+        let recall = "this is the most evictable recall segment";
+        let anchor_t = estimate_text_tokens(anchor);
+        // Budget admits only the anchor.
+        let budget = anchor_t + estimate_text_tokens(recall) - 1;
+        let mut b = ContextEnvelopeBuilder::new(None).with_budget_tokens(Some(budget));
+        b.push(seg("persona.immutable_anchor", anchor, PRIORITY_IMMUTABLE_ANCHOR))
+            .push(seg("semantic_recall", recall, PRIORITY_SEMANTIC_RECALL));
+        let env = b.build();
+        assert!(env.pressure);
+        let sources: Vec<&str> = env.segments().iter().map(|s| s.source.as_str()).collect();
+        assert_eq!(sources, vec!["persona.immutable_anchor"]);
+        let total = env.total_tokens().expect("token budget active → Some");
+        assert!(total <= budget, "retained tokens {total} must be <= {budget}");
+    }
+
+    #[test]
+    fn token_eviction_order_recall_then_introspection_then_index() {
+        // Mirror eviction_order_recall_then_introspection_then_index, driven by
+        // a token budget that admits only the anchor.
+        let anchor = "anchor";
+        let budget = estimate_text_tokens(anchor);
+        let mut b = ContextEnvelopeBuilder::new(None).with_budget_tokens(Some(budget));
+        b.push(seg("persona.immutable_anchor", anchor, PRIORITY_IMMUTABLE_ANCHOR))
+            .push(seg("skill_dispatch", "skill dispatch text", PRIORITY_SKILL_INJECTION))
+            .push(seg("skill_index", "skill index text", PRIORITY_SKILL_INDEX))
+            .push(seg("self_introspection", "self introspection text", PRIORITY_SELF_INTROSPECTION))
+            .push(seg("semantic_recall", "semantic recall text", PRIORITY_SEMANTIC_RECALL));
+        let env = b.build();
+        assert!(env.pressure);
+        let sources: Vec<&str> = env.segments().iter().map(|s| s.source.as_str()).collect();
+        assert_eq!(sources, vec!["persona.immutable_anchor"]);
+        // Evicted in canonical order: recall, introspection, index, dispatch.
+        let evicted: Vec<&str> = env.evicted().iter().map(|e| e.source.as_str()).collect();
+        assert_eq!(
+            evicted,
+            vec!["semantic_recall", "self_introspection", "skill_index", "skill_dispatch"]
+        );
+    }
+
+    #[test]
+    fn token_equal_priority_later_evicted_first() {
+        // Two equal-priority segments under token pressure: the later one is
+        // evicted first so earlier context is preferentially retained.
+        let anchor = "anchor";
+        let first = "first recall block of words";
+        let second = "second recall block of words";
+        // Budget admits the anchor plus exactly one recall block.
+        let budget = estimate_text_tokens(anchor)
+            + estimate_text_tokens(first).max(estimate_text_tokens(second));
+        let mut b = ContextEnvelopeBuilder::new(None).with_budget_tokens(Some(budget));
+        b.push(seg("persona.immutable_anchor", anchor, PRIORITY_IMMUTABLE_ANCHOR))
+            .push(seg("recall_first", first, PRIORITY_SEMANTIC_RECALL))
+            .push(seg("recall_second", second, PRIORITY_SEMANTIC_RECALL));
+        let env = b.build();
+        assert!(env.pressure);
+        let evicted: Vec<&str> = env.evicted().iter().map(|e| e.source.as_str()).collect();
+        assert_eq!(evicted, vec!["recall_second"]);
+    }
+
+    #[test]
+    fn anchor_never_evicted_under_token_pressure() {
+        // Anchor alone exceeds the token budget, yet it is retained.
+        let anchor = "this is a fairly long immutable anchor segment that exceeds the budget";
+        let budget = 1;
+        let mut b = ContextEnvelopeBuilder::new(None).with_budget_tokens(Some(budget));
+        b.push(seg("persona.immutable_anchor", anchor, PRIORITY_IMMUTABLE_ANCHOR))
+            .push(seg("semantic_recall", "recall text", PRIORITY_SEMANTIC_RECALL));
+        let env = b.build();
+        assert!(env.pressure);
+        let sources: Vec<&str> = env.segments().iter().map(|s| s.source.as_str()).collect();
+        assert_eq!(sources, vec!["persona.immutable_anchor"]);
+    }
+
+    #[test]
+    fn char_only_evicted_have_no_token_len_and_total_tokens_none() {
+        // Only a char budget set: evicted records carry token_len None and
+        // total_tokens() is None.
+        let mut b = ContextEnvelopeBuilder::new(Some(6));
+        b.push(seg("persona.immutable_anchor", "anchor", PRIORITY_IMMUTABLE_ANCHOR))
+            .push(seg("semantic_recall", "recall", PRIORITY_SEMANTIC_RECALL));
+        let env = b.build();
+        assert!(env.pressure);
+        assert!(env.total_tokens().is_none());
+        assert!(env.evicted().iter().all(|e| e.token_len.is_none()));
+    }
+
+    #[test]
+    fn combined_char_and_token_pressure_satisfies_union() {
+        // Construct so the char budget alone would evict only the largest
+        // (recall) segment, but the token budget forces a second eviction.
+        let anchor = "anchor";
+        let mid = "midmid"; // 6 chars
+        let recall = "recallrecallrecall"; // 18 chars, largest
+        let anchor_c = anchor.chars().count();
+        let mid_c = mid.chars().count();
+        let recall_c = recall.chars().count();
+        // Char budget admits anchor + mid (evicts only recall).
+        let char_budget = anchor_c + mid_c;
+        assert!(char_budget < anchor_c + mid_c + recall_c);
+        // Token budget admits only the anchor (forces mid out too, beyond the
+        // single char-driven recall eviction).
+        let token_budget = estimate_text_tokens(anchor);
+        let mut b = ContextEnvelopeBuilder::new(Some(char_budget))
+            .with_budget_tokens(Some(token_budget));
+        b.push(seg("persona.immutable_anchor", anchor, PRIORITY_IMMUTABLE_ANCHOR))
+            .push(seg("skill_index", mid, PRIORITY_SKILL_INDEX))
+            .push(seg("semantic_recall", recall, PRIORITY_SEMANTIC_RECALL));
+        let env = b.build();
+        assert!(env.pressure);
+        // Both recall and mid evicted, each exactly once, in canonical order.
+        let evicted: Vec<&str> = env.evicted().iter().map(|e| e.source.as_str()).collect();
+        assert_eq!(evicted, vec!["semantic_recall", "skill_index"]);
+        // No double-counting: each evicted source unique.
+        let mut uniq = evicted.clone();
+        uniq.sort_unstable();
+        uniq.dedup();
+        assert_eq!(uniq.len(), evicted.len());
+        // Records carry both char_len and Some(token_len).
+        assert!(env.evicted().iter().all(|e| e.char_len > 0 && e.token_len.is_some()));
+        // Union constraint satisfied where satisfiable: only the anchor remains.
+        let sources: Vec<&str> = env.segments().iter().map(|s| s.source.as_str()).collect();
+        assert_eq!(sources, vec!["persona.immutable_anchor"]);
+        // Retained token total within budget (anchor alone is within token_budget).
+        let total = env.total_tokens().expect("token budget active → Some");
+        assert!(total <= token_budget);
+    }
+
+    #[test]
+    fn token_budget_zero_treated_as_disabled() {
+        // Some(0) token budget mirrors zero_budget_treated_as_unlimited: no
+        // eviction, no token total.
+        let mut b = ContextEnvelopeBuilder::new(None).with_budget_tokens(Some(0));
+        b.push(seg("a", "hello world this is plenty of text", PRIORITY_SKILL_INJECTION));
+        let env = b.build();
+        assert!(!env.pressure);
+        assert_eq!(env.segments().len(), 1);
+        assert!(env.total_tokens().is_none());
+    }
+
+    #[test]
+    fn evicted_token_len_equals_estimate_of_dropped_content() {
+        let anchor = "anchor";
+        let recall = "the recall content that will be dropped";
+        let budget = estimate_text_tokens(anchor);
+        let mut b = ContextEnvelopeBuilder::new(None).with_budget_tokens(Some(budget));
+        b.push(seg("persona.immutable_anchor", anchor, PRIORITY_IMMUTABLE_ANCHOR))
+            .push(seg("semantic_recall", recall, PRIORITY_SEMANTIC_RECALL));
+        let env = b.build();
+        assert!(env.pressure);
+        let evicted = env.evicted();
+        assert_eq!(evicted.len(), 1);
+        assert_eq!(evicted[0].source, "semantic_recall");
+        assert_eq!(evicted[0].token_len, Some(estimate_text_tokens(recall)));
     }
 }

--- a/rust/crates/sera-runtime/src/context_engine/mod.rs
+++ b/rust/crates/sera-runtime/src/context_engine/mod.rs
@@ -18,7 +18,26 @@ pub use envelope::{
 };
 
 use async_trait::async_trait;
+use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
+use tiktoken_rs::CoreBPE;
+use tiktoken_rs::cl100k_base;
+
+/// `cl100k_base` encoder shared by the envelope token-budget estimator.
+/// Mirrors `pipeline.rs`'s private `TOKENIZER_CL100K` static; kept separate so
+/// `pipeline.rs` stays untouched. Budgeting only — an approximation, not an
+/// exact per-provider token count.
+static ENVELOPE_TOKENIZER_CL100K: Lazy<CoreBPE> =
+    Lazy::new(|| cl100k_base().expect("cl100k_base encoding must be available"));
+
+/// Estimate the token count of a single text blob for envelope segment
+/// budgeting (sera-ibkr.3). Mirrors `pipeline.rs`'s `estimate_tokens`
+/// (`cl100k_base` + `encode_ordinary`) but operates on raw text rather than
+/// JSON messages. Approximation for budgeting only — not an exact
+/// per-provider token count.
+pub fn estimate_text_tokens(text: &str) -> usize {
+    ENVELOPE_TOKENIZER_CL100K.encode_ordinary(text).len()
+}
 
 /// Token budget for context assembly.
 #[derive(Debug, Clone)]


### PR DESCRIPTION
## Summary

Adds an optional **token budget** (`SERA_CONTEXT_BUDGET_TOKENS`) to the gateway ContextEnvelope injected-context assembly path, alongside the existing char budget (`SERA_CONTEXT_BUDGET_CHARS`). The two compose as a **union constraint**: whole-segment eviction continues while *either* active cap is exceeded, by descending priority (most evictable first). The persona immutable anchor (priority 0) is **never evicted** under token pressure, as under char pressure.

This is the next narrow sera-ibkr.3 Hermes-parity slice. It budgets injected envelope segments only — no transcript/KV-cache compaction, no memory write/retain governance, no model-tokenizer subsystem.

## Changes

- **`sera-runtime/src/context_engine/mod.rs`** — `estimate_text_tokens`, a budgeting-only token estimate via tiktoken `cl100k_base` + `encode_ordinary`, mirroring `pipeline.rs`'s private tokenizer. Documented as an approximation, not an exact per-provider count.
- **`sera-runtime/src/context_engine/envelope.rs`** — `ContextEnvelopeBuilder::with_budget_tokens`, union eviction in a single build pass, `EvictedSegment.token_len`, `ContextEnvelope::total_tokens()`. Token estimation runs **only** when a token budget is active; char-only and unlimited paths stay byte-identical (`total_tokens()` is `None`).
- **`sera-gateway/src/bin/sera.rs`** — pure `parse_context_budget` env helper (unset/empty/invalid/zero fail closed to disabled, with a `warn!`); OCSF context-pressure audit gains `budget_tokens`, `retained_tokens`, and per-evicted `token_len`; `policy.name` names the active budget(s) (`context_budget_chars` / `context_budget_tokens` / `context_budget`). Segment content is never emitted.

## Approximation note

Token counts use `cl100k_base` for **budgeting only** — they are not exact per-provider token counts. This reuses the tokenizer already vendored for `pipeline.rs`; no model-router/tokenizer abstraction was introduced in this slice (filed as the recommended next slice).

## Tests

All green:

- `cargo test -p sera-runtime context_engine --lib` → **63 passed**
- `cargo test -p sera-gateway --bin sera-gateway budget` → **7 passed**
- `cargo test -p sera-gateway --bin sera-gateway context_pressure` → **3 passed**
- `cargo check -p sera-gateway -p sera-runtime -p sera-types` → clean
- `cargo clippy -p sera-runtime --lib` and `-p sera-gateway --bin sera-gateway` → clean (only a pre-existing unrelated `a2a.rs` test-import warning)

Coverage: token-only, char-only, combined token+char, zero/invalid disabled, anchor non-eviction (token + char + combined), eviction order, equal-priority later-first, and audit-payload privacy (exhaustive key-set assertion) / fields.

## Reviewed

Independent review lane run over the diff (verdict: COMMENT, non-blocking). Both findings applied:
- audit `policy.name` no-budget arm given a distinct `context_budget_none` value so it can't masquerade as the both-active record;
- envelope running totals use `saturating_sub` for defence in depth.

## Next slice (recommended)

Exact per-provider token accounting / model-tokenizer abstraction for the envelope budget — the current `cl100k_base` estimate is a deliberate budgeting approximation. That is a larger architecture effort and was intentionally kept out of this PR.

Do **not** merge — leaving open for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)