### PR TITLE
test(gateway): prove tool failure status crosses gateway boundary

### DIFF
--- a/rust/crates/sera-gateway/src/agent_transport.rs
+++ b/rust/crates/sera-gateway/src/agent_transport.rs
@@ -47,6 +47,35 @@ pub enum ToolEvent {
     },
 }
 
+/// Parse the `msg` object from a runtime NDJSON `tool_call_end` frame into the
+/// gateway's [`ToolEvent::End`]. This is the production parser used by the
+/// stdio supervisor's `send_turn_inner` read loop — tests must call this helper
+/// rather than duplicating field extraction (`sera-tqzd`).
+pub fn tool_event_end_from_runtime_ndjson_msg(msg: &Value) -> ToolEvent {
+    let status = match msg.get("status").and_then(|v| v.as_str()) {
+        Some("failure") => ToolCallStatus::Failure,
+        _ => ToolCallStatus::Success,
+    };
+    let error_class = msg
+        .get("error_class")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+    ToolEvent::End {
+        call_id: msg
+            .get("call_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string(),
+        content: msg
+            .get("result")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string(),
+        status,
+        error_class,
+    }
+}
+
 /// Provider-reported token usage extracted from the terminal
 /// `TurnCompleted` frame.
 #[derive(Serialize, Debug, Clone, Copy, Default)]
@@ -221,5 +250,29 @@ mod tests {
     #[test]
     fn trait_is_object_safe() {
         let _: Arc<dyn AgentTurnTransport> = Arc::new(DummyTransport);
+    }
+
+    #[test]
+    fn tool_event_end_from_runtime_ndjson_msg_preserves_failure_markers() {
+        let msg = serde_json::json!({
+            "type": "tool_call_end",
+            "call_id": "call_fail_1",
+            "result": "[tool error: execution_failed]",
+            "status": "failure",
+            "error_class": "execution_failed",
+        });
+        match tool_event_end_from_runtime_ndjson_msg(&msg) {
+            ToolEvent::End {
+                status,
+                error_class,
+                call_id,
+                ..
+            } => {
+                assert_eq!(call_id, "call_fail_1");
+                assert_eq!(status, ToolCallStatus::Failure);
+                assert_eq!(error_class.as_deref(), Some("execution_failed"));
+            }
+            other => panic!("expected End, got {other:?}"),
+        }
     }
 }

--- a/rust/crates/sera-gateway/src/bin/sera.rs
+++ b/rust/crates/sera-gateway/src/bin/sera.rs
@@ -61,7 +61,9 @@ use sera_gateway::admin::{
     AdminAppState, AdminAuditLogger, AdminAuth, AdminSessionInfo, resolve_admin_bind,
     resolve_admin_port, serve_admin,
 };
-use sera_gateway::agent_transport::{AgentTurnTransport, ToolEvent, TurnEvents, UsageInfo};
+use sera_gateway::agent_transport::{
+    tool_event_end_from_runtime_ndjson_msg, AgentTurnTransport, ToolEvent, TurnEvents, UsageInfo,
+};
 use sera_gateway::capability_enforcement::{CapabilityRegistry, PolicyDenial};
 use sera_gateway::embedded_transport::EmbeddedRuntimeTransport;
 use sera_gateway::external_agent_registry::{DelegatorValidator, ExternalAgentRegistry};
@@ -628,36 +630,9 @@ impl StdioHarness {
                 }
                 "tool_call_end" => {
                     if let Some(msg) = event.get("msg") {
-                        // sera-tqzd / sera-q66q: the runtime sets `status` /
-                        // `error_class` on `EventMsg::ToolCallEnd` when
-                        // dispatch fails. Default to `Success` so older
-                        // runtimes (which never emit the fields) still
-                        // produce sensible audit rows.
-                        let status = match msg
-                            .get("status")
-                            .and_then(|v| v.as_str())
-                        {
-                            Some("failure") => sera_types::envelope::ToolCallStatus::Failure,
-                            _ => sera_types::envelope::ToolCallStatus::Success,
-                        };
-                        let error_class = msg
-                            .get("error_class")
-                            .and_then(|v| v.as_str())
-                            .map(|s| s.to_string());
-                        result.tool_events.push(ToolEvent::End {
-                            call_id: msg
-                                .get("call_id")
-                                .and_then(|v| v.as_str())
-                                .unwrap_or("")
-                                .to_string(),
-                            content: msg
-                                .get("result")
-                                .and_then(|v| v.as_str())
-                                .unwrap_or("")
-                                .to_string(),
-                            status,
-                            error_class,
-                        });
+                        result
+                            .tool_events
+                            .push(tool_event_end_from_runtime_ndjson_msg(msg));
                     }
                 }
                 "turn_completed" => {
@@ -10083,16 +10058,9 @@ mod tests {
     #[test]
     fn ndjson_tool_call_end_failure_status_preserved_at_gateway_boundary() {
         // sera-tqzd AC3: prove failures are NOT swallowed at the gateway
-        // NDJSON boundary.  The runtime serialises `EventMsg::ToolCallEnd`
-        // with `status=failure` and `error_class`; `send_turn_inner` must
-        // extract both fields into `ToolEvent::End` without dropping them.
-        //
-        // This test generates the exact JSON shape the runtime writes to
-        // stdout via `serde_json::to_value(&EventMsg::ToolCallEnd { … })`
-        // and then applies the same field extraction as `send_turn_inner`
-        // (bin/sera.rs lines 629-660).  If the serde tag or field names
-        // ever drift between emitter and parser this test will catch the
-        // regression.
+        // NDJSON boundary. Exercise the shared production parser used by
+        // `send_turn_inner`, not a copied extraction block.
+        use sera_gateway::agent_transport::tool_event_end_from_runtime_ndjson_msg;
         use sera_types::envelope::{EventMsg, ToolCallStatus};
 
         let msg = EventMsg::ToolCallEnd {
@@ -10104,45 +10072,38 @@ mod tests {
         };
 
         let msg_json = serde_json::to_value(&msg).expect("EventMsg must serialize");
-        let event = serde_json::json!({
-            "id": uuid::Uuid::nil(),
-            "submission_id": uuid::Uuid::nil(),
-            "msg": msg_json,
-            "timestamp": "2026-06-27T00:00:00Z",
-        });
-
-        // Mirror the extraction from send_turn_inner.
-        let msg_val = event.get("msg").expect("msg field present");
-        let msg_type = msg_val.get("type").and_then(|t| t.as_str()).unwrap_or("");
         assert_eq!(
-            msg_type, "tool_call_end",
+            msg_json.get("type").and_then(|t| t.as_str()),
+            Some("tool_call_end"),
             "EventMsg serde tag must produce snake_case 'tool_call_end'"
         );
 
-        let status = match msg_val.get("status").and_then(|v| v.as_str()) {
-            Some("failure") => ToolCallStatus::Failure,
-            _ => ToolCallStatus::Success,
-        };
-        let error_class = msg_val
-            .get("error_class")
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string());
-        let call_id = msg_val
-            .get("call_id")
-            .and_then(|v| v.as_str())
-            .unwrap_or("");
-
-        assert_eq!(
-            status,
-            ToolCallStatus::Failure,
-            "gateway must NOT swallow failure status at NDJSON boundary (sera-tqzd)"
-        );
-        assert_eq!(
-            error_class.as_deref(),
-            Some("policy_denied"),
-            "gateway must NOT swallow error_class at NDJSON boundary (sera-tqzd)"
-        );
-        assert_eq!(call_id, "call_fail_gw_1");
+        let parsed = tool_event_end_from_runtime_ndjson_msg(&msg_json);
+        match parsed {
+            ToolEvent::End {
+                call_id,
+                content,
+                status,
+                error_class,
+            } => {
+                assert_eq!(call_id, "call_fail_gw_1");
+                assert!(
+                    content.contains("policy denied"),
+                    "result content must flow through parser"
+                );
+                assert_eq!(
+                    status,
+                    ToolCallStatus::Failure,
+                    "gateway must NOT swallow failure status at NDJSON boundary (sera-tqzd)"
+                );
+                assert_eq!(
+                    error_class.as_deref(),
+                    Some("policy_denied"),
+                    "gateway must NOT swallow error_class at NDJSON boundary (sera-tqzd)"
+                );
+            }
+            other => panic!("expected ToolEvent::End, got {other:?}"),
+        }
     }
 
     #[test]

--- a/rust/crates/sera-gateway/src/bin/sera.rs
+++ b/rust/crates/sera-gateway/src/bin/sera.rs
@@ -10078,6 +10078,118 @@ mod tests {
         assert_ne!(ok["action_id"], bad["action_id"]);
     }
 
+    // ── sera-tqzd AC3: failures not swallowed at runtime/gateway boundary ──
+
+    #[test]
+    fn ndjson_tool_call_end_failure_status_preserved_at_gateway_boundary() {
+        // sera-tqzd AC3: prove failures are NOT swallowed at the gateway
+        // NDJSON boundary.  The runtime serialises `EventMsg::ToolCallEnd`
+        // with `status=failure` and `error_class`; `send_turn_inner` must
+        // extract both fields into `ToolEvent::End` without dropping them.
+        //
+        // This test generates the exact JSON shape the runtime writes to
+        // stdout via `serde_json::to_value(&EventMsg::ToolCallEnd { … })`
+        // and then applies the same field extraction as `send_turn_inner`
+        // (bin/sera.rs lines 629-660).  If the serde tag or field names
+        // ever drift between emitter and parser this test will catch the
+        // regression.
+        use sera_types::envelope::{EventMsg, ToolCallStatus};
+
+        let msg = EventMsg::ToolCallEnd {
+            turn_id: uuid::Uuid::nil(),
+            call_id: "call_fail_gw_1".to_string(),
+            result: "[tool error: policy denied: denied for gate test]".to_string(),
+            status: ToolCallStatus::Failure,
+            error_class: Some("policy_denied".to_string()),
+        };
+
+        let msg_json = serde_json::to_value(&msg).expect("EventMsg must serialize");
+        let event = serde_json::json!({
+            "id": uuid::Uuid::nil(),
+            "submission_id": uuid::Uuid::nil(),
+            "msg": msg_json,
+            "timestamp": "2026-06-27T00:00:00Z",
+        });
+
+        // Mirror the extraction from send_turn_inner.
+        let msg_val = event.get("msg").expect("msg field present");
+        let msg_type = msg_val.get("type").and_then(|t| t.as_str()).unwrap_or("");
+        assert_eq!(
+            msg_type, "tool_call_end",
+            "EventMsg serde tag must produce snake_case 'tool_call_end'"
+        );
+
+        let status = match msg_val.get("status").and_then(|v| v.as_str()) {
+            Some("failure") => ToolCallStatus::Failure,
+            _ => ToolCallStatus::Success,
+        };
+        let error_class = msg_val
+            .get("error_class")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let call_id = msg_val
+            .get("call_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+
+        assert_eq!(
+            status,
+            ToolCallStatus::Failure,
+            "gateway must NOT swallow failure status at NDJSON boundary (sera-tqzd)"
+        );
+        assert_eq!(
+            error_class.as_deref(),
+            Some("policy_denied"),
+            "gateway must NOT swallow error_class at NDJSON boundary (sera-tqzd)"
+        );
+        assert_eq!(call_id, "call_fail_gw_1");
+    }
+
+    #[test]
+    fn credential_in_tool_error_does_not_escape_into_status_detail() {
+        // sera-tqzd AC3: no private payload leaks into the operator-visible
+        // `status_detail` field of the OCSF audit payload.
+        //
+        // A tool that fails with a credential-bearing error message must NOT
+        // expose that credential in `status_detail` — only the structured
+        // error class string (e.g. "execution_failed") may appear there.
+        // Raw error content is confined to `unmapped.result_snippet` and is
+        // bounded by `TOOL_EXEC_AUDIT_CONTENT_LIMIT` (512 bytes).
+        let fake_key = "sk_live_FAKEFAKEFAKE_this_is_not_a_real_key_1234567890abcdef";
+        let error_content = format!(
+            "[tool error: tool execution failed: API call rejected, bearer: {fake_key}]"
+        );
+
+        let payload = make_tool_execution_audit_payload(
+            "agent-test",
+            "sess-credleak",
+            "call_credleak_1",
+            "http-request",
+            sera_types::envelope::ToolCallStatus::Failure,
+            Some("execution_failed"),
+            &error_content,
+        );
+
+        let status_detail = payload["status_detail"].as_str().unwrap_or_default();
+        assert_eq!(
+            status_detail, "execution_failed",
+            "status_detail must hold only the error class, not raw error content"
+        );
+        assert!(
+            !status_detail.contains(fake_key),
+            "status_detail must not expose credential-like patterns: {status_detail}"
+        );
+
+        // Snippet is bounded so a long credential-bearing error cannot bloat
+        // the audit ledger row.
+        let snippet = payload["unmapped"]["result_snippet"].as_str().unwrap_or_default();
+        assert!(
+            snippet.len() <= TOOL_EXEC_AUDIT_CONTENT_LIMIT + 32,
+            "result_snippet must be bounded: len={}",
+            snippet.len()
+        );
+    }
+
     #[tokio::test]
     async fn submissions_route_rolls_back_registration_when_persistence_fails() {
         let mut state = test_state();


### PR DESCRIPTION
## Summary

Adds regression coverage for the `sera-tqzd` tool/API failure surfacing and audit slice.

The branch was produced by the OMC implementation lane for `source_bead_id: sera-tqzd`. The main implementation was already present on the branch; this PR adds the missing AC3 proofs that failure status is preserved at the runtime/gateway boundary and credential-like payloads do not escape into the operator-visible audit `status_detail` field.

## Changes

- Adds `ndjson_tool_call_end_failure_status_preserved_at_gateway_boundary`.
- Adds `credential_in_tool_error_does_not_escape_into_status_detail`.

## Verification

Rerun locally from the PR worktree:

```bash
cargo test -p sera-gateway ndjson_tool_call_end_failure_status_preserved -- --nocapture
cargo test -p sera-gateway credential_in_tool_error -- --nocapture
```

Both focused tests passed.

OMC lane also reported:

```bash
cargo test -p sera-gateway --lib
cargo test -p sera-runtime --lib
```

## Notes / remaining follow-up

- `sera-q66q` remains the canonical follow-up for full hash-chain stitching.
- Active scrubbing for `unmapped.result_snippet` would be a follow-up; this PR proves `status_detail` remains class-only and snippet length remains bounded.
- Embedded transport projection coverage is not added here; this PR is intentionally the narrow gateway NDJSON boundary proof.
