### PR TITLE
fix(runtime): complete provider wire-conformance — snake_case tool transcript + doom-loop diagnostics (sera-xbmz)

### DIFF
--- a/rust/crates/sera-runtime/src/default_runtime.rs
+++ b/rust/crates/sera-runtime/src/default_runtime.rs
@@ -501,11 +501,21 @@ impl AgentRuntime for DefaultRuntime {
                     plan_tool_call_count = plan.tool_calls.len(),
                     "PlanAndAct: dispatching staged plan (skipping LLM call)"
                 );
+                // sera-xbmz: embed the staged plan's tool_calls in the synthetic
+                // execution response so the assistant row pushed before the tool
+                // results (RunAgain arm below) is a well-formed OpenAI tool-call
+                // message. Without this, the PlanAndAct dispatch path emits an
+                // assistant row without tool_calls followed by `role:"tool"` rows,
+                // recreating the orphaned transcript strict providers reject.
+                let mut response = serde_json::json!({
+                    "role": "assistant",
+                    "content": plan.rationale.clone(),
+                });
+                if !plan.tool_calls.is_empty() {
+                    response["tool_calls"] = serde_json::Value::Array(plan.tool_calls.clone());
+                }
                 turn::ThinkResult {
-                    response: serde_json::json!({
-                        "role": "assistant",
-                        "content": plan.rationale.clone(),
-                    }),
+                    response,
                     tool_calls: plan.tool_calls.clone(),
                     tokens: sera_types::runtime::TokenUsage::default(),
                     plan: None,
@@ -2007,6 +2017,77 @@ mod tests {
             seen_names,
             vec!["plan-tool-a".to_string(), "plan-tool-b".to_string()],
             "plan's tool calls must dispatch in order during the act phase"
+        );
+    }
+
+    /// LLM that captures the messages it receives on its most recent call, so a
+    /// test can inspect the post-dispatch transcript shape.
+    struct CapturingPlanLlm {
+        rounds: std::sync::Mutex<std::collections::VecDeque<Vec<serde_json::Value>>>,
+        last_messages: std::sync::Arc<std::sync::Mutex<Vec<serde_json::Value>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl turn::LlmProvider for CapturingPlanLlm {
+        async fn chat(
+            &self,
+            messages: &[serde_json::Value],
+            _tools: &[serde_json::Value],
+        ) -> Result<turn::ThinkResult, turn::ThinkError> {
+            *self.last_messages.lock().unwrap() = messages.to_vec();
+            let calls = self.rounds.lock().unwrap().pop_front().unwrap_or_default();
+            Ok(turn::ThinkResult {
+                response: serde_json::json!({
+                    "role": "assistant",
+                    "content": "planning",
+                }),
+                tool_calls: calls,
+                tokens: sera_types::runtime::TokenUsage::default(),
+                plan: None,
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn plan_and_act_execution_response_embeds_tool_calls_before_tool_results() {
+        // sera-xbmz: in the PlanAndAct dispatch iteration the synthetic
+        // execution response must carry the plan's tool_calls, so the assistant
+        // row persisted before the tool-result rows is a well-formed OpenAI
+        // tool-call transcript (no orphan that strict providers reject).
+        let last_messages = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let llm = CapturingPlanLlm {
+            rounds: std::sync::Mutex::new(
+                vec![vec![tool_call("p1", "plan-tool-a")], vec![]].into(),
+            ),
+            last_messages: last_messages.clone(),
+        };
+        let seen = std::sync::Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+        let dispatcher = RecordingDispatcher { seen };
+
+        let runtime = DefaultRuntime::new(make_context_engine())
+            .with_allow_missing_constitutional_gate(true)
+            .with_llm(Box::new(llm))
+            .with_tool_dispatcher(Box::new(dispatcher));
+
+        let _ = runtime
+            .execute_turn(plan_and_act_ctx())
+            .await
+            .expect("execute_turn");
+
+        // The final LLM call sees the conversation after plan dispatch: the
+        // synthetic assistant execution response followed by the tool result.
+        let msgs = last_messages.lock().unwrap().clone();
+        let tool_idx = msgs
+            .iter()
+            .position(|m| m.get("role").and_then(|r| r.as_str()) == Some("tool"))
+            .expect("expected a tool-result row in the post-dispatch transcript");
+        assert!(tool_idx > 0, "tool result must be preceded by an assistant row");
+        let assistant = &msgs[tool_idx - 1];
+        assert_eq!(assistant["role"], "assistant");
+        assert_eq!(
+            assistant["tool_calls"][0]["function"]["name"],
+            "plan-tool-a",
+            "assistant row before tool results must carry the plan's tool_calls (no orphan): {msgs:?}"
         );
     }
 

--- a/rust/crates/sera-runtime/src/fallback_chain.rs
+++ b/rust/crates/sera-runtime/src/fallback_chain.rs
@@ -207,11 +207,19 @@ impl LlmProvider for FallbackChain {
             })
             .collect();
 
+        // Mirror the direct `LlmClient` adapter (sera-xbmz): embed the assistant
+        // `tool_calls` in the transcript message so the next provider request
+        // carries a well-formed assistant tool-call row before its tool results.
+        let mut response = serde_json::json!({
+            "role": "assistant",
+            "content": result.message.content,
+        });
+        if !tool_calls.is_empty() {
+            response["tool_calls"] = serde_json::Value::Array(tool_calls.clone());
+        }
+
         Ok(ThinkResult {
-            response: serde_json::json!({
-                "role": "assistant",
-                "content": result.message.content,
-            }),
+            response,
             tool_calls,
             tokens: TokenUsage {
                 prompt_tokens: result.prompt_tokens,
@@ -276,5 +284,51 @@ mod tests {
         let client = LlmClient::with_params("http://unused.invalid", "m", None, 1_000);
         let chain = FallbackChain::new(vec![client]);
         assert_eq!(chain.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn fallback_chain_adapter_embeds_tool_calls_in_assistant_transcript() {
+        // sera-xbmz: the FallbackChain LlmProvider adapter must embed assistant
+        // tool_calls in the transcript response, same as the direct LlmClient
+        // adapter — otherwise the SERA_LLM_FALLBACK_* configuration recreates
+        // the orphaned tool-transcript / provider-400 scenario.
+        use crate::turn::LlmProvider;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let sse = concat!(
+            "data: {\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"file-write\",\"arguments\":\"{}\"}}]},\"finish_reason\":null}]}\n\n",
+            "data: {\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"tool_calls\"}]}\n\n",
+            "data: [DONE]\n\n",
+        );
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(sse))
+            .mount(&server)
+            .await;
+
+        let client = LlmClient::with_params(&server.uri(), "test-model", None, 512);
+        let chain = FallbackChain::new(vec![client]);
+        let tool = serde_json::json!({
+            "type": "function",
+            "function": {
+                "name": "file-write",
+                "description": "Tool file-write",
+                "parameters": {"type":"object","properties":{}}
+            }
+        });
+        let result = <FallbackChain as LlmProvider>::chat(
+            &chain,
+            &[serde_json::json!({"role":"user","content":"create a file"})],
+            &[tool],
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.tool_calls[0]["id"], "call_1");
+        assert_eq!(result.response["role"], "assistant");
+        assert_eq!(result.response["tool_calls"][0]["id"], "call_1");
+        assert_eq!(result.response["tool_calls"][0]["function"]["name"], "file-write");
     }
 }

--- a/rust/crates/sera-runtime/src/llm_client.rs
+++ b/rust/crates/sera-runtime/src/llm_client.rs
@@ -1072,7 +1072,12 @@ impl LlmProvider for LlmClient {
             .await
             .map_err(|e| ThinkError::Llm(e.to_string()))?;
 
-        // Convert tool calls to Value
+        // Convert tool calls to Value once, then embed the same OpenAI-shape
+        // calls in the assistant transcript message. Without this, the next
+        // provider request contains a bare `{role:"assistant"}` followed by
+        // tool results, so local OpenAI-compatible models cannot ground the
+        // results and tend to repeat the same tool call until the doom-loop
+        // guard interrupts.
         let tool_calls: Vec<serde_json::Value> = result
             .message
             .tool_calls
@@ -1090,11 +1095,16 @@ impl LlmProvider for LlmClient {
             })
             .collect();
 
+        let mut response = serde_json::json!({
+            "role": "assistant",
+            "content": result.message.content,
+        });
+        if !tool_calls.is_empty() {
+            response["tool_calls"] = serde_json::Value::Array(tool_calls.clone());
+        }
+
         Ok(ThinkResult {
-            response: serde_json::json!({
-                "role": "assistant",
-                "content": result.message.content,
-            }),
+            response,
             tool_calls,
             tokens: TokenUsage {
                 prompt_tokens: result.prompt_tokens,
@@ -1730,6 +1740,33 @@ mod tests {
         }
     }
 
+    fn make_assistant_tool_call_msg(call_id: &str, tool_name: &str) -> ChatMessage {
+        ChatMessage {
+            role: "assistant".to_string(),
+            content: None,
+            tool_calls: Some(vec![ToolCall {
+                id: call_id.to_string(),
+                call_type: "function".to_string(),
+                function: ToolCallFunction {
+                    name: tool_name.to_string(),
+                    arguments: "{}".to_string(),
+                },
+            }]),
+            tool_call_id: None,
+            name: None,
+        }
+    }
+
+    fn make_tool_result_msg(call_id: &str, content: &str) -> ChatMessage {
+        ChatMessage {
+            role: "tool".to_string(),
+            content: Some(content.to_string()),
+            tool_calls: None,
+            tool_call_id: Some(call_id.to_string()),
+            name: None,
+        }
+    }
+
     // --- system message coalesce (sera-xbmz) ---
 
     #[test]
@@ -1822,6 +1859,52 @@ mod tests {
         assert_eq!(msgs.len(), 2, "consecutive system rows must coalesce on the wire");
         assert_eq!(msgs[0]["role"], "system");
         assert_eq!(msgs[1]["role"], "user");
+    }
+
+    #[test]
+    fn request_body_preserves_openai_tool_transcript_wire_keys() {
+        // Live LM Studio/Gemma failure mode: after a tool call SERA used to
+        // send `{role:"assistant"}` followed by `{role:"tool", content:...}`
+        // because `tool_calls` was kept outside the assistant transcript and
+        // `tool_call_id` was lost through camelCase serde. OpenAI-compatible
+        // providers need both snake_case fields to connect result → call.
+        let body = build_streaming_body(
+            "gpt-4",
+            512,
+            &[
+                make_user_msg("create a file"),
+                make_assistant_tool_call_msg("call_1", "file-write"),
+                make_tool_result_msg("call_1", "{\"ok\":true}"),
+            ],
+            &[make_tool("file-write")],
+            &ToolUseBehavior::Auto,
+        )
+        .unwrap();
+
+        let msgs = body["messages"].as_array().expect("messages array");
+        assert_eq!(msgs[1]["role"], "assistant");
+        assert_eq!(msgs[1]["tool_calls"][0]["id"], "call_1");
+        assert_eq!(msgs[1]["tool_calls"][0]["function"]["name"], "file-write");
+        assert!(msgs[1].get("toolCalls").is_none(), "must not emit camelCase toolCalls");
+
+        assert_eq!(msgs[2]["role"], "tool");
+        assert_eq!(msgs[2]["tool_call_id"], "call_1");
+        assert!(msgs[2].get("toolCallId").is_none(), "must not emit camelCase toolCallId");
+    }
+
+    #[test]
+    fn chat_message_accepts_legacy_camel_tool_fields_but_serializes_snake_case() {
+        let msg: ChatMessage = serde_json::from_value(serde_json::json!({
+            "role": "tool",
+            "content": "ok",
+            "toolCallId": "legacy_call"
+        }))
+        .unwrap();
+        assert_eq!(msg.tool_call_id.as_deref(), Some("legacy_call"));
+
+        let out = serde_json::to_value(msg).unwrap();
+        assert_eq!(out["tool_call_id"], "legacy_call");
+        assert!(out.get("toolCallId").is_none());
     }
 
     // --- streaming body ---
@@ -2074,6 +2157,39 @@ mod tests {
         let parsed: NonStreamingResponse = serde_json::from_str(json).unwrap();
         assert_eq!(parsed.choices[0].finish_reason.as_deref(), Some("tool_calls"));
         assert_eq!(parsed.choices[0].message.tool_calls.as_ref().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn llm_provider_adapter_embeds_tool_calls_in_assistant_transcript() {
+        use crate::turn::LlmProvider;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let sse = concat!(
+            "data: {\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"file-write\",\"arguments\":\"{}\"}}]},\"finish_reason\":null}]}\n\n",
+            "data: {\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"tool_calls\"}]}\n\n",
+            "data: [DONE]\n\n",
+        );
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(sse))
+            .mount(&server)
+            .await;
+
+        let client = LlmClient::with_params(&server.uri(), "test-model", None, 512);
+        let result = <LlmClient as LlmProvider>::chat(
+            &client,
+            &[serde_json::json!({"role":"user","content":"create a file"})],
+            &[serde_json::to_value(make_tool("file-write")).unwrap()],
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.tool_calls[0]["id"], "call_1");
+        assert_eq!(result.response["role"], "assistant");
+        assert_eq!(result.response["tool_calls"][0]["id"], "call_1");
+        assert_eq!(result.response["tool_calls"][0]["function"]["name"], "file-write");
     }
 
     #[test]

--- a/rust/crates/sera-runtime/src/turn.rs
+++ b/rust/crates/sera-runtime/src/turn.rs
@@ -376,8 +376,19 @@ pub async fn think(
             rationale,
             created_at_ms,
         };
+        // The planning checkpoint is persisted as an assistant message, but the
+        // tool calls are deferred into `plan` and not dispatched (with matching
+        // tool-result rows) until the next iteration. Strip the embedded
+        // `tool_calls` from the persisted response so it is not an orphaned
+        // assistant tool-call row that strict OpenAI-compatible providers
+        // (e.g. MiniMax) reject on the next request. The calls are preserved
+        // in `plan.tool_calls` and re-surface via `TurnOutcome::PlanEmitted`.
+        let mut response = raw.response;
+        if let Some(obj) = response.as_object_mut() {
+            obj.remove("tool_calls");
+        }
         return ThinkResult {
-            response: raw.response,
+            response,
             // Empty tool_calls so act() does not dispatch in this iteration.
             tool_calls: vec![],
             tokens: raw.tokens,
@@ -1523,6 +1534,65 @@ mod tests {
                 plan: None,
             })
         }
+    }
+
+    /// Provider whose `response` already embeds `tool_calls` (mirroring the
+    /// real `LlmClient` adapter), used to verify PlanAndAct strips them from
+    /// the persisted planning checkpoint.
+    struct EmbeddedToolCallProvider;
+
+    #[async_trait]
+    impl LlmProvider for EmbeddedToolCallProvider {
+        async fn chat(
+            &self,
+            _messages: &[serde_json::Value],
+            _tools: &[serde_json::Value],
+        ) -> Result<ThinkResult, ThinkError> {
+            let tool_calls = vec![serde_json::json!({
+                "id": "call_1",
+                "type": "function",
+                "function": { "name": "status_probe", "arguments": "{}" }
+            })];
+            Ok(ThinkResult {
+                response: serde_json::json!({
+                    "role": "assistant",
+                    "content": "let me check the status",
+                    "tool_calls": tool_calls,
+                }),
+                tool_calls,
+                tokens: TokenUsage::default(),
+                plan: None,
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn plan_and_act_strips_tool_calls_from_persisted_planning_response() {
+        // sera-xbmz: think() defers dispatch under PlanAndAct, so the persisted
+        // planning checkpoint must not be an orphaned assistant tool-call row.
+        let provider = EmbeddedToolCallProvider;
+        let result = think(
+            &[],
+            &[],
+            &ReactMode::PlanAndAct,
+            Some(&provider),
+            &ToolUseBehavior::Auto,
+        )
+        .await;
+
+        // Plan carries the deferred calls; act() sees none this iteration.
+        assert!(result.tool_calls.is_empty(), "act must not dispatch this iteration");
+        let plan = result.plan.expect("PlanAndAct should produce a plan");
+        assert_eq!(plan.tool_calls.len(), 1);
+        assert_eq!(plan.tool_calls[0]["function"]["name"], "status_probe");
+
+        // The persisted planning response must not carry orphaned tool_calls.
+        assert!(
+            result.response.get("tool_calls").is_none(),
+            "planning checkpoint must not persist an orphaned assistant tool-call row: {:?}",
+            result.response
+        );
+        assert_eq!(result.response["content"], "let me check the status");
     }
 
     #[tokio::test]

--- a/rust/crates/sera-runtime/src/turn.rs
+++ b/rust/crates/sera-runtime/src/turn.rs
@@ -419,6 +419,22 @@ impl ThinkResult {
     }
 }
 
+fn tool_call_names(tool_calls: &[serde_json::Value]) -> String {
+    let names = tool_calls
+        .iter()
+        .filter_map(|tc| {
+            tc.get("function")
+                .and_then(|f| f.get("name"))
+                .and_then(|n| n.as_str())
+        })
+        .collect::<Vec<_>>();
+    if names.is_empty() {
+        "unknown".to_string()
+    } else {
+        names.join(",")
+    }
+}
+
 /// Act — dispatch tool calls, check for handoffs, doom-loop detection.
 ///
 /// When a `ToolDispatcher` is provided, tool calls from the LLM are dispatched
@@ -447,10 +463,11 @@ pub async fn act(
 
     // Doom loop check applies only when the model is trying another act cycle.
     if ctx.doom_loop_count >= DOOM_LOOP_THRESHOLD {
+        let tools = tool_call_names(&think_result.tool_calls);
         return ActResult::Interruption {
             reason: format!(
-                "doom loop: {} consecutive act cycles",
-                ctx.doom_loop_count
+                "doom loop: {} consecutive act cycles; latest attempted tool(s): {}",
+                ctx.doom_loop_count, tools
             ),
         };
     }
@@ -1216,6 +1233,10 @@ mod tests {
         match result {
             ActResult::Interruption { reason } => {
                 assert!(reason.contains("doom loop"), "unexpected reason: {reason}");
+                assert!(
+                    reason.contains("status_probe"),
+                    "doom-loop interruption should name latest attempted tool: {reason}"
+                );
             }
             other => panic!("expected doom-loop Interruption, got {:?}", other),
         }

--- a/rust/crates/sera-runtime/src/types.rs
+++ b/rust/crates/sera-runtime/src/types.rs
@@ -30,14 +30,16 @@ pub struct TaskOutput {
 
 /// A chat message in the conversation.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
-#[serde(rename_all = "camelCase")]
 pub struct ChatMessage {
     pub role: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    // Provider wire compatibility: OpenAI-compatible chat expects snake_case
+    // `tool_calls` / `tool_call_id`. Accept the old internal camelCase aliases
+    // on read, but never emit them toward providers.
+    #[serde(skip_serializing_if = "Option::is_none", alias = "toolCalls")]
     pub tool_calls: Option<Vec<ToolCall>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "toolCallId")]
     pub tool_call_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,


### PR DESCRIPTION
## Summary

Completes the remaining `sera-xbmz` provider wire-conformance slice. Consecutive-`system` coalescing and the gateway-side orphan tool-row guard already landed in #1280; this PR adds the wire-conformance pieces that were **not** part of that commit, plus the review-driven completions so the fix holds across every transcript-producing path.

### Core fix
1. **Snake_case tool transcript on the wire.** `ChatMessage` now serializes OpenAI-compatible `tool_calls` / `tool_call_id` (was camelCase via struct-level `rename_all`), while accepting legacy `toolCalls` / `toolCallId` as read aliases for backward compatibility. Aligns the runtime type with what the gateway and providers already use.
2. **Assistant `tool_calls` embedded in the transcript response.** The `LlmProvider` adapter embeds the assistant tool calls in the `response` message, so the next provider request carries a well-formed assistant tool-call row before its tool results (rather than a bare `{role:"assistant"}` that models can't ground and #1280's guard would drop as an orphan).
3. **Doom-loop diagnostics name the attempted tool(s).**

### Review-driven completions (same wire-conformance concern, all transcript paths)
4. **PlanAndAct planning checkpoint** no longer persists orphaned `tool_calls` — the deferred calls live in `plan` and re-surface via `PlanEmitted`.
5. **PlanAndAct execution iteration** embeds the staged plan's `tool_calls` in the synthetic execution response, so the assistant row pushed before the dispatched tool results is well-formed.
6. **FallbackChain adapter** mirrors the embedding, so the `SERA_LLM_FALLBACK_*` configuration doesn't bypass the fix.

Provider-conformance enablement that also indirectly unblocks `sera-ile` routing/failover work; the closeout here is **`sera-xbmz`** only.

## Scope

Surgical, five files in `sera-runtime` (all directly wire-conformance):
- `src/types.rs` — snake_case serialization + camelCase read aliases
- `src/llm_client.rs` — adapter `tool_calls` embedding + tests
- `src/turn.rs` — doom-loop tool-name diagnostic + PlanAndAct planning-checkpoint strip + tests
- `src/fallback_chain.rs` — mirror adapter embedding + test
- `src/default_runtime.rs` — PlanAndAct execution-response embedding + test

## Tests

- `cargo check -p sera-runtime --tests` — pass
- `cargo test -p sera-runtime --lib llm_client` — 82 passed
- `cargo test -p sera-runtime --lib turn` — 100 passed
- `cargo test -p sera-runtime --lib fallback_chain` — 8 passed
- `cargo test -p sera-runtime --lib default_runtime` — 37 passed
- `cargo clippy -p sera-runtime --tests` — clean on touched files
- `git diff --check` — clean
- Full CI green (validate-rust, ci-e2e-smoke, ci-validate-sdk-py, CodeQL, Analyze).

New tests: snake_case wire keys, legacy camelCase read compatibility, adapter `tool_calls` embedding (direct + fallback chain), doom-loop tool-name reporting, PlanAndAct planning-checkpoint strip, and PlanAndAct execution transcript well-formedness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)