### PR TITLE
feat(cli): replay Circle fixtures into proof bundles

### DIFF
--- a/rust/crates/sera-cli/src/circle_replay.rs
+++ b/rust/crates/sera-cli/src/circle_replay.rs
@@ -378,22 +378,14 @@ fn required_str<'a>(value: &'a Value, field: &str) -> Result<&'a str, String> {
         .ok_or_else(|| format!("role summary missing string field {field}"))
 }
 
-fn canonical_provider(provider_cli: &str, model: &str) -> String {
+fn canonical_provider(provider_cli: &str, _model: &str) -> String {
     let provider = provider_cli.trim().to_ascii_lowercase();
-    let model = model.trim().to_ascii_lowercase();
 
     if provider.contains("ollama") {
         return "ollama".to_string();
     }
     let provider_compact = provider.replace(['-', '_'], "");
-    if provider.contains("local")
-        || provider_compact.contains("lmstudio")
-        || provider == "custom"
-        || model.contains("gemma")
-        || model.contains("qwen")
-        || model.contains("llama")
-        || model.contains("mistral")
-    {
+    if provider.contains("local") || provider_compact.contains("lmstudio") || provider == "custom" {
         return "local-lmstudio".to_string();
     }
 

--- a/rust/crates/sera-cli/src/circle_replay.rs
+++ b/rust/crates/sera-cli/src/circle_replay.rs
@@ -1,0 +1,431 @@
+use std::path::{Path, PathBuf};
+
+use sera_types::{circle::CollaborationProofBundle, circle_validator::validate_proof_bundle};
+use serde_json::{Value, json};
+
+use crate::sha256_hex;
+
+pub fn print_circle_replay_footer(verdict: &str, bundle_sha256: &str) {
+    println!("circle-replay: {verdict} {bundle_sha256}");
+}
+
+pub fn run_circle_replay(
+    fixture_dir: Option<PathBuf>,
+    bundle_out: Option<PathBuf>,
+    json_out: bool,
+) -> i32 {
+    let Some(fixture_dir) = fixture_dir else {
+        eprintln!("missing required --fixture-dir <DIR> for Circle replay");
+        print_circle_replay_footer("USAGE_ERROR", "unknown");
+        return 3;
+    };
+
+    let Some(bundle_out) = bundle_out else {
+        eprintln!("missing required --bundle-out <PATH> for Circle replay");
+        print_circle_replay_footer("USAGE_ERROR", "unknown");
+        return 3;
+    };
+
+    let bundle = match build_replay_bundle(&fixture_dir) {
+        Ok(bundle) => bundle,
+        Err(err) => {
+            eprintln!("failed to build Circle replay bundle: {err}");
+            print_circle_replay_footer("USAGE_ERROR", "unknown");
+            return 3;
+        }
+    };
+
+    let bytes = match serde_json::to_vec_pretty(&bundle) {
+        Ok(bytes) => bytes,
+        Err(err) => {
+            eprintln!("failed to serialize Circle replay bundle: {err}");
+            print_circle_replay_footer("USAGE_ERROR", "unknown");
+            return 3;
+        }
+    };
+    let bundle_sha256 = sha256_hex(&bytes);
+
+    if let Some(parent) = bundle_out
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        if let Err(err) = std::fs::create_dir_all(parent) {
+            eprintln!(
+                "failed to create Circle replay output directory {}: {err}",
+                parent.display()
+            );
+            print_circle_replay_footer("USAGE_ERROR", "unknown");
+            return 3;
+        }
+    }
+
+    if let Err(err) = std::fs::write(&bundle_out, &bytes) {
+        eprintln!(
+            "failed to write Circle replay bundle {}: {err}",
+            bundle_out.display()
+        );
+        print_circle_replay_footer("USAGE_ERROR", "unknown");
+        return 3;
+    }
+
+    match validate_proof_bundle(&bundle) {
+        Ok(()) => {
+            if json_out {
+                println!(
+                    "{}",
+                    json!({
+                        "verdict": "PASS",
+                        "bundle_sha256": bundle_sha256,
+                        "bundle_out": bundle_out.display().to_string(),
+                        "entries": bundle.entries.len(),
+                        "execution_receipts": bundle.execution_receipts.len(),
+                        "lineage_edges": bundle.lineage.len(),
+                        "circle_id": bundle.circle_id,
+                        "run_id": bundle.run_id,
+                    })
+                );
+            } else {
+                println!(
+                    "Circle replay bundle PASS: wrote {} entries={} receipts={} lineage={} run_id={} circle_id={}",
+                    bundle_out.display(),
+                    bundle.entries.len(),
+                    bundle.execution_receipts.len(),
+                    bundle.lineage.len(),
+                    bundle.run_id,
+                    bundle.circle_id
+                );
+            }
+            print_circle_replay_footer("PASS", &bundle_sha256);
+            0
+        }
+        Err(errors) => {
+            if json_out {
+                println!(
+                    "{}",
+                    json!({
+                        "verdict": "FAIL",
+                        "bundle_sha256": bundle_sha256,
+                        "bundle_out": bundle_out.display().to_string(),
+                        "entries": bundle.entries.len(),
+                        "execution_receipts": bundle.execution_receipts.len(),
+                        "lineage_edges": bundle.lineage.len(),
+                        "circle_id": bundle.circle_id,
+                        "run_id": bundle.run_id,
+                        "errors": errors.iter().map(|e| format!("{:?}", e.kind)).collect::<Vec<_>>(),
+                    })
+                );
+            } else {
+                eprintln!(
+                    "Circle replay bundle FAIL: wrote {} with {} validation error(s)",
+                    bundle_out.display(),
+                    errors.len()
+                );
+                for error in &errors {
+                    eprintln!("- {:?}", error.kind);
+                }
+            }
+            print_circle_replay_footer("FAIL", &bundle_sha256);
+            1
+        }
+    }
+}
+
+fn build_replay_bundle(fixture_dir: &Path) -> Result<CollaborationProofBundle, String> {
+    let summary_path = fixture_dir.join("summary.json");
+    let summary = read_json(&summary_path)?;
+    let metadata_source = replay_metadata_source(fixture_dir, &summary)?;
+    let roles = summary
+        .get("roles")
+        .and_then(Value::as_array)
+        .ok_or_else(|| format!("{} must contain roles[]", summary_path.display()))?;
+
+    if roles.is_empty() {
+        return Err(format!("{} roles[] is empty", summary_path.display()));
+    }
+
+    let mut roster = Vec::with_capacity(roles.len());
+    let mut entries = Vec::with_capacity(roles.len());
+    let mut receipts = Vec::with_capacity(roles.len());
+    let mut last_referee: Option<(String, String, String)> = None;
+
+    for (index, role_summary) in roles.iter().enumerate() {
+        let role_id = required_str(role_summary, "role_id")?.to_string();
+        let role_fixture = read_json(&fixture_dir.join(format!("{role_id}.json")))?;
+        let role_label = role_fixture
+            .get("role")
+            .and_then(Value::as_str)
+            .or_else(|| role_summary.get("role").and_then(Value::as_str))
+            .unwrap_or_else(|| default_role_label(&role_id));
+        let provider_cli = role_fixture
+            .get("provider_cli")
+            .and_then(Value::as_str)
+            .or_else(|| role_summary.get("provider_cli").and_then(Value::as_str))
+            .unwrap_or("unknown");
+        let model = role_fixture
+            .get("model")
+            .and_then(Value::as_str)
+            .or_else(|| role_summary.get("model").and_then(Value::as_str))
+            .unwrap_or("unknown");
+        let provider = role_fixture
+            .get("provider")
+            .and_then(Value::as_str)
+            .map(str::to_owned)
+            .unwrap_or_else(|| canonical_provider(provider_cli, model));
+        let session_id = role_fixture
+            .get("session_id")
+            .and_then(Value::as_str)
+            .or_else(|| role_summary.get("session_id").and_then(Value::as_str))
+            .unwrap_or("unknown");
+        let returncode = role_fixture
+            .get("returncode")
+            .and_then(Value::as_i64)
+            .or_else(|| role_summary.get("returncode").and_then(Value::as_i64))
+            .unwrap_or(0);
+        let duration_ms = role_fixture
+            .get("duration_ms")
+            .and_then(Value::as_u64)
+            .or_else(|| role_summary.get("duration_ms").and_then(Value::as_u64))
+            .unwrap_or(0);
+        let timestamp = role_fixture
+            .get("ended_at")
+            .and_then(Value::as_str)
+            .or_else(|| role_fixture.get("timestamp").and_then(Value::as_str))
+            .ok_or_else(|| format!("{role_id}.json must contain ended_at or timestamp"))?;
+        let response = role_fixture
+            .get("answer_cleaned")
+            .and_then(Value::as_str)
+            .or_else(|| role_fixture.get("answer").and_then(Value::as_str))
+            .ok_or_else(|| format!("{role_id}.json must contain answer_cleaned or answer"))?;
+
+        roster.push(json!({
+            "participant_id": role_id,
+            "role": role_label,
+        }));
+
+        entries.push(json!({
+            "entry_id": (index + 1) as u64,
+            "author": role_id,
+            "timestamp": timestamp,
+            "artifact_type": artifact_type_for(&role_id, index, roles.len()),
+            "payload": {
+                "role": role_id,
+                "provider": provider,
+                "provider_cli": provider_cli,
+                "model": model,
+                "session_id": session_id,
+                "response": response,
+                "harness_warning_cleaned_from_raw": role_fixture
+                    .get("answer_had_harness_warnings")
+                    .and_then(Value::as_bool)
+                    .or_else(|| role_summary.get("harness_warning_cleaned_from_raw").and_then(Value::as_bool))
+                    .unwrap_or(false),
+            }
+        }));
+
+        let outcome = if returncode == 0 {
+            json!("success")
+        } else {
+            json!({ "failure": { "reason": format!("fixture returncode {returncode}") } })
+        };
+        receipts.push(json!({
+            "receipt_id": format!("rcpt_{:03}_{role_id}", index + 1),
+            "executor": role_id,
+            "timestamp": timestamp,
+            "action": role_fixture.get("action").and_then(Value::as_str).unwrap_or("hermes_chat"),
+            "parameters": {
+                "provider": provider,
+                "provider_cli": provider_cli,
+                "model": model,
+                "session_id": session_id,
+                "duration_ms": duration_ms,
+                "returncode": returncode,
+                "harness_warning_cleaned_from_raw": role_fixture
+                    .get("answer_had_harness_warnings")
+                    .and_then(Value::as_bool)
+                    .or_else(|| role_summary.get("harness_warning_cleaned_from_raw").and_then(Value::as_bool))
+                    .unwrap_or(false),
+            },
+            "outcome": outcome,
+        }));
+
+        if role_id.contains("referee") || index + 1 == roles.len() {
+            last_referee = Some((role_id, timestamp.to_string(), response.to_string()));
+        }
+    }
+
+    let lineage: Vec<Value> = (1..roles.len())
+        .map(|index| {
+            json!({
+                "from_entry_id": index as u64,
+                "to_entry_id": (index + 1) as u64,
+                "relation": lineage_relation_for(index, roles.len()),
+            })
+        })
+        .collect();
+
+    let verdict_type = summary.get("verdict_type").cloned().or_else(|| {
+        metadata_source
+            .as_ref()
+            .and_then(|metadata| metadata.get("verdict"))
+            .and_then(|verdict| verdict.get("verdict_type"))
+            .cloned()
+    });
+
+    let verdict = verdict_type.map(|verdict_type| {
+        let (reviewer, timestamp, rationale) = last_referee.clone().unwrap_or_else(|| {
+            (
+                "unknown_referee".to_string(),
+                "1970-01-01T00:00:00Z".to_string(),
+                "No referee rationale captured in replay fixture.".to_string(),
+            )
+        });
+        json!({
+            "reviewer": reviewer,
+            "timestamp": timestamp,
+            "verdict_type": verdict_type,
+            "rationale": rationale,
+        })
+    });
+
+    let mut bundle = json!({
+        "run_id": str_from_summary_or_metadata(&summary, metadata_source.as_ref(), "run_id")
+            .unwrap_or("circle-replay-fixture-run"),
+        "circle_id": str_from_summary_or_metadata(&summary, metadata_source.as_ref(), "circle_id")
+            .unwrap_or("circle-replay-fixture"),
+        "objective": str_from_summary_or_metadata(&summary, metadata_source.as_ref(), "objective")
+            .unwrap_or("Replay Circle fixture transcript into a collaboration proof bundle."),
+        "success_metric": value_from_summary_or_metadata(&summary, metadata_source.as_ref(), "success_metric").unwrap_or_else(|| json!({
+            "kind": "inline",
+            "description": "Replay fixture produces a structurally valid CollaborationProofBundle."
+        })),
+        "roster": roster,
+        "entries": entries,
+        "lineage": lineage,
+        "execution_receipts": receipts,
+    });
+
+    if let Some(snapshot) =
+        value_from_summary_or_metadata(&summary, metadata_source.as_ref(), "budget_snapshot")
+    {
+        bundle["budget_snapshot"] = snapshot.clone();
+    }
+    if let Some(verdict) = verdict {
+        bundle["verdict"] = verdict;
+    }
+
+    serde_json::from_value(bundle)
+        .map_err(|err| format!("replay produced invalid bundle shape: {err}"))
+}
+
+fn replay_metadata_source(fixture_dir: &Path, summary: &Value) -> Result<Option<Value>, String> {
+    let explicit = summary
+        .get("artifact")
+        .and_then(Value::as_str)
+        .map(PathBuf::from);
+    let local = fixture_dir.join("proof_bundle.json");
+    let candidate = explicit.or_else(|| local.exists().then_some(local));
+
+    match candidate {
+        Some(path) if path.exists() => read_json(&path).map(Some),
+        Some(path) => Err(format!(
+            "summary artifact metadata source does not exist: {}",
+            path.display()
+        )),
+        None => Ok(None),
+    }
+}
+
+fn str_from_summary_or_metadata<'a>(
+    summary: &'a Value,
+    metadata: Option<&'a Value>,
+    field: &str,
+) -> Option<&'a str> {
+    summary.get(field).and_then(Value::as_str).or_else(|| {
+        metadata
+            .and_then(|metadata| metadata.get(field))
+            .and_then(Value::as_str)
+    })
+}
+
+fn value_from_summary_or_metadata(
+    summary: &Value,
+    metadata: Option<&Value>,
+    field: &str,
+) -> Option<Value> {
+    summary
+        .get(field)
+        .cloned()
+        .or_else(|| metadata.and_then(|metadata| metadata.get(field)).cloned())
+}
+
+fn read_json(path: &Path) -> Result<Value, String> {
+    let bytes =
+        std::fs::read(path).map_err(|err| format!("failed to read {}: {err}", path.display()))?;
+    serde_json::from_slice(&bytes)
+        .map_err(|err| format!("failed to parse {}: {err}", path.display()))
+}
+
+fn required_str<'a>(value: &'a Value, field: &str) -> Result<&'a str, String> {
+    value
+        .get(field)
+        .and_then(Value::as_str)
+        .ok_or_else(|| format!("role summary missing string field {field}"))
+}
+
+fn canonical_provider(provider_cli: &str, model: &str) -> String {
+    let provider = provider_cli.trim().to_ascii_lowercase();
+    let model = model.trim().to_ascii_lowercase();
+
+    if provider.contains("ollama") {
+        return "ollama".to_string();
+    }
+    if provider.contains("local")
+        || provider == "custom"
+        || model.contains("gemma")
+        || model.contains("qwen")
+        || model.contains("llama")
+        || model.contains("mistral")
+    {
+        return "local-lmstudio".to_string();
+    }
+
+    provider
+}
+
+fn default_role_label(role_id: &str) -> &str {
+    if role_id.contains("specifier") {
+        "specifier"
+    } else if role_id.contains("builder") {
+        "builder"
+    } else if role_id.contains("critic") {
+        "critic"
+    } else if role_id.contains("referee") {
+        "referee/integrator"
+    } else {
+        "perspective"
+    }
+}
+
+fn artifact_type_for(role_id: &str, index: usize, total: usize) -> &'static str {
+    if role_id.contains("specifier") || index == 0 {
+        "specification"
+    } else if role_id.contains("builder") {
+        "implementation_plan"
+    } else if role_id.contains("critic") {
+        "critique"
+    } else if role_id.contains("referee") || index + 1 == total {
+        "verdict"
+    } else {
+        "perspective"
+    }
+}
+
+fn lineage_relation_for(index: usize, total: usize) -> &'static str {
+    if index + 1 == total {
+        "resolves"
+    } else if index >= 2 {
+        "criticizes"
+    } else {
+        "derives_from"
+    }
+}

--- a/rust/crates/sera-cli/src/circle_replay.rs
+++ b/rust/crates/sera-cli/src/circle_replay.rs
@@ -320,7 +320,14 @@ fn replay_metadata_source(fixture_dir: &Path, summary: &Value) -> Result<Option<
     let explicit = summary
         .get("artifact")
         .and_then(Value::as_str)
-        .map(PathBuf::from);
+        .map(|artifact| {
+            let path = PathBuf::from(artifact);
+            if path.is_absolute() {
+                path
+            } else {
+                fixture_dir.join(path)
+            }
+        });
     let local = fixture_dir.join("proof_bundle.json");
     let candidate = explicit.or_else(|| local.exists().then_some(local));
 
@@ -378,7 +385,9 @@ fn canonical_provider(provider_cli: &str, model: &str) -> String {
     if provider.contains("ollama") {
         return "ollama".to_string();
     }
+    let provider_compact = provider.replace(['-', '_'], "");
     if provider.contains("local")
+        || provider_compact.contains("lmstudio")
         || provider == "custom"
         || model.contains("gemma")
         || model.contains("qwen")

--- a/rust/crates/sera-cli/src/circle_replay.rs
+++ b/rust/crates/sera-cli/src/circle_replay.rs
@@ -164,7 +164,16 @@ fn build_replay_bundle(fixture_dir: &Path) -> Result<CollaborationProofBundle, S
             .unwrap_or("unknown");
         let explicit_provider = non_blank_str(&role_fixture, "provider")
             .or_else(|| non_blank_str(role_summary, "provider"));
-        let provider_source = explicit_provider.or(provider_cli).ok_or_else(|| {
+        if let (Some(explicit_provider), Some(provider_cli)) = (explicit_provider, provider_cli) {
+            let explicit_provider = canonical_provider(explicit_provider, model);
+            let provider_cli = canonical_provider(provider_cli, model);
+            if explicit_provider != provider_cli {
+                return Err(format!(
+                    "{role_id} fixture has conflicting provider evidence: provider={explicit_provider} provider_cli={provider_cli}"
+                ));
+            }
+        }
+        let provider_source = provider_cli.or(explicit_provider).ok_or_else(|| {
             format!("{role_id} fixture must contain provider or provider_cli evidence")
         })?;
         let provider_cli = provider_cli.unwrap_or(provider_source);

--- a/rust/crates/sera-cli/src/circle_replay.rs
+++ b/rust/crates/sera-cli/src/circle_replay.rs
@@ -168,7 +168,7 @@ fn build_replay_bundle(fixture_dir: &Path) -> Result<CollaborationProofBundle, S
         let provider = role_fixture
             .get("provider")
             .and_then(Value::as_str)
-            .map(str::to_owned)
+            .map(|provider| canonical_provider(provider, model))
             .unwrap_or_else(|| canonical_provider(provider_cli, model));
         let session_id = role_fixture
             .get("session_id")

--- a/rust/crates/sera-cli/src/circle_replay.rs
+++ b/rust/crates/sera-cli/src/circle_replay.rs
@@ -48,15 +48,14 @@ pub fn run_circle_replay(
     if let Some(parent) = bundle_out
         .parent()
         .filter(|parent| !parent.as_os_str().is_empty())
+        && let Err(err) = std::fs::create_dir_all(parent)
     {
-        if let Err(err) = std::fs::create_dir_all(parent) {
-            eprintln!(
-                "failed to create Circle replay output directory {}: {err}",
-                parent.display()
-            );
-            print_circle_replay_footer("USAGE_ERROR", "unknown");
-            return 3;
-        }
+        eprintln!(
+            "failed to create Circle replay output directory {}: {err}",
+            parent.display()
+        );
+        print_circle_replay_footer("USAGE_ERROR", "unknown");
+        return 3;
     }
 
     if let Err(err) = std::fs::write(&bundle_out, &bytes) {

--- a/rust/crates/sera-cli/src/circle_replay.rs
+++ b/rust/crates/sera-cli/src/circle_replay.rs
@@ -351,7 +351,6 @@ fn replay_metadata_source(fixture_dir: &Path, summary: &Value) -> Result<Option<
     let needs_fallback = ["run_id", "circle_id", "objective", "success_metric"]
         .into_iter()
         .any(|field| summary.get(field).is_none())
-        || (summary.get("budget_snapshot").is_none() && local.exists())
         || summary.get("verdict_type").is_none();
 
     if needs_fallback && local.exists() {

--- a/rust/crates/sera-cli/src/circle_replay.rs
+++ b/rust/crates/sera-cli/src/circle_replay.rs
@@ -155,16 +155,15 @@ fn build_replay_bundle(fixture_dir: &Path) -> Result<CollaborationProofBundle, S
             .and_then(Value::as_str)
             .or_else(|| role_summary.get("role").and_then(Value::as_str))
             .unwrap_or_else(|| default_role_label(&role_id));
-        let provider_cli = role_fixture
-            .get("provider_cli")
-            .and_then(Value::as_str)
-            .or_else(|| role_summary.get("provider_cli").and_then(Value::as_str));
+        let provider_cli = non_blank_str(&role_fixture, "provider_cli")
+            .or_else(|| non_blank_str(role_summary, "provider_cli"));
         let model = role_fixture
             .get("model")
             .and_then(Value::as_str)
             .or_else(|| role_summary.get("model").and_then(Value::as_str))
             .unwrap_or("unknown");
-        let explicit_provider = role_fixture.get("provider").and_then(Value::as_str);
+        let explicit_provider = non_blank_str(&role_fixture, "provider")
+            .or_else(|| non_blank_str(role_summary, "provider"));
         let provider_source = explicit_provider.or(provider_cli).ok_or_else(|| {
             format!("{role_id} fixture must contain provider or provider_cli evidence")
         })?;
@@ -369,6 +368,14 @@ fn read_json(path: &Path) -> Result<Value, String> {
         std::fs::read(path).map_err(|err| format!("failed to read {}: {err}", path.display()))?;
     serde_json::from_slice(&bytes)
         .map_err(|err| format!("failed to parse {}: {err}", path.display()))
+}
+
+fn non_blank_str<'a>(value: &'a Value, field: &str) -> Option<&'a str> {
+    value
+        .get(field)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
 }
 
 fn required_str<'a>(value: &'a Value, field: &str) -> Result<&'a str, String> {

--- a/rust/crates/sera-cli/src/circle_replay.rs
+++ b/rust/crates/sera-cli/src/circle_replay.rs
@@ -336,16 +336,28 @@ fn replay_metadata_source(fixture_dir: &Path, summary: &Value) -> Result<Option<
                 fixture_dir.join(path)
             }
         });
