### PR TITLE
feat(cli): add first-class Circle run command

### DIFF
--- a/rust/crates/sera-cli/src/circle_replay.rs
+++ b/rust/crates/sera-cli/src/circle_replay.rs
@@ -129,7 +129,7 @@ pub fn run_circle_replay(
     }
 }
 
-fn build_replay_bundle(fixture_dir: &Path) -> Result<CollaborationProofBundle, String> {
+pub(crate) fn build_replay_bundle(fixture_dir: &Path) -> Result<CollaborationProofBundle, String> {
     let summary_path = fixture_dir.join("summary.json");
     let summary = read_json(&summary_path)?;
     let metadata_source = replay_metadata_source(fixture_dir, &summary)?;
@@ -315,6 +315,11 @@ fn build_replay_bundle(fixture_dir: &Path) -> Result<CollaborationProofBundle, S
         value_from_summary_or_metadata(&summary, metadata_source.as_ref(), "budget_snapshot")
     {
         bundle["budget_snapshot"] = snapshot.clone();
+    }
+    if let Some(peer_challenges) =
+        value_from_summary_or_metadata(&summary, metadata_source.as_ref(), "peer_challenges")
+    {
+        bundle["peer_challenges"] = peer_challenges;
     }
     if let Some(verdict) = verdict {
         bundle["verdict"] = verdict;

--- a/rust/crates/sera-cli/src/circle_run.rs
+++ b/rust/crates/sera-cli/src/circle_run.rs
@@ -1,0 +1,320 @@
+use std::collections::HashSet;
+use std::path::{Component, Path, PathBuf};
+
+use serde_json::{Value, json};
+
+use crate::{circle_replay, sha256_hex};
+use sera_types::circle_validator::validate_proof_bundle;
+
+pub fn print_circle_run_footer(verdict: &str, bundle_sha256: &str) {
+    println!("circle-run: {verdict} {bundle_sha256}");
+}
+
+pub fn run_circle_run(
+    spec: Option<PathBuf>,
+    capture_dir: Option<PathBuf>,
+    bundle_out: Option<PathBuf>,
+    json_out: bool,
+) -> i32 {
+    let Some(spec) = spec else {
+        eprintln!("missing required --spec <PATH> for Circle run");
+        print_circle_run_footer("USAGE_ERROR", "unknown");
+        return 3;
+    };
+    let Some(capture_dir) = capture_dir else {
+        eprintln!("missing required --capture-dir <DIR> for Circle run");
+        print_circle_run_footer("USAGE_ERROR", "unknown");
+        return 3;
+    };
+    let Some(bundle_out) = bundle_out else {
+        eprintln!("missing required --bundle-out <PATH> for Circle run");
+        print_circle_run_footer("USAGE_ERROR", "unknown");
+        return 3;
+    };
+
+    if let Err(err) = materialize_run_fixtures(&spec, &capture_dir) {
+        eprintln!("failed to capture Circle run fixtures: {err}");
+        print_circle_run_footer("USAGE_ERROR", "unknown");
+        return 3;
+    }
+    if let Err(err) = remove_colocated_replay_metadata(&capture_dir) {
+        eprintln!("failed to prepare Circle run capture directory: {err}");
+        print_circle_run_footer("USAGE_ERROR", "unknown");
+        return 3;
+    }
+
+    let bundle = match circle_replay::build_replay_bundle(&capture_dir) {
+        Ok(bundle) => bundle,
+        Err(err) => {
+            eprintln!("failed to replay captured Circle run: {err}");
+            print_circle_run_footer("USAGE_ERROR", "unknown");
+            return 3;
+        }
+    };
+
+    let bytes = match serde_json::to_vec_pretty(&bundle) {
+        Ok(bytes) => bytes,
+        Err(err) => {
+            eprintln!("failed to serialize Circle run bundle: {err}");
+            print_circle_run_footer("USAGE_ERROR", "unknown");
+            return 3;
+        }
+    };
+    let bundle_sha256 = sha256_hex(&bytes);
+
+    if let Some(parent) = bundle_out
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        && let Err(err) = std::fs::create_dir_all(parent)
+    {
+        eprintln!(
+            "failed to create Circle run output directory {}: {err}",
+            parent.display()
+        );
+        print_circle_run_footer("USAGE_ERROR", "unknown");
+        return 3;
+    }
+
+    if let Err(err) = std::fs::write(&bundle_out, &bytes) {
+        eprintln!(
+            "failed to write Circle run bundle {}: {err}",
+            bundle_out.display()
+        );
+        print_circle_run_footer("USAGE_ERROR", "unknown");
+        return 3;
+    }
+
+    match validate_proof_bundle(&bundle) {
+        Ok(()) => {
+            if json_out {
+                println!(
+                    "{}",
+                    json!({
+                        "verdict": "PASS",
+                        "bundle_sha256": bundle_sha256,
+                        "spec": spec.display().to_string(),
+                        "capture_dir": capture_dir.display().to_string(),
+                        "bundle_out": bundle_out.display().to_string(),
+                        "entries": bundle.entries.len(),
+                        "execution_receipts": bundle.execution_receipts.len(),
+                        "lineage_edges": bundle.lineage.len(),
+                        "peer_challenges": bundle.peer_challenges.len(),
+                        "circle_id": bundle.circle_id,
+                        "run_id": bundle.run_id,
+                    })
+                );
+            } else {
+                println!(
+                    "Circle run PASS: captured {} role fixtures, wrote {} entries={} receipts={} peer_challenges={} run_id={} circle_id={}",
+                    bundle.roster.len(),
+                    bundle_out.display(),
+                    bundle.entries.len(),
+                    bundle.execution_receipts.len(),
+                    bundle.peer_challenges.len(),
+                    bundle.run_id,
+                    bundle.circle_id
+                );
+            }
+            print_circle_run_footer("PASS", &bundle_sha256);
+            0
+        }
+        Err(errors) => {
+            if json_out {
+                println!(
+                    "{}",
+                    json!({
+                        "verdict": "FAIL",
+                        "bundle_sha256": bundle_sha256,
+                        "spec": spec.display().to_string(),
+                        "capture_dir": capture_dir.display().to_string(),
+                        "bundle_out": bundle_out.display().to_string(),
+                        "entries": bundle.entries.len(),
+                        "execution_receipts": bundle.execution_receipts.len(),
+                        "lineage_edges": bundle.lineage.len(),
+                        "peer_challenges": bundle.peer_challenges.len(),
+                        "circle_id": bundle.circle_id,
+                        "run_id": bundle.run_id,
+                        "errors": errors.iter().map(|e| format!("{:?}", e.kind)).collect::<Vec<_>>(),
+                    })
+                );
+            } else {
+                eprintln!(
+                    "Circle run FAIL: wrote {} with {} validation error(s)",
+                    bundle_out.display(),
+                    errors.len()
+                );
+                for error in &errors {
+                    eprintln!("- {:?}", error.kind);
+                }
+            }
+            print_circle_run_footer("FAIL", &bundle_sha256);
+            1
+        }
+    }
+}
+
+fn materialize_run_fixtures(spec_path: &Path, capture_dir: &Path) -> Result<(), String> {
+    let spec = read_spec(spec_path)?;
+    let roles = spec
+        .get("roles")
+        .and_then(Value::as_array)
+        .ok_or_else(|| format!("{} must contain roles[]", spec_path.display()))?;
+    if roles.is_empty() {
+        return Err(format!("{} roles[] is empty", spec_path.display()));
+    }
+
+    std::fs::create_dir_all(capture_dir).map_err(|err| {
+        format!(
+            "failed to create Circle run capture directory {}: {err}",
+            capture_dir.display()
+        )
+    })?;
+
+    let mut summary = spec.clone();
+    let summary_obj = summary
+        .as_object_mut()
+        .ok_or_else(|| format!("{} must be a JSON/YAML object", spec_path.display()))?;
+    let mut summary_roles = Vec::with_capacity(roles.len());
+    let mut role_fixtures = Vec::with_capacity(roles.len());
+    let mut seen_role_ids = HashSet::new();
+
+    for role in roles {
+        let role_id = required_str(role, "role_id")?;
+        validate_role_id(role_id, &mut seen_role_ids)?;
+        let timestamp = role
+            .get("ended_at")
+            .and_then(Value::as_str)
+            .or_else(|| role.get("timestamp").and_then(Value::as_str))
+            .ok_or_else(|| format!("role {role_id} must contain ended_at or timestamp"))?;
+        let answer = role
+            .get("answer_cleaned")
+            .and_then(Value::as_str)
+            .or_else(|| role.get("answer").and_then(Value::as_str))
+            .ok_or_else(|| format!("role {role_id} must contain answer_cleaned or answer"))?;
+        if answer.trim().is_empty() {
+            return Err(format!("role {role_id} answer is blank"));
+        }
+
+        let mut role_fixture = role.clone();
+        role_fixture["role_id"] = json!(role_id);
+        role_fixture["ended_at"] = json!(timestamp);
+        if role_fixture.get("answer_cleaned").is_none() {
+            role_fixture["answer_cleaned"] = json!(answer);
+        }
+        if role_fixture.get("returncode").is_none() {
+            role_fixture["returncode"] = json!(0);
+        }
+        if role_fixture.get("duration_ms").is_none() {
+            role_fixture["duration_ms"] = json!(0);
+        }
+        if role_fixture.get("session_id").is_none() {
+            role_fixture["session_id"] = json!(format!("circle-run-{role_id}"));
+        }
+        if role_fixture.get("action").is_none() {
+            role_fixture["action"] = json!("sera_circle_run_role_capture");
+        }
+
+        let role_fixture_bytes = serde_json::to_vec_pretty(&role_fixture)
+            .map_err(|err| format!("failed to serialize role fixture {role_id}: {err}"))?;
+        summary_roles.push(role_summary(&role_fixture));
+        role_fixtures.push((role_id.to_string(), role_fixture_bytes));
+    }
+
+    summary_obj.insert("roles".to_string(), Value::Array(summary_roles));
+    summary_obj.remove("artifact");
+    let summary_bytes = serde_json::to_vec_pretty(&summary)
+        .map_err(|err| format!("failed to serialize summary.json: {err}"))?;
+
+    for (role_id, role_fixture_bytes) in role_fixtures {
+        std::fs::write(
+            capture_dir.join(format!("{role_id}.json")),
+            role_fixture_bytes,
+        )
+        .map_err(|err| format!("failed to write role fixture {role_id}: {err}"))?;
+    }
+    std::fs::write(capture_dir.join("summary.json"), summary_bytes)
+        .map_err(|err| format!("failed to write summary.json: {err}"))?;
+
+    Ok(())
+}
+
+fn role_summary(role: &Value) -> Value {
+    let fields = [
+        "role_id",
+        "role",
+        "provider",
+        "provider_cli",
+        "model",
+        "session_id",
+        "returncode",
+        "duration_ms",
+        "answer_had_harness_warnings",
+    ];
+    let mut out = serde_json::Map::new();
+    for field in fields {
+        if let Some(value) = role.get(field) {
+            out.insert(field.to_string(), value.clone());
+        }
+    }
+    Value::Object(out)
+}
+
+fn remove_colocated_replay_metadata(capture_dir: &Path) -> Result<(), String> {
+    let stale_bundle = capture_dir.join("proof_bundle.json");
+    match std::fs::remove_file(&stale_bundle) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(format!(
+            "failed to remove {}: {err}",
+            stale_bundle.display()
+        )),
+    }
+}
+
+fn validate_role_id(role_id: &str, seen: &mut HashSet<String>) -> Result<(), String> {
+    if role_id.trim().is_empty() || role_id.trim() != role_id {
+        return Err(format!(
+            "unsafe role_id {role_id:?}: must be a nonblank filename atom"
+        ));
+    }
+    if role_id.contains('/') || role_id.contains('\\') {
+        return Err(format!(
+            "unsafe role_id {role_id:?}: path separators are not allowed"
+        ));
+    }
+    let mut components = Path::new(role_id).components();
+    match (components.next(), components.next()) {
+        (Some(Component::Normal(_)), None) => {}
+        _ => {
+            return Err(format!(
+                "unsafe role_id {role_id:?}: must be a single filename atom"
+            ));
+        }
+    }
+    let normalized_role_id = role_id.to_lowercase();
+    if matches!(normalized_role_id.as_str(), "summary" | "proof_bundle") {
+        return Err(format!("reserved role_id {role_id:?}"));
+    }
+    if !seen.insert(normalized_role_id) {
+        return Err(format!("duplicate role_id {role_id:?}"));
+    }
+    Ok(())
+}
+
+fn read_spec(path: &Path) -> Result<Value, String> {
+    let bytes =
+        std::fs::read(path).map_err(|err| format!("failed to read {}: {err}", path.display()))?;
+    match path.extension().and_then(|ext| ext.to_str()) {
+        Some("yaml") | Some("yml") => serde_yaml::from_slice(&bytes)
+            .map_err(|err| format!("failed to parse {}: {err}", path.display())),
+        _ => serde_json::from_slice(&bytes)
+            .map_err(|err| format!("failed to parse {}: {err}", path.display())),
+    }
+}
+
+fn required_str<'a>(value: &'a Value, field: &str) -> Result<&'a str, String> {
+    value
+        .get(field)
+        .and_then(Value::as_str)
+        .ok_or_else(|| format!("role missing string field {field}"))
+}

