### PR TITLE
fix(gateway): provider file-secret bridge for sera-eb3n

### DIFF
--- a/rust/crates/sera-config/src/manifest_loader.rs
+++ b/rust/crates/sera-config/src/manifest_loader.rs
@@ -738,6 +738,52 @@ spec: {}
         }
     }
 
+    // sera-eb3n: provider API keys must resolve from the file-backed
+    // SecretResolver, not env-only. This is the path the gateway harness loop
+    // uses to feed LLM_API_KEY to the runtime; the 2026-06-18 MiniMax live
+    // probe hit a 401 because the file-mounted key was ignored.
+    #[test]
+    fn resolve_provider_api_key_with_reads_file_secret() {
+        let dir = tempfile::tempdir().unwrap();
+        let resolver = crate::secrets::SecretResolver::new(dir.path());
+        resolver
+            .store("providers/minimax/api-key", "file-minimax-key")
+            .unwrap();
+        let spec = ProviderSpec {
+            kind: "openai".to_string(),
+            base_url: "https://api.minimax.io/v1".to_string(),
+            default_model: Some("MiniMax-M3".to_string()),
+            api_key: Some(sera_types::config_manifest::SecretRef {
+                secret: "providers/minimax/api-key".to_string(),
+            }),
+        };
+        let key = resolve_provider_api_key_with(&spec, &resolver);
+        assert_eq!(key.as_deref(), Some("file-minimax-key"));
+    }
+
+    // Env fallback must remain intact when no file secret is present.
+    #[test]
+    fn resolve_provider_api_key_with_falls_back_to_env() {
+        let dir = tempfile::tempdir().unwrap();
+        let resolver = crate::secrets::SecretResolver::new(dir.path());
+        unsafe {
+            std::env::set_var("SERA_SECRET_PROVIDERS_MINIMAX_API_KEY", "env-minimax-key");
+        }
+        let spec = ProviderSpec {
+            kind: "openai".to_string(),
+            base_url: "https://api.minimax.io/v1".to_string(),
+            default_model: None,
+            api_key: Some(sera_types::config_manifest::SecretRef {
+                secret: "providers/minimax/api-key".to_string(),
+            }),
+        };
+        let key = resolve_provider_api_key_with(&spec, &resolver);
+        unsafe {
+            std::env::remove_var("SERA_SECRET_PROVIDERS_MINIMAX_API_KEY");
+        }
+        assert_eq!(key.as_deref(), Some("env-minimax-key"));
+    }
+
     #[test]
     fn split_yaml_documents_basic() {
         let docs = split_yaml_documents("a: 1\n---\nb: 2");

--- a/rust/crates/sera-gateway/src/bin/sera.rs
+++ b/rust/crates/sera-gateway/src/bin/sera.rs
@@ -32,6 +32,7 @@ use tracing_subscriber::util::SubscriberInitExt;
 
 use sera_config::manifest_loader::{
     ManifestSet, load_manifest_file, parse_manifests, resolve_provider_api_key,
+    resolve_provider_api_key_with,
 };
 use sera_config::secrets::SecretResolver;
 use sera_db::lane_queue::LaneQueue;
@@ -8101,7 +8102,7 @@ async fn run_start(config: PathBuf, port: u16, local: bool) -> anyhow::Result<()
 
         let (base_url, model, api_key_val) = match provider_spec {
             Some(ref p) => {
-                let key = resolve_provider_api_key(p).unwrap_or_default();
+                let key = resolve_provider_api_key_with(p, &secret_resolver).unwrap_or_default();
                 let model = agent_spec
                     .model
                     .as_deref()


### PR DESCRIPTION
## Summary

Wires provider API-key resolution through the file-backed `SecretResolver` so a `ProviderSpec.api_key.secret` reference (e.g. `providers/minimax/api-key`) resolves from a mounted secret file, not just `SERA_SECRET_PROVIDERS_*` env vars.

**Root cause:** The gateway harness boot loop built `LLM_API_KEY` for each runtime child via env-only `resolve_provider_api_key(spec)`. The connector token path already used `resolve_*_with(SecretResolver)`, but the provider path did not. The 2026-06-18 xbmz MiniMax live probe hit HTTP 401 on the first chat attempt despite a known-good file-mounted key, and only passed after env-bridging `MINIMAX_API_KEY` → `SERA_SECRET_PROVIDERS_MINIMAX_API_KEY`.

**Fix:** Switch the harness loop call site to `resolve_provider_api_key_with(p, &secret_resolver)`. The `secret_resolver` (file + env fallback) is already constructed in the same function and used by the connector loop, so the change is one line plus the import. File secrets resolve first; env fallback is preserved.

## Changes
- `sera-gateway/src/bin/sera.rs`: harness loop uses `resolve_provider_api_key_with(&secret_resolver)`; import added.
- `sera-config/src/manifest_loader.rs`: two regression tests — file-backed `providers/minimax/api-key` resolution and env fallback.

## Verification
- `cargo test -p sera-config --lib manifest_loader::tests` → 36 passed, 0 failed (includes new tests + existing `resolve_connector_token_integration`).
- `cargo check -p sera-gateway` → clean.

## Scope notes
The inference-proxy path (`resolve_proxy_upstream`, `AppState`-scoped) has the same env-only class but was not exercised by the probe and would require threading a resolver into `AppState` — left out to keep this surgical per the bead. No registry/model-router/fallback-chain changes.

Source bead: sera-eb3n

🤖 Generated with [Claude Code](https://claude.com/claude-code)