### PR TITLE
feat(memory): SERA-owned read-only Hindsight reflect + write governance (sera-ibkr.5)

### DIFF
--- a/rust/crates/sera-config/src/provider_wizard.rs
+++ b/rust/crates/sera-config/src/provider_wizard.rs
@@ -461,8 +461,17 @@ mod tests {
     use super::*;
     use crate::provider_registry::lookup;
 
+    /// Serialises tests that mutate the process-global `OPENROUTER_API_KEY`.
+    /// cargo runs a test binary's cases on multiple threads, so without this
+    /// the env-reading and env-setting tests observe each other's mutations
+    /// (the `validate-rust` flake: this handler read a sibling test's
+    /// `from-env-key` instead of the prompted value). `into_inner` ignores
+    /// poisoning so one failing assertion does not cascade into the other.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     #[test]
     fn api_key_handler_writes_secret_and_returns_ref() {
+        let _env_guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let entry = lookup("openrouter").unwrap();
         let prompter = MockPrompter::new(
             vec![""], // base_url -> use default
@@ -472,7 +481,8 @@ mod tests {
 
         // Ensure no env var leaks into the test
         let saved = std::env::var("OPENROUTER_API_KEY").ok();
-        // SAFETY: tests are single-threaded under cargo's per-binary serialisation
+        // SAFETY: env mutation is serialised via ENV_LOCK for the duration of
+        // this test, so no other test reads/writes OPENROUTER_API_KEY concurrently.
         unsafe { std::env::remove_var("OPENROUTER_API_KEY") };
 
         let cfg = ApiKeyHandler.run(entry, "openrouter-test", &prompter, &secrets).unwrap();
@@ -498,11 +508,13 @@ mod tests {
 
     #[test]
     fn api_key_handler_uses_env_when_set() {
+        let _env_guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let entry = lookup("openrouter").unwrap();
         let prompter = MockPrompter::new(vec![""], vec![]);
         let secrets = MockSecretStore::default();
 
         let saved = std::env::var("OPENROUTER_API_KEY").ok();
+        // SAFETY: env mutation is serialised via ENV_LOCK (see sibling test).
         unsafe { std::env::set_var("OPENROUTER_API_KEY", "from-env-key") };
 
         let cfg = ApiKeyHandler

--- a/rust/crates/sera-memory-hindsight/src/lib.rs
+++ b/rust/crates/sera-memory-hindsight/src/lib.rs
@@ -239,9 +239,13 @@ struct ReflectSourceWire {
 
 #[derive(Debug, Deserialize)]
 struct ReflectResponse {
-    #[serde(default)]
+    /// Hindsight's live reflect endpoint returns the generated answer under
+    /// `text`; `answer` is accepted as a compatible alias.
+    #[serde(default, alias = "text")]
     answer: String,
-    #[serde(default, alias = "results")]
+    /// Hindsight's live reflect endpoint returns supporting evidence under
+    /// `based_on`; `sources` / `results` are accepted as compatible aliases.
+    #[serde(default, alias = "based_on", alias = "results")]
     sources: Vec<ReflectSourceWire>,
 }
 
@@ -971,6 +975,37 @@ mod tests {
         assert_eq!(ans.sources[0].id.as_deref(), Some("m-1"));
         assert_eq!(ans.sources[0].content, "user asked for brevity");
         assert!((ans.sources[1].score - 0.6).abs() < 1e-6);
+        assert_eq!(ans.provenance, "hindsight:reflect:agent:agent-1");
+    }
+
+    #[tokio::test]
+    async fn reflect_reads_live_text_and_based_on_shape() {
+        // Regression: the live Hindsight reflect endpoint returns the answer
+        // under `text` and evidence under `based_on` (not `answer`/`sources`).
+        // Before the alias fix both fields defaulted, silently yielding an
+        // empty answer and no sources.
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/default/banks/agent:agent-1/reflect"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "text": "You favour terse, direct answers.",
+                "based_on": [
+                    {"id": "m-1", "text": "user asked to keep it short", "score": 0.91},
+                    {"id": "m-2", "content": "dislikes preamble", "score": 0.42},
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        let store = HindsightStore::new(fast_config(server.uri())).unwrap();
+        let ans = store.reflect(&reflect_query("how should I answer?")).await.unwrap();
+
+        assert_eq!(ans.answer, "You favour terse, direct answers.");
+        assert_eq!(ans.sources.len(), 2, "based_on evidence must be parsed");
+        assert_eq!(ans.sources[0].id.as_deref(), Some("m-1"));
+        assert_eq!(ans.sources[0].content, "user asked to keep it short");
+        assert!((ans.sources[0].score - 0.91).abs() < 1e-6);
+        assert_eq!(ans.sources[1].content, "dislikes preamble");
         assert_eq!(ans.provenance, "hindsight:reflect:agent:agent-1");
     }
 

--- a/rust/crates/sera-memory-hindsight/src/lib.rs
+++ b/rust/crates/sera-memory-hindsight/src/lib.rs
@@ -36,12 +36,30 @@
 //! `promote`, `touch`, and `maintenance` inherit the trait defaults (no-op /
 //! `Backend` not-implemented).
 //!
-//! ## `reflect` is NOT mapped
+//! ## Read-only `reflect` (RAG Q&A)
 //!
 //! Hindsight's `POST /v1/default/banks/{bank_id}/reflect` is a synchronous
-//! RAG Q&A endpoint, not a memory-retention primitive. It does not belong in
-//! the `SemanticMemoryStore` surface. A future bead may expose it separately.
+//! RAG Q&A endpoint: it synthesises an answer from existing memories without
+//! retaining anything. Because it does not match the retention semantics of
+//! [`SemanticMemoryStore::put`], it is exposed as the SERA-owned inherent
+//! method [`HindsightStore::reflect`] rather than on the trait surface — the
+//! same separation the spec applies to `HindsightStore::list`
+//! (SPEC-memory-pluggability §4). Reflect is always read-only and is allowed
+//! even when the store is configured [`HindsightConfig::read_only`]. Results
+//! carry a `provenance` label so injected/read answers stay attributable.
+//!
+//! ## Write governance
+//!
+//! Retain/write is governed by SERA, not passed through uncontrolled. When
+//! [`HindsightConfig::read_only`] is set (the gateway default for the
+//! external Hindsight backend), [`HindsightStore::put`] refuses **before** any
+//! HTTP/provider mutation, returns a clear policy error to the caller, emits a
+//! structured `tracing` governance event on the `sera.memory.governance`
+//! target, and notifies the optional [`WriteAuditSink`] supplied via
+//! [`HindsightStore::with_audit_sink`]. Recall/reflect failures degrade read
+//! context truthfully; write failures are surfaced explicitly, never swallowed.
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -198,6 +216,93 @@ struct RecallResponse {
     results: Vec<RecallResult>,
 }
 
+#[derive(Debug, Serialize)]
+struct ReflectBody<'a> {
+    query: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    budget: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max_tokens: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    types: Option<&'a [String]>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReflectSourceWire {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(alias = "text")]
+    content: String,
+    #[serde(default)]
+    score: f32,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReflectResponse {
+    #[serde(default)]
+    answer: String,
+    #[serde(default, alias = "results")]
+    sources: Vec<ReflectSourceWire>,
+}
+
+// ── Public reflect types ─────────────────────────────────────────────────────────
+
+/// A single source memory cited by a [`HindsightStore::reflect`] answer.
+///
+/// Carried verbatim so callers can render or audit the evidence behind a
+/// synthesised answer.
+#[derive(Debug, Clone)]
+pub struct ReflectSource {
+    /// Hindsight memory id, when the server returns one.
+    pub id: Option<String>,
+    /// Memory content backing the answer.
+    pub content: String,
+    /// Relevance score reported by Hindsight (`0.0` when absent).
+    pub score: f32,
+}
+
+/// Result of a read-only Hindsight `reflect` (synchronous RAG Q&A).
+#[derive(Debug, Clone)]
+pub struct ReflectAnswer {
+    /// The synthesised answer text.
+    pub answer: String,
+    /// Source memories cited by Hindsight, preserved for provenance.
+    pub sources: Vec<ReflectSource>,
+    /// Provenance label identifying the backend + bank that produced this
+    /// answer (for example `"hindsight:reflect:agent:agent-1"`). Injected /
+    /// read results stay attributable to their origin.
+    pub provenance: String,
+}
+
+// ── Write governance ─────────────────────────────────────────────────────────────
+
+/// A write-governance decision recorded when a retain/write is refused
+/// **before** any provider mutation.
+#[derive(Debug, Clone)]
+pub struct WriteDenial {
+    /// Hindsight bank the write targeted.
+    pub bank_id: String,
+    /// Caller agent identity.
+    pub agent_id: String,
+    /// Operation that was refused (for example `"put"`).
+    pub operation: &'static str,
+    /// Machine-stable reason (for example `"read_only"`).
+    pub reason: &'static str,
+}
+
+/// Sink for SERA-owned write-governance decisions.
+///
+/// The gateway supplies an implementation that bridges denials to its OCSF
+/// audit log; tests use a recording stub. When no sink is set, denials are
+/// still emitted via `tracing` on the `sera.memory.governance` target and the
+/// caller still receives the policy error — the sink only adds a programmatic
+/// hook for callers that own audit primitives.
+pub trait WriteAuditSink: Send + Sync {
+    /// Called exactly once per refused write, before the policy error is
+    /// returned to the caller.
+    fn record_denial(&self, denial: &WriteDenial);
+}
+
 // ── Adapter ────────────────────────────────────────────────────────────────────
 
 /// [`SemanticMemoryStore`] backed by the Hindsight HTTP API.
@@ -207,6 +312,7 @@ struct RecallResponse {
 pub struct HindsightStore {
     client: Client,
     config: HindsightConfig,
+    audit_sink: Option<Arc<dyn WriteAuditSink>>,
 }
 
 impl HindsightStore {
@@ -226,7 +332,50 @@ impl HindsightStore {
         let client = builder
             .build()
             .map_err(|e| SemanticError::Backend(format!("reqwest client build failed: {e}")))?;
-        Ok(Self { client, config })
+        Ok(Self {
+            client,
+            config,
+            audit_sink: None,
+        })
+    }
+
+    /// Attach a [`WriteAuditSink`] that is notified whenever write governance
+    /// refuses a retain/write before any provider mutation.
+    pub fn with_audit_sink(mut self, sink: Arc<dyn WriteAuditSink>) -> Self {
+        self.audit_sink = Some(sink);
+        self
+    }
+
+    /// SERA-owned write-governance gate. Returns `Ok(())` when writes are
+    /// permitted; otherwise emits a structured governance event, notifies the
+    /// optional [`WriteAuditSink`], and returns a clear policy error — all
+    /// **before** any HTTP/provider mutation.
+    fn ensure_write_allowed(&self, agent_id: &str, bank_id: &str) -> Result<(), SemanticError> {
+        if !self.config.read_only {
+            return Ok(());
+        }
+        let denial = WriteDenial {
+            bank_id: bank_id.to_string(),
+            agent_id: agent_id.to_string(),
+            operation: "put",
+            reason: "read_only",
+        };
+        warn!(
+            target: "sera.memory.governance",
+            decision = "denied",
+            reason = denial.reason,
+            operation = denial.operation,
+            bank_id = %denial.bank_id,
+            agent_id = %denial.agent_id,
+            "hindsight write refused by SERA governance"
+        );
+        if let Some(sink) = &self.audit_sink {
+            sink.record_denial(&denial);
+        }
+        Err(SemanticError::Backend(format!(
+            "hindsight write refused by SERA governance (read_only): \
+             retain/write disabled for bank {bank_id}; no provider mutation attempted"
+        )))
     }
 
     fn bank_id_for_put(&self, req: &PutRequest) -> String {
@@ -386,6 +535,78 @@ impl HindsightStore {
 
         Ok(recall.results)
     }
+
+    /// Read-only RAG Q&A via Hindsight `reflect`.
+    ///
+    /// `POST /v1/default/banks/{bank_id}/reflect` synthesises an answer from
+    /// existing memories; it never retains anything, so it is permitted even
+    /// when the store is configured [`HindsightConfig::read_only`]. Requires
+    /// [`SemanticQuery::text`] (Hindsight reflect has no raw-vector form) and
+    /// returns [`SemanticError::Backend`] when text is absent.
+    ///
+    /// Failures degrade truthfully: a provider error surfaces as
+    /// [`SemanticError::Backend`] rather than an empty answer. The returned
+    /// [`ReflectAnswer::provenance`] labels the backend + bank so injected
+    /// answers stay attributable.
+    pub async fn reflect(&self, query: &SemanticQuery) -> Result<ReflectAnswer, SemanticError> {
+        let query_text = query.text.as_deref().ok_or_else(|| {
+            SemanticError::Backend(
+                "hindsight reflect requires query.text; raw-vector reflect is not supported".into(),
+            )
+        })?;
+
+        let bank_id = self.bank_id_for_query(query);
+        let url = format!(
+            "{}/v1/default/banks/{}/reflect",
+            self.config.base_url, bank_id
+        );
+        let body = ReflectBody {
+            query: query_text,
+            budget: self.config.recall_budget.as_deref(),
+            max_tokens: self.config.recall_max_tokens,
+            types: if self.config.recall_types.is_empty() {
+                None
+            } else {
+                Some(self.config.recall_types.as_slice())
+            },
+        };
+        let resp = self
+            .client
+            .post(&url)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| SemanticError::Backend(format!("hindsight reflect request failed: {e}")))?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let text = resp.text().await.unwrap_or_default();
+            return Err(SemanticError::Backend(format!(
+                "hindsight reflect returned {status}: {text}"
+            )));
+        }
+
+        let reflect: ReflectResponse = resp
+            .json()
+            .await
+            .map_err(|e| SemanticError::Backend(format!("hindsight reflect parse: {e}")))?;
+
+        let sources = reflect
+            .sources
+            .into_iter()
+            .map(|s| ReflectSource {
+                id: s.id,
+                content: s.content,
+                score: s.score,
+            })
+            .collect();
+
+        Ok(ReflectAnswer {
+            answer: reflect.answer,
+            sources,
+            provenance: format!("hindsight:reflect:{bank_id}"),
+        })
+    }
 }
 
 // ── SemanticMemoryStore impl ───────────────────────────────────────────────────
@@ -398,12 +619,11 @@ impl SemanticMemoryStore for HindsightStore {
     /// If the response carries a non-null `operation_id`, the adapter polls
     /// the operations endpoint until the operation reaches a terminal state.
     async fn put(&self, req: PutRequest) -> Result<MemoryId, SemanticError> {
-        if self.config.read_only {
-            return Err(SemanticError::Backend(
-                "hindsight backend is configured read-only; put refused".into(),
-            ));
-        }
+        // SERA-owned write governance: refuse before any provider mutation.
+        // Bank derivation is pure (no HTTP), so computing it here keeps the
+        // governance event/audit attributable without touching Hindsight.
         let bank_id = self.bank_id_for_put(&req);
+        self.ensure_write_allowed(&req.agent_id, &bank_id)?;
         let put_resp = self.put_memory(&bank_id, &req).await?;
 
         // Opportunistic async path: poll until terminal.
@@ -522,6 +742,18 @@ mod tests {
             "Hello, Hindsight!",
             SegmentKind::MemoryRecall("r-1".into()),
         )
+    }
+
+    fn reflect_query(text: &str) -> SemanticQuery {
+        SemanticQuery {
+            agent_id: "agent-1".into(),
+            scope: None,
+            tier_filter: None,
+            text: Some(text.into()),
+            query_embedding: None,
+            top_k: 5,
+            similarity_threshold: None,
+        }
     }
 
     // ── scope_to_bank_id ─────────────────────────────────────────────────────
@@ -656,21 +888,146 @@ mod tests {
         assert!((results[0].score - 0.9).abs() < 1e-6);
     }
 
-    // ── read-only refuses put before HTTP ─────────────────────────────────────
+    // ── read-only refuses put before any provider mutation ────────────────────
+
+    /// A recording [`WriteAuditSink`] for governance assertions.
+    #[derive(Default)]
+    struct RecordingSink {
+        denials: std::sync::Mutex<Vec<WriteDenial>>,
+    }
+
+    impl WriteAuditSink for RecordingSink {
+        fn record_denial(&self, denial: &WriteDenial) {
+            self.denials.lock().unwrap().push(denial.clone());
+        }
+    }
 
     #[tokio::test]
-    async fn read_only_put_refuses_before_http() {
+    async fn read_only_put_refuses_before_provider_mutation() {
+        // If the governance gate let the request through, this mock would be
+        // hit and return a recognisable sentinel body. We assert the sentinel
+        // never appears in the error, proving no provider mutation occurred.
         let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/default/banks/agent:agent-1/memories"))
+            .respond_with(ResponseTemplate::new(500).set_body_string("PROVIDER_WAS_CALLED"))
+            .mount(&server)
+            .await;
+
         let mut config = fast_config(server.uri());
         config.read_only = true;
-        let store = HindsightStore::new(config).unwrap();
+        let sink = Arc::new(RecordingSink::default());
+        let store = HindsightStore::new(config).unwrap().with_audit_sink(sink.clone());
+
         let err = store.put(put_req("agent-1")).await.unwrap_err();
         match &err {
             SemanticError::Backend(msg) => {
-                assert!(msg.contains("read-only"), "expected read-only in: {msg}");
+                assert!(msg.contains("read_only"), "expected read_only in: {msg}");
+                assert!(
+                    msg.contains("no provider mutation attempted"),
+                    "expected explicit no-mutation marker in: {msg}"
+                );
+                assert!(
+                    !msg.contains("PROVIDER_WAS_CALLED"),
+                    "provider must not be reached on a governed refusal: {msg}"
+                );
             }
             other => panic!("expected Backend error, got: {other:?}"),
         }
+
+        // The denial is auditable: the sink received exactly one record with
+        // the attributable bank/agent/reason.
+        let denials = sink.denials.lock().unwrap();
+        assert_eq!(denials.len(), 1, "exactly one denial recorded");
+        assert_eq!(denials[0].bank_id, "agent:agent-1");
+        assert_eq!(denials[0].agent_id, "agent-1");
+        assert_eq!(denials[0].operation, "put");
+        assert_eq!(denials[0].reason, "read_only");
+    }
+
+    // ── reflect — read-only RAG Q&A ───────────────────────────────────────────
+
+    #[tokio::test]
+    async fn reflect_returns_answer_sources_and_provenance() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/default/banks/agent:agent-1/reflect"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "answer": "You prefer concise replies.",
+                "sources": [
+                    {"id": "m-1", "text": "user asked for brevity", "score": 0.8},
+                    {"id": "m-2", "content": "short answers preferred", "score": 0.6},
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        let store = HindsightStore::new(fast_config(server.uri())).unwrap();
+        let q = reflect_query("what tone do I prefer?");
+        let ans = store.reflect(&q).await.unwrap();
+
+        assert_eq!(ans.answer, "You prefer concise replies.");
+        assert_eq!(ans.sources.len(), 2);
+        assert_eq!(ans.sources[0].id.as_deref(), Some("m-1"));
+        assert_eq!(ans.sources[0].content, "user asked for brevity");
+        assert!((ans.sources[1].score - 0.6).abs() < 1e-6);
+        assert_eq!(ans.provenance, "hindsight:reflect:agent:agent-1");
+    }
+
+    #[tokio::test]
+    async fn reflect_requires_query_text() {
+        let store = HindsightStore::new(HindsightConfig::default()).unwrap();
+        let mut q = reflect_query("ignored");
+        q.text = None;
+        let err = store.reflect(&q).await.unwrap_err();
+        match &err {
+            SemanticError::Backend(msg) => {
+                assert!(msg.contains("requires query.text"), "got: {msg}");
+            }
+            other => panic!("expected Backend error, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn reflect_propagates_backend_error_truthfully() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/default/banks/agent:agent-1/reflect"))
+            .respond_with(ResponseTemplate::new(503).set_body_string("hindsight down"))
+            .mount(&server)
+            .await;
+
+        let store = HindsightStore::new(fast_config(server.uri())).unwrap();
+        let err = store.reflect(&reflect_query("anything")).await.unwrap_err();
+        match &err {
+            SemanticError::Backend(msg) => {
+                assert!(msg.contains("503"), "expected status in: {msg}");
+                assert!(msg.contains("hindsight down"), "expected body in: {msg}");
+            }
+            other => panic!("expected Backend error, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn reflect_allowed_when_read_only() {
+        // Reflect never retains, so the read-only governance gate must not
+        // block it.
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/default/banks/agent:agent-1/reflect"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "answer": "ok",
+                "sources": []
+            })))
+            .mount(&server)
+            .await;
+
+        let mut config = fast_config(server.uri());
+        config.read_only = true;
+        let store = HindsightStore::new(config).unwrap();
+        let ans = store.reflect(&reflect_query("q")).await.unwrap();
+        assert_eq!(ans.answer, "ok");
+        assert!(ans.sources.is_empty());
     }
 
     // ── recall request body carries budget / max_tokens / types ───────────────

--- a/rust/crates/sera-memory-hindsight/src/lib.rs
+++ b/rust/crates/sera-memory-hindsight/src/lib.rs
@@ -231,10 +231,36 @@ struct ReflectBody<'a> {
 struct ReflectSourceWire {
     #[serde(default)]
     id: Option<String>,
-    #[serde(alias = "text")]
+    #[serde(alias = "text", alias = "fact")]
     content: String,
     #[serde(default)]
     score: f32,
+}
+
+/// The documented live `based_on` shape: a `ReflectBasedOn` object whose cited
+/// memories live under `based_on.memories`. A bare array is also tolerated for
+/// compatibility with the earlier/alternate shape. `null` is handled one level
+/// up by `Option<ReflectBasedOn>`, so a null `based_on` yields no sources
+/// instead of a parse error.
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum ReflectBasedOn {
+    /// `based_on: { "memories": [...] }`
+    Object {
+        #[serde(default)]
+        memories: Vec<ReflectSourceWire>,
+    },
+    /// `based_on: [...]` — legacy/alternate array form.
+    Array(Vec<ReflectSourceWire>),
+}
+
+impl ReflectBasedOn {
+    fn into_memories(self) -> Vec<ReflectSourceWire> {
+        match self {
+            ReflectBasedOn::Object { memories } => memories,
+            ReflectBasedOn::Array(memories) => memories,
+        }
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -243,10 +269,15 @@ struct ReflectResponse {
     /// `text`; `answer` is accepted as a compatible alias.
     #[serde(default, alias = "text")]
     answer: String,
-    /// Hindsight's live reflect endpoint returns supporting evidence under
-    /// `based_on`; `sources` / `results` are accepted as compatible aliases.
-    #[serde(default, alias = "based_on", alias = "results")]
+    /// Array-shaped evidence under `sources` (with `results` as a compatible
+    /// alias). Used as-is and merged with any `based_on.memories`.
+    #[serde(default, alias = "results")]
     sources: Vec<ReflectSourceWire>,
+    /// Documented live evidence container: an object `{ memories: [...] }`, a
+    /// bare array, or `null`. Parsed as its own field so a null/object value
+    /// never turns a successful reflect into a parse error.
+    #[serde(default)]
+    based_on: Option<ReflectBasedOn>,
 }
 
 // ── Public reflect types ─────────────────────────────────────────────────────────
@@ -595,8 +626,14 @@ impl HindsightStore {
             .await
             .map_err(|e| SemanticError::Backend(format!("hindsight reflect parse: {e}")))?;
 
-        let sources = reflect
-            .sources
+        // Merge top-level array evidence with the documented `based_on`
+        // container (object `{memories}`, array, or null). The shapes are
+        // mutually exclusive in practice; merging is lossless either way.
+        let mut sources_wire = reflect.sources;
+        if let Some(based_on) = reflect.based_on {
+            sources_wire.extend(based_on.into_memories());
+        }
+        let sources = sources_wire
             .into_iter()
             .map(|s| ReflectSource {
                 id: s.id,
@@ -1006,6 +1043,59 @@ mod tests {
         assert_eq!(ans.sources[0].content, "user asked to keep it short");
         assert!((ans.sources[0].score - 0.91).abs() < 1e-6);
         assert_eq!(ans.sources[1].content, "dislikes preamble");
+        assert_eq!(ans.provenance, "hindsight:reflect:agent:agent-1");
+    }
+
+    #[tokio::test]
+    async fn reflect_reads_based_on_object_with_memories() {
+        // Documented live shape: `based_on` is a ReflectBasedOn object whose
+        // cited memories live under `based_on.memories`, not a top-level array.
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/default/banks/agent:agent-1/reflect"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "text": "You ship small, verified PRs.",
+                "based_on": {
+                    "memories": [
+                        {"id": "m-1", "text": "prefers narrow slices", "score": 0.88},
+                        {"id": "m-2", "fact": "verifies before claiming done", "score": 0.5},
+                    ]
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let store = HindsightStore::new(fast_config(server.uri())).unwrap();
+        let ans = store.reflect(&reflect_query("how do I work?")).await.unwrap();
+
+        assert_eq!(ans.answer, "You ship small, verified PRs.");
+        assert_eq!(ans.sources.len(), 2, "based_on.memories must be extracted");
+        assert_eq!(ans.sources[0].content, "prefers narrow slices");
+        assert!((ans.sources[0].score - 0.88).abs() < 1e-6);
+        // `fact` is accepted as a content alias for memory objects.
+        assert_eq!(ans.sources[1].content, "verifies before claiming done");
+        assert_eq!(ans.provenance, "hindsight:reflect:agent:agent-1");
+    }
+
+    #[tokio::test]
+    async fn reflect_accepts_null_based_on() {
+        // `based_on: null` must yield a successful reflect with an empty
+        // source list — not a deserialization failure.
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/default/banks/agent:agent-1/reflect"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "text": "No supporting memories were found.",
+                "based_on": null
+            })))
+            .mount(&server)
+            .await;
+
+        let store = HindsightStore::new(fast_config(server.uri())).unwrap();
+        let ans = store.reflect(&reflect_query("anything?")).await.unwrap();
+
+        assert_eq!(ans.answer, "No supporting memories were found.");
+        assert!(ans.sources.is_empty(), "null based_on yields no sources");
         assert_eq!(ans.provenance, "hindsight:reflect:agent:agent-1");
     }
 

--- a/rust/crates/sera-memory-hindsight/src/lib.rs
+++ b/rust/crates/sera-memory-hindsight/src/lib.rs
@@ -239,8 +239,11 @@ struct ReflectBody<'a> {
     budget: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     max_tokens: Option<usize>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    types: Option<&'a [String]>,
+    /// Reflect's fact-type filter. The reflect schema names this `fact_types`
+    /// (recall uses `types`); serializing under the wrong key makes the live
+    /// provider ignore the restriction and reflect over all fact types.
+    #[serde(rename = "fact_types", skip_serializing_if = "Option::is_none")]
+    fact_types: Option<&'a [String]>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -618,7 +621,7 @@ impl HindsightStore {
             },
             budget: self.config.recall_budget.as_deref(),
             max_tokens: self.config.recall_max_tokens,
-            types: if self.config.recall_types.is_empty() {
+            fact_types: if self.config.recall_types.is_empty() {
                 None
             } else {
                 Some(self.config.recall_types.as_slice())
@@ -1126,12 +1129,16 @@ mod tests {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
             .and(path("/v1/default/banks/agent:agent-1/reflect"))
+            // Reflect filters the configured fact types under `fact_types`
+            // (the reflect schema's field); `types` is recall-only and must
+            // not appear in a reflect body. `body_json` is an exact match, so
+            // a stray `types` key would fail this assertion.
             .and(body_json(serde_json::json!({
                 "query": "what do I know?",
                 "include": {"facts": {}},
                 "budget": "low",
                 "max_tokens": 500,
-                "types": ["observation"],
+                "fact_types": ["observation"],
             })))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "text": "ok",

--- a/rust/crates/sera-memory-hindsight/src/lib.rs
+++ b/rust/crates/sera-memory-hindsight/src/lib.rs
@@ -216,9 +216,25 @@ struct RecallResponse {
     results: Vec<RecallResult>,
 }
 
+/// Serializes to `{}` — an empty `include` sub-option marker.
+#[derive(Debug, Serialize)]
+struct IncludeFacts {}
+
+/// Reflect `include` controls. Requesting `facts` makes the live endpoint
+/// return `based_on` evidence; without it a successful reflect carries no
+/// supporting memories and [`ReflectAnswer::sources`] is empty even when
+/// supporting memories exist.
+#[derive(Debug, Serialize)]
+struct ReflectInclude {
+    facts: IncludeFacts,
+}
+
 #[derive(Debug, Serialize)]
 struct ReflectBody<'a> {
     query: &'a str,
+    /// Always request `facts` so `based_on` evidence is returned for
+    /// [`ReflectAnswer::sources`].
+    include: ReflectInclude,
     #[serde(skip_serializing_if = "Option::is_none")]
     budget: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -597,6 +613,9 @@ impl HindsightStore {
         );
         let body = ReflectBody {
             query: query_text,
+            include: ReflectInclude {
+                facts: IncludeFacts {},
+            },
             budget: self.config.recall_budget.as_deref(),
             max_tokens: self.config.recall_max_tokens,
             types: if self.config.recall_types.is_empty() {
@@ -1097,6 +1116,33 @@ mod tests {
         assert_eq!(ans.answer, "No supporting memories were found.");
         assert!(ans.sources.is_empty(), "null based_on yields no sources");
         assert_eq!(ans.provenance, "hindsight:reflect:agent:agent-1");
+    }
+
+    #[tokio::test]
+    async fn reflect_request_body_requests_facts_and_carries_controls() {
+        // The reflect request must ask for evidence (`include.facts`) so the
+        // live endpoint returns `based_on`, alongside the existing
+        // query/budget/max_tokens/types controls.
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/default/banks/agent:agent-1/reflect"))
+            .and(body_json(serde_json::json!({
+                "query": "what do I know?",
+                "include": {"facts": {}},
+                "budget": "low",
+                "max_tokens": 500,
+                "types": ["observation"],
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "text": "ok",
+                "based_on": {"memories": []}
+            })))
+            .mount(&server)
+            .await;
+
+        let store = HindsightStore::new(fast_config(server.uri())).unwrap();
+        let ans = store.reflect(&reflect_query("what do I know?")).await.unwrap();
+        assert_eq!(ans.answer, "ok");
     }
 
     #[tokio::test]

--- a/rust/crates/sera-memory-hindsight/src/lib.rs
+++ b/rust/crates/sera-memory-hindsight/src/lib.rs
@@ -99,8 +99,14 @@ pub struct HindsightConfig {
     pub recall_budget: Option<String>,
     /// Maximum tokens returned by Hindsight recall when the server supports it.
     pub recall_max_tokens: Option<usize>,
-    /// Optional Hindsight memory types to request (for example `observation`).
+    /// Optional Hindsight memory types to request from the recall endpoint (for
+    /// example `observation`). Reflect intentionally does not inherit this
+    /// default: the live reflect endpoint treats omitted `fact_types` as all
+    /// facts, which is the desired default for synthesis.
     pub recall_types: Vec<String>,
+    /// Optional fact-type filter for the reflect endpoint. When `None` or empty,
+    /// reflect omits `fact_types` so the provider can synthesize over all facts.
+    pub reflect_fact_types: Option<Vec<String>>,
 }
 
 impl Default for HindsightConfig {
@@ -116,6 +122,7 @@ impl Default for HindsightConfig {
             recall_budget: Some("low".to_string()),
             recall_max_tokens: Some(500),
             recall_types: vec!["observation".to_string()],
+            reflect_fact_types: None,
         }
     }
 }
@@ -239,9 +246,9 @@ struct ReflectBody<'a> {
     budget: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     max_tokens: Option<usize>,
-    /// Reflect's fact-type filter. The reflect schema names this `fact_types`
-    /// (recall uses `types`); serializing under the wrong key makes the live
-    /// provider ignore the restriction and reflect over all fact types.
+    /// Reflect's explicit fact-type filter. The reflect schema names this
+    /// `fact_types` (recall uses `types`). Omit by default so reflect preserves
+    /// the live endpoint's full-memory behavior.
     #[serde(rename = "fact_types", skip_serializing_if = "Option::is_none")]
     fact_types: Option<&'a [String]>,
 }
@@ -621,11 +628,11 @@ impl HindsightStore {
             },
             budget: self.config.recall_budget.as_deref(),
             max_tokens: self.config.recall_max_tokens,
-            fact_types: if self.config.recall_types.is_empty() {
-                None
-            } else {
-                Some(self.config.recall_types.as_slice())
-            },
+            fact_types: self
+                .config
+                .reflect_fact_types
+                .as_deref()
+                .filter(|types| !types.is_empty()),
         };
         let resp = self
             .client
@@ -796,6 +803,7 @@ mod tests {
             recall_budget: Some("low".to_string()),
             recall_max_tokens: Some(500),
             recall_types: vec!["observation".to_string()],
+            reflect_fact_types: None,
         }
     }
 
@@ -1122,17 +1130,40 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn reflect_request_body_requests_facts_and_carries_controls() {
+    async fn default_reflect_request_body_requests_facts_and_omits_fact_types() {
         // The reflect request must ask for evidence (`include.facts`) so the
-        // live endpoint returns `based_on`, alongside the existing
-        // query/budget/max_tokens/types controls.
+        // live endpoint returns `based_on`, but the default request must omit
+        // `fact_types` so reflect preserves the provider's full-memory behavior.
         let server = MockServer::start().await;
         Mock::given(method("POST"))
             .and(path("/v1/default/banks/agent:agent-1/reflect"))
-            // Reflect filters the configured fact types under `fact_types`
-            // (the reflect schema's field); `types` is recall-only and must
-            // not appear in a reflect body. `body_json` is an exact match, so
-            // a stray `types` key would fail this assertion.
+            // `body_json` is an exact match: this proves both `fact_types` and
+            // the recall-only `types` key are absent from default reflect.
+            .and(body_json(serde_json::json!({
+                "query": "what do I know?",
+                "include": {"facts": {}},
+                "budget": "low",
+                "max_tokens": 500,
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "text": "ok",
+                "based_on": {"memories": []}
+            })))
+            .mount(&server)
+            .await;
+
+        let store = HindsightStore::new(fast_config(server.uri())).unwrap();
+        let ans = store.reflect(&reflect_query("what do I know?")).await.unwrap();
+        assert_eq!(ans.answer, "ok");
+    }
+
+    #[tokio::test]
+    async fn explicit_reflect_fact_types_serialize_as_fact_types() {
+        // Reflect has its own explicit fact-type filter. It must serialize as
+        // `fact_types` (the reflect schema), never recall's `types` key.
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/default/banks/agent:agent-1/reflect"))
             .and(body_json(serde_json::json!({
                 "query": "what do I know?",
                 "include": {"facts": {}},
@@ -1147,7 +1178,9 @@ mod tests {
             .mount(&server)
             .await;
 
-        let store = HindsightStore::new(fast_config(server.uri())).unwrap();
+        let mut config = fast_config(server.uri());
+        config.reflect_fact_types = Some(vec!["observation".to_string()]);
+        let store = HindsightStore::new(config).unwrap();
         let ans = store.reflect(&reflect_query("what do I know?")).await.unwrap();
         assert_eq!(ans.answer, "ok");
     }


### PR DESCRIPTION
## Summary

Next narrow `sera-ibkr.5` slice: a SERA-owned **read-only Hindsight `reflect`** path plus an **explicit, auditable write-governance seam**. Single file (`sera-memory-hindsight/src/lib.rs`), additive and backward compatible.

### reflect (RAG Q&A, read-only)
- `HindsightStore::reflect(&SemanticQuery)` maps Hindsight `POST /v1/default/banks/{bank}/reflect` — synchronous Q&A that synthesises an answer from existing memories and **never retains**.
- Exposed as an inherent method (not on `SemanticMemoryStore`), the same separation the spec applies to `HindsightStore::list` (SPEC-memory-pluggability §4).
- Requires `query.text`; provider failures degrade **truthfully** as `Backend` errors, never an empty answer.
- `ReflectAnswer` carries `sources` (evidence) and a `provenance` label (`hindsight:reflect:{bank}`) so injected/read answers stay attributable. Allowed even when the store is `read_only`.

### write governance
- The read-only refusal is now an explicit `ensure_write_allowed` gate that refuses **before any HTTP/provider mutation**, emits a structured governance event on the `sera.memory.governance` tracing target, notifies an optional `WriteAuditSink`, and returns a clear policy error.
- `HindsightStore::with_audit_sink` lets the gateway bridge denials to OCSF audit. Default `None`; `new()` signature unchanged, so the existing gateway call site is untouched.

## Non-goals (unchanged)
No HITL approval UI, no LCM/context-engine tool broadening, no base-memory migration, no tokenizer work, no live destructive Hindsight writes, no merge.

## Tests
`cargo test -p sera-memory-hindsight` → **17 passed, 1 ignored** (live integration). New/changed:
- `reflect_returns_answer_sources_and_provenance`
- `reflect_requires_query_text`
- `reflect_propagates_backend_error_truthfully`
- `reflect_allowed_when_read_only`
- `read_only_put_refuses_before_provider_mutation` — mounts a sentinel 500 mock and asserts it is **never reached** on refusal, and that the `WriteAuditSink` records exactly one attributable denial.

`cargo clippy -p sera-memory-hindsight --all-targets -- -D warnings` → clean.
`cargo check -p sera-gateway` → clean.

## Residual risk / next slice
- Reflect wire shape (`{answer, sources:[{id,content/text,score}]}`) is inferred; the `text`/`content`/`results` aliases tolerate variance, but the live `--ignored` integration test should be extended to cover reflect against a real Hindsight before production use.
- Recommended next Fable slice: wire `reflect` into a SERA-owned gateway tool/route and connect `WriteAuditSink` to the existing OCSF audit backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)