### PR TITLE
feat(config): provider schema bridge for apiKeyEnvVar/apiKeySecret refs

### DIFF
--- a/rust/crates/sera-config/src/providers.rs
+++ b/rust/crates/sera-config/src/providers.rs
@@ -9,7 +9,10 @@
 
 use crate::secrets::SecretResolver;
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+use std::{
+    collections::BTreeMap,
+    path::{Component, Path},
+};
 
 /// Top-level providers.json structure.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -119,12 +122,32 @@ impl ProviderEntry {
         Ok(if let Some(var) = &self.api_key_env_var {
             CredentialSource::Env(var.clone())
         } else if let Some(path) = &self.api_key_secret {
+            Self::validate_secret_ref(path)?;
             CredentialSource::Secret(path.clone())
         } else if !self.api_key.is_empty() {
             CredentialSource::Inline
         } else {
             CredentialSource::None
         })
+    }
+
+    fn validate_secret_ref(path: &str) -> Result<(), CredentialError> {
+        let parsed = Path::new(path);
+        let invalid = path.trim().is_empty()
+            || parsed.components().any(|component| {
+                matches!(
+                    component,
+                    Component::Prefix(_) | Component::RootDir | Component::ParentDir
+                )
+            });
+
+        if invalid {
+            return Err(CredentialError::InvalidSecretPath {
+                path: path.to_string(),
+            });
+        }
+
+        Ok(())
     }
 
     /// Resolve the API key value, following an `apiKeyEnvVar` env reference or
@@ -140,18 +163,23 @@ impl ProviderEntry {
         match self.credential_source()? {
             CredentialSource::None => Ok(None),
             CredentialSource::Inline => Ok(Some(self.api_key.clone())),
-            CredentialSource::Env(var) => std::env::var(&var).map(Some).map_err(|_| {
-                CredentialError::EnvVarUnset {
-                    model_name: self.model_name.clone(),
-                    var,
-                }
-            }),
-            CredentialSource::Secret(path) => resolver.resolve(&path).map(Some).ok_or(
-                CredentialError::SecretUnresolved {
-                    model_name: self.model_name.clone(),
-                    path,
-                },
-            ),
+            CredentialSource::Env(var) => {
+                std::env::var(&var)
+                    .map(Some)
+                    .map_err(|_| CredentialError::EnvVarUnset {
+                        model_name: self.model_name.clone(),
+                        var,
+                    })
+            }
+            CredentialSource::Secret(path) => {
+                resolver
+                    .resolve(&path)
+                    .map(Some)
+                    .ok_or(CredentialError::SecretUnresolved {
+                        model_name: self.model_name.clone(),
+                        path,
+                    })
+            }
         }
     }
 }
@@ -192,20 +220,25 @@ pub enum CredentialError {
         "provider '{model_name}' declares conflicting credential sources ({sources}); \
          specify exactly one of apiKey, apiKeyEnvVar, apiKeySecret"
     )]
-    ConflictingSources {
-        model_name: String,
-        sources: String,
-    },
+    ConflictingSources { model_name: String, sources: String },
     #[error("provider '{model_name}' references env var '{var}' which is not set")]
     EnvVarUnset { model_name: String, var: String },
     #[error("provider '{model_name}' references secret '{path}' which could not be resolved")]
     SecretUnresolved { model_name: String, path: String },