-    let local = fixture_dir.join("proof_bundle.json");
-    let candidate = explicit.or_else(|| local.exists().then_some(local));
 
-    match candidate {
-        Some(path) if path.exists() => read_json(&path).map(Some),
-        Some(path) => Err(format!(
-            "summary artifact metadata source does not exist: {}",
-            path.display()
-        )),
-        None => Ok(None),
+    if let Some(path) = explicit {
+        return match path.exists() {
+            true => read_json(&path).map(Some),
+            false => Err(format!(
+                "summary artifact metadata source does not exist: {}",
+                path.display()
+            )),
+        };
+    }
+
+    let local = fixture_dir.join("proof_bundle.json");
+    let needs_fallback = ["run_id", "circle_id", "objective", "success_metric"]
+        .into_iter()
+        .any(|field| summary.get(field).is_none())
+        || (summary.get("budget_snapshot").is_none() && local.exists())
+        || summary.get("verdict_type").is_none();
+
+    if needs_fallback && local.exists() {
+        read_json(&local).map(Some)
+    } else {
+        Ok(None)
     }
 }
 

--- a/rust/crates/sera-cli/src/circle_replay.rs
+++ b/rust/crates/sera-cli/src/circle_replay.rs
@@ -158,18 +158,18 @@ fn build_replay_bundle(fixture_dir: &Path) -> Result<CollaborationProofBundle, S
         let provider_cli = role_fixture
             .get("provider_cli")
             .and_then(Value::as_str)