--- a/rust/crates/sera-cli/src/main.rs
+++ b/rust/crates/sera-cli/src/main.rs
@@ -15,6 +15,7 @@ use sera_cli::config::CliConfig;
 use sera_cli::token_store::best_available_store;
 
 mod circle_replay;
+mod circle_run;
 
 /// SERA — Sandboxed Extensible Reasoning Agent CLI
 #[derive(Parser)]
@@ -172,6 +173,21 @@ enum CircleCommand {
         /// Directory containing summary.json plus one <role_id>.json file per role
         #[arg(long, value_name = "DIR", num_args = 0..=1)]
         fixture_dir: Option<PathBuf>,
+        /// Path to write the generated CollaborationProofBundle JSON artifact
+        #[arg(long, value_name = "PATH", num_args = 0..=1)]
+        bundle_out: Option<PathBuf>,
+        /// Emit a compact JSON report before the machine-parseable footer
+        #[arg(long)]
+        json: bool,
+    },
+    /// Run a configured Circle roster through capture -> replay -> validate
+    Run {
+        /// JSON/YAML Circle run spec containing roles[] with captured outputs
+        #[arg(long, value_name = "PATH", num_args = 0..=1)]
+        spec: Option<PathBuf>,
+        /// Directory where role fixtures and summary.json are captured
+        #[arg(long, value_name = "DIR", num_args = 0..=1)]
+        capture_dir: Option<PathBuf>,
         /// Path to write the generated CollaborationProofBundle JSON artifact
         #[arg(long, value_name = "PATH", num_args = 0..=1)]
         bundle_out: Option<PathBuf>,
@@ -423,6 +439,17 @@ async fn main() -> Result<()> {
                 bundle_out,
                 json,
             } => circle_replay::run_circle_replay(fixture_dir.clone(), bundle_out.clone(), *json),
+            CircleCommand::Run {
+                spec,
+                capture_dir,
+                bundle_out,
+                json,
+            } => circle_run::run_circle_run(
+                spec.clone(),
+                capture_dir.clone(),
+                bundle_out.clone(),
+                *json,
+            ),
         };
         if exit_code != 0 {
             std::process::exit(exit_code);
@@ -794,6 +821,17 @@ async fn main() -> Result<()> {
                 json,
             } => {
                 let exit_code = circle_replay::run_circle_replay(fixture_dir, bundle_out, json);
+                if exit_code != 0 {
+                    std::process::exit(exit_code);
+                }
+            }
+            CircleCommand::Run {
+                spec,
+                capture_dir,
+                bundle_out,
+                json,
+            } => {
+                let exit_code = circle_run::run_circle_run(spec, capture_dir, bundle_out, json);
                 if exit_code != 0 {
                     std::process::exit(exit_code);
                 }

--- a/rust/crates/sera-cli/tests/circle_validate.rs
+++ b/rust/crates/sera-cli/tests/circle_validate.rs
@@ -747,3 +747,429 @@ fn circle_replay_cli_usage_error_footer_when_bundle_out_is_omitted() {
         "stderr={stderr}"
     );
 }
+
+#[test]
+fn circle_run_cli_captures_replays_validates_and_preserves_peer_challenges() {
+    let temp = tempfile::tempdir().unwrap();
+    let spec = temp.path().join("circle-run-spec.json");
+    let capture_dir = temp.path().join("capture");
+    let bundle_out = temp.path().join("out").join("proof_bundle.json");
+    std::fs::write(
+        &spec,
+        r#"{
+  "run_id": "circle-run-fixture-run",
+  "circle_id": "sera-nqh3-run-fixture",
+  "objective": "Run a configured Circle roster through capture, replay, validate, prove.",
+  "success_metric": {
+    "kind": "inline",
+    "description": "first-class run writes a valid proof bundle"
+  },
+  "roles": [
+    {"role_id":"specifier_minimax","provider_cli":"minimax","model":"MiniMax-M3","session_id":"sess_spec","returncode":0,"duration_ms":101,"role":"cloud specifier","ended_at":"2026-06-30T08:00:01Z","answer_cleaned":"Specification: preserve configured run receipts."},
+    {"role_id":"builder_local_gemma","provider_cli":"custom","model":"gemma4-local","session_id":"sess_build","returncode":0,"duration_ms":102,"role":"local builder","ended_at":"2026-06-30T08:00:02Z","answer_cleaned":"Builder: materialize role fixtures from run spec."},
+    {"role_id":"critic_minimax","provider_cli":"minimax","model":"MiniMax-M3","session_id":"sess_critic","returncode":0,"duration_ms":103,"role":"cloud critic","ended_at":"2026-06-30T08:00:03Z","answer_cleaned":"Critic: demand structured peer challenge evidence."},
+    {"role_id":"referee_local_gemma","provider_cli":"custom","model":"gemma4-local","session_id":"sess_ref","returncode":0,"duration_ms":104,"role":"local referee/rule process","ended_at":"2026-06-30T08:00:04Z","answer_cleaned":"APPROVED: run preserved peer challenges and validation receipts."}
+  ],
+  "peer_challenges": [
+    {
+      "challenge_id": "challenge_critic_001",
+      "challenger": "critic_minimax",
+      "target_entry_id": 2,
+      "claim": "The builder's fixture materialization is enough proof by itself.",
+      "challenge": "The run must also validate the generated proof bundle and preserve dissent.",
+      "evidence": ["circle-run stdout footer", "generated proof_bundle.json"],
+      "severity": "high",
+      "response_by": "referee_local_gemma",
+      "disposition": "resolved"
+    }
+  ],
+  "budget_snapshot": {"max_iterations":4,"current_usage":4},
+  "verdict_type": {"kind":"approved"}
+}
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_sera"))
+        .args([
+            "circle",
+            "run",
+            "--spec",
+            spec.to_str().unwrap(),
+            "--capture-dir",
+            capture_dir.to_str().unwrap(),
+            "--bundle-out",
+            bundle_out.to_str().unwrap(),
+            "--json",
+        ])
+        .output()
+        .expect("run sera circle run");
+
+    assert!(
+        output.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("circle-run: PASS "), "stdout={stdout}");
+    assert!(stdout.contains("\"peer_challenges\":1"), "stdout={stdout}");
+    assert!(capture_dir.join("summary.json").exists());
+    assert!(capture_dir.join("critic_minimax.json").exists());
+    assert!(bundle_out.exists(), "bundle was not written");
+
+    let bundle: Value = serde_json::from_slice(&std::fs::read(&bundle_out).unwrap()).unwrap();
+    assert_eq!(bundle["peer_challenges"].as_array().unwrap().len(), 1);
+    assert_eq!(
+        bundle["peer_challenges"][0]["disposition"]
+            .as_str()
+            .unwrap(),
+        "resolved"
+    );
+}
+
+#[test]
+fn circle_run_cli_rejects_unsafe_role_id_path_component() {
+    let temp = tempfile::tempdir().unwrap();
+    let spec = temp.path().join("bad-role-id.json");
+    let capture_dir = temp.path().join("capture");
+    let bundle_out = temp.path().join("proof_bundle.json");
+    std::fs::write(
+        &spec,
+        r#"{
+  "run_id": "unsafe-role-run",
+  "circle_id": "unsafe-role-circle",
+  "objective": "Reject unsafe role ids.",
+  "success_metric": {"kind":"inline","description":"unsafe role ids fail before file writes"},
+  "roles": [
+    {"role_id":"../escape","provider_cli":"minimax","model":"MiniMax-M3","ended_at":"2026-06-30T08:00:01Z","answer_cleaned":"This must not be written outside capture_dir."}
+  ],
+  "verdict_type": {"kind":"approved"}
+}
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_sera"))
+        .args([
+            "circle",
+            "run",
+            "--spec",
+            spec.to_str().unwrap(),
+            "--capture-dir",
+            capture_dir.to_str().unwrap(),
+            "--bundle-out",
+            bundle_out.to_str().unwrap(),
+        ])
+        .output()
+        .expect("run sera circle run with unsafe role id");
+
+    assert_eq!(output.status.code(), Some(3));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stdout.contains("circle-run: USAGE_ERROR unknown"),
+        "stdout={stdout}"
+    );
+    assert!(stderr.contains("unsafe role_id"), "stderr={stderr}");
+    assert!(
+        !temp.path().join("escape.json").exists(),
+        "unsafe role id wrote outside capture_dir"
+    );
+}
+
+#[test]
+fn circle_run_cli_rejects_reserved_role_id_basename() {
+    let temp = tempfile::tempdir().unwrap();
+    let spec = temp.path().join("reserved-role-id.json");
+    let capture_dir = temp.path().join("capture");
+    let bundle_out = temp.path().join("proof_bundle.json");
+    std::fs::write(
+        &spec,
+        r#"{
+  "run_id": "reserved-role-run",
+  "circle_id": "reserved-role-circle",
+  "objective": "Reject reserved fixture basenames.",
+  "success_metric": {"kind":"inline","description":"reserved role ids fail before fixture corruption"},
+  "roles": [
+    {"role_id":"Summary","provider_cli":"minimax","model":"MiniMax-M3","ended_at":"2026-06-30T08:00:01Z","answer_cleaned":"This must not collide with summary.json."}
+  ],
+  "verdict_type": {"kind":"approved"}
+}
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_sera"))
+        .args([
+            "circle",
+            "run",
+            "--spec",
+            spec.to_str().unwrap(),
+            "--capture-dir",
+            capture_dir.to_str().unwrap(),
+            "--bundle-out",
+            bundle_out.to_str().unwrap(),
+        ])
+        .output()
+        .expect("run sera circle run with reserved role id");
+
+    assert_eq!(output.status.code(), Some(3));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stdout.contains("circle-run: USAGE_ERROR unknown"),
+        "stdout={stdout}"
+    );
+    assert!(stderr.contains("reserved role_id"), "stderr={stderr}");
+}
+
+#[test]
+fn circle_run_cli_rejects_duplicate_role_ids() {
+    let temp = tempfile::tempdir().unwrap();
+    let spec = temp.path().join("duplicate-role-id.json");
+    let capture_dir = temp.path().join("capture");
+    let bundle_out = temp.path().join("proof_bundle.json");
+    std::fs::write(
+        &spec,
+        r#"{
+  "run_id": "duplicate-role-run",
+  "circle_id": "duplicate-role-circle",
+  "objective": "Reject duplicate role ids.",
+  "success_metric": {"kind":"inline","description":"duplicate role ids fail before overwrite"},
+  "roles": [
+    {"role_id":"critic","provider_cli":"minimax","model":"MiniMax-M3","ended_at":"2026-06-30T08:00:01Z","answer_cleaned":"first"},
+    {"role_id":"Critic","provider_cli":"custom","model":"gemma4-local","ended_at":"2026-06-30T08:00:02Z","answer_cleaned":"second"}
+  ],
+  "verdict_type": {"kind":"approved"}
+}
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_sera"))
+        .args([
+            "circle",
+            "run",
+            "--spec",
+            spec.to_str().unwrap(),
+            "--capture-dir",
+            capture_dir.to_str().unwrap(),
+            "--bundle-out",
+            bundle_out.to_str().unwrap(),
+        ])
+        .output()
+        .expect("run sera circle run with duplicate role id");
+
+    assert_eq!(output.status.code(), Some(3));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stdout.contains("circle-run: USAGE_ERROR unknown"),
+        "stdout={stdout}"
+    );
+    assert!(stderr.contains("duplicate role_id"), "stderr={stderr}");
+}
+
+#[test]
+fn circle_run_cli_does_not_overwrite_reused_capture_dir_on_late_spec_error() {
+    let temp = tempfile::tempdir().unwrap();
+    let spec = temp.path().join("late-error-role-id.json");
+    let capture_dir = temp.path().join("capture");
+    std::fs::create_dir(&capture_dir).unwrap();
+    let old_role = capture_dir.join("critic.json");
+    std::fs::write(&old_role, r#"{"role_id":"critic","answer_cleaned":"old"}"#).unwrap();
+    std::fs::write(
+        capture_dir.join("summary.json"),
+        r#"{"roles":[{"role_id":"critic"}]}"#,
+    )
+    .unwrap();
+    let bundle_out = temp.path().join("proof_bundle.json");
+    std::fs::write(
+        &spec,
+        r#"{
+  "run_id": "late-error-role-run",
+  "circle_id": "late-error-role-circle",
+  "objective": "Do not partially overwrite reused capture dirs on invalid specs.",
+  "success_metric": {"kind":"inline","description":"late duplicate should not write first fixture"},
+  "roles": [
+    {"role_id":"critic","provider_cli":"minimax","model":"MiniMax-M3","ended_at":"2026-06-30T08:00:01Z","answer_cleaned":"new content must not be written"},
+    {"role_id":"Critic","provider_cli":"custom","model":"gemma4-local","ended_at":"2026-06-30T08:00:02Z","answer_cleaned":"duplicate fails after first fixture was built in memory"}
+  ],
+  "verdict_type": {"kind":"approved"}
+}
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_sera"))
+        .args([
+            "circle",
+            "run",
+            "--spec",
+            spec.to_str().unwrap(),
+            "--capture-dir",
+            capture_dir.to_str().unwrap(),
+            "--bundle-out",
+            bundle_out.to_str().unwrap(),
+        ])
+        .output()
+        .expect("run sera circle run with late spec error over reused capture dir");
+
+    assert_eq!(output.status.code(), Some(3));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stdout.contains("circle-run: USAGE_ERROR unknown"),
+        "stdout={stdout}"
+    );
+    assert!(stderr.contains("duplicate role_id"), "stderr={stderr}");
+    let role_contents = std::fs::read_to_string(&old_role).unwrap();
+    assert_eq!(
+        role_contents, r#"{"role_id":"critic","answer_cleaned":"old"}"#,
+        "invalid spec partially overwrote reused capture fixture"
+    );
+}
+
+#[test]
+fn circle_run_cli_ignores_explicit_artifact_replay_metadata() {
+    let temp = tempfile::tempdir().unwrap();
+    let spec = temp.path().join("artifact-no-verdict-run-spec.json");
+    let capture_dir = temp.path().join("capture");
+    std::fs::create_dir(&capture_dir).unwrap();
+    let bundle_out = temp.path().join("proof_bundle.json");
+    std::fs::write(
+        capture_dir.join("stale-proof.json"),
+        r#"{
+  "run_id": "artifact-stale-run",
+  "circle_id": "artifact-stale-circle",
+  "objective": "stale artifact metadata must not be reused",
+  "success_metric": {"kind":"inline","description":"stale artifact"},
+  "verdict": {"reviewer":"stale","timestamp":"2026-06-30T08:00:00Z","verdict_type":{"kind":"approved"},"rationale":"stale artifact"}
+}
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        &spec,
+        r#"{
+  "run_id": "circle-run-no-artifact-verdict",
+  "circle_id": "sera-nqh3-no-artifact-verdict",
+  "objective": "Run must not borrow explicit artifact metadata.",
+  "success_metric": {"kind":"inline","description":"artifact metadata should be stripped"},
+  "artifact": "stale-proof.json",
+  "roles": [
+    {"role_id":"specifier_minimax","provider_cli":"minimax","model":"MiniMax-M3","session_id":"sess_spec","returncode":0,"duration_ms":101,"role":"cloud specifier","ended_at":"2026-06-30T08:00:01Z","answer_cleaned":"Specification: no verdict supplied."},
+    {"role_id":"builder_local_gemma","provider_cli":"custom","model":"gemma4-local","session_id":"sess_build","returncode":0,"duration_ms":102,"role":"local builder","ended_at":"2026-06-30T08:00:02Z","answer_cleaned":"Builder: valid local provider evidence."},
+    {"role_id":"critic_minimax","provider_cli":"minimax","model":"MiniMax-M3","session_id":"sess_critic","returncode":0,"duration_ms":103,"role":"cloud critic","ended_at":"2026-06-30T08:00:03Z","answer_cleaned":"Critic: verdict is intentionally absent."},
+    {"role_id":"referee_local_gemma","provider_cli":"custom","model":"gemma4-local","session_id":"sess_ref","returncode":0,"duration_ms":104,"role":"local referee/rule process","ended_at":"2026-06-30T08:00:04Z","answer_cleaned":"Referee: no verdict_type field supplied."}
+  ]
+}
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_sera"))
+        .args([
+            "circle",
+            "run",
+            "--spec",
+            spec.to_str().unwrap(),
+            "--capture-dir",
+            capture_dir.to_str().unwrap(),
+            "--bundle-out",
+            bundle_out.to_str().unwrap(),
+            "--json",
+        ])
+        .output()
+        .expect("run sera circle run with stale explicit artifact metadata");
+
+    assert_eq!(output.status.code(), Some(1));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("circle-run: FAIL "), "stdout={stdout}");
+    assert!(stdout.contains("MissingVerdict"), "stdout={stdout}");
+    let written_summary: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(capture_dir.join("summary.json")).unwrap()).unwrap();
+    assert!(
+        written_summary.get("artifact").is_none(),
+        "run summary should strip replay artifact metadata: {written_summary}"
+    );
+}
+
+#[test]
+fn circle_run_cli_ignores_stale_colocated_replay_metadata() {
+    let temp = tempfile::tempdir().unwrap();
+    let spec = temp.path().join("no-verdict-run-spec.json");
+    let capture_dir = temp.path().join("capture");
+    std::fs::create_dir(&capture_dir).unwrap();
+    let bundle_out = capture_dir.join("proof_bundle.json");
+    std::fs::write(
+        &bundle_out,
+        r#"{
+  "run_id": "stale-run",
+  "circle_id": "stale-circle",
+  "objective": "stale metadata must not be reused",
+  "success_metric": {"kind":"inline","description":"stale"},
+  "verdict": {"reviewer":"stale","timestamp":"2026-06-30T08:00:00Z","verdict_type":{"kind":"approved"},"rationale":"stale"}
+}
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        &spec,
+        r#"{
+  "run_id": "circle-run-no-verdict",
+  "circle_id": "sera-nqh3-no-verdict",
+  "objective": "Run must not borrow stale verdict metadata.",
+  "success_metric": {"kind":"inline","description":"missing verdict should fail"},
+  "roles": [
+    {"role_id":"specifier_minimax","provider_cli":"minimax","model":"MiniMax-M3","session_id":"sess_spec","returncode":0,"duration_ms":101,"role":"cloud specifier","ended_at":"2026-06-30T08:00:01Z","answer_cleaned":"Specification: no verdict supplied."},
+    {"role_id":"builder_local_gemma","provider_cli":"custom","model":"gemma4-local","session_id":"sess_build","returncode":0,"duration_ms":102,"role":"local builder","ended_at":"2026-06-30T08:00:02Z","answer_cleaned":"Builder: valid local provider evidence."},
+    {"role_id":"critic_minimax","provider_cli":"minimax","model":"MiniMax-M3","session_id":"sess_critic","returncode":0,"duration_ms":103,"role":"cloud critic","ended_at":"2026-06-30T08:00:03Z","answer_cleaned":"Critic: verdict is intentionally absent."},
+    {"role_id":"referee_local_gemma","provider_cli":"custom","model":"gemma4-local","session_id":"sess_ref","returncode":0,"duration_ms":104,"role":"local referee/rule process","ended_at":"2026-06-30T08:00:04Z","answer_cleaned":"Referee: no verdict_type field supplied."}
+  ]
+}
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_sera"))
+        .args([
+            "circle",
+            "run",
+            "--spec",
+            spec.to_str().unwrap(),
+            "--capture-dir",
+            capture_dir.to_str().unwrap(),
+            "--bundle-out",
+            bundle_out.to_str().unwrap(),
+            "--json",
+        ])
+        .output()
+        .expect("run sera circle run without verdict_type over stale capture dir");
+
+    assert_eq!(output.status.code(), Some(1));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("circle-run: FAIL "), "stdout={stdout}");
+    assert!(stdout.contains("MissingVerdict"), "stdout={stdout}");
+}
+
+#[test]
+fn circle_run_cli_usage_error_footer_when_spec_is_omitted() {
+    let output = Command::new(env!("CARGO_BIN_EXE_sera"))
+        .args(["circle", "run"])
+        .output()
+        .expect("run sera circle run without spec");
+
+    assert_eq!(output.status.code(), Some(3));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stdout.contains("circle-run: USAGE_ERROR unknown"),
+        "stdout={stdout}"
+    );
+    assert!(
+        stderr.contains("missing required --spec"),
+        "stderr={stderr}"
+    );
+}

