### PR TITLE
docs(env): MiniMax-primary + local fallback template (sera-m1k8.1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,6 +74,8 @@ SECRETS_MASTER_KEY= # 32-byte hex string (64 characters)
 #     base_url: "https://<minimax-openai-compatible-host>/v1"
 #     default_model: <minimax-model-id>
 #     api_key: { secret: "llm/minimax-api-key" }   # resolved via SERA_SECRET_LLM_MINIMAX_API_KEY
+#   # Set SERA_SECRET_LLM_MINIMAX_API_KEY in your local .env; docker-compose.rust.yaml
+#   # passes it through to the gateway so the Provider SecretRef resolves at startup.
 #   ---
 #   apiVersion: sera.dev/v1
 #   kind: Agent

--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,26 @@ SECRETS_MASTER_KEY= # 32-byte hex string (64 characters)
 # ANTHROPIC_API_KEY=
 # GOOGLE_API_KEY=         # or GEMINI_API_KEY — both are accepted
 
+# ── MiniMax-primary + local LM Studio/Qwen fallback (sera-m1k8) ──
+# Ordered provider chain: the primary (LLM_*) is tried first; SERA falls back
+# to the secondary (SERA_LLM_FALLBACK_*) ONLY on retryable upstream errors
+# (rate-limit, timeout, provider-unavailable). Request / policy / tool / schema
+# errors surface verbatim and do NOT trigger fallback.
+# Placeholders only — keep real keys and private hostnames in your local .env.
+#
+# Primary — MiniMax over the OpenAI-compatible path:
+# LLM_BASE_URL=https://<minimax-openai-compatible-host>/v1
+# LLM_MODEL=<minimax-model-id>
+# LLM_API_KEY=<minimax-api-key>
+# SERA_LLM_PROVIDER_ID=minimax              # optional: pin provider for routing/audit
+#
+# Fallback — local LM Studio / Qwen:
+# SERA_LLM_FALLBACK_BASE_URL=http://host.docker.internal:1234/v1
+# SERA_LLM_FALLBACK_MODEL=qwen3.5-35b-a3b
+# SERA_LLM_FALLBACK_API_KEY=lm-studio       # placeholder; LM Studio ignores the value
+# SERA_LLM_FALLBACK_PROVIDER_ID=qwen-local  # optional: explicit fallback provider id
+# SERA_LLM_FALLBACK_MAX_TOKENS=2048         # optional: defaults to primary MAX_TOKENS
+
 # ── Web (sera-web) ──
 # Vite dev server proxies /api to sera-core automatically.
 # VITE_API_URL=http://sera-core:3001

--- a/.env.example
+++ b/.env.example
@@ -59,6 +59,29 @@ SECRETS_MASTER_KEY= # 32-byte hex string (64 characters)
 # LLM_API_KEY=<minimax-api-key>
 # SERA_LLM_PROVIDER_ID=minimax              # optional: pin provider for routing/audit
 #
+# REQUIRED for the Rust gateway/compose path (docker compose -f docker-compose.rust.yaml):
+# the gateway picks the PRIMARY provider from sera.yaml (each agent's spec.provider),
+# and overwrites LLM_BASE_URL/LLM_MODEL/LLM_API_KEY from that Provider manifest before
+# spawning the runtime (sera-gateway/src/bin/sera.rs run_start). So the primary LLM_* vars
+# above only make MiniMax primary when running sera-runtime standalone (no gateway). Under
+# the gateway, also add/point a Provider in sera.yaml at MiniMax, e.g.:
+#   ---
+#   apiVersion: sera.dev/v1
+#   kind: Provider
+#   metadata: { name: minimax }
+#   spec:
+#     kind: openai-compatible
+#     base_url: "https://<minimax-openai-compatible-host>/v1"
+#     default_model: <minimax-model-id>
+#     api_key: { secret: "llm/minimax-api-key" }   # resolved via SERA_SECRET_LLM_MINIMAX_API_KEY
+#   ---
+#   apiVersion: sera.dev/v1
+#   kind: Agent
+#   metadata: { name: sera }
+#   spec: { provider: minimax }                     # reference the Provider above
+# The SERA_LLM_FALLBACK_* vars below are read straight from process env by the runtime,
+# so they take effect in both paths once exported (compose already passes them through).
+#
 # Fallback — local LM Studio / Qwen:
 # SERA_LLM_FALLBACK_BASE_URL=http://host.docker.internal:1234/v1
 # SERA_LLM_FALLBACK_MODEL=qwen3.5-35b-a3b

--- a/docker-compose.rust.yaml
+++ b/docker-compose.rust.yaml
@@ -81,6 +81,20 @@ services:
       OLLAMA_BASE_URL: ${OLLAMA_BASE_URL:-http://host.docker.internal:11434}
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      # Ordered provider chain (see .env.example "MiniMax-primary + local fallback").
+      # Primary provider (LLM_*) tried first; runtime falls back to the secondary
+      # (SERA_LLM_FALLBACK_*) only on retryable upstream errors. These must be passed
+      # through here — Compose otherwise uses .env solely for interpolation, so the
+      # gateway child process would never see them. Empty defaults = single-provider.
+      LLM_BASE_URL: ${LLM_BASE_URL:-}
+      LLM_MODEL: ${LLM_MODEL:-}
+      LLM_API_KEY: ${LLM_API_KEY:-}
+      SERA_LLM_PROVIDER_ID: ${SERA_LLM_PROVIDER_ID:-}
+      SERA_LLM_FALLBACK_BASE_URL: ${SERA_LLM_FALLBACK_BASE_URL:-}
+      SERA_LLM_FALLBACK_MODEL: ${SERA_LLM_FALLBACK_MODEL:-}
+      SERA_LLM_FALLBACK_API_KEY: ${SERA_LLM_FALLBACK_API_KEY:-}
+      SERA_LLM_FALLBACK_PROVIDER_ID: ${SERA_LLM_FALLBACK_PROVIDER_ID:-}
+      SERA_LLM_FALLBACK_MAX_TOKENS: ${SERA_LLM_FALLBACK_MAX_TOKENS:-}
       SERA_EMBEDDING_PROVIDER: ${SERA_EMBEDDING_PROVIDER:-ollama}
       SERA_EMBEDDING_MODEL: ${SERA_EMBEDDING_MODEL:-nomic-embed-text}
       SERA_LOG_DIR: /app/logs

--- a/docker-compose.rust.yaml
+++ b/docker-compose.rust.yaml
@@ -90,6 +90,9 @@ services:
       LLM_MODEL: ${LLM_MODEL:-}
       LLM_API_KEY: ${LLM_API_KEY:-}
       SERA_LLM_PROVIDER_ID: ${SERA_LLM_PROVIDER_ID:-}
+      # Env-backed Provider SecretRef for the example `llm/minimax-api-key`.
+      # Secret path `llm/minimax-api-key` maps to SERA_SECRET_LLM_MINIMAX_API_KEY.
+      SERA_SECRET_LLM_MINIMAX_API_KEY: ${SERA_SECRET_LLM_MINIMAX_API_KEY:-}
       SERA_LLM_FALLBACK_BASE_URL: ${SERA_LLM_FALLBACK_BASE_URL:-}
       SERA_LLM_FALLBACK_MODEL: ${SERA_LLM_FALLBACK_MODEL:-}
       SERA_LLM_FALLBACK_API_KEY: ${SERA_LLM_FALLBACK_API_KEY:-}


### PR DESCRIPTION
## Summary

Documents the MiniMax-primary (OpenAI-compatible) + local LM Studio/Qwen fallback provider chain required by `sera-m1k8` acceptance, **and wires the documented env vars through the Rust Docker Compose stack** so the template actually takes effect.

Bead: `sera-m1k8.1` (parent `sera-m1k8`).

## Changes

- `.env.example`: commented, secret-free provider-chain block under the LLM Providers section
  - Primary: `LLM_BASE_URL` / `LLM_MODEL` / `LLM_API_KEY` / `SERA_LLM_PROVIDER_ID`
  - Fallback: `SERA_LLM_FALLBACK_BASE_URL` / `_MODEL` / `_API_KEY` / `_PROVIDER_ID` / `_MAX_TOKENS`
  - Documents retryable-only fallback semantics (rate-limit / timeout / provider-unavailable; request/policy/tool/schema errors surface verbatim).
- `docker-compose.rust.yaml`: pass the full ordered-chain through the `sera-gateway` `environment:` block (Codex P2 fix). Compose only uses `.env` for interpolation, so without an explicit `environment:` entry the gateway child never saw these vars. All use `${VAR:-}` empty defaults — single-provider setups are unchanged.

Var names mirror the documented env-var contract and the runtime reads in `sera-runtime/src/llm_client.rs` / `sera-config/src/core_config.rs`.

## Scope

Docs/template + compose env pass-through only. No provider routing/runtime behavior changes; no merge.

## Verification

- `docker compose -f docker-compose.rust.yaml config` → exit 0; all 9 provider-chain vars render under `sera-gateway`, interpolation confirmed (set values flow through).
- Secret scan (heuristic grep for key/JWT/IP-literal patterns) on touched files: **clean** — new entries are commented placeholders / empty-default interpolations only; matches are pre-existing loopback/bind addresses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