-            .or_else(|| role_summary.get("provider_cli").and_then(Value::as_str))
-            .unwrap_or("unknown");
+            .or_else(|| role_summary.get("provider_cli").and_then(Value::as_str));
         let model = role_fixture
             .get("model")
             .and_then(Value::as_str)
             .or_else(|| role_summary.get("model").and_then(Value::as_str))
             .unwrap_or("unknown");
-        let provider = role_fixture
-            .get("provider")
-            .and_then(Value::as_str)
-            .map(|provider| canonical_provider(provider, model))
-            .unwrap_or_else(|| canonical_provider(provider_cli, model));
+        let explicit_provider = role_fixture.get("provider").and_then(Value::as_str);
+        let provider_source = explicit_provider.or(provider_cli).ok_or_else(|| {
+            format!("{role_id} fixture must contain provider or provider_cli evidence")
+        })?;
+        let provider_cli = provider_cli.unwrap_or(provider_source);
+        let provider = canonical_provider(provider_source, model);
         let session_id = role_fixture
             .get("session_id")
             .and_then(Value::as_str)

--- a/rust/crates/sera-cli/src/main.rs
+++ b/rust/crates/sera-cli/src/main.rs
@@ -14,6 +14,8 @@ use sha2::{Digest, Sha256};
 use sera_cli::config::CliConfig;
 use sera_cli::token_store::best_available_store;
 
+mod circle_replay;
+
 /// SERA — Sandboxed Extensible Reasoning Agent CLI
 #[derive(Parser)]
 #[command(
