### PR TITLE
feat(cli): validate Circle proof bundles offline

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5070,6 +5070,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2",
  "tempfile",
  "tokio",
  "tokio-stream",

--- a/rust/crates/sera-cli/Cargo.toml
+++ b/rust/crates/sera-cli/Cargo.toml
@@ -19,6 +19,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+sha2 = { workspace = true }
 serde_yaml = { workspace = true }
 toml = { workspace = true }
 reqwest = { workspace = true }

--- a/rust/crates/sera-cli/src/main.rs
+++ b/rust/crates/sera-cli/src/main.rs
@@ -8,6 +8,8 @@ use std::path::PathBuf;
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use sera_commands::{CommandArgs, CommandContext};
+use sera_types::{circle::CollaborationProofBundle, circle_validator::validate_proof_bundle};
+use sha2::{Digest, Sha256};
 
 use sera_cli::config::CliConfig;
 use sera_cli::token_store::best_available_store;
@@ -94,6 +96,11 @@ enum Commands {
         #[command(subcommand)]
         command: KillswitchCommand,
     },
+    /// Validate Circle proof bundles offline
+    Circle {
+        #[command(subcommand)]
+        command: CircleCommand,
+    },
     /// Read or modify config.yaml locally (no gateway round-trip)
     Config {
         #[command(subcommand)]
@@ -106,17 +113,11 @@ enum WorkflowCommand {
     /// List workflows
     List,
     /// Show one workflow by id
-    Show {
-        id: String,
-    },
+    Show { id: String },
     /// Create a workflow from a manifest file (deferred to L.5)
-    Create {
-        file: PathBuf,
-    },
+    Create { file: PathBuf },
     /// Delete a workflow by id (deferred to L.5)
-    Delete {
-        id: String,
-    },
+    Delete { id: String },
 }
 
 #[derive(Subcommand)]
@@ -124,9 +125,7 @@ enum PolicyCommand {
     /// List capability policies
     List,
     /// Show one policy by name
-    Show {
-        name: String,
-    },
+    Show { name: String },
     /// Reload policies from disk
     Reload,
     /// Validate every policy YAML
@@ -138,13 +137,9 @@ enum SessionCommand {
     /// List active sessions
     List,
     /// Show one session by id
-    Show {
-        id: String,
-    },
+    Show { id: String },
     /// Cancel a session
-    Kill {
-        id: String,
-    },
+    Kill { id: String },
     /// Paginated browser (TTY-aware)
     Browse,
 }
@@ -160,16 +155,24 @@ enum KillswitchCommand {
 }
 
 #[derive(Subcommand)]
+enum CircleCommand {
+    /// Validate a mixed-provider Circle collaboration proof bundle
+    Validate {
+        /// Path to a CollaborationProofBundle JSON artifact
+        #[arg(long, value_name = "PATH")]
+        bundle: PathBuf,
+        /// Emit a compact JSON report before the machine-parseable footer
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+#[derive(Subcommand)]
 enum ConfigCommand {
     /// Read a value by dotted path
-    Get {
-        key: String,
-    },
+    Get { key: String },
     /// Write a string value at a dotted path
-    Set {
-        key: String,
-        value: String,
-    },
+    Set { key: String, value: String },
     /// Open config.yaml in $EDITOR
     Edit,
     /// Print the resolved config.yaml path
@@ -279,6 +282,100 @@ enum AuthCommand {
     },
     /// Remove the stored token
     Logout,
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    format!("{:x}", hasher.finalize())
+}
+
+fn print_circle_footer(verdict: &str, bundle_sha256: &str) {
+    println!("circle-validate: {verdict} {bundle_sha256}");
+}
+
+fn run_circle_validate(bundle_path: PathBuf, json: bool) -> i32 {
+    let bytes = match std::fs::read(&bundle_path) {
+        Ok(bytes) => bytes,
+        Err(err) => {
+            eprintln!(
+                "failed to read Circle proof bundle {}: {err}",
+                bundle_path.display()
+            );
+            print_circle_footer("USAGE_ERROR", "unknown");
+            return 3;
+        }
+    };
+
+    let bundle_sha256 = sha256_hex(&bytes);
+    let bundle: CollaborationProofBundle = match serde_json::from_slice(&bytes) {
+        Ok(bundle) => bundle,
+        Err(err) => {
+            eprintln!(
+                "failed to parse Circle proof bundle {}: {err}",
+                bundle_path.display()
+            );
+            print_circle_footer("USAGE_ERROR", &bundle_sha256);
+            return 3;
+        }
+    };
+
+    match validate_proof_bundle(&bundle) {
+        Ok(()) => {
+            if json {
+                println!(
+                    "{}",
+                    serde_json::json!({
+                        "verdict": "PASS",
+                        "bundle_sha256": bundle_sha256,
+                        "entries": bundle.entries.len(),
+                        "execution_receipts": bundle.execution_receipts.len(),
+                        "lineage_edges": bundle.lineage.len(),
+                        "circle_id": bundle.circle_id,
+                        "run_id": bundle.run_id,
+                    })
+                );
+            } else {
+                println!(
+                    "Circle proof bundle PASS: entries={} receipts={} lineage={} run_id={} circle_id={}",
+                    bundle.entries.len(),
+                    bundle.execution_receipts.len(),
+                    bundle.lineage.len(),
+                    bundle.run_id,
+                    bundle.circle_id
+                );
+            }
+            print_circle_footer("PASS", &bundle_sha256);
+            0
+        }
+        Err(errors) => {
+            if json {
+                println!(
+                    "{}",
+                    serde_json::json!({
+                        "verdict": "FAIL",
+                        "bundle_sha256": bundle_sha256,
+                        "entries": bundle.entries.len(),
+                        "execution_receipts": bundle.execution_receipts.len(),
+                        "lineage_edges": bundle.lineage.len(),
+                        "circle_id": bundle.circle_id,
+                        "run_id": bundle.run_id,
+                        "errors": errors.iter().map(|e| format!("{:?}", e.kind)).collect::<Vec<_>>(),
+                    })
+                );
+            } else {
+                eprintln!(
+                    "Circle proof bundle FAIL: {} validation error(s)",
+                    errors.len()
+                );
+                for error in &errors {
+                    eprintln!("- {:?}", error.kind);
+                }
+            }
+            print_circle_footer("FAIL", &bundle_sha256);
+            1
+        }
+    }
 }
 
 #[tokio::main]
@@ -430,7 +527,13 @@ async fn main() -> Result<()> {
                 }
             }
 
-            AgentCommand::Run { id, prompt, endpoint, raw, no_stream } => {
+            AgentCommand::Run {
+                id,
+                prompt,
+                endpoint,
+                raw,
+                no_stream,
+            } => {
                 let mut args = CommandArgs::new();
                 let resolved = endpoint.unwrap_or_else(|| config.endpoint.clone());
                 args.insert("endpoint", resolved);
@@ -639,6 +742,15 @@ async fn main() -> Result<()> {
                 std::process::exit(result.exit_code);
             }
         }
+
+        Commands::Circle { command } => match command {
+            CircleCommand::Validate { bundle, json } => {
+                let exit_code = run_circle_validate(bundle, json);
+                if exit_code != 0 {
+                    std::process::exit(exit_code);
+                }
+            }
+        },
 
         Commands::Config { command } => {
             let (cmd_name, args) = match command {

--- a/rust/crates/sera-cli/src/main.rs
+++ b/rust/crates/sera-cli/src/main.rs
@@ -159,8 +159,8 @@ enum CircleCommand {
     /// Validate a mixed-provider Circle collaboration proof bundle
     Validate {
         /// Path to a CollaborationProofBundle JSON artifact
-        #[arg(long, value_name = "PATH")]
-        bundle: PathBuf,
+        #[arg(long, value_name = "PATH", num_args = 0..=1)]
+        bundle: Option<PathBuf>,
         /// Emit a compact JSON report before the machine-parseable footer
         #[arg(long)]
         json: bool,
@@ -294,7 +294,13 @@ fn print_circle_footer(verdict: &str, bundle_sha256: &str) {
     println!("circle-validate: {verdict} {bundle_sha256}");
 }
 
-fn run_circle_validate(bundle_path: PathBuf, json: bool) -> i32 {
+fn run_circle_validate(bundle_path: Option<PathBuf>, json: bool) -> i32 {
+    let Some(bundle_path) = bundle_path else {
+        eprintln!("missing required --bundle <PATH> for Circle proof validation");
+        print_circle_footer("USAGE_ERROR", "unknown");
+        return 3;
+    };
+
     let bytes = match std::fs::read(&bundle_path) {
         Ok(bytes) => bytes,
         Err(err) => {

--- a/rust/crates/sera-cli/src/main.rs
+++ b/rust/crates/sera-cli/src/main.rs
@@ -392,6 +392,20 @@ async fn main() -> Result<()> {
         .with_target(false)
         .init();
 
+    // Offline Circle proof-bundle validation must not depend on gateway config
+    // or token stores. Keep this path usable in CI and stale/corrupt operator
+    // environments, and always emit the `circle-validate:` footer.
+    if let Commands::Circle {
+        command: CircleCommand::Validate { bundle, json },
+    } = &cli.command
+    {
+        let exit_code = run_circle_validate(bundle.clone(), *json);
+        if exit_code != 0 {
+            std::process::exit(exit_code);
+        }
+        return Ok(());
+    }
+
     // Load config (graceful if file absent).
     let config_path = cli.config.unwrap_or_else(CliConfig::default_path);
     let config = CliConfig::load(&config_path)

--- a/rust/crates/sera-cli/tests/circle_validate.rs
+++ b/rust/crates/sera-cli/tests/circle_validate.rs
@@ -1,0 +1,81 @@
+use std::path::PathBuf;
+use std::process::Command;
+
+fn fixture(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join(name)
+}
+
+#[test]
+fn circle_validate_cli_passes_valid_mixed_provider_bundle() {
+    let output = Command::new(env!("CARGO_BIN_EXE_sera"))
+        .args([
+            "circle",
+            "validate",
+            "--bundle",
+            fixture("circle_valid_mixed_provider.json")
+                .to_str()
+                .unwrap(),
+        ])
+        .output()
+        .expect("run sera circle validate");
+
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Circle proof bundle PASS"),
+        "stdout={stdout}"
+    );
+    assert!(stdout.contains("circle-validate: PASS "), "stdout={stdout}");
+}
+
+#[test]
+fn circle_validate_cli_fails_receipt_provider_mismatch() {
+    let output = Command::new(env!("CARGO_BIN_EXE_sera"))
+        .args([
+            "circle",
+            "validate",
+            "--bundle",
+            fixture("circle_receipt_provider_mismatch.json")
+                .to_str()
+                .unwrap(),
+        ])
+        .output()
+        .expect("run sera circle validate");
+
+    assert_eq!(output.status.code(), Some(1));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stdout.contains("circle-validate: FAIL "), "stdout={stdout}");
+    assert!(
+        stderr.contains("ReceiptProviderEvidenceMismatch"),
+        "stderr={stderr}"
+    );
+}
+
+#[test]
+fn circle_validate_cli_usage_error_for_missing_bundle_file() {
+    let missing = fixture("does-not-exist.json");
+    let output = Command::new(env!("CARGO_BIN_EXE_sera"))
+        .args(["circle", "validate", "--bundle", missing.to_str().unwrap()])
+        .output()
+        .expect("run sera circle validate");
+
+    assert_eq!(output.status.code(), Some(3));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stdout.contains("circle-validate: USAGE_ERROR unknown"),
+        "stdout={stdout}"
+    );
+    assert!(
+        stderr.contains("failed to read Circle proof bundle"),
+        "stderr={stderr}"
+    );
+}

--- a/rust/crates/sera-cli/tests/circle_validate.rs
+++ b/rust/crates/sera-cli/tests/circle_validate.rs
@@ -59,8 +59,6 @@ fn circle_validate_cli_fails_receipt_provider_mismatch() {
     );
 }
 
-
-
 #[test]
 fn circle_validate_cli_bypasses_corrupt_config() {
     let bad_config = std::env::temp_dir().join(format!(
@@ -77,7 +75,9 @@ fn circle_validate_cli_bypasses_corrupt_config() {
             "circle",
             "validate",
             "--bundle",
-            fixture("circle_valid_mixed_provider.json").to_str().unwrap(),
+            fixture("circle_valid_mixed_provider.json")
+                .to_str()
+                .unwrap(),
         ])
         .output()
         .expect("run sera circle validate with corrupt config");
@@ -91,6 +91,46 @@ fn circle_validate_cli_bypasses_corrupt_config() {
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("circle-validate: PASS "), "stdout={stdout}");
+}
+
+#[test]
+fn circle_validate_cli_usage_error_footer_when_bundle_is_omitted() {
+    let output = Command::new(env!("CARGO_BIN_EXE_sera"))
+        .args(["circle", "validate"])
+        .output()
+        .expect("run sera circle validate without bundle");
+
+    assert_eq!(output.status.code(), Some(3));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stdout.contains("circle-validate: USAGE_ERROR unknown"),
+        "stdout={stdout}"
+    );
+    assert!(
+        stderr.contains("missing required --bundle"),
+        "stderr={stderr}"
+    );
+}
+
+#[test]
+fn circle_validate_cli_usage_error_footer_when_bundle_value_is_omitted() {
+    let output = Command::new(env!("CARGO_BIN_EXE_sera"))
+        .args(["circle", "validate", "--bundle"])
+        .output()
+        .expect("run sera circle validate with value-less bundle flag");
+
+    assert_eq!(output.status.code(), Some(3));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stdout.contains("circle-validate: USAGE_ERROR unknown"),
+        "stdout={stdout}"
+    );
+    assert!(
+        stderr.contains("missing required --bundle"),
+        "stderr={stderr}"
+    );
 }
 
 #[test]

--- a/rust/crates/sera-cli/tests/circle_validate.rs
+++ b/rust/crates/sera-cli/tests/circle_validate.rs
@@ -59,6 +59,40 @@ fn circle_validate_cli_fails_receipt_provider_mismatch() {
     );
 }
 
+
+
+#[test]
+fn circle_validate_cli_bypasses_corrupt_config() {
+    let bad_config = std::env::temp_dir().join(format!(
+        "sera-bad-config-{}-{}.toml",
+        std::process::id(),
+        "circle-validate"
+    ));
+    std::fs::write(&bad_config, "endpoint = [this is invalid toml").unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_sera"))
+        .args([
+            "--config",
+            bad_config.to_str().unwrap(),
+            "circle",
+            "validate",
+            "--bundle",
+            fixture("circle_valid_mixed_provider.json").to_str().unwrap(),
+        ])
+        .output()
+        .expect("run sera circle validate with corrupt config");
+    let _ = std::fs::remove_file(&bad_config);
+
+    assert!(
+        output.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("circle-validate: PASS "), "stdout={stdout}");
+}
+
 #[test]
 fn circle_validate_cli_usage_error_for_missing_bundle_file() {
     let missing = fixture("does-not-exist.json");

--- a/rust/crates/sera-cli/tests/fixtures/circle_receipt_provider_mismatch.json
+++ b/rust/crates/sera-cli/tests/fixtures/circle_receipt_provider_mismatch.json
@@ -1,0 +1,53 @@
+{
+  "run_id": "cli-valid-mixed-provider",
+  "circle_id": "sera-nqh3-cli-test",
+  "objective": "Validate mixed-provider proof bundle through CLI",
+  "success_metric": { "kind": "inline", "description": "CLI accepts receipt-anchored local+cloud evidence" },
+  "roster": [
+    { "participant_id": "cloud_minimax", "role": "cloud perspective" },
+    { "participant_id": "local_gemma", "role": "local perspective" }
+  ],
+  "entries": [
+    {
+      "entry_id": 1,
+      "author": "cloud_minimax",
+      "timestamp": "2026-06-29T15:53:02Z",
+      "artifact_type": "provider_response",
+      "payload": { "provider": "minimax", "model": "MiniMax-M3", "response": "cloud answer" }
+    },
+    {
+      "entry_id": 2,
+      "author": "local_gemma",
+      "timestamp": "2026-06-29T15:53:20Z",
+      "artifact_type": "provider_response",
+      "payload": { "provider": "local-lmstudio", "model": "gemma-local", "response": "local answer" }
+    }
+  ],
+  "lineage": [
+    { "from_entry_id": 1, "to_entry_id": 2, "relation": "derives_from" }
+  ],
+  "execution_receipts": [
+    {
+      "receipt_id": "rcpt_cloud",
+      "executor": "cloud_minimax",
+      "timestamp": "2026-06-29T15:53:02Z",
+      "action": "hermes_chat",
+      "parameters": { "provider": "minimax", "model": "MiniMax-M3", "returncode": 0 },
+      "outcome": "success"
+    },
+    {
+      "receipt_id": "rcpt_local_wrong",
+      "executor": "local_gemma",
+      "timestamp": "2026-06-29T15:53:20Z",
+      "action": "hermes_chat",
+      "parameters": { "provider": "minimax", "model": "MiniMax-M3", "returncode": 0 },
+      "outcome": "success"
+    }
+  ],
+  "verdict": {
+    "reviewer": "referee",
+    "timestamp": "2026-06-29T15:54:00Z",
+    "verdict_type": { "kind": "approved" },
+    "rationale": "fixture passes"
+  }
+}

--- a/rust/crates/sera-cli/tests/fixtures/circle_valid_mixed_provider.json
+++ b/rust/crates/sera-cli/tests/fixtures/circle_valid_mixed_provider.json
@@ -1,0 +1,53 @@
+{
+  "run_id": "cli-valid-mixed-provider",
+  "circle_id": "sera-nqh3-cli-test",
+  "objective": "Validate mixed-provider proof bundle through CLI",
+  "success_metric": { "kind": "inline", "description": "CLI accepts receipt-anchored local+cloud evidence" },
+  "roster": [
+    { "participant_id": "cloud_minimax", "role": "cloud perspective" },
+    { "participant_id": "local_gemma", "role": "local perspective" }
+  ],
+  "entries": [
+    {
+      "entry_id": 1,
+      "author": "cloud_minimax",
+      "timestamp": "2026-06-29T15:53:02Z",
+      "artifact_type": "provider_response",
+      "payload": { "provider": "minimax", "model": "MiniMax-M3", "response": "cloud answer" }
+    },
+    {
+      "entry_id": 2,
+      "author": "local_gemma",
+      "timestamp": "2026-06-29T15:53:20Z",
+      "artifact_type": "provider_response",
+      "payload": { "provider": "local-lmstudio", "model": "gemma-local", "response": "local answer" }
+    }
+  ],
+  "lineage": [
+    { "from_entry_id": 1, "to_entry_id": 2, "relation": "derives_from" }
+  ],
+  "execution_receipts": [
+    {
+      "receipt_id": "rcpt_cloud",
+      "executor": "cloud_minimax",
+      "timestamp": "2026-06-29T15:53:02Z",
+      "action": "hermes_chat",
+      "parameters": { "provider": "minimax", "model": "MiniMax-M3", "returncode": 0 },
+      "outcome": "success"
+    },
+    {
+      "receipt_id": "rcpt_local",
+      "executor": "local_gemma",
+      "timestamp": "2026-06-29T15:53:20Z",
+      "action": "hermes_chat",
+      "parameters": { "provider": "local-lmstudio", "model": "gemma-local", "returncode": 0 },
+      "outcome": "success"
+    }
+  ],
+  "verdict": {
+    "reviewer": "referee",
+    "timestamp": "2026-06-29T15:54:00Z",
+    "verdict_type": { "kind": "approved" },
+    "rationale": "fixture passes"
+  }
+}


### PR DESCRIPTION
## Summary

Continues `sera-nqh3` from the merged proof-bundle validator into a first operator-facing CLI seam:

- adds `sera circle validate --bundle <path>` to `sera-cli`;
- reads a `CollaborationProofBundle` JSON artifact offline;
- calls `sera_types::circle_validator::validate_proof_bundle` with no network/provider calls;
- emits a machine-parseable footer: `circle-validate: PASS|FAIL|USAGE_ERROR <bundle-sha256|unknown>`;
- supports `--json` for compact report output;
- adds CLI subprocess regressions for valid mixed-provider proof, receipt/provider mismatch, and missing bundle usage error.

## Why

PR #1334 made the validator deterministic and receipt-anchored. This PR makes that seam usable from the SERA CLI, so a live mixed-provider Circle artifact can be validated without ad-hoc temporary Rust tests.

## Verification

Local:

- `cargo test -p sera-cli circle_validate -- --nocapture`
  - 3 tests passed.
- `cargo test -p sera-types circle_validator -- --nocapture`
  - 16 focused validator tests passed.
- `cargo check -p sera-cli`
  - passed.
- Real rich mixed-provider artifact smoke:
  - command: `cargo run -p sera-cli -- circle validate --bundle /home/entity/projects/sera-live-main-current-20260629-pr1334/artifacts/reports/circle/rich-mixed-provider-20260629-1800/proof_bundle.json --json`
  - output included:
    - `"verdict":"PASS"`
    - `"entries":4`
    - `"execution_receipts":4`
    - `"lineage_edges":3`
    - `circle-validate: PASS 67a445f6b552a99a16198a054856ea5c055b2416f27498d396bfef99bdf6206d`

## Notes

The CLI deliberately validates existing proof bundles only. It does not call providers and does not attempt to run a Circle. First-class provider fixture replay / runner generation remains a follow-up slice.