+    #[error(
+        "provider references invalid apiKeySecret path '{path}'; use a relative path without parent components"
+    )]
+    InvalidSecretPath { path: String },
 }
 
 impl ProvidersConfig {
     /// Add a new provider entry. Returns error if modelName already exists.
     pub fn add_provider(&mut self, entry: ProviderEntry) -> Result<(), String> {
-        if self.providers.iter().any(|p| p.model_name == entry.model_name) {
+        if self
+            .providers
+            .iter()
+            .any(|p| p.model_name == entry.model_name)
+        {
             return Err(format!("Provider '{}' already exists", entry.model_name));
         }
         self.providers.push(entry);
@@ -258,8 +291,8 @@ impl ProvidersConfig {
 
     /// Save to a JSON file.
     pub fn save_to_file(&self, path: &str) -> Result<(), String> {
-        let json = serde_json::to_string_pretty(self)
-            .map_err(|e| format!("Failed to serialize: {e}"))?;
+        let json =
+            serde_json::to_string_pretty(self).map_err(|e| format!("Failed to serialize: {e}"))?;
         std::fs::write(path, json).map_err(|e| format!("Failed to write {path}: {e}"))
     }
 }
@@ -449,11 +482,16 @@ mod tests {
         }"#;
         let config = ProvidersConfig::from_json(json).unwrap();
         let entry = &config.providers[0];
-        assert_eq!(entry.api_key_secret.as_deref(), Some("providers/minimax/key"));
+        assert_eq!(
+            entry.api_key_secret.as_deref(),
+            Some("providers/minimax/key")
+        );
 
         let dir = tempfile::tempdir().unwrap();
         let resolver = SecretResolver::new(dir.path());
-        resolver.store("providers/minimax/key", "mm-fake-xyz").unwrap();
+        resolver
+            .store("providers/minimax/key", "mm-fake-xyz")
+            .unwrap();
 
         assert_eq!(
             entry.credential_source().unwrap(),
@@ -496,6 +534,54 @@ mod tests {
         assert!(matches!(
             entry.credential_source(),
             Err(CredentialError::ConflictingSources { .. })
+        ));
+    }
+
+    #[test]
+    fn absolute_api_key_secret_path_is_rejected() {
+        let json = r#"{
+            "providers": [{
+                "modelName": "bad-secret-absolute",
+                "provider": "minimax",
+                "apiKeySecret": "/etc/hostname"
+            }]
+        }"#;
+        let entry = &ProvidersConfig::from_json(json).unwrap().providers[0];
+        assert!(matches!(
+            entry.credential_source(),
+            Err(CredentialError::InvalidSecretPath { .. })
+        ));
+    }
+
+    #[test]
+    fn parent_component_api_key_secret_path_is_rejected() {
+        let json = r#"{
+            "providers": [{
+                "modelName": "bad-secret-parent",
+                "provider": "minimax",
+                "apiKeySecret": "providers/../host-secret"
+            }]
+        }"#;
+        let entry = &ProvidersConfig::from_json(json).unwrap().providers[0];
+        assert!(matches!(
+            entry.resolve_api_key(&SecretResolver::new(tempfile::tempdir().unwrap().path())),
+            Err(CredentialError::InvalidSecretPath { .. })
+        ));
+    }
+
+    #[test]
+    fn blank_api_key_secret_path_is_rejected() {
+        let json = r#"{
+            "providers": [{
+                "modelName": "bad-secret-blank",
+                "provider": "minimax",
+                "apiKeySecret": "   "
+            }]
+        }"#;
+        let entry = &ProvidersConfig::from_json(json).unwrap().providers[0];
+        assert!(matches!(
+            entry.credential_source(),
+            Err(CredentialError::InvalidSecretPath { .. })
         ));
     }
 
@@ -592,8 +678,14 @@ mod tests {
 
     #[test]
     fn extract_provider_rejects_non_matching_names() {
-        assert_eq!(ProviderAccountsConfig::extract_provider("OPENAI_KEYS"), None);
-        assert_eq!(ProviderAccountsConfig::extract_provider("SERA_OPENAI"), None);
+        assert_eq!(
+            ProviderAccountsConfig::extract_provider("OPENAI_KEYS"),
+            None
+        );
+        assert_eq!(
+            ProviderAccountsConfig::extract_provider("SERA_OPENAI"),
+            None
+        );
         assert_eq!(ProviderAccountsConfig::extract_provider("SERA__KEYS"), None);
         assert_eq!(ProviderAccountsConfig::extract_provider("SERA_KEYS"), None);
     }
@@ -611,7 +703,10 @@ mod tests {
         let keys = cfg
             .keys_for("jvi_from_env_test")
             .expect("keys should be present");
-        assert_eq!(keys, &vec!["sk-a".to_string(), "sk-b".to_string(), "sk-c".to_string()]);
+        assert_eq!(
+            keys,
+            &vec!["sk-a".to_string(), "sk-b".to_string(), "sk-c".to_string()]
+        );
     }
 
     #[test]

--- a/rust/crates/sera-config/src/providers.rs
+++ b/rust/crates/sera-config/src/providers.rs
@@ -7,6 +7,7 @@
 //! the gateway / runtime can turn into a
 //! [`sera_models::account_pool::AccountPool`].
 
+use crate::secrets::SecretResolver;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -29,6 +30,16 @@ pub struct ProviderEntry {
     pub base_url: String,
     #[serde(default)]
     pub api_key: String,
+    /// Reference to an environment variable holding the API key
+    /// (Hermes-style `apiKeyEnvVar`). Mutually exclusive with `api_key`
+    /// and `api_key_secret`; resolved lazily via [`ProviderEntry::resolve_api_key`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub api_key_env_var: Option<String>,
+    /// Reference to a file-backed secret path resolved through
+    /// [`SecretResolver`] (Hermes-style `apiKeySecret`). Mutually exclusive
+    /// with `api_key` and `api_key_env_var`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub api_key_secret: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -80,6 +91,115 @@ impl ProviderEntry {
     pub fn effective_max_tokens(&self) -> u64 {
         self.max_tokens.unwrap_or(4096)
     }
+
+    /// Determine where this entry's API key comes from, validating that at
+    /// most one of `apiKey` / `apiKeyEnvVar` / `apiKeySecret` is declared.
+    ///
+    /// Returns [`CredentialError::ConflictingSources`] when more than one is
+    /// set so the misconfiguration surfaces instead of being silently
+    /// resolved in an arbitrary order.
+    pub fn credential_source(&self) -> Result<CredentialSource, CredentialError> {
+        let mut declared = Vec::new();
+        if !self.api_key.is_empty() {
+            declared.push("apiKey");
+        }
+        if self.api_key_env_var.is_some() {
+            declared.push("apiKeyEnvVar");
+        }
+        if self.api_key_secret.is_some() {
+            declared.push("apiKeySecret");
+        }
+        if declared.len() > 1 {
+            return Err(CredentialError::ConflictingSources {
+                model_name: self.model_name.clone(),
+                sources: declared.join(", "),
+            });
+        }
+
+        Ok(if let Some(var) = &self.api_key_env_var {
+            CredentialSource::Env(var.clone())
+        } else if let Some(path) = &self.api_key_secret {
+            CredentialSource::Secret(path.clone())
+        } else if !self.api_key.is_empty() {
+            CredentialSource::Inline
+        } else {
+            CredentialSource::None
+        })
+    }
+
+    /// Resolve the API key value, following an `apiKeyEnvVar` env reference or
+    /// an `apiKeySecret` file-backed reference through `resolver`.
+    ///
+    /// Returns `Ok(None)` only when no credential is configured (e.g. a local
+    /// LM Studio endpoint). A declared-but-unresolvable reference is an error,
+    /// not a silent drop.
+    pub fn resolve_api_key(
+        &self,
+        resolver: &SecretResolver,
+    ) -> Result<Option<String>, CredentialError> {
+        match self.credential_source()? {
+            CredentialSource::None => Ok(None),
+            CredentialSource::Inline => Ok(Some(self.api_key.clone())),
+            CredentialSource::Env(var) => std::env::var(&var).map(Some).map_err(|_| {
+                CredentialError::EnvVarUnset {
+                    model_name: self.model_name.clone(),
+                    var,
+                }
+            }),
+            CredentialSource::Secret(path) => resolver.resolve(&path).map(Some).ok_or(
+                CredentialError::SecretUnresolved {
+                    model_name: self.model_name.clone(),
+                    path,
+                },
+            ),
+        }
+    }
+}
+
+/// Origin of a provider entry's API key.
+///
+/// Never carries the raw inline key value — only references (env var name,
+/// secret path) that are safe to surface in logs and audit rows.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CredentialSource {
+    /// No credential configured (e.g. a local endpoint with no key).
+    None,
+    /// An inline literal key supplied in the `apiKey` field.
+    Inline,
+    /// A reference to a named environment variable (`apiKeyEnvVar`).
+    Env(String),
+    /// A reference to a file-backed secret path (`apiKeySecret`).
+    Secret(String),
+}
+
+impl CredentialSource {
+    /// Audit-safe label. Exposes the reference (env var name / secret path)
+    /// but never the raw inline key value.
+    pub fn label(&self) -> String {
+        match self {
+            CredentialSource::None => "none".to_string(),
+            CredentialSource::Inline => "inline".to_string(),
+            CredentialSource::Env(var) => format!("env:{var}"),
+            CredentialSource::Secret(path) => format!("secret:{path}"),
+        }
+    }
+}
+
+/// Errors raised while determining or resolving a provider credential.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum CredentialError {
+    #[error(
+        "provider '{model_name}' declares conflicting credential sources ({sources}); \
+         specify exactly one of apiKey, apiKeyEnvVar, apiKeySecret"
+    )]
+    ConflictingSources {
+        model_name: String,
+        sources: String,
+    },
+    #[error("provider '{model_name}' references env var '{var}' which is not set")]
+    EnvVarUnset { model_name: String, var: String },
+    #[error("provider '{model_name}' references secret '{path}' which could not be resolved")]
+    SecretUnresolved { model_name: String, path: String },
 }
 
 impl ProvidersConfig {
@@ -277,6 +397,167 @@ mod tests {
         assert_eq!(entry.effective_context_window(), 131_072);
         assert_eq!(entry.effective_max_tokens(), 4096);
         assert!(!entry.reasoning);
+    }
+
+    // -----------------------------------------------------------------------
+    // sera-parity-schema-bridge — apiKeyEnvVar / apiKeySecret credential refs
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn parse_entry_with_api_key_env_var_round_trips() {
+        // Mirrors the legacy kilocode group: apiKeyEnvVar, no inline apiKey.
+        let json = r#"{
+            "providers": [{
+                "modelName": "minimax/minimax-m2.1:free",
+                "provider": "kilocode",
+                "baseUrl": "https://api.kilo.ai/api/gateway",
+                "apiKeyEnvVar": "SERA_SCHEMA_BRIDGE_TEST_KEY"
+            }]
+        }"#;
+        let config = ProvidersConfig::from_json(json).unwrap();
+        let entry = &config.providers[0];
+
+        // The env reference is parsed, not dropped.
+        assert_eq!(
+            entry.api_key_env_var.as_deref(),
+            Some("SERA_SCHEMA_BRIDGE_TEST_KEY")
+        );
+        assert_eq!(
+            entry.credential_source().unwrap(),
+            CredentialSource::Env("SERA_SCHEMA_BRIDGE_TEST_KEY".to_string())
+        );
+
+        // And it resolves to the env var's value.
+        let resolver = SecretResolver::new(tempfile::tempdir().unwrap().path());
+        let var = "SERA_SCHEMA_BRIDGE_TEST_KEY";
+        // SAFETY: single-threaded test, namespaced var.
+        unsafe { std::env::set_var(var, "kc-fake-123") };
+        let resolved = entry.resolve_api_key(&resolver);
+        unsafe { std::env::remove_var(var) };
+        assert_eq!(resolved.unwrap(), Some("kc-fake-123".to_string()));
+    }
+
+    #[test]
+    fn parse_entry_with_api_key_secret_resolves_via_resolver() {
+        let json = r#"{
+            "providers": [{
+                "modelName": "minimax-secret",
+                "provider": "minimax",
+                "baseUrl": "https://api.minimax.example/v1",
+                "apiKeySecret": "providers/minimax/key"
+            }]
+        }"#;
+        let config = ProvidersConfig::from_json(json).unwrap();
+        let entry = &config.providers[0];
+        assert_eq!(entry.api_key_secret.as_deref(), Some("providers/minimax/key"));
+
+        let dir = tempfile::tempdir().unwrap();
+        let resolver = SecretResolver::new(dir.path());
+        resolver.store("providers/minimax/key", "mm-fake-xyz").unwrap();
+
+        assert_eq!(
+            entry.credential_source().unwrap(),
+            CredentialSource::Secret("providers/minimax/key".to_string())
+        );
+        assert_eq!(
+            entry.resolve_api_key(&resolver).unwrap(),
+            Some("mm-fake-xyz".to_string())
+        );
+    }
+
+    #[test]
+    fn conflicting_inline_and_env_is_rejected() {
+        let json = r#"{
+            "providers": [{
+                "modelName": "conflict-a",
+                "provider": "kilocode",
+                "apiKey": "inline-fake",
+                "apiKeyEnvVar": "SOME_VAR"
+            }]
+        }"#;
+        let entry = &ProvidersConfig::from_json(json).unwrap().providers[0];
+        assert!(matches!(
+            entry.credential_source(),
+            Err(CredentialError::ConflictingSources { .. })
+        ));
+    }
+
+    #[test]
+    fn conflicting_env_and_secret_is_rejected() {
+        let json = r#"{
+            "providers": [{
+                "modelName": "conflict-b",
+                "provider": "kilocode",
+                "apiKeyEnvVar": "SOME_VAR",
+                "apiKeySecret": "providers/x/key"
+            }]
+        }"#;
+        let entry = &ProvidersConfig::from_json(json).unwrap().providers[0];
+        assert!(matches!(
+            entry.credential_source(),
+            Err(CredentialError::ConflictingSources { .. })
+        ));
+    }
+
+    #[test]
+    fn inline_api_key_remains_backward_compatible() {
+        // Legacy lmstudio placeholder entry: inline apiKey only.
+        let config = ProvidersConfig::from_json(SAMPLE_JSON).unwrap();
+        let lm = config.find_by_model("lmstudio-local").unwrap();
+        assert_eq!(lm.credential_source().unwrap(), CredentialSource::Inline);
+
+        let resolver = SecretResolver::new(tempfile::tempdir().unwrap().path());
+        assert_eq!(
+            lm.resolve_api_key(&resolver).unwrap(),
+            Some("lm-studio".to_string())
+        );
+    }
+
+    #[test]
+    fn no_credential_configured_is_none() {
+        let json = r#"{"providers": [{"modelName": "keyless", "provider": "lmstudio"}]}"#;
+        let entry = &ProvidersConfig::from_json(json).unwrap().providers[0];
+        assert_eq!(entry.credential_source().unwrap(), CredentialSource::None);
+        let resolver = SecretResolver::new(tempfile::tempdir().unwrap().path());
+        assert_eq!(entry.resolve_api_key(&resolver).unwrap(), None);
+    }
+
+    #[test]
+    fn unset_env_var_reference_errors_rather_than_dropping() {
+        let json = r#"{
+            "providers": [{
+                "modelName": "missing-env",
+                "provider": "kilocode",
+                "apiKeyEnvVar": "SERA_SCHEMA_BRIDGE_DEFINITELY_UNSET"
+            }]
+        }"#;
+        let entry = &ProvidersConfig::from_json(json).unwrap().providers[0];
+        let resolver = SecretResolver::new(tempfile::tempdir().unwrap().path());
+        assert!(matches!(
+            entry.resolve_api_key(&resolver),
+            Err(CredentialError::EnvVarUnset { .. })
+        ));
+    }
+
+    #[test]
+    fn credential_source_label_never_exposes_inline_value() {
+        let json = r#"{
+            "providers": [{"modelName": "labeltest", "provider": "x", "apiKey": "sk-super-secret"}]
+        }"#;
+        let entry = &ProvidersConfig::from_json(json).unwrap().providers[0];
+        let label = entry.credential_source().unwrap().label();
+        assert_eq!(label, "inline");
+        assert!(!label.contains("sk-super-secret"));
+
+        // Env / secret labels expose only the reference, never a value.
+        assert_eq!(
+            CredentialSource::Env("KILOCODE_API_KEY".to_string()).label(),
+            "env:KILOCODE_API_KEY"
+        );
+        assert_eq!(
+            CredentialSource::Secret("providers/minimax/key".to_string()).label(),
+            "secret:providers/minimax/key"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implements the narrow provider schema bridge for `sera-parity-schema-bridge` under `sera-ile`.

`ProviderEntry` now preserves and validates Hermes-style credential references instead of silently dropping them:

- `apiKeyEnvVar` → env-var credential source
- `apiKeySecret` → `SecretResolver` credential source
- inline `apiKey` remains backward-compatible
- conflicting credential sources error explicitly
- audit-safe credential labels avoid exposing raw key values

Scope is intentionally schema parse + resolution seam + tests only. This does not wire broad provider-router/model-router behavior and does not duplicate the runtime-child file-secret fix from PR #1316.

## Verification

- `cargo test -p sera-config providers::` → 18 passed
- `cargo clippy -p sera-config --all-targets -- -D warnings` → clean

## Bead / evidence

- Bead: `sera-parity-schema-bridge`
- Kanban task: `t_6c6cff11`
- OMC report: `/home/entity/projects/sera-omc/t_6c6cff11/artifacts/kanban/t_6c6cff11-omc-report.md`