@@ -161,6 +163,18 @@ enum CircleCommand {
         /// Path to a CollaborationProofBundle JSON artifact
         #[arg(long, value_name = "PATH", num_args = 0..=1)]
         bundle: Option<PathBuf>,
+        /// Emit a compact JSON report before the machine-parseable footer
+        #[arg(long)]
+        json: bool,
+    },
+    /// Replay captured Circle role fixtures into a proof bundle
+    Replay {
+        /// Directory containing summary.json plus one <role_id>.json file per role
+        #[arg(long, value_name = "DIR", num_args = 0..=1)]
+        fixture_dir: Option<PathBuf>,
+        /// Path to write the generated CollaborationProofBundle JSON artifact
+        #[arg(long, value_name = "PATH", num_args = 0..=1)]
+        bundle_out: Option<PathBuf>,
         /// Emit a compact JSON report before the machine-parseable footer
         #[arg(long)]
         json: bool,
@@ -398,14 +412,18 @@ async fn main() -> Result<()> {
         .with_target(false)
         .init();
 
-    // Offline Circle proof-bundle validation must not depend on gateway config
-    // or token stores. Keep this path usable in CI and stale/corrupt operator
-    // environments, and always emit the `circle-validate:` footer.
-    if let Commands::Circle {
-        command: CircleCommand::Validate { bundle, json },
-    } = &cli.command
-    {
-        let exit_code = run_circle_validate(bundle.clone(), *json);
+    // Offline Circle proof-bundle operations must not depend on gateway config
+    // or token stores. Keep these paths usable in CI and stale/corrupt operator
+    // environments, and always emit their machine footers.
+    if let Commands::Circle { command } = &cli.command {
+        let exit_code = match command {
+            CircleCommand::Validate { bundle, json } => run_circle_validate(bundle.clone(), *json),
+            CircleCommand::Replay {
+                fixture_dir,
+                bundle_out,
+                json,
+            } => circle_replay::run_circle_replay(fixture_dir.clone(), bundle_out.clone(), *json),
+        };
         if exit_code != 0 {
             std::process::exit(exit_code);
         }
@@ -766,6 +784,16 @@ async fn main() -> Result<()> {
         Commands::Circle { command } => match command {
             CircleCommand::Validate { bundle, json } => {
                 let exit_code = run_circle_validate(bundle, json);
+                if exit_code != 0 {
+                    std::process::exit(exit_code);
+                }
+            }
+            CircleCommand::Replay {
+                fixture_dir,
+                bundle_out,
+                json,
+            } => {
+                let exit_code = circle_replay::run_circle_replay(fixture_dir, bundle_out, json);
                 if exit_code != 0 {
                     std::process::exit(exit_code);
                 }

--- a/rust/crates/sera-cli/tests/circle_validate.rs
+++ b/rust/crates/sera-cli/tests/circle_validate.rs
@@ -388,6 +388,15 @@ fn circle_replay_cli_treats_lm_studio_provider_as_local() {
         .unwrap();
     }
 
+    for path in [
+        fixture_dir.join("builder_local_gemma.json"),
+        fixture_dir.join("referee_local_gemma.json"),
+    ] {
+        let mut fixture: Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        fixture["provider"] = json!("lm-studio");
+        std::fs::write(&path, serde_json::to_vec_pretty(&fixture).unwrap()).unwrap();
+    }
+
     let bundle_out = temp.path().join("proof_bundle.json");
     let output = Command::new(env!("CARGO_BIN_EXE_sera"))
         .args([

--- a/rust/crates/sera-cli/tests/circle_validate.rs
+++ b/rust/crates/sera-cli/tests/circle_validate.rs
@@ -427,6 +427,52 @@ fn circle_replay_cli_treats_lm_studio_provider_as_local() {
 }
 
 #[test]
+fn circle_replay_cli_does_not_infer_local_from_open_source_model_name() {
+    let temp = tempfile::tempdir().unwrap();
+    let fixture_dir = temp.path().join("fixtures");
+    std::fs::create_dir(&fixture_dir).unwrap();
+    write_replay_fixture(&fixture_dir);
+
+    for path in [
+        fixture_dir.join("builder_local_gemma.json"),
+        fixture_dir.join("referee_local_gemma.json"),
+    ] {
+        let mut fixture: Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        fixture["provider_cli"] = json!("openrouter");
+        fixture["model"] = json!("mistral-large-cloud");
+        std::fs::write(&path, serde_json::to_vec_pretty(&fixture).unwrap()).unwrap();
+    }
+
+    let bundle_out = temp.path().join("proof_bundle.json");
+    let output = Command::new(env!("CARGO_BIN_EXE_sera"))
+        .args([
+            "circle",
+            "replay",
+            "--fixture-dir",
+            fixture_dir.to_str().unwrap(),
+            "--bundle-out",
+            bundle_out.to_str().unwrap(),
+        ])
+        .output()
+        .expect("run sera circle replay with cloud open-source model names");
+
+    assert_eq!(output.status.code(), Some(1));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stdout.contains("circle-replay: FAIL "), "stdout={stdout}");
+    assert!(
+        stderr.contains("MissingMixedProviderEvidence"),
+        "stderr={stderr}"
+    );
+
+    let bundle: Value = serde_json::from_slice(&std::fs::read(&bundle_out).unwrap()).unwrap();
+    let provider = bundle["execution_receipts"][1]["parameters"]["provider"]
+        .as_str()
+        .unwrap();
+    assert_eq!(provider, "openrouter");
+}
+
+#[test]
 fn circle_replay_cli_bypasses_corrupt_config() {
     let temp = tempfile::tempdir().unwrap();
     let fixture_dir = temp.path().join("fixtures");

--- a/rust/crates/sera-cli/tests/circle_validate.rs
+++ b/rust/crates/sera-cli/tests/circle_validate.rs
@@ -473,6 +473,64 @@ fn circle_replay_cli_does_not_infer_local_from_open_source_model_name() {
 }
 
 #[test]
+fn circle_replay_cli_rejects_missing_provider_evidence() {
+    let temp = tempfile::tempdir().unwrap();
+    let fixture_dir = temp.path().join("fixtures");
+    std::fs::create_dir(&fixture_dir).unwrap();
+    write_replay_fixture(&fixture_dir);
+
+    let summary_path = fixture_dir.join("summary.json");
+    let mut summary: Value =
+        serde_json::from_slice(&std::fs::read(&summary_path).unwrap()).unwrap();
+    let roles = summary["roles"].as_array_mut().unwrap();
+    roles[0].as_object_mut().unwrap().remove("provider_cli");
+    roles[2]["provider_cli"] = json!("custom");
+    roles[2]["model"] = json!("gemma4-local");
+    std::fs::write(&summary_path, serde_json::to_vec_pretty(&summary).unwrap()).unwrap();
+
+    let specifier_path = fixture_dir.join("specifier_minimax.json");
+    let mut specifier: Value =
+        serde_json::from_slice(&std::fs::read(&specifier_path).unwrap()).unwrap();
+    specifier.as_object_mut().unwrap().remove("provider_cli");
+    std::fs::write(
+        &specifier_path,
+        serde_json::to_vec_pretty(&specifier).unwrap(),
+    )
+    .unwrap();
+
+    let critic_path = fixture_dir.join("critic_minimax.json");
+    let mut critic: Value = serde_json::from_slice(&std::fs::read(&critic_path).unwrap()).unwrap();
+    critic["provider_cli"] = json!("custom");
+    critic["model"] = json!("gemma4-local");
+    std::fs::write(&critic_path, serde_json::to_vec_pretty(&critic).unwrap()).unwrap();
+
+    let bundle_out = temp.path().join("proof_bundle.json");
+    let output = Command::new(env!("CARGO_BIN_EXE_sera"))
+        .args([
+            "circle",
+            "replay",
+            "--fixture-dir",
+            fixture_dir.to_str().unwrap(),
+            "--bundle-out",
+            bundle_out.to_str().unwrap(),
+        ])
+        .output()
+        .expect("run sera circle replay with missing provider evidence");
+
+    assert_eq!(output.status.code(), Some(3));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stdout.contains("circle-replay: USAGE_ERROR unknown"),
+        "stdout={stdout}"
+    );
+    assert!(
+        stderr.contains("provider or provider_cli evidence"),
+        "stderr={stderr}"
+    );
+}
+
+#[test]
 fn circle_replay_cli_bypasses_corrupt_config() {
     let temp = tempfile::tempdir().unwrap();
     let fixture_dir = temp.path().join("fixtures");

--- a/rust/crates/sera-cli/tests/circle_validate.rs
+++ b/rust/crates/sera-cli/tests/circle_validate.rs
@@ -362,6 +362,38 @@ fn circle_replay_cli_resolves_relative_artifact_metadata_under_fixture_dir() {
 }
 
 #[test]
+fn circle_replay_cli_ignores_colocated_metadata_when_summary_is_complete() {
+    let temp = tempfile::tempdir().unwrap();
+    let fixture_dir = temp.path().join("fixtures");
+    std::fs::create_dir(&fixture_dir).unwrap();
+    write_replay_fixture(&fixture_dir);
+    std::fs::write(fixture_dir.join("proof_bundle.json"), b"not valid json").unwrap();
+
+    let bundle_out = temp.path().join("proof_bundle.json");
+    let output = Command::new(env!("CARGO_BIN_EXE_sera"))
+        .args([
+            "circle",
+            "replay",
+            "--fixture-dir",
+            fixture_dir.to_str().unwrap(),
+            "--bundle-out",
+            bundle_out.to_str().unwrap(),
+            "--json",
+        ])
+        .output()
+        .expect("run sera circle replay with stale colocated proof bundle");
+
+    assert!(
+        output.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("circle-replay: PASS "), "stdout={stdout}");
+}
+
+#[test]
 fn circle_replay_cli_treats_lm_studio_provider_as_local() {
     let temp = tempfile::tempdir().unwrap();
     let fixture_dir = temp.path().join("fixtures");

--- a/rust/crates/sera-cli/tests/circle_validate.rs
+++ b/rust/crates/sera-cli/tests/circle_validate.rs
@@ -473,6 +473,58 @@ fn circle_replay_cli_does_not_infer_local_from_open_source_model_name() {
 }
 
 #[test]
+fn circle_replay_cli_uses_summary_provider_evidence() {
+    let temp = tempfile::tempdir().unwrap();
+    let fixture_dir = temp.path().join("fixtures");
+    std::fs::create_dir(&fixture_dir).unwrap();
+    write_replay_fixture(&fixture_dir);
+
+    let summary_path = fixture_dir.join("summary.json");
+    let mut summary: Value =
+        serde_json::from_slice(&std::fs::read(&summary_path).unwrap()).unwrap();
+    let roles = summary["roles"].as_array_mut().unwrap();
+    for index in [1usize, 3usize] {
+        roles[index].as_object_mut().unwrap().remove("provider_cli");
+        roles[index]["provider"] = json!("lm-studio");
+    }
+    std::fs::write(&summary_path, serde_json::to_vec_pretty(&summary).unwrap()).unwrap();
+
+    for path in [
+        fixture_dir.join("builder_local_gemma.json"),
+        fixture_dir.join("referee_local_gemma.json"),
+    ] {
+        let mut fixture: Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        fixture.as_object_mut().unwrap().remove("provider_cli");
+        std::fs::write(&path, serde_json::to_vec_pretty(&fixture).unwrap()).unwrap();
+    }
+
+    let bundle_out = temp.path().join("proof_bundle.json");
+    let output = Command::new(env!("CARGO_BIN_EXE_sera"))
+        .args([
+            "circle",
+            "replay",
+            "--fixture-dir",
+            fixture_dir.to_str().unwrap(),
+            "--bundle-out",
+            bundle_out.to_str().unwrap(),
+        ])
+        .output()
+        .expect("run sera circle replay with summary provider evidence");
+
+    assert!(
+        output.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let bundle: Value = serde_json::from_slice(&std::fs::read(&bundle_out).unwrap()).unwrap();
+    let provider = bundle["execution_receipts"][1]["parameters"]["provider"]
+        .as_str()
+        .unwrap();
+    assert_eq!(provider, "local-lmstudio");
+}
+
+#[test]
 fn circle_replay_cli_rejects_missing_provider_evidence() {
     let temp = tempfile::tempdir().unwrap();
     let fixture_dir = temp.path().join("fixtures");
@@ -483,7 +535,7 @@ fn circle_replay_cli_rejects_missing_provider_evidence() {
     let mut summary: Value =
         serde_json::from_slice(&std::fs::read(&summary_path).unwrap()).unwrap();
     let roles = summary["roles"].as_array_mut().unwrap();
-    roles[0].as_object_mut().unwrap().remove("provider_cli");
+    roles[0]["provider_cli"] = json!("   ");
     roles[2]["provider_cli"] = json!("custom");
     roles[2]["model"] = json!("gemma4-local");
     std::fs::write(&summary_path, serde_json::to_vec_pretty(&summary).unwrap()).unwrap();
@@ -491,7 +543,7 @@ fn circle_replay_cli_rejects_missing_provider_evidence() {
     let specifier_path = fixture_dir.join("specifier_minimax.json");
     let mut specifier: Value =
         serde_json::from_slice(&std::fs::read(&specifier_path).unwrap()).unwrap();
-    specifier.as_object_mut().unwrap().remove("provider_cli");
+    specifier["provider_cli"] = json!("\t ");
     std::fs::write(
         &specifier_path,
         serde_json::to_vec_pretty(&specifier).unwrap(),

--- a/rust/crates/sera-cli/tests/circle_validate.rs
+++ b/rust/crates/sera-cli/tests/circle_validate.rs
@@ -367,6 +367,12 @@ fn circle_replay_cli_ignores_colocated_metadata_when_summary_is_complete() {
     let fixture_dir = temp.path().join("fixtures");
     std::fs::create_dir(&fixture_dir).unwrap();
     write_replay_fixture(&fixture_dir);
+
+    let summary_path = fixture_dir.join("summary.json");
+    let mut summary: Value =
+        serde_json::from_slice(&std::fs::read(&summary_path).unwrap()).unwrap();
+    summary.as_object_mut().unwrap().remove("budget_snapshot");
+    std::fs::write(&summary_path, serde_json::to_vec_pretty(&summary).unwrap()).unwrap();
     std::fs::write(fixture_dir.join("proof_bundle.json"), b"not valid json").unwrap();
 
     let bundle_out = temp.path().join("proof_bundle.json");

--- a/rust/crates/sera-cli/tests/circle_validate.rs
+++ b/rust/crates/sera-cli/tests/circle_validate.rs
@@ -1,6 +1,8 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use serde_json::{Value, json};
+
 fn fixture(name: &str) -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("tests")
@@ -292,6 +294,127 @@ fn circle_replay_cli_generates_valid_bundle_from_fixture_dir() {
         validate_stdout.contains("circle-validate: PASS "),
         "stdout={validate_stdout}"
     );
+}
+
+#[test]
+fn circle_replay_cli_resolves_relative_artifact_metadata_under_fixture_dir() {
+    let temp = tempfile::tempdir().unwrap();
+    let fixture_dir = temp.path().join("fixtures");
+    std::fs::create_dir(&fixture_dir).unwrap();
+    write_replay_fixture(&fixture_dir);
+
+    let metadata_dir = fixture_dir.join("metadata");
+    std::fs::create_dir(&metadata_dir).unwrap();
+    std::fs::write(
+        metadata_dir.join("proof_bundle.json"),
+        serde_json::to_vec_pretty(&json!({
+            "run_id": "relative-artifact-run",
+            "circle_id": "relative-artifact-circle",
+            "objective": "Metadata came from a relative artifact path under fixture_dir.",
+            "success_metric": {
+                "kind": "inline",
+                "description": "relative artifact metadata resolved"
+            }
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    let summary_path = fixture_dir.join("summary.json");
+    let mut summary: Value =
+        serde_json::from_slice(&std::fs::read(&summary_path).unwrap()).unwrap();
+    for field in [
+        "run_id",
+        "circle_id",
+        "objective",
+        "success_metric",
+        "budget_snapshot",
+    ] {
+        summary.as_object_mut().unwrap().remove(field);
+    }
+    summary["artifact"] = json!("metadata/proof_bundle.json");
+    std::fs::write(&summary_path, serde_json::to_vec_pretty(&summary).unwrap()).unwrap();
+
+    let bundle_out = temp.path().join("out").join("proof_bundle.json");
+    let output = Command::new(env!("CARGO_BIN_EXE_sera"))
+        .current_dir(temp.path())
+        .args([
+            "circle",
+            "replay",
+            "--fixture-dir",
+            fixture_dir.to_str().unwrap(),
+            "--bundle-out",
+            bundle_out.to_str().unwrap(),
+            "--json",
+        ])
+        .output()
+        .expect("run sera circle replay with relative artifact metadata");
+
+    assert!(
+        output.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("relative-artifact-run"), "stdout={stdout}");
+    assert!(stdout.contains("circle-replay: PASS "), "stdout={stdout}");
+}
+
+#[test]
+fn circle_replay_cli_treats_lm_studio_provider_as_local() {
+    let temp = tempfile::tempdir().unwrap();
+    let fixture_dir = temp.path().join("fixtures");
+    std::fs::create_dir(&fixture_dir).unwrap();
+    write_replay_fixture(&fixture_dir);
+
+    for path in [
+        fixture_dir.join("summary.json"),
+        fixture_dir.join("builder_local_gemma.json"),
+        fixture_dir.join("referee_local_gemma.json"),
+    ] {
+        let text = std::fs::read_to_string(&path).unwrap();
+        std::fs::write(
+            &path,
+            text.replace(
+                "\"provider_cli\":\"custom\"",
+                "\"provider_cli\":\"lm-studio\"",
+            )
+            .replace(
+                "\"provider_cli\": \"custom\"",
+                "\"provider_cli\": \"lm-studio\"",
+            ),
+        )
+        .unwrap();
+    }
+
+    let bundle_out = temp.path().join("proof_bundle.json");
+    let output = Command::new(env!("CARGO_BIN_EXE_sera"))
+        .args([
+            "circle",
+            "replay",
+            "--fixture-dir",
+            fixture_dir.to_str().unwrap(),
+            "--bundle-out",
+            bundle_out.to_str().unwrap(),
+        ])
+        .output()
+        .expect("run sera circle replay with lm-studio fixtures");
+
+    assert!(
+        output.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("circle-replay: PASS "), "stdout={stdout}");
+
+    let bundle: Value = serde_json::from_slice(&std::fs::read(&bundle_out).unwrap()).unwrap();
+    let provider = bundle["execution_receipts"][1]["parameters"]["provider"]
+        .as_str()
+        .unwrap();
+    assert_eq!(provider, "local-lmstudio");
 }
 
 #[test]

--- a/rust/crates/sera-cli/tests/circle_validate.rs
+++ b/rust/crates/sera-cli/tests/circle_validate.rs
@@ -583,6 +583,50 @@ fn circle_replay_cli_rejects_missing_provider_evidence() {
 }
 
 #[test]
+fn circle_replay_cli_rejects_conflicting_provider_evidence() {
+    let temp = tempfile::tempdir().unwrap();
+    let fixture_dir = temp.path().join("fixtures");
+    std::fs::create_dir(&fixture_dir).unwrap();
+    write_replay_fixture(&fixture_dir);
+
+    let specifier_path = fixture_dir.join("specifier_minimax.json");
+    let mut specifier: Value =
+        serde_json::from_slice(&std::fs::read(&specifier_path).unwrap()).unwrap();
+    specifier["provider"] = json!("local-lmstudio");
+    specifier["provider_cli"] = json!("minimax");
+    std::fs::write(
+        &specifier_path,
+        serde_json::to_vec_pretty(&specifier).unwrap(),
+    )
+    .unwrap();
+
+    let bundle_out = temp.path().join("proof_bundle.json");
+    let output = Command::new(env!("CARGO_BIN_EXE_sera"))
+        .args([
+            "circle",
+            "replay",
+            "--fixture-dir",
+            fixture_dir.to_str().unwrap(),
+            "--bundle-out",
+            bundle_out.to_str().unwrap(),
+        ])
+        .output()
+        .expect("run sera circle replay with conflicting provider evidence");
+
+    assert_eq!(output.status.code(), Some(3));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stdout.contains("circle-replay: USAGE_ERROR unknown"),
+        "stdout={stdout}"
+    );
+    assert!(
+        stderr.contains("conflicting provider evidence"),
+        "stderr={stderr}"
+    );
+}
+
+#[test]
 fn circle_replay_cli_bypasses_corrupt_config() {
     let temp = tempfile::tempdir().unwrap();
     let fixture_dir = temp.path().join("fixtures");

--- a/rust/crates/sera-cli/tests/circle_validate.rs
+++ b/rust/crates/sera-cli/tests/circle_validate.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 fn fixture(name: &str) -> PathBuf {
@@ -6,6 +6,89 @@ fn fixture(name: &str) -> PathBuf {
         .join("tests")
         .join("fixtures")
         .join(name)
+}
+
+fn write_replay_fixture(dir: &Path) {
+    std::fs::write(
+        dir.join("summary.json"),
+        r#"{
+  "run_id": "circle-replay-fixture-run",
+  "circle_id": "sera-nqh3-replay-fixture",
+  "objective": "Replay captured MiniMax and local Gemma role fixtures into a SERA Circle proof bundle.",
+  "success_metric": {
+    "kind": "inline",
+    "description": "Replay fixture produces a structurally valid mixed-provider CollaborationProofBundle."
+  },
+  "roster": [],
+  "roles": [
+    {"role_id":"specifier_minimax","provider_cli":"minimax","model":"MiniMax-M3","session_id":"sess_spec","returncode":0,"duration_ms":101,"role":"cloud specifier"},
+    {"role_id":"builder_local_gemma","provider_cli":"custom","model":"gemma4-local","session_id":"sess_build","returncode":0,"duration_ms":102,"role":"local builder"},
+    {"role_id":"critic_minimax","provider_cli":"minimax","model":"MiniMax-M3","session_id":"sess_critic","returncode":0,"duration_ms":103,"role":"cloud critic"},
+    {"role_id":"referee_local_gemma","provider_cli":"custom","model":"gemma4-local","session_id":"sess_ref","returncode":0,"duration_ms":104,"role":"local referee/integrator"}
+  ],
+  "budget_snapshot": {"max_iterations":4,"current_usage":410},
+  "verdict_type": {"kind":"revision_required","feedback":"Fixture replay preserved referee revision request."}
+}
+"#,
+    )
+    .unwrap();
+
+    let roles = [
+        (
+            "specifier_minimax",
+            "minimax",
+            "MiniMax-M3",
+            "sess_spec",
+            "2026-06-29T18:00:01Z",
+            "Specification: build the smallest deterministic replay seam.",
+        ),
+        (
+            "builder_local_gemma",
+            "custom",
+            "gemma4-local",
+            "sess_build",
+            "2026-06-29T18:00:02Z",
+            "Builder: assemble a proof bundle from replay fixtures without provider calls.",
+        ),
+        (
+            "critic_minimax",
+            "minimax",
+            "MiniMax-M3",
+            "sess_critic",
+            "2026-06-29T18:00:03Z",
+            "Critic: require receipt-anchored provider evidence and subprocess tests.",
+        ),
+        (
+            "referee_local_gemma",
+            "custom",
+            "gemma4-local",
+            "sess_ref",
+            "2026-06-29T18:00:04Z",
+            "REVISION_REQUIRED: first-class replay works; live run remains a future slice.",
+        ),
+    ];
+
+    for (role_id, provider_cli, model, session_id, ended_at, answer_cleaned) in roles {
+        std::fs::write(
+            dir.join(format!("{role_id}.json")),
+            format!(
+                r#"{{
+  "role_id": "{role_id}",
+  "provider_cli": "{provider_cli}",
+  "model": "{model}",
+  "started_at": "2026-06-29T18:00:00Z",
+  "ended_at": "{ended_at}",
+  "duration_ms": 100,
+  "returncode": 0,
+  "session_id": "{session_id}",
+  "answer_cleaned": "{answer_cleaned}",
+  "answer_had_harness_warnings": false
+}}
+"#
+            ),
+        )
+        .unwrap();
+    }
 }
 
 #[test]
@@ -150,6 +233,147 @@ fn circle_validate_cli_usage_error_for_missing_bundle_file() {
     );
     assert!(
         stderr.contains("failed to read Circle proof bundle"),
+        "stderr={stderr}"
+    );
+}
+
+#[test]
+fn circle_replay_cli_generates_valid_bundle_from_fixture_dir() {
+    let temp = tempfile::tempdir().unwrap();
+    let fixture_dir = temp.path().join("fixtures");
+    std::fs::create_dir(&fixture_dir).unwrap();
+    write_replay_fixture(&fixture_dir);
+    let bundle_out = temp.path().join("out").join("proof_bundle.json");
+
+    let replay = Command::new(env!("CARGO_BIN_EXE_sera"))
+        .args([
+            "circle",
+            "replay",
+            "--fixture-dir",
+            fixture_dir.to_str().unwrap(),
+            "--bundle-out",
+            bundle_out.to_str().unwrap(),
+            "--json",
+        ])
+        .output()
+        .expect("run sera circle replay");
+
+    assert!(
+        replay.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&replay.stdout),
+        String::from_utf8_lossy(&replay.stderr)
+    );
+    let replay_stdout = String::from_utf8_lossy(&replay.stdout);
+    assert!(
+        replay_stdout.contains("circle-replay: PASS "),
+        "stdout={replay_stdout}"
+    );
+    assert!(bundle_out.exists(), "bundle was not written");
+
+    let validate = Command::new(env!("CARGO_BIN_EXE_sera"))
+        .args([
+            "circle",
+            "validate",
+            "--bundle",
+            bundle_out.to_str().unwrap(),
+            "--json",
+        ])
+        .output()
+        .expect("validate replayed bundle");
+    assert!(
+        validate.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&validate.stdout),
+        String::from_utf8_lossy(&validate.stderr)
+    );
+    let validate_stdout = String::from_utf8_lossy(&validate.stdout);
+    assert!(
+        validate_stdout.contains("circle-validate: PASS "),
+        "stdout={validate_stdout}"
+    );
+}
+
+#[test]
+fn circle_replay_cli_bypasses_corrupt_config() {
+    let temp = tempfile::tempdir().unwrap();
+    let fixture_dir = temp.path().join("fixtures");
+    std::fs::create_dir(&fixture_dir).unwrap();
+    write_replay_fixture(&fixture_dir);
+    let bundle_out = temp.path().join("proof_bundle.json");
+    let bad_config = temp.path().join("bad.toml");
+    std::fs::write(&bad_config, "endpoint = [this is invalid toml").unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_sera"))
+        .args([
+            "--config",
+            bad_config.to_str().unwrap(),
+            "circle",
+            "replay",
+            "--fixture-dir",
+            fixture_dir.to_str().unwrap(),
+            "--bundle-out",
+            bundle_out.to_str().unwrap(),
+        ])
+        .output()
+        .expect("run sera circle replay with corrupt config");
+
+    assert!(
+        output.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("circle-replay: PASS "), "stdout={stdout}");
+}
+
+#[test]
+fn circle_replay_cli_usage_error_footer_when_fixture_dir_is_omitted() {
+    let output = Command::new(env!("CARGO_BIN_EXE_sera"))
+        .args(["circle", "replay"])
+        .output()
+        .expect("run sera circle replay without fixture dir");
+
+    assert_eq!(output.status.code(), Some(3));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stdout.contains("circle-replay: USAGE_ERROR unknown"),
+        "stdout={stdout}"
+    );
+    assert!(
+        stderr.contains("missing required --fixture-dir"),
+        "stderr={stderr}"
+    );
+}
+
+#[test]
+fn circle_replay_cli_usage_error_footer_when_bundle_out_is_omitted() {
+    let temp = tempfile::tempdir().unwrap();
+    let fixture_dir = temp.path().join("fixtures");
+    std::fs::create_dir(&fixture_dir).unwrap();
+    write_replay_fixture(&fixture_dir);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_sera"))
+        .args([
+            "circle",
+            "replay",
+            "--fixture-dir",
+            fixture_dir.to_str().unwrap(),
+        ])
+        .output()
+        .expect("run sera circle replay without bundle out");
+
+    assert_eq!(output.status.code(), Some(3));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stdout.contains("circle-replay: USAGE_ERROR unknown"),
+        "stdout={stdout}"
+    );
+    assert!(
+        stderr.contains("missing required --bundle-out"),
         "stderr={stderr}"
     );
 }


### PR DESCRIPTION
## Summary

Continues `sera-nqh3` Circle proof promotion after #1335 by adding a first-class offline replay seam:

- adds `sera circle replay --fixture-dir <dir> --bundle-out <path> [--json]`;
- reads `summary.json` plus one `<role_id>.json` captured role fixture per perspective;
- emits a `CollaborationProofBundle` inside SERA CLI code rather than relying on the external orchestration script;
- immediately validates the generated bundle with `validate_proof_bundle` before returning PASS/FAIL;
- keeps the command fully offline and config/token independent, with stable `circle-replay:` footer.

This is deliberately not live provider execution yet. It is the next deterministic rung: fixture transcript → SERA-produced proof bundle → existing offline validator.

## Verification

Local checks from `/home/entity/projects/sera-omc/t_circle_replay_cli_20260629/rust`:

```text
cargo test -p sera-cli circle_ -- --nocapture
# 10 passed

cargo check -p sera-cli
# passed
```

Real rich smoke replay from the previous MiniMax/local-Gemma run:

```text
cargo run -p sera-cli -- circle replay \
  --fixture-dir /home/entity/projects/sera-live-main-current-20260629-pr1334/artifacts/reports/circle/rich-mixed-provider-20260629-1800 \
  --bundle-out /tmp/sera-rich-replayed-proof-bundle.json \
  --json
```

Returned:

```text
circle-replay: PASS c5843f530c287ca5782a9ff0ffe435610c4664c7117a37bf09fabad8897e0625
```

Then:

```text
cargo run -p sera-cli -- circle validate --bundle /tmp/sera-rich-replayed-proof-bundle.json --json
```

Returned:

```text
circle-validate: PASS c5843f530c287ca5782a9ff0ffe435610c4664c7117a37bf09fabad8897e0625
```

## Notes

- The replay command can use metadata from `summary.json`; if absent, it can read a colocated/declared proof bundle only for top-level metadata such as `run_id`, `circle_id`, `objective`, `success_metric`, and verdict type. Entries/receipts are rebuilt from role fixtures.
- Usage errors emit `circle-replay: USAGE_ERROR unknown`, including omitted `--fixture-dir` or `--bundle-out`.
- Corrupt config is bypassed the same way as `circle validate`.