--- a/rust/crates/sera-types/src/circle.rs
+++ b/rust/crates/sera-types/src/circle.rs
@@ -553,6 +553,54 @@ pub struct CollaborationVerdictRecord {
     pub rationale: String,
 }
 
+/// Severity of a peer challenge raised during Circle deliberation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PeerChallengeSeverity {
+    Low,
+    Medium,
+    High,
+    Blocking,
+}
+
+/// Current disposition of a peer challenge.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PeerChallengeDisposition {
+    Open,
+    Accepted,
+    Rejected,
+    Resolved,
+    Superseded,
+}
+
+fn default_peer_challenge_disposition() -> PeerChallengeDisposition {
+    PeerChallengeDisposition::Open
+}
+
+/// Structured challenge object preserving dissent before final integration.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PeerChallenge {
+    /// Stable id for this challenge within the run.
+    pub challenge_id: String,
+    /// Participant that raised the challenge.
+    pub challenger: String,
+    /// Blackboard entry being challenged.
+    pub target_entry_id: u64,
+    /// Claim under dispute.
+    pub claim: String,
+    /// Concrete challenge or objection.
+    pub challenge: String,
+    /// Receipt ids, file paths, quotes, or other compact evidence pointers.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub evidence: Vec<String>,
+    pub severity: PeerChallengeSeverity,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub response_by: Option<String>,
+    #[serde(default = "default_peer_challenge_disposition")]
+    pub disposition: PeerChallengeDisposition,
+}
+
 /// Complete proof bundle for a collaboration run.
 ///
 /// Serialises to / deserialises from JSON as the golden fixture format for
@@ -570,6 +618,9 @@ pub struct CollaborationProofBundle {
     pub entries: Vec<ProofBundleEntry>,
     pub lineage: Vec<LineageEdge>,
     pub execution_receipts: Vec<ExecutionReceipt>,
+    /// Structured challenges raised by peers before referee integration.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub peer_challenges: Vec<PeerChallenge>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub verdict: Option<CollaborationVerdictRecord>,
 }
@@ -968,8 +1019,7 @@ mod tests {
         let bundle = CollaborationProofBundle {
             run_id: "run_sera_nqh3_001".to_string(),
             circle_id: "sera-nqh3-circle".to_string(),
-            objective: "Verify and deduplicate the Hermes-parity gap map for sera-nqh3"
-                .to_string(),
+            objective: "Verify and deduplicate the Hermes-parity gap map for sera-nqh3".to_string(),
             success_metric: MetricRef::Evaluator {
                 evaluator_id: "metric_dedup_complete".to_string(),
                 description: Some(
@@ -1075,6 +1125,19 @@ mod tests {
                 outcome: ReceiptOutcome::Success,
                 cost_tokens: Some(120),
             }],
+            peer_challenges: vec![PeerChallenge {
+                challenge_id: "challenge_critic_001".to_string(),
+                challenger: "critic".to_string(),
+                target_entry_id: 2,
+                claim: "The builder proposal cited every relevant Circle coordination file."
+                    .to_string(),
+                challenge: "The proposal missed ResultAggregator evidence in sera-workflow."
+                    .to_string(),
+                evidence: vec!["rust/crates/sera-workflow/src/coordination.rs".to_string()],
+                severity: PeerChallengeSeverity::High,
+                response_by: Some("builder".to_string()),
+                disposition: PeerChallengeDisposition::Resolved,
+            }],
             verdict: Some(CollaborationVerdictRecord {
                 reviewer: "referee".to_string(),
                 timestamp: "2026-06-29T16:04:00Z".parse().unwrap(),
@@ -1116,10 +1179,14 @@ mod tests {
             entries: vec![],
             lineage: vec![],
             execution_receipts: vec![],
+            peer_challenges: vec![],
             verdict: None,
         };
         let json = serde_json::to_string(&bundle).unwrap();
-        assert!(!json.contains("verdict"), "verdict should be absent: {json}");
+        assert!(
+            !json.contains("verdict"),
+            "verdict should be absent: {json}"
+        );
         assert!(
             !json.contains("budget_snapshot"),
             "budget_snapshot should be absent: {json}"

--- a/rust/crates/sera-types/src/circle_validator.rs
+++ b/rust/crates/sera-types/src/circle_validator.rs
@@ -34,6 +34,21 @@ pub enum ValidationErrorKind {
     MissingVerdict,
     /// The bundle lacks evidence of at least one local provider and one cloud/non-local provider.
     MissingMixedProviderEvidence,
+    /// A peer challenge references an entry id not present in `entries`.
+    BrokenPeerChallengeRef {
+        challenge_id: String,
+        target_entry_id: u64,
+    },
+    /// Two or more peer challenges share the same stable challenge id.
+    DuplicatePeerChallengeId { challenge_id: String },
+    /// A peer challenge actor is not present in the run roster/authors.
+    UnknownPeerChallengeActor {
+        challenge_id: String,
+        field: String,
+        actor: String,
+    },
+    /// A peer challenge is missing the concrete disputed claim, challenge, or challenger.
+    BlankPeerChallengeField { challenge_id: String, field: String },
 }
 
 /// A single validation failure produced by [`validate_proof_bundle`].
@@ -71,10 +86,17 @@ pub fn validate_proof_bundle(
     check_unique_entry_ids(bundle, &mut errors);
 
     let entry_id_set: HashSet<u64> = bundle.entries.iter().map(|e| e.entry_id).collect();
+    let actor_set: HashSet<&str> = bundle
+        .roster
+        .iter()
+        .map(|member| member.participant_id.as_str())
+        .chain(bundle.entries.iter().map(|entry| entry.author.as_str()))
+        .collect();
 
     check_lineage_refs(bundle, &entry_id_set, &mut errors);
     check_blank_responses(bundle, &mut errors);
     check_receipts_for_provider_entries(bundle, &mut errors);
+    check_peer_challenges(bundle, &entry_id_set, &actor_set, &mut errors);
     check_verdict_present(bundle, &mut errors);
     check_mixed_provider_evidence(bundle, &mut errors);
 
@@ -168,6 +190,72 @@ fn check_receipts_for_provider_entries(
     }
 }
 
+fn check_peer_challenges(
+    bundle: &CollaborationProofBundle,
+    entry_id_set: &HashSet<u64>,
+    actor_set: &HashSet<&str>,
+    errors: &mut Vec<ValidationError>,
+) {
+    let mut seen_challenge_ids: HashSet<&str> = HashSet::new();
+    for challenge in &bundle.peer_challenges {
+        if !seen_challenge_ids.insert(challenge.challenge_id.as_str()) {
+            errors.push(ValidationError::new(
+                ValidationErrorKind::DuplicatePeerChallengeId {
+                    challenge_id: challenge.challenge_id.clone(),
+                },
+            ));
+        }
+        if !entry_id_set.contains(&challenge.target_entry_id) {
+            errors.push(ValidationError::new(
+                ValidationErrorKind::BrokenPeerChallengeRef {
+                    challenge_id: challenge.challenge_id.clone(),
+                    target_entry_id: challenge.target_entry_id,
+                },
+            ));
+        }
+        if !challenge.challenger.trim().is_empty()
+            && !actor_set.contains(challenge.challenger.as_str())
+        {
+            errors.push(ValidationError::new(
+                ValidationErrorKind::UnknownPeerChallengeActor {
+                    challenge_id: challenge.challenge_id.clone(),
+                    field: "challenger".to_string(),
+                    actor: challenge.challenger.clone(),
+                },
+            ));
+        }
+        if let Some(response_by) = challenge
+            .response_by
+            .as_deref()
+            .filter(|response_by| !response_by.trim().is_empty())
+            && !actor_set.contains(response_by)
+        {
+            errors.push(ValidationError::new(
+                ValidationErrorKind::UnknownPeerChallengeActor {
+                    challenge_id: challenge.challenge_id.clone(),
+                    field: "response_by".to_string(),
+                    actor: response_by.to_string(),
+                },
+            ));
+        }
+        for (field, value) in [
+            ("challenge_id", challenge.challenge_id.as_str()),
+            ("challenger", challenge.challenger.as_str()),
+            ("claim", challenge.claim.as_str()),
+            ("challenge", challenge.challenge.as_str()),
+        ] {
+            if value.trim().is_empty() {
+                errors.push(ValidationError::new(
+                    ValidationErrorKind::BlankPeerChallengeField {
+                        challenge_id: challenge.challenge_id.clone(),
+                        field: field.to_string(),
+                    },
+                ));
+            }
+        }
+    }
+}
+
 fn check_verdict_present(bundle: &CollaborationProofBundle, errors: &mut Vec<ValidationError>) {
     if bundle.verdict.is_none() {
         errors.push(ValidationError::new(ValidationErrorKind::MissingVerdict));
@@ -239,8 +327,8 @@ mod tests {
     use super::*;
     use crate::circle::{
         BudgetSnapshot, CollaborationProofBundle, CollaborationVerdictRecord, ExecutionReceipt,
-        LineageEdge, LineageRelation, MetricRef, ProofBundleEntry, ProofBundleMember,
-        ReceiptOutcome, VerdictType,
+        LineageEdge, LineageRelation, MetricRef, PeerChallenge, PeerChallengeDisposition,
+        PeerChallengeSeverity, ProofBundleEntry, ProofBundleMember, ReceiptOutcome, VerdictType,
     };
 
     // -----------------------------------------------------------------
@@ -420,6 +508,7 @@ mod tests {
                     cost_tokens: None,
                 },
             ],
+            peer_challenges: vec![],
             verdict: Some(CollaborationVerdictRecord {
                 reviewer: "referee_local_gemma".into(),
                 timestamp: ts("2026-06-29T15:07:41Z"),
@@ -647,6 +736,127 @@ mod tests {
                 ValidationErrorKind::ReceiptProviderEvidenceMismatch { entry_id: 1, .. }
             )),
             "expected receipt/provider evidence mismatch when receipt omits provider"
+        );
+    }
+
+    #[test]
+    fn peer_challenge_to_nonexistent_entry_fails() {
+        let mut bundle = mixed_provider_fixture();
+        bundle.peer_challenges.push(PeerChallenge {
+            challenge_id: "challenge_missing_target".into(),
+            challenger: "critic_minimax".into(),
+            target_entry_id: 999,
+            claim: "Builder output is fully grounded.".into(),
+            challenge: "Target entry is not present in the bundle.".into(),
+            evidence: vec!["test fixture".into()],
+            severity: PeerChallengeSeverity::Blocking,
+            response_by: None,
+            disposition: PeerChallengeDisposition::Open,
+        });
+        let errors = validate_proof_bundle(&bundle).unwrap_err();
+        assert!(
+            errors.iter().any(|e| matches!(
+                e.kind,
+                ValidationErrorKind::BrokenPeerChallengeRef {
+                    target_entry_id: 999,
+                    ..
+                }
+            )),
+            "expected BrokenPeerChallengeRef for target_entry_id=999"
+        );
+    }
+
+    #[test]
+    fn duplicate_peer_challenge_id_fails() {
+        let mut bundle = mixed_provider_fixture();
+        bundle.peer_challenges.push(PeerChallenge {
+            challenge_id: "challenge_duplicate".into(),
+            challenger: "critic_minimax".into(),
+            target_entry_id: 2,
+            claim: "Builder output is fully grounded.".into(),
+            challenge: "First challenge with this id.".into(),
+            evidence: vec!["test fixture".into()],
+            severity: PeerChallengeSeverity::High,
+            response_by: Some("referee_local_gemma".into()),
+            disposition: PeerChallengeDisposition::Open,
+        });
+        bundle.peer_challenges.push(PeerChallenge {
+            challenge_id: "challenge_duplicate".into(),
+            challenger: "specifier_minimax".into(),
+            target_entry_id: 3,
+            claim: "Critic output is fully grounded.".into(),
+            challenge: "Second challenge with conflicting content but same id.".into(),
+            evidence: vec!["test fixture".into()],
+            severity: PeerChallengeSeverity::Medium,
+            response_by: Some("referee_local_gemma".into()),
+            disposition: PeerChallengeDisposition::Resolved,
+        });
+        let errors = validate_proof_bundle(&bundle).unwrap_err();
+        assert!(
+            errors.iter().any(|e| matches!(
+                e.kind,
+                ValidationErrorKind::DuplicatePeerChallengeId { ref challenge_id }
+                    if challenge_id == "challenge_duplicate"
+            )),
+            "expected DuplicatePeerChallengeId for challenge_duplicate"
+        );
+    }
+
+    #[test]
+    fn peer_challenge_unknown_actor_fails() {
+        let mut bundle = mixed_provider_fixture();
+        bundle.peer_challenges.push(PeerChallenge {
+            challenge_id: "challenge_unknown_actor".into(),
+            challenger: "invented_critic".into(),
+            target_entry_id: 2,
+            claim: "Builder output is fully grounded.".into(),
+            challenge: "Challenger must be a real run participant.".into(),
+            evidence: vec!["test fixture".into()],
+            severity: PeerChallengeSeverity::High,
+            response_by: Some("invented_referee".into()),
+            disposition: PeerChallengeDisposition::Open,
+        });
+        let errors = validate_proof_bundle(&bundle).unwrap_err();
+        assert!(
+            errors.iter().any(|e| matches!(
+                e.kind,
+                ValidationErrorKind::UnknownPeerChallengeActor { ref field, ref actor, .. }
+                    if field == "challenger" && actor == "invented_critic"
+            )),
+            "expected UnknownPeerChallengeActor for challenger"
+        );
+        assert!(
+            errors.iter().any(|e| matches!(
+                e.kind,
+                ValidationErrorKind::UnknownPeerChallengeActor { ref field, ref actor, .. }
+                    if field == "response_by" && actor == "invented_referee"
+            )),
+            "expected UnknownPeerChallengeActor for response_by"
+        );
+    }
+
+    #[test]
+    fn blank_peer_challenge_claim_fails() {
+        let mut bundle = mixed_provider_fixture();
+        bundle.peer_challenges.push(PeerChallenge {
+            challenge_id: "challenge_blank_claim".into(),
+            challenger: "critic_minimax".into(),
+            target_entry_id: 2,
+            claim: " ".into(),
+            challenge: "The disputed claim must be explicit.".into(),
+            evidence: vec![],
+            severity: PeerChallengeSeverity::High,
+            response_by: Some("referee_local_gemma".into()),
+            disposition: PeerChallengeDisposition::Open,
+        });
+        let errors = validate_proof_bundle(&bundle).unwrap_err();
+        assert!(
+            errors.iter().any(|e| matches!(
+                e.kind,
+                ValidationErrorKind::BlankPeerChallengeField { ref field, .. }
+                    if field == "claim"
+            )),
+            "expected BlankPeerChallengeField for claim"
         );
     }
 


### PR DESCRIPTION
## Summary
- add `sera circle run` as a first-class capture -> replay -> validate -> prove wrapper over configured Circle run specs
- add structured `peer_challenges` proof-bundle objects and deterministic validation for target refs / blank fields
- preserve replay/validate offline config-bypass behavior with machine-parseable `circle-run` footers

## Verification
- `cargo test -p sera-types circle_validator -- --nocapture`
- `cargo test -p sera-types proof_bundle -- --nocapture`
- `cargo test -p sera-cli circle_ -- --nocapture`
- `cargo check -p sera-cli`
- manual `sera circle run --spec ... --capture-dir ... --bundle-out ... --json` smoke: PASS, entries=4, receipts=4, peer_challenges=1

## Notes
This is the thinnest deterministic runner seam: it materializes configured role outputs into captured fixtures, reuses the existing replay bundle builder, validates the generated proof bundle, and emits a run footer/hash. Live provider execution can layer on this seam next without weakening offline proof determinism.