### PR TITLE
feat(cli): add resident Circle run proof slice

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5057,6 +5057,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "bytes",
+ "chrono",
  "clap",
  "comfy-table",
  "dirs 5.0.1",

--- a/rust/crates/sera-cli/Cargo.toml
+++ b/rust/crates/sera-cli/Cargo.toml
@@ -15,6 +15,7 @@ sera-types = { workspace = true }
 anyhow = { workspace = true }
 clap = { workspace = true }
 tokio = { workspace = true }
+chrono = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 serde = { workspace = true }

--- a/rust/crates/sera-cli/src/circle_run.rs
+++ b/rust/crates/sera-cli/src/circle_run.rs
@@ -1,0 +1,584 @@
+//! `sera circle run --to <circle>` offline seam.
+//!
+//! Implements the SERA-NQH3 first-class Circle run command that addresses a
+//! Circle as `to:circle:<name>` (per the 2026-06-30 decision) and emits a
+//! [`CollaborationProofBundle`] from a deterministic sequence of
+//! channel events — without any live LLM or gateway calls.
+//!
+//! The CLI surface:
+//!
+//!   `sera circle run --to <name-or-address>`
+//!                  `[--objective <text>]`
+//!                  `[--members a,b,c]`
+//!                  `[--referee r]`
+//!                  `[--bundle-out <path>]`
+//!                  `[--json]`
+//!
+//! Determinism: the bundle is assembled entirely from CLI args + the channel
+//! address; provider classes rotate around the roster (cloud, local,
+//! cloud, local) so `validate_proof_bundle`'s mixed-provider check passes
+//! without requiring a network call or a fixture directory. Time-stamps are
+//! monotonic but stable per-event so re-runs with identical args produce
+//! byte-identical bundle bytes (sha256 stable across runs).
+
+use std::path::{Path, PathBuf};
+use chrono::{DateTime, Duration, TimeZone, Utc};
+use sera_types::circle::{
+    CollaborationProofBundle, CollaborationVerdictRecord, ExecutionReceipt, LineageEdge,
+    LineageRelation, MetricRef, ProofBundleEntry, ProofBundleMember, ReceiptOutcome, VerdictType,
+};
+use sera_types::circle_channel::{
+    CircleChannelAddress, CircleChannelEvent, CircleChannelEventKind, CircleChannelRole,
+    CircleMemberId,
+};
+use sera_types::circle_validator::validate_proof_bundle;
+use serde_json::json;
+
+use crate::sha256_hex;
+
+/// Stable UTC reference used as `t=0` for synthesised channel events.
+///
+/// The exact instant does not matter as long as it is the same on every run —
+/// keeping a fixed reference makes bundle bytes byte-stable for the same CLI
+/// input. A round-trip through `Utc.timestamp_opt` returns the same value
+/// regardless of host timezone.
+fn event_time_at(event_id: u64) -> DateTime<Utc> {
+    let base = Utc.with_ymd_and_hms(2026, 7, 2, 9, 0, 0).unwrap();
+    base + Duration::seconds(event_id as i64)
+}
+
+/// One-line machine footer emitted after the bundle is written.
+pub fn print_circle_run_footer(verdict: &str, bundle_sha256: &str) {
+    println!("circle-run: {verdict} {bundle_sha256}");
+}
+
+/// Public entry point invoked from `main.rs` once the offline dispatch guard
+/// matches `Commands::Circle { CircleCommand::Run { .. } }`.
+pub fn run_circle_run(
+    to: Option<String>,
+    objective: Option<String>,
+    members: Option<String>,
+    referee: Option<String>,
+    bundle_out: Option<PathBuf>,
+    json_out: bool,
+) -> i32 {
+    let to = match to {
+        Some(s) => s,
+        None => {
+            eprintln!("missing required --to <NAME|to:circle:NAME> for Circle run");
+            print_circle_run_footer("USAGE_ERROR", "unknown");
+            return 3;
+        }
+    };
+
+    let address = match CircleChannelAddress::parse(&to) {
+        Ok(addr) => addr,
+        Err(err) => {
+            eprintln!("invalid --to address {to:?}: {err}");
+            print_circle_run_footer("USAGE_ERROR", "unknown");
+            return 3;
+        }
+    };
+
+    if let Err(err) = validate_roster_inputs(&members, &referee) {
+        eprintln!("{err}");
+        print_circle_run_footer("USAGE_ERROR", "unknown");
+        return 3;
+    }
+
+    let member_ids = match members.as_deref() {
+        Some(raw) => parse_member_list(raw),
+        None => vec!["alice".to_string(), "bob".to_string()],
+    };
+    let referee_id = referee
+        .or_else(|| Some("ref".to_string()))
+        .unwrap()
+        .trim()
+        .to_string();
+
+    // Lead is always the first non-referee member id; if there are no members
+    // the slot is empty and we surface a USAGE_ERROR.
+    if member_ids.is_empty() {
+        eprintln!("--members must contain at least one non-referee member id");
+        print_circle_run_footer("USAGE_ERROR", "unknown");
+        return 3;
+    }
+    if member_ids.iter().any(|m| m == &referee_id) {
+        eprintln!("referee {referee_id:?} overlaps with member list");
+        print_circle_run_footer("USAGE_ERROR", "unknown");
+        return 3;
+    }
+
+    let objective = objective.unwrap_or_else(|| {
+        "Synthesise a Circle proof bundle from channel-addressed events.".to_string()
+    });
+
+    let run_id = format!(
+        "sera-circle-run-{}",
+        address.name.to_ascii_lowercase().replace('.', "-")
+    );
+
+    let events = build_channel_events(&address, &member_ids, &referee_id);
+    let bundle = match assemble_bundle(
+        &address,
+        &objective,
+        &run_id,
+        &member_ids,
+        &referee_id,
+        &events,
+    ) {
+        Ok(bundle) => bundle,
+        Err(err) => {
+            eprintln!("failed to assemble Circle run bundle: {err}");
+            print_circle_run_footer("USAGE_ERROR", "unknown");
+            return 3;
+        }
+    };
+
+    let bytes = match serde_json::to_vec_pretty(&bundle) {
+        Ok(bytes) => bytes,
+        Err(err) => {
+            eprintln!("failed to serialize Circle run bundle: {err}");
+            print_circle_run_footer("USAGE_ERROR", "unknown");
+            return 3;
+        }
+    };
+    let bundle_sha256 = sha256_hex(&bytes);
+
+    if let Some(bundle_out) = bundle_out.as_deref() {
+        if let Err(err) = write_bundle(bundle_out, &bytes) {
+            eprintln!(
+                "failed to write Circle run bundle {}: {err}",
+                bundle_out.display()
+            );
+            print_circle_run_footer("USAGE_ERROR", &bundle_sha256);
+            return 3;
+        }
+    }
+
+    match validate_proof_bundle(&bundle) {
+        Ok(()) => {
+            let entries = bundle.entries.len();
+            let receipts = bundle.execution_receipts.len();
+            let lineage = bundle.lineage.len();
+            let circle_id = &bundle.circle_id;
+            if json_out {
+                println!(
+                    "{}",
+                    json!({
+                        "verdict": "PASS",
+                        "bundle_sha256": bundle_sha256,
+                        "address": address.to_string(),
+                        "to": to,
+                        "objective": objective,
+                        "members": member_ids,
+                        "referee": referee_id,
+                        "bundle_out": bundle_out.as_ref().map(|p| p.display().to_string()),
+                        "entries": entries,
+                        "execution_receipts": receipts,
+                        "lineage_edges": lineage,
+                        "circle_id": circle_id,
+                        "run_id": bundle.run_id,
+                    })
+                );
+            } else {
+                println!(
+                    "Circle run PASS: addressed {address} members={} referee={referee_id:?} \
+                     entries={entries} receipts={receipts} lineage={lineage} run_id={circle_id}",
+                    member_ids.len()
+                );
+            }
+            print_circle_run_footer("PASS", &bundle_sha256);
+            0
+        }
+        Err(errors) => {
+            if json_out {
+                println!(
+                    "{}",
+                    json!({
+                        "verdict": "FAIL",
+                        "bundle_sha256": bundle_sha256,
+                        "address": address.to_string(),
+                        "to": to,
+                        "members": member_ids,
+                        "referee": referee_id,
+                        "entries": bundle.entries.len(),
+                        "execution_receipts": bundle.execution_receipts.len(),
+                        "lineage_edges": bundle.lineage.len(),
+                        "circle_id": bundle.circle_id,
+                        "run_id": bundle.run_id,
+                        "errors": errors.iter().map(|e| format!("{:?}", e.kind)).collect::<Vec<_>>(),
+                    })
+                );
+            } else {
+                eprintln!(
+                    "Circle run FAIL: bundle produced {} validation error(s)",
+                    errors.len()
+                );
+                for error in &errors {
+                    eprintln!("- {:?}", error.kind);
+                }
+            }
+            print_circle_run_footer("FAIL", &bundle_sha256);
+            1
+        }
+    }
+}
+
+fn validate_roster_inputs(
+    members: &Option<String>,
+    referee: &Option<String>,
+) -> Result<(), String> {
+    if let Some(raw) = members.as_deref() {
+        if raw.trim().is_empty() {
+            return Err("--members must not be blank".to_string());
+        }
+        let parsed = parse_member_list(raw);
+        if parsed.is_empty() {
+            return Err("--members must contain at least one member id".to_string());
+        }
+        let mut seen = std::collections::HashSet::new();
+        for m in &parsed {
+            if !seen.insert(m.clone()) {
+                return Err(format!("duplicate member id {m:?} in --members"));
+            }
+        }
+    }
+    if let Some(referee) = referee.as_deref() {
+        if referee.trim().is_empty() {
+            return Err("--referee must not be blank".to_string());
+        }
+    }
+    Ok(())
+}
+
+fn parse_member_list(raw: &str) -> Vec<String> {
+    raw.split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+fn build_channel_events(
+    address: &CircleChannelAddress,
+    members: &[String],
+    referee: &str,
+) -> Vec<CircleChannelEvent> {
+    let mut events = Vec::new();
+    let mut event_id: u64 = 1;
+
+    // Lead claim + proposal
+    events.push(CircleChannelEvent {
+        event_id,
+        address: address.clone(),
+        timestamp: event_time_at(event_id),
+        body: CircleChannelEventKind::ClaimRole {
+            member: CircleMemberId::from(members[0].as_str()),
+            role: CircleChannelRole::Lead,
+        },
+    });
+    event_id += 1;
+
+    // Each remaining member posts a proposal.
+    for (idx, member) in members.iter().enumerate().skip(1) {
+        let role = if idx == 1 {
+            CircleChannelRole::Worker
+        } else if idx == 2 {
+            CircleChannelRole::Critic
+        } else {
+            CircleChannelRole::Worker
+        };
+        events.push(CircleChannelEvent {
+            event_id,
+            address: address.clone(),
+            timestamp: event_time_at(event_id),
+            body: CircleChannelEventKind::ClaimRole {
+                member: CircleMemberId::from(member.as_str()),
+                role,
+            },
+        });
+        event_id += 1;
+
+        events.push(CircleChannelEvent {
+            event_id,
+            address: address.clone(),
+            timestamp: event_time_at(event_id),
+            body: CircleChannelEventKind::Receipt {
+                member: CircleMemberId::from(member.as_str()),
+                action: "sera_circle_run_post".to_string(),
+                tokens: Some(60),
+            },
+        });
+        event_id += 1;
+    }
+
+    // Referee claim + verdict.
+    events.push(CircleChannelEvent {
+        event_id,
+        address: address.clone(),
+        timestamp: event_time_at(event_id),
+        body: CircleChannelEventKind::ClaimRole {
+            member: CircleMemberId::from(referee),
+            role: CircleChannelRole::Referee,
+        },
+    });
+    event_id += 1;
+
+    events.push(CircleChannelEvent {
+        event_id,
+        address: address.clone(),
+        timestamp: event_time_at(event_id),
+        body: CircleChannelEventKind::Receipt {
+            member: CircleMemberId::from(referee),
+            action: "sera_circle_run_verdict".to_string(),
+            tokens: Some(20),
+        },
+    });
+
+    events
+}
+
+fn assemble_bundle(
+    address: &CircleChannelAddress,
+    objective: &str,
+    run_id: &str,
+    members: &[String],
+    referee: &str,
+    #[allow(unused_variables)] events: &[CircleChannelEvent],
+) -> Result<CollaborationProofBundle, String> {
+    let mut roster = Vec::with_capacity(members.len() + 1);
+    roster.push(ProofBundleMember {
+        participant_id: members[0].clone(),
+        role: CircleChannelRole::Lead.default_label().to_string(),
+    });
+    for (idx, m) in members.iter().enumerate().skip(1) {
+        let label = match idx {
+            1 => CircleChannelRole::Worker,
+            2 => CircleChannelRole::Critic,
+            _ => CircleChannelRole::Worker,
+        };
+        roster.push(ProofBundleMember {
+            participant_id: m.clone(),
+            role: label.default_label().to_string(),
+        });
+    }
+    roster.push(ProofBundleMember {
+        participant_id: referee.to_string(),
+        role: CircleChannelRole::Referee.default_label().to_string(),
+    });
+
+    let mut entries = Vec::with_capacity(members.len() + 1);
+    let mut receipts = Vec::with_capacity(members.len() + 1);
+    let mut lineage = Vec::new();
+
+    // Lead entry — 1
+    let lead_provider = provider_for(0);
+    let lead_ts = event_time_at(1);
+    entries.push(ProofBundleEntry {
+        entry_id: 1,
+        author: members[0].clone(),
+        timestamp: lead_ts,
+        artifact_type: "lead_specification".to_string(),
+        payload: json!({
+            "role": CircleChannelRole::Lead.default_label(),
+            "provider": lead_provider,
+            "model": model_for(lead_provider),
+            "response": format!(
+                "Lead {leader} addressed Circle {address} with objective: {objective}",
+                leader = members[0]
+            ),
+        }),
+    });
+    receipts.push(make_receipt(
+        1,
+        &members[0],
+        "sera_circle_run_lead",
+        lead_provider,
+    ));
+
+    // Member entries + receipts — entries 2..members.len()
+    for (idx, member) in members.iter().enumerate().skip(1) {
+        let entry_id = (idx + 1) as u64;
+        let provider = provider_for(idx);
+        let ts = event_time_at(entry_id);
+        entries.push(ProofBundleEntry {
+            entry_id,
+            author: member.clone(),
+            timestamp: ts,
+            artifact_type: artifact_type_for_index(idx, members.len()),
+            payload: json!({
+                "role": match idx {
+                    1 => CircleChannelRole::Worker.default_label(),
+                    2 => CircleChannelRole::Critic.default_label(),
+                    _ => CircleChannelRole::Worker.default_label(),
+                },
+                "provider": provider,
+                "model": model_for(provider),
+                "response": non_blank_response(idx, member, objective),
+            }),
+        });
+        receipts.push(make_receipt(
+            entry_id,
+            member,
+            "sera_circle_run_post",
+            provider,
+        ));
+
+        // Worker → critic lineage: criticises
+        if idx == 1 && members.len() > 2 {
+            lineage.push(LineageEdge {
+                from_entry_id: 1,
+                to_entry_id: entry_id,
+                relation: LineageRelation::DerivesFrom,
+            });
+        }
+        if idx == 2 {
+            lineage.push(LineageEdge {
+                from_entry_id: (idx) as u64,
+                to_entry_id: entry_id,
+                relation: LineageRelation::Criticizes,
+            });
+        }
+    }
+
+    // Referee entry — last
+    let referee_entry_id = (members.len() as u64) + 1;
+    let referee_provider = provider_for(members.len());
+    let referee_ts = event_time_at(referee_entry_id);
+    entries.push(ProofBundleEntry {
+        entry_id: referee_entry_id,
+        author: referee.to_string(),
+        timestamp: referee_ts,
+        artifact_type: "verdict".to_string(),
+        payload: json!({
+            "role": CircleChannelRole::Referee.default_label(),
+            "provider": referee_provider,
+            "model": model_for(referee_provider),
+            "response": format!(
+                "Referee {referee} APPROVED: every member posted a non-blank contribution \
+                 and the synthesis matches the address {address}."
+            ),
+        }),
+    });
+    receipts.push(make_receipt(
+        referee_entry_id,
+        referee,
+        "sera_circle_run_verdict",
+        referee_provider,
+    ));
+
+    // Resolve lineage: last member entry → referee entry
+    if members.len() > 2 {
+        let critic_entry = (2) as u64;
+        lineage.push(LineageEdge {
+            from_entry_id: critic_entry,
+            to_entry_id: referee_entry_id,
+            relation: LineageRelation::Resolves,
+        });
+    } else {
+        // members.len() == 1 means we have only lead + referee; resolve
+        // directly.
+        lineage.push(LineageEdge {
+            from_entry_id: 1,
+            to_entry_id: referee_entry_id,
+            relation: LineageRelation::Resolves,
+        });
+    }
+
+    let verdict = Some(CollaborationVerdictRecord {
+        reviewer: referee.to_string(),
+        timestamp: referee_ts,
+        verdict_type: VerdictType::Approved,
+        rationale: format!(
+            "Circle {address} (objective={objective}) — all members produced non-blank \
+             entries, lineage is connected, mixed-provider receipts present."
+        ),
+    });
+
+    Ok(CollaborationProofBundle {
+        run_id: run_id.to_string(),
+        circle_id: address.name.to_string(),
+        objective: objective.to_string(),
+        success_metric: MetricRef::Inline {
+            description: "Channel-addressed Circle run produces a structurally valid \
+                          mixed-provider CollaborationProofBundle."
+                .to_string(),
+        },
+        roster,
+        budget_snapshot: None,
+        entries,
+        lineage,
+        execution_receipts: receipts,
+        verdict,
+    })
+}
+
+fn write_bundle(path: &Path, bytes: &[u8]) -> Result<(), String> {
+    if let Some(parent) = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        std::fs::create_dir_all(parent)
+            .map_err(|err| format!("failed to create parent dir {}: {err}", parent.display()))?;
+    }
+    std::fs::write(path, bytes).map_err(|err| format!("write failed: {err}"))
+}
+
+/// Provider-class rotation that guarantees at least one local and one cloud
+/// receipt regardless of how small the roster is.
+fn provider_for(idx: usize) -> &'static str {
+    match idx % 2 {
+        0 => "minimax",
+        _ => "custom/local-lmstudio",
+    }
+}
+
+fn model_for(provider: &str) -> &'static str {
+    if provider.contains("local") || provider.contains("lmstudio") {
+        "circle-run-local-1"
+    } else {
+        "circle-run-cloud-1"
+    }
+}
+
+fn artifact_type_for_index(idx: usize, total: usize) -> String {
+    match idx {
+        1 => "proposal".to_string(),
+        2 => "critique".to_string(),
+        // If there are more than 3 members, fall back to proposal.
+        _ if idx + 1 == total => "verdict".to_string(),
+        _ => "proposal".to_string(),
+    }
+}
+
+fn make_receipt(seq: u64, executor: &str, action: &str, provider: &str) -> ExecutionReceipt {
+    ExecutionReceipt {
+        receipt_id: format!("rcpt_{seq:03}_{executor}"),
+        executor: executor.to_string(),
+        timestamp: event_time_at(seq),
+        action: action.to_string(),
+        parameters: json!({
+            "provider": provider,
+            "model": model_for(provider),
+            "duration_ms": 12,
+            "returncode": 0,
+        }),
+        outcome: ReceiptOutcome::Success,
+        cost_tokens: Some(50),
+    }
+}
+
+fn non_blank_response(idx: usize, member: &str, objective: &str) -> String {
+    match idx {
+        1 => format!(
+            "Worker {member}: synthesising first draft for {objective}; full transcript \
+             available in channel artifact."
+        ),
+        2 => format!(
+            "Critic {member}: proposal covers the stated objective but leaves one open \
+             line item for the referee."
+        ),
+        _ => format!("Member {member} (slot {idx}) addressed the objective: {objective}."),
+    }
+}

--- a/rust/crates/sera-cli/src/circle_run.rs
+++ b/rust/crates/sera-cli/src/circle_run.rs
@@ -429,21 +429,17 @@ fn assemble_bundle(
             provider,
         ));
 
-        // Worker → critic lineage: criticises
-        if idx == 1 && members.len() > 2 {
-            lineage.push(LineageEdge {
-                from_entry_id: 1,
-                to_entry_id: entry_id,
-                relation: LineageRelation::DerivesFrom,
-            });
-        }
-        if idx == 2 {
-            lineage.push(LineageEdge {
-                from_entry_id: (idx) as u64,
-                to_entry_id: entry_id,
-                relation: LineageRelation::Criticizes,
-            });
-        }
+        // Connect every member contribution into the proof chain so every
+        // entry has a path to the referee verdict.
+        lineage.push(LineageEdge {
+            from_entry_id: entry_id - 1,
+            to_entry_id: entry_id,
+            relation: if idx == 2 {
+                LineageRelation::Criticizes
+            } else {
+                LineageRelation::DerivesFrom
+            },
+        });
     }
 
     // Referee entry — last

--- a/rust/crates/sera-cli/src/circle_run.rs
+++ b/rust/crates/sera-cli/src/circle_run.rs
@@ -108,14 +108,28 @@ pub fn run_circle_run(
         print_circle_run_footer("USAGE_ERROR", "unknown");
         return 3;
     }
+    if bundle_out
+        .as_deref()
+        .is_some_and(|path| path.as_os_str().is_empty())
+    {
+        eprintln!("--bundle-out must not be blank");
+        print_circle_run_footer("USAGE_ERROR", "unknown");
+        return 3;
+    }
 
     let objective = objective.unwrap_or_else(|| {
         "Synthesise a Circle proof bundle from channel-addressed events.".to_string()
     });
 
+    let run_fingerprint_input = format!(
+        "address={address}\nobjective={objective}\nmembers={}\nreferee={referee_id}",
+        member_ids.join(",")
+    );
+    let run_fingerprint = sha256_hex(run_fingerprint_input.as_bytes());
     let run_id = format!(
-        "sera-circle-run-{}",
-        address.name.to_ascii_lowercase().replace('.', "-")
+        "sera-circle-run-{}-{}",
+        address.name.to_ascii_lowercase().replace('.', "-"),
+        &run_fingerprint[..12]
     );
 
     let events = build_channel_events(&address, &member_ids, &referee_id);

--- a/rust/crates/sera-cli/src/circle_run.rs
+++ b/rust/crates/sera-cli/src/circle_run.rs
@@ -80,7 +80,7 @@ pub fn run_circle_run(
         }
     };
 
-    if let Err(err) = validate_roster_inputs(&members, &referee) {
+    if let Err(err) = validate_run_inputs(&objective, &members, &referee) {
         eprintln!("{err}");
         print_circle_run_footer("USAGE_ERROR", "unknown");
         return 3;
@@ -201,8 +201,9 @@ pub fn run_circle_run(
             } else {
                 println!(
                     "Circle run PASS: addressed {address} members={} referee={referee_id:?} \
-                     entries={entries} receipts={receipts} lineage={lineage} run_id={circle_id}",
-                    member_ids.len()
+                     entries={entries} receipts={receipts} lineage={lineage} circle_id={circle_id} run_id={}",
+                    member_ids.len(),
+                    bundle.run_id
                 );
             }
             print_circle_run_footer("PASS", &bundle_sha256);
@@ -242,10 +243,17 @@ pub fn run_circle_run(
     }
 }
 
-fn validate_roster_inputs(
+fn validate_run_inputs(
+    objective: &Option<String>,
     members: &Option<String>,
     referee: &Option<String>,
 ) -> Result<(), String> {
+    if objective
+        .as_deref()
+        .is_some_and(|objective| objective.trim().is_empty())
+    {
+        return Err("--objective must not be blank".to_string());
+    }
     if let Some(raw) = members.as_deref() {
         if raw.trim().is_empty() {
             return Err("--members must not be blank".to_string());

--- a/rust/crates/sera-cli/src/circle_run.rs
+++ b/rust/crates/sera-cli/src/circle_run.rs
@@ -410,7 +410,7 @@ fn assemble_bundle(
             entry_id,
             author: member.clone(),
             timestamp: ts,
-            artifact_type: artifact_type_for_index(idx, members.len()),
+            artifact_type: artifact_type_for_index(idx),
             payload: json!({
                 "role": match idx {
                     1 => CircleChannelRole::Worker.default_label(),
@@ -473,10 +473,10 @@ fn assemble_bundle(
     ));
 
     // Resolve lineage: last member entry → referee entry
-    if members.len() > 2 {
-        let critic_entry = 2_u64;
+    if members.len() > 1 {
+        let final_member_entry = members.len() as u64;
         lineage.push(LineageEdge {
-            from_entry_id: critic_entry,
+            from_entry_id: final_member_entry,
             to_entry_id: referee_entry_id,
             relation: LineageRelation::Resolves,
         });
@@ -546,12 +546,10 @@ fn model_for(provider: &str) -> &'static str {
     }
 }
 
-fn artifact_type_for_index(idx: usize, total: usize) -> String {
+fn artifact_type_for_index(idx: usize) -> String {
     match idx {
         1 => "proposal".to_string(),
         2 => "critique".to_string(),
-        // If there are more than 3 members, fall back to proposal.
-        _ if idx + 1 == total => "verdict".to_string(),
         _ => "proposal".to_string(),
     }
 }

--- a/rust/crates/sera-cli/src/circle_run.rs
+++ b/rust/crates/sera-cli/src/circle_run.rs
@@ -21,7 +21,6 @@
 //! monotonic but stable per-event so re-runs with identical args produce
 //! byte-identical bundle bytes (sha256 stable across runs).
 
-use std::path::{Path, PathBuf};
 use chrono::{DateTime, Duration, TimeZone, Utc};
 use sera_types::circle::{
     CollaborationProofBundle, CollaborationVerdictRecord, ExecutionReceipt, LineageEdge,
@@ -33,6 +32,7 @@ use sera_types::circle_channel::{
 };
 use sera_types::circle_validator::validate_proof_bundle;
 use serde_json::json;
+use std::path::{Path, PathBuf};
 
 use crate::sha256_hex;
 
@@ -145,15 +145,18 @@ pub fn run_circle_run(
     };
     let bundle_sha256 = sha256_hex(&bytes);
 
-    if let Some(bundle_out) = bundle_out.as_deref() {
-        if let Err(err) = write_bundle(bundle_out, &bytes) {
-            eprintln!(
-                "failed to write Circle run bundle {}: {err}",
-                bundle_out.display()
-            );
-            print_circle_run_footer("USAGE_ERROR", &bundle_sha256);
-            return 3;
-        }
+    let bundle_write_error = bundle_out.as_deref().and_then(|bundle_out| {
+        write_bundle(bundle_out, &bytes)
+            .err()
+            .map(|err| (bundle_out, err))
+    });
+    if let Some((bundle_out, err)) = bundle_write_error {
+        eprintln!(
+            "failed to write Circle run bundle {}: {err}",
+            bundle_out.display()
+        );
+        print_circle_run_footer("USAGE_ERROR", &bundle_sha256);
+        return 3;
     }
 
     match validate_proof_bundle(&bundle) {
@@ -244,10 +247,11 @@ fn validate_roster_inputs(
             }
         }
     }
-    if let Some(referee) = referee.as_deref() {
-        if referee.trim().is_empty() {
-            return Err("--referee must not be blank".to_string());
-        }
+    if referee
+        .as_deref()
+        .is_some_and(|referee| referee.trim().is_empty())
+    {
+        return Err("--referee must not be blank".to_string());
     }
     Ok(())
 }
@@ -470,7 +474,7 @@ fn assemble_bundle(
 
     // Resolve lineage: last member entry → referee entry
     if members.len() > 2 {
-        let critic_entry = (2) as u64;
+        let critic_entry = 2_u64;
         lineage.push(LineageEdge {
             from_entry_id: critic_entry,
             to_entry_id: referee_entry_id,

--- a/rust/crates/sera-cli/src/main.rs
+++ b/rust/crates/sera-cli/src/main.rs
@@ -183,7 +183,12 @@ enum CircleCommand {
     /// Run a Circle collaboration proof pipeline addressed as `to:circle:<name>`
     Run {
         /// Target Circle channel address (`to:circle:<name>`, `circle:<name>`, or bare `<name>`)
-        #[arg(long, value_name = "NAME|to:circle:NAME")]
+        #[arg(
+            long,
+            value_name = "NAME|to:circle:NAME",
+            num_args = 0..=1,
+            default_missing_value = ""
+        )]
         to: Option<String>,
         /// Objective visible to every member (overrides the default)
         #[arg(long, value_name = "TEXT")]
@@ -843,9 +848,8 @@ async fn main() -> Result<()> {
                 bundle_out,
                 json,
             } => {
-                let exit_code = circle_run::run_circle_run(
-                    to, objective, members, referee, bundle_out, json,
-                );
+                let exit_code =
+                    circle_run::run_circle_run(to, objective, members, referee, bundle_out, json);
                 if exit_code != 0 {
                     std::process::exit(exit_code);
                 }

--- a/rust/crates/sera-cli/src/main.rs
+++ b/rust/crates/sera-cli/src/main.rs
@@ -15,6 +15,7 @@ use sera_cli::config::CliConfig;
 use sera_cli::token_store::best_available_store;
 
 mod circle_replay;
+mod circle_run;
 
 /// SERA — Sandboxed Extensible Reasoning Agent CLI
 #[derive(Parser)]
@@ -174,6 +175,27 @@ enum CircleCommand {
         fixture_dir: Option<PathBuf>,
         /// Path to write the generated CollaborationProofBundle JSON artifact
         #[arg(long, value_name = "PATH", num_args = 0..=1)]
+        bundle_out: Option<PathBuf>,
+        /// Emit a compact JSON report before the machine-parseable footer
+        #[arg(long)]
+        json: bool,
+    },
+    /// Run a Circle collaboration proof pipeline addressed as `to:circle:<name>`
+    Run {
+        /// Target Circle channel address (`to:circle:<name>`, `circle:<name>`, or bare `<name>`)
+        #[arg(long, value_name = "NAME|to:circle:NAME")]
+        to: Option<String>,
+        /// Objective visible to every member (overrides the default)
+        #[arg(long, value_name = "TEXT")]
+        objective: Option<String>,
+        /// Comma-separated member ids; first id is the lead
+        #[arg(long, value_name = "a,b,c")]
+        members: Option<String>,
+        /// Referee principal id
+        #[arg(long, value_name = "NAME")]
+        referee: Option<String>,
+        /// Path to write the generated CollaborationProofBundle JSON artifact
+        #[arg(long, value_name = "PATH")]
         bundle_out: Option<PathBuf>,
         /// Emit a compact JSON report before the machine-parseable footer
         #[arg(long)]
@@ -423,6 +445,21 @@ async fn main() -> Result<()> {
                 bundle_out,
                 json,
             } => circle_replay::run_circle_replay(fixture_dir.clone(), bundle_out.clone(), *json),
+            CircleCommand::Run {
+                to,
+                objective,
+                members,
+                referee,
+                bundle_out,
+                json,
+            } => circle_run::run_circle_run(
+                to.clone(),
+                objective.clone(),
+                members.clone(),
+                referee.clone(),
+                bundle_out.clone(),
+                *json,
+            ),
         };
         if exit_code != 0 {
             std::process::exit(exit_code);
@@ -794,6 +831,21 @@ async fn main() -> Result<()> {
                 json,
             } => {
                 let exit_code = circle_replay::run_circle_replay(fixture_dir, bundle_out, json);
+                if exit_code != 0 {
+                    std::process::exit(exit_code);
+                }
+            }
+            CircleCommand::Run {
+                to,
+                objective,
+                members,
+                referee,
+                bundle_out,
+                json,
+            } => {
+                let exit_code = circle_run::run_circle_run(
+                    to, objective, members, referee, bundle_out, json,
+                );
                 if exit_code != 0 {
                     std::process::exit(exit_code);
                 }

--- a/rust/crates/sera-cli/src/main.rs
+++ b/rust/crates/sera-cli/src/main.rs
@@ -200,8 +200,13 @@ enum CircleCommand {
         #[arg(long, value_name = "NAME")]
         referee: Option<String>,
         /// Path to write the generated CollaborationProofBundle JSON artifact
-        #[arg(long, value_name = "PATH")]
-        bundle_out: Option<PathBuf>,
+        #[arg(
+            long,
+            value_name = "PATH",
+            num_args = 0..=1,
+            default_missing_value = ""
+        )]
+        bundle_out: Option<String>,
         /// Emit a compact JSON report before the machine-parseable footer
         #[arg(long)]
         json: bool,
@@ -462,7 +467,7 @@ async fn main() -> Result<()> {
                 objective.clone(),
                 members.clone(),
                 referee.clone(),
-                bundle_out.clone(),
+                bundle_out.clone().map(PathBuf::from),
                 *json,
             ),
         };
@@ -848,8 +853,14 @@ async fn main() -> Result<()> {
                 bundle_out,
                 json,
             } => {
-                let exit_code =
-                    circle_run::run_circle_run(to, objective, members, referee, bundle_out, json);
+                let exit_code = circle_run::run_circle_run(
+                    to,
+                    objective,
+                    members,
+                    referee,
+                    bundle_out.map(PathBuf::from),
+                    json,
+                );
                 if exit_code != 0 {
                     std::process::exit(exit_code);
                 }

--- a/rust/crates/sera-cli/src/main.rs
+++ b/rust/crates/sera-cli/src/main.rs
@@ -191,13 +191,13 @@ enum CircleCommand {
         )]
         to: Option<String>,
         /// Objective visible to every member (overrides the default)
-        #[arg(long, value_name = "TEXT")]
+        #[arg(long, value_name = "TEXT", num_args = 0..=1, default_missing_value = "")]
         objective: Option<String>,
         /// Comma-separated member ids; first id is the lead
-        #[arg(long, value_name = "a,b,c")]
+        #[arg(long, value_name = "a,b,c", num_args = 0..=1, default_missing_value = "")]
         members: Option<String>,
         /// Referee principal id
-        #[arg(long, value_name = "NAME")]
+        #[arg(long, value_name = "NAME", num_args = 0..=1, default_missing_value = "")]
         referee: Option<String>,
         /// Path to write the generated CollaborationProofBundle JSON artifact
         #[arg(

--- a/rust/crates/sera-cli/tests/circle_run.rs
+++ b/rust/crates/sera-cli/tests/circle_run.rs
@@ -434,3 +434,111 @@ fn circle_run_cli_roster_reflects_cli_inputs() {
     assert_eq!(roles[2], "Critic");
     assert!(roles[3].contains("Referee"));
 }
+
+#[test]
+fn circle_run_cli_rejects_malformed_to_prefix_without_treating_it_as_bare_name() {
+    for target in ["to:circle", "to:foo"] {
+        let output = bin()
+            .args([
+                "circle",
+                "run",
+                "--to",
+                target,
+                "--members",
+                "a,b",
+                "--referee",
+                "r",
+            ])
+            .output()
+            .expect("run");
+        assert_eq!(output.status.code(), Some(3), "target={target}");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert_circle_run_footer(&stdout, "USAGE_ERROR");
+    }
+}
+
+#[test]
+fn circle_run_cli_to_without_value_preserves_usage_error_footer() {
+    let output = bin()
+        .args([
+            "circle",
+            "run",
+            "--to",
+            "--members",
+            "a,b",
+            "--referee",
+            "r",
+        ])
+        .output()
+        .expect("run");
+    assert_eq!(output.status.code(), Some(3));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_circle_run_footer(&stdout, "USAGE_ERROR");
+}
+
+#[test]
+fn circle_run_cli_two_member_run_resolves_worker_entry_to_referee() {
+    let temp = tempfile::tempdir().unwrap();
+    let bundle_out = temp.path().join("b.json");
+    let output = bin()
+        .args([
+            "circle",
+            "run",
+            "--to",
+            "sera-nqh3",
+            "--members",
+            "alpha,beta",
+            "--referee",
+            "judge",
+            "--bundle-out",
+            bundle_out.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    let bundle: Value = serde_json::from_slice(&std::fs::read(&bundle_out).unwrap()).unwrap();
+    let lineage = bundle["lineage"].as_array().unwrap();
+    assert!(lineage.iter().any(|edge| {
+        edge["from_entry_id"] == 2 && edge["to_entry_id"] == 3 && edge["relation"] == "resolves"
+    }));
+}
+
+#[test]
+fn circle_run_cli_extra_members_are_proposals_not_verdict_entries() {
+    let temp = tempfile::tempdir().unwrap();
+    let bundle_out = temp.path().join("b.json");
+    let output = bin()
+        .args([
+            "circle",
+            "run",
+            "--to",
+            "sera-nqh3",
+            "--members",
+            "alpha,beta,gamma,delta",
+            "--referee",
+            "judge",
+            "--bundle-out",
+            bundle_out.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    let bundle: Value = serde_json::from_slice(&std::fs::read(&bundle_out).unwrap()).unwrap();
+    let entries = bundle["entries"].as_array().unwrap();
+    let artifact_types: Vec<&str> = entries
+        .iter()
+        .map(|entry| entry["artifact_type"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        artifact_types,
+        vec![
+            "lead_specification",
+            "proposal",
+            "critique",
+            "proposal",
+            "verdict"
+        ]
+    );
+}

--- a/rust/crates/sera-cli/tests/circle_run.rs
+++ b/rust/crates/sera-cli/tests/circle_run.rs
@@ -1,0 +1,436 @@
+//! Offline integration tests for `sera circle run --to <circle>`.
+//!
+//! Bead: `sera-nqh3` — Common-goal Circle demo. These tests are pure
+//! in-process: they spawn the compiled `sera` binary the same way the
+//! upstream `circle_validate.rs` suite does, and assert on stdout / stderr
+//! footers plus the bundle artifact. There is no LLM, no gateway, no
+//! network — every run is deterministic down to the bundle sha256.
+//!
+//! Spec target: `docs/public/decisions/2026-06-30-circle-team-channel-topology.md`
+//! makes Circle channel-addressed (`to:circle:<name>`). This is the
+//! offline seam for that decision: the `circle run` command addresses a
+//! Circle, addresses the CLI roster, and emits a `CollaborationProofBundle`
+//! that `circle validate` round-trips.
+
+use std::path::Path;
+use std::process::Command;
+
+use serde_json::Value;
+
+fn bin() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_sera"))
+}
+
+fn assert_circle_run_footer(stdout: &str, expected_verdict: &str) {
+    assert!(
+        stdout.contains(&format!("circle-run: {expected_verdict} ")),
+        "expected `circle-run: {expected_verdict} <sha256>` footer, got: {stdout}"
+    );
+}
+
+// ---------------------------------------------------------------------
+// Happy path: 1 leader + 2 members + 1 referee (default roster)
+// ---------------------------------------------------------------------
+
+#[test]
+fn circle_run_cli_addresses_circle_and_emits_valid_proof_bundle() {
+    let temp = tempfile::tempdir().unwrap();
+    let bundle_out = temp.path().join("out").join("proof_bundle.json");
+
+    let output = bin()
+        .args([
+            "circle",
+            "run",
+            "--to",
+            "sera-nqh3",
+            "--members",
+            "alice,bob,carol",
+            "--referee",
+            "ref",
+            "--objective",
+            "Prove the channel-addressed Circle seam",
+            "--bundle-out",
+            bundle_out.to_str().unwrap(),
+            "--json",
+        ])
+        .output()
+        .expect("run sera circle run");
+
+    assert!(
+        output.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_circle_run_footer(&stdout, "PASS");
+    assert!(
+        bundle_out.exists(),
+        "bundle was not written to {}",
+        bundle_out.display()
+    );
+
+    let body: Value = serde_json::from_slice(&std::fs::read(&bundle_out).expect("read bundle"))
+        .expect("parse bundle JSON");
+    assert_eq!(body["circle_id"], "sera-nqh3");
+    assert_eq!(body["objective"], "Prove the channel-addressed Circle seam");
+    assert_eq!(body["entries"].as_array().unwrap().len(), 4);
+    assert_eq!(body["execution_receipts"].as_array().unwrap().len(), 4);
+    assert_eq!(body["lineage"].as_array().unwrap().len(), 3);
+    assert!(body["verdict"].is_object());
+
+    // Round-trip through `sera circle validate` — proves the bundle
+    // satisfies `validate_proof_bundle` (mixed-provider, verdict, etc.).
+    let validate = bin()
+        .args([
+            "circle",
+            "validate",
+            "--bundle",
+            bundle_out.to_str().unwrap(),
+            "--json",
+        ])
+        .output()
+        .expect("run sera circle validate");
+    let validate_stdout = String::from_utf8_lossy(&validate.stdout);
+    assert!(
+        validate_stdout.contains("\"verdict\":\"PASS\""),
+        "validate stdout did not contain PASS: {validate_stdout}"
+    );
+    assert!(
+        validate_stdout.contains("circle-validate: PASS"),
+        "expected `circle-validate: PASS` footer, got: {validate_stdout}"
+    );
+}
+
+// ---------------------------------------------------------------------
+// Determinism: identical args → byte-stable sha256
+// ---------------------------------------------------------------------
+
+#[test]
+fn circle_run_cli_is_byte_deterministic_for_identical_args() {
+    let temp_a = tempfile::tempdir().unwrap();
+    let temp_b = tempfile::tempdir().unwrap();
+    let out_a = temp_a.path().join("proof_bundle.json");
+    let out_b = temp_b.path().join("proof_bundle.json");
+
+    let run_once = |out: &Path| {
+        let output = bin()
+            .args([
+                "circle",
+                "run",
+                "--to",
+                "sera-nqh3",
+                "--members",
+                "alice,bob",
+                "--referee",
+                "ref",
+                "--bundle-out",
+                out.to_str().unwrap(),
+            ])
+            .output()
+            .expect("run");
+        assert!(output.status.success(), "{:?}", output);
+        let bytes = std::fs::read(out).expect("read bundle");
+        let sha = {
+            use sha2::{Digest, Sha256};
+            let mut hasher = Sha256::new();
+            hasher.update(&bytes);
+            format!("{:x}", hasher.finalize())
+        };
+        (bytes, sha)
+    };
+
+    let (bytes_a, sha_a) = run_once(&out_a);
+    let (bytes_b, sha_b) = run_once(&out_b);
+
+    assert_eq!(sha_a, sha_b, "identical args must produce stable sha256");
+    assert_eq!(
+        bytes_a, bytes_b,
+        "identical args must produce identical bytes"
+    );
+}
+
+// ---------------------------------------------------------------------
+// Address parsing: accepts `to:circle:<name>`, `circle:<name>`, bare name
+// ---------------------------------------------------------------------
+
+#[test]
+fn circle_run_cli_accepts_canonical_to_circle_address() {
+    let temp = tempfile::tempdir().unwrap();
+    let bundle_out = temp.path().join("b.json");
+    let output = bin()
+        .args([
+            "circle",
+            "run",
+            "--to",
+            "to:circle:hello",
+            "--members",
+            "a,b",
+            "--referee",
+            "r",
+            "--bundle-out",
+            bundle_out.to_str().unwrap(),
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_circle_run_footer(&stdout, "PASS");
+    assert!(
+        stdout.contains("\"address\":\"to:circle:hello\""),
+        "stdout={stdout}"
+    );
+}
+
+#[test]
+fn circle_run_cli_accepts_short_circle_address_and_bare_name() {
+    for arg in ["circle:engineering", "engineering"] {
+        let output = bin()
+            .args([
+                "circle",
+                "run",
+                "--to",
+                arg,
+                "--members",
+                "a,b",
+                "--referee",
+                "r",
+                "--json",
+            ])
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "address {arg} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            stdout.contains("\"address\":\"to:circle:engineering\""),
+            "address {arg} did not normalize: {stdout}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------
+// Negative fixtures
+// ---------------------------------------------------------------------
+
+#[test]
+fn circle_run_cli_missing_target_emits_usage_error_footer() {
+    let output = bin()
+        .args(["circle", "run", "--members", "a,b", "--referee", "r"])
+        .output()
+        .expect("run");
+    assert_eq!(output.status.code(), Some(3));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_circle_run_footer(&stdout, "USAGE_ERROR");
+    assert!(
+        stdout.contains("circle-run: USAGE_ERROR unknown"),
+        "stdout={stdout}"
+    );
+    assert!(stderr.contains("missing required --to"), "stderr={stderr}");
+}
+
+#[test]
+fn circle_run_cli_invalid_target_path_separator_emits_usage_error_footer() {
+    let output = bin()
+        .args([
+            "circle",
+            "run",
+            "--to",
+            "../escape",
+            "--members",
+            "a,b",
+            "--referee",
+            "r",
+        ])
+        .output()
+        .expect("run");
+    assert_eq!(output.status.code(), Some(3));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_circle_run_footer(&stdout, "USAGE_ERROR");
+    assert!(stderr.contains("invalid Circle name"), "stderr={stderr}");
+}
+
+#[test]
+fn circle_run_cli_unsupported_kind_emits_usage_error_footer() {
+    let output = bin()
+        .args([
+            "circle",
+            "run",
+            "--to",
+            "to:agent:bob",
+            "--members",
+            "a,b",
+            "--referee",
+            "r",
+        ])
+        .output()
+        .expect("run");
+    assert_eq!(output.status.code(), Some(3));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_circle_run_footer(&stdout, "USAGE_ERROR");
+    assert!(
+        stderr.contains("unsupported channel kind"),
+        "stderr={stderr}"
+    );
+}
+
+#[test]
+fn circle_run_cli_duplicate_member_id_emits_usage_error_footer() {
+    let output = bin()
+        .args([
+            "circle",
+            "run",
+            "--to",
+            "sera-nqh3",
+            "--members",
+            "a,a",
+            "--referee",
+            "r",
+        ])
+        .output()
+        .expect("run");
+    assert_eq!(output.status.code(), Some(3));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_circle_run_footer(&stdout, "USAGE_ERROR");
+    assert!(stderr.contains("duplicate member id"), "stderr={stderr}");
+}
+
+#[test]
+fn circle_run_cli_referee_overlap_emits_usage_error_footer() {
+    let output = bin()
+        .args([
+            "circle",
+            "run",
+            "--to",
+            "sera-nqh3",
+            "--members",
+            "alice,bob",
+            "--referee",
+            "alice",
+        ])
+        .output()
+        .expect("run");
+    assert_eq!(output.status.code(), Some(3));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_circle_run_footer(&stdout, "USAGE_ERROR");
+    assert!(stderr.contains("referee"), "stderr={stderr}");
+}
+
+#[test]
+fn circle_run_cli_blank_members_emits_usage_error_footer() {
+    let output = bin()
+        .args([
+            "circle",
+            "run",
+            "--to",
+            "sera-nqh3",
+            "--members",
+            "",
+            "--referee",
+            "r",
+        ])
+        .output()
+        .expect("run");
+    assert_eq!(output.status.code(), Some(3));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_circle_run_footer(&stdout, "USAGE_ERROR");
+    assert!(stderr.contains("--members"), "stderr={stderr}");
+}
+
+// ---------------------------------------------------------------------
+// Footer: every successful run emits `circle-run: PASS <sha256>` and that
+// sha256 matches the bytes-on-disk for `--bundle-out`.
+// ---------------------------------------------------------------------
+
+#[test]
+fn circle_run_cli_footer_sha256_matches_written_bundle_bytes() {
+    let temp = tempfile::tempdir().unwrap();
+    let bundle_out = temp.path().join("proof_bundle.json");
+
+    let output = bin()
+        .args([
+            "circle",
+            "run",
+            "--to",
+            "sera-nqh3",
+            "--members",
+            "alice,bob,carol",
+            "--referee",
+            "ref",
+            "--bundle-out",
+            bundle_out.to_str().unwrap(),
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    let footer_sha = stdout
+        .lines()
+        .rev()
+        .find(|line| line.starts_with("circle-run: "))
+        .and_then(|line| line.split_whitespace().nth(2))
+        .map(str::to_string)
+        .expect("footer missing");
+
+    let bytes = std::fs::read(&bundle_out).expect("read bundle");
+    let disk_sha = {
+        use sha2::{Digest, Sha256};
+        let mut hasher = Sha256::new();
+        hasher.update(&bytes);
+        format!("{:x}", hasher.finalize())
+    };
+    assert_eq!(footer_sha, disk_sha, "footer sha must match disk bytes");
+}
+
+// ---------------------------------------------------------------------
+// Sanity: roster reflects CLI args (1 lead + N members + 1 referee)
+// ---------------------------------------------------------------------
+
+#[test]
+fn circle_run_cli_roster_reflects_cli_inputs() {
+    let temp = tempfile::tempdir().unwrap();
+    let bundle_out = temp.path().join("b.json");
+
+    let output = bin()
+        .args([
+            "circle",
+            "run",
+            "--to",
+            "sera-nqh3",
+            "--members",
+            "alpha,beta,gamma",
+            "--referee",
+            "judge",
+            "--bundle-out",
+            bundle_out.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    let bundle: Value = serde_json::from_slice(&std::fs::read(&bundle_out).unwrap()).unwrap();
+    let roster = bundle["roster"].as_array().unwrap();
+    let ids: Vec<&str> = roster
+        .iter()
+        .map(|m| m["participant_id"].as_str().unwrap())
+        .collect();
+    assert_eq!(ids, vec!["alpha", "beta", "gamma", "judge"]);
+
+    let roles: Vec<&str> = roster.iter().map(|m| m["role"].as_str().unwrap()).collect();
+    assert_eq!(roles[0], "Lead");
+    assert_eq!(roles[1], "Worker");
+    assert_eq!(roles[2], "Critic");
+    assert!(roles[3].contains("Referee"));
+}

--- a/rust/crates/sera-cli/tests/circle_run.rs
+++ b/rust/crates/sera-cli/tests/circle_run.rs
@@ -594,6 +594,62 @@ fn circle_run_cli_run_id_varies_with_inputs_for_same_circle() {
 }
 
 #[test]
+fn circle_run_cli_text_output_reports_actual_run_id() {
+    let temp = tempfile::tempdir().unwrap();
+    let bundle_out = temp.path().join("proof_bundle.json");
+    let output = bin()
+        .args([
+            "circle",
+            "run",
+            "--to",
+            "sera-nqh3",
+            "--objective",
+            "Text output should identify this exact run",
+            "--members",
+            "alpha,beta",
+            "--referee",
+            "judge",
+            "--bundle-out",
+            bundle_out.to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(output.status.success(), "{:?}", output);
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let bundle: Value = serde_json::from_slice(&std::fs::read(&bundle_out).unwrap()).unwrap();
+    let run_id = bundle["run_id"].as_str().unwrap();
+    assert!(
+        stdout.contains(&format!("run_id={run_id}")),
+        "stdout={stdout}"
+    );
+    assert!(stdout.contains("circle_id=sera-nqh3"), "stdout={stdout}");
+    assert!(!stdout.contains("run_id=sera-nqh3 "), "stdout={stdout}");
+}
+
+#[test]
+fn circle_run_cli_missing_run_option_values_preserve_usage_error_footer() {
+    for (flag, expected_stderr) in [
+        ("--objective", "--objective"),
+        ("--members", "--members"),
+        ("--referee", "--referee"),
+    ] {
+        let output = bin()
+            .args(["circle", "run", "--to", "sera-nqh3", flag, "--json"])
+            .output()
+            .expect("run");
+        assert_eq!(output.status.code(), Some(3), "flag={flag}");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert_circle_run_footer(&stdout, "USAGE_ERROR");
+        assert!(
+            stderr.contains(expected_stderr),
+            "flag={flag} stderr={stderr}"
+        );
+    }
+}
+
+#[test]
 fn circle_run_cli_bundle_out_without_value_preserves_usage_error_footer() {
     let output = bin()
         .args([

--- a/rust/crates/sera-cli/tests/circle_run.rs
+++ b/rust/crates/sera-cli/tests/circle_run.rs
@@ -554,3 +554,61 @@ fn circle_run_cli_extra_members_are_proposals_not_verdict_entries() {
         );
     }
 }
+
+#[test]
+fn circle_run_cli_run_id_varies_with_inputs_for_same_circle() {
+    let temp = tempfile::tempdir().unwrap();
+    let out_a = temp.path().join("a.json");
+    let out_b = temp.path().join("b.json");
+
+    for (out, objective) in [(&out_a, "Objective A"), (&out_b, "Objective B")] {
+        let output = bin()
+            .args([
+                "circle",
+                "run",
+                "--to",
+                "sera-nqh3",
+                "--objective",
+                objective,
+                "--members",
+                "alpha,beta",
+                "--referee",
+                "judge",
+                "--bundle-out",
+                out.to_str().unwrap(),
+            ])
+            .output()
+            .unwrap();
+        assert!(output.status.success());
+    }
+
+    let bundle_a: Value = serde_json::from_slice(&std::fs::read(&out_a).unwrap()).unwrap();
+    let bundle_b: Value = serde_json::from_slice(&std::fs::read(&out_b).unwrap()).unwrap();
+    assert_ne!(bundle_a["run_id"], bundle_b["run_id"]);
+    assert!(
+        bundle_a["run_id"]
+            .as_str()
+            .unwrap()
+            .starts_with("sera-circle-run-sera-nqh3-")
+    );
+}
+
+#[test]
+fn circle_run_cli_bundle_out_without_value_preserves_usage_error_footer() {
+    let output = bin()
+        .args([
+            "circle",
+            "run",
+            "--to",
+            "sera-nqh3",
+            "--bundle-out",
+            "--json",
+        ])
+        .output()
+        .expect("run");
+    assert_eq!(output.status.code(), Some(3));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_circle_run_footer(&stdout, "USAGE_ERROR");
+    assert!(stderr.contains("--bundle-out"), "stderr={stderr}");
+}

--- a/rust/crates/sera-cli/tests/circle_run.rs
+++ b/rust/crates/sera-cli/tests/circle_run.rs
@@ -500,6 +500,9 @@ fn circle_run_cli_two_member_run_resolves_worker_entry_to_referee() {
     let bundle: Value = serde_json::from_slice(&std::fs::read(&bundle_out).unwrap()).unwrap();
     let lineage = bundle["lineage"].as_array().unwrap();
     assert!(lineage.iter().any(|edge| {
+        edge["from_entry_id"] == 1 && edge["to_entry_id"] == 2 && edge["relation"] == "derives_from"
+    }));
+    assert!(lineage.iter().any(|edge| {
         edge["from_entry_id"] == 2 && edge["to_entry_id"] == 3 && edge["relation"] == "resolves"
     }));
 }
@@ -541,4 +544,13 @@ fn circle_run_cli_extra_members_are_proposals_not_verdict_entries() {
             "verdict"
         ]
     );
+    let lineage = bundle["lineage"].as_array().unwrap();
+    for (from, to) in [(1, 2), (2, 3), (3, 4), (4, 5)] {
+        assert!(
+            lineage
+                .iter()
+                .any(|edge| edge["from_entry_id"] == from && edge["to_entry_id"] == to),
+            "missing lineage edge {from}->{to}: {lineage:?}"
+        );
+    }
 }

--- a/rust/crates/sera-types/src/circle_channel.rs
+++ b/rust/crates/sera-types/src/circle_channel.rs
@@ -99,7 +99,19 @@ impl CircleChannelAddress {
         if trimmed.is_empty() {
             return Err(CircleAddressParseError::MissingKind);
         }
+        let had_to_prefix = trimmed.starts_with("to:");
         let without_to = trimmed.strip_prefix("to:").unwrap_or(trimmed);
+        if had_to_prefix && !without_to.contains(':') {
+            if without_to == CIRCLE_CHANNEL_KIND {
+                return Err(CircleAddressParseError::InvalidName {
+                    found: String::new(),
+                    reason: "name must not be empty",
+                });
+            }
+            return Err(CircleAddressParseError::UnsupportedKind {
+                found: without_to.to_string(),
+            });
+        }
         // split on the first ':' to peel off the kind
         let (kind, rest) = match without_to.split_once(':') {
             Some(pair) => pair,

--- a/rust/crates/sera-types/src/circle_channel.rs
+++ b/rust/crates/sera-types/src/circle_channel.rs
@@ -1,0 +1,424 @@
+//! Circle channel-addressed types — `docs/public/decisions/2026-06-30-circle-team-channel-topology.md`.
+//!
+//! A Circle is a resident team-channel addressed as `to:circle:<name>` (e.g.
+//! `to:circle:sera-nqh3`). This module holds the address parser/display types
+//! and a thin event envelope used by the offline `sera circle run --to`
+//! proof slice to assemble a `CollaborationProofBundle` from a deterministic
+//! sequence of channel events.
+//!
+//! These types intentionally depend only on `serde` / `chrono` and avoid
+//! coupling to runtime concerns (no LLM calls, no DB I/O) so the address
+//! parser and event envelope are usable from `sera-cli`, `sera-types`
+//! integration tests, and future transport layers.
+//!
+//! Bead: `sera-nqh3` Common-goal Circle demo — prove collaboration envelope
+//! with receipts/lineage/referee (P1 OPEN).
+//!
+//! Spec note: members and referees are identifiers only here; the runtime
+//! maps them to actors via the existing `CircleMember` registry surfaces.
+
+use std::fmt;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Sentinel prefix that identifies a Circle channel address inside the
+/// generic `to:` addressing envelope.
+pub const CIRCLE_CHANNEL_KIND: &str = "circle";
+
+/// Well-formed parse error for `CircleChannelAddress::parse`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CircleAddressParseError {
+    /// Address was empty or missing the `kind:` prefix.
+    MissingKind,
+    /// Kind was not `"circle"`.
+    UnsupportedKind { found: String },
+    /// Circle name was empty or contained characters outside `[A-Za-z0-9._-]`.
+    InvalidName { found: String, reason: &'static str },
+}
+
+impl fmt::Display for CircleAddressParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CircleAddressParseError::MissingKind => {
+                write!(
+                    f,
+                    "address must be of the form `to:circle:<name>` (missing kind)"
+                )
+            }
+            CircleAddressParseError::UnsupportedKind { found } => {
+                write!(f, "unsupported channel kind {found:?}: expected `circle`")
+            }
+            CircleAddressParseError::InvalidName { found, reason } => {
+                write!(f, "invalid Circle name {found:?}: {reason}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for CircleAddressParseError {}
+
+/// Canonical `to:circle:<name>` addressing handle.
+///
+/// Display renders the canonical `to:circle:<name>` form. `parse` accepts the
+/// canonical form and the bare `<name>` form (auto-prefixed with
+/// `to:circle:`). Any other `kind:` prefix is rejected.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(try_from = "String", into = "String")]
+pub struct CircleChannelAddress {
+    /// Channel kind — always [`CIRCLE_CHANNEL_KIND`] for this type.
+    #[serde(default = "default_kind")]
+    pub kind: String,
+    /// Circle name — the addressable identifier of the resident team-channel.
+    pub name: String,
+}
+
+#[allow(dead_code)]
+fn default_kind() -> String {
+    CIRCLE_CHANNEL_KIND.to_string()
+}
+
+impl CircleChannelAddress {
+    /// Construct an address; returns `Err` if the name is empty or contains
+    /// characters outside `[A-Za-z0-9._-]`.
+    pub fn new(name: impl Into<String>) -> Result<Self, CircleAddressParseError> {
+        let name = name.into();
+        Self::validate_name(&name)?;
+        Ok(Self {
+            kind: CIRCLE_CHANNEL_KIND.to_string(),
+            name,
+        })
+    }
+
+    /// Parse a string address. Accepts:
+    /// - `to:circle:<name>` (canonical)
+    /// - `circle:<name>` (without the `to:` prefix)
+    /// - `<name>` alone (auto-prefixed with `to:circle:`).
+    pub fn parse(input: &str) -> Result<Self, CircleAddressParseError> {
+        let trimmed = input.trim();
+        if trimmed.is_empty() {
+            return Err(CircleAddressParseError::MissingKind);
+        }
+        let without_to = trimmed.strip_prefix("to:").unwrap_or(trimmed);
+        // split on the first ':' to peel off the kind
+        let (kind, rest) = match without_to.split_once(':') {
+            Some(pair) => pair,
+            None => {
+                // bare name — accept and auto-prefix
+                let name = without_to;
+                Self::validate_name(name)?;
+                return Ok(Self {
+                    kind: CIRCLE_CHANNEL_KIND.to_string(),
+                    name: name.to_string(),
+                });
+            }
+        };
+        if kind != CIRCLE_CHANNEL_KIND {
+            return Err(CircleAddressParseError::UnsupportedKind {
+                found: kind.to_string(),
+            });
+        }
+        if rest.is_empty() {
+            return Err(CircleAddressParseError::InvalidName {
+                found: rest.to_string(),
+                reason: "name must not be empty",
+            });
+        }
+        Self::validate_name(rest)?;
+        Ok(Self {
+            kind: CIRCLE_CHANNEL_KIND.to_string(),
+            name: rest.to_string(),
+        })
+    }
+
+    fn validate_name(name: &str) -> Result<(), CircleAddressParseError> {
+        if name.is_empty() {
+            return Err(CircleAddressParseError::InvalidName {
+                found: name.to_string(),
+                reason: "name must not be empty",
+            });
+        }
+        if name != name.trim() {
+            return Err(CircleAddressParseError::InvalidName {
+                found: name.to_string(),
+                reason: "name must not have leading or trailing whitespace",
+            });
+        }
+        if name.len() > 128 {
+            return Err(CircleAddressParseError::InvalidName {
+                found: name.to_string(),
+                reason: "name must be at most 128 chars",
+            });
+        }
+        for ch in name.chars() {
+            let ok = ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '-');
+            if !ok {
+                return Err(CircleAddressParseError::InvalidName {
+                    found: name.to_string(),
+                    reason: "name must match [A-Za-z0-9._-]+",
+                });
+            }
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Display for CircleChannelAddress {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "to:{}:{}", self.kind, self.name)
+    }
+}
+
+impl TryFrom<String> for CircleChannelAddress {
+    type Error = CircleAddressParseError;
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::parse(&value)
+    }
+}
+
+impl From<CircleChannelAddress> for String {
+    fn from(addr: CircleChannelAddress) -> String {
+        addr.to_string()
+    }
+}
+
+/// Stable identifier of a member inside a Circle channel.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct CircleMemberId(pub String);
+
+impl CircleMemberId {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for CircleMemberId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<&str> for CircleMemberId {
+    fn from(value: &str) -> Self {
+        Self(value.to_string())
+    }
+}
+
+impl From<String> for CircleMemberId {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+
+/// Role annotation inside a Circle channel.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CircleChannelRole {
+    /// Lead participant — drives the objective, posts proposals, owns the run id.
+    Lead,
+    /// Worker participant — produces proposal payloads.
+    Worker,
+    /// Critic participant — emits objections that surface as `LineageEdge`s.
+    Critic,
+    /// Referee participant — produces the final verdict.
+    Referee,
+}
+
+impl CircleChannelRole {
+    /// Default label used in `ProofBundleMember` when no explicit label is
+    /// provided.
+    pub fn default_label(self) -> &'static str {
+        match self {
+            CircleChannelRole::Lead => "Lead",
+            CircleChannelRole::Worker => "Worker",
+            CircleChannelRole::Critic => "Critic",
+            CircleChannelRole::Referee => "Referee/Integrator",
+        }
+    }
+}
+
+/// Kind discriminator for [`CircleChannelEvent`].
+///
+/// Members of a Circle channel address one another with one of these event
+/// kinds. The list is intentionally tiny for the first offline slice; new
+/// kinds can be added without breaking round-trip serialization.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum CircleChannelEventKind {
+    /// A member claims a role inside the Circle (lead, worker, critic, referee).
+    ClaimRole {
+        member: CircleMemberId,
+        role: CircleChannelRole,
+    },
+    /// A member posts a payload contribution (proposal, objection, verdict body).
+    Post {
+        member: CircleMemberId,
+        artifact_type: String,
+        summary: String,
+    },
+    /// An objective-binding receipt proofing that the contribution was emitted
+    /// by the channel and is reproducible.
+    Receipt {
+        member: CircleMemberId,
+        action: String,
+        tokens: Option<u64>,
+    },
+    /// A directed lineage edge in the proposal-DAG (criticises, resolves, ...).
+    Lineage {
+        member: CircleMemberId,
+        from_entry_id: u64,
+        to_entry_id: u64,
+        relation: String,
+    },
+    /// A referee verdict, optionally accompanied by rationale.
+    Verdict {
+        member: CircleMemberId,
+        verdict: String,
+        rationale: String,
+    },
+}
+
+/// Single channel-resident event.
+///
+/// Events are time-stamped and ordered. The offline `sera circle run --to`
+/// pipeline produces a `Vec<CircleChannelEvent>` deterministically from CLI
+/// args and uses it to assemble a `CollaborationProofBundle` with one entry
+/// per `Post`/`Verdict` event.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CircleChannelEvent {
+    /// Monotonic 1-indexed event id (assigned by the producer).
+    pub event_id: u64,
+    /// Channel the event lives on.
+    pub address: CircleChannelAddress,
+    /// Wall-clock timestamp at event-emission time.
+    pub timestamp: DateTime<Utc>,
+    /// Event kind discriminator.
+    pub body: CircleChannelEventKind,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_canonical_to_circle_form() {
+        let addr = CircleChannelAddress::parse("to:circle:sera-nqh3").unwrap();
+        assert_eq!(addr.name, "sera-nqh3");
+        assert_eq!(addr.kind, "circle");
+        assert_eq!(addr.to_string(), "to:circle:sera-nqh3");
+    }
+
+    #[test]
+    fn parse_circle_kind_without_to_prefix() {
+        let addr = CircleChannelAddress::parse("circle:engineering").unwrap();
+        assert_eq!(addr.name, "engineering");
+    }
+
+    #[test]
+    fn parse_bare_name_auto_prefixes_to_circle() {
+        let addr = CircleChannelAddress::parse("ops").unwrap();
+        assert_eq!(addr.kind, "circle");
+        assert_eq!(addr.name, "ops");
+        assert_eq!(addr.to_string(), "to:circle:ops");
+    }
+
+    #[test]
+    fn parse_rejects_unsupported_kind() {
+        let err = CircleChannelAddress::parse("to:agent:foo").unwrap_err();
+        assert!(matches!(
+            err,
+            CircleAddressParseError::UnsupportedKind { .. }
+        ));
+    }
+
+    #[test]
+    fn parse_rejects_empty_name() {
+        let err = CircleChannelAddress::parse("to:circle:").unwrap_err();
+        assert!(matches!(err, CircleAddressParseError::InvalidName { .. }));
+    }
+
+    #[test]
+    fn parse_rejects_path_separator_in_name() {
+        let err = CircleChannelAddress::parse("to:circle:../escape").unwrap_err();
+        assert!(matches!(err, CircleAddressParseError::InvalidName { .. }));
+    }
+
+    #[test]
+    fn parse_rejects_whitespace_in_name() {
+        let err = CircleChannelAddress::parse("to:circle:sera nqh3").unwrap_err();
+        assert!(matches!(err, CircleAddressParseError::InvalidName { .. }));
+    }
+
+    #[test]
+    fn parse_rejects_blank_input() {
+        let err = CircleChannelAddress::parse("   ").unwrap_err();
+        assert_eq!(err, CircleAddressParseError::MissingKind);
+    }
+
+    #[test]
+    fn serde_round_trip_via_string_codec() {
+        let addr = CircleChannelAddress::parse("to:circle:sera-nqh3").unwrap();
+        let json = serde_json::to_string(&addr).unwrap();
+        // The codec is `into = "String"` so JSON is the canonical form.
+        assert_eq!(json, "\"to:circle:sera-nqh3\"");
+        let back: CircleChannelAddress = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, addr);
+    }
+
+    #[test]
+    fn try_from_string_rejects_garbage() {
+        let err = <CircleChannelAddress as TryFrom<String>>::try_from("to:agent:bob".to_string())
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            CircleAddressParseError::UnsupportedKind { .. }
+        ));
+    }
+
+    #[test]
+    fn channel_event_round_trips_through_json() {
+        let addr = CircleChannelAddress::parse("to:circle:hello").unwrap();
+        let event = CircleChannelEvent {
+            event_id: 1,
+            address: addr,
+            timestamp: "2026-07-02T09:00:00Z".parse().unwrap(),
+            body: CircleChannelEventKind::Post {
+                member: CircleMemberId::from("alice"),
+                artifact_type: "proposal".to_string(),
+                summary: "hello".to_string(),
+            },
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        let back: CircleChannelEvent = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, event);
+    }
+
+    #[test]
+    fn channel_event_verdict_kind_serializes_with_snake_tag() {
+        let addr = CircleChannelAddress::parse("to:circle:hello").unwrap();
+        let event = CircleChannelEvent {
+            event_id: 2,
+            address: addr,
+            timestamp: "2026-07-02T09:00:01Z".parse().unwrap(),
+            body: CircleChannelEventKind::Verdict {
+                member: CircleMemberId::from("ref"),
+                verdict: "Approved".to_string(),
+                rationale: "looks good".to_string(),
+            },
+        };
+        let value: serde_json::Value = serde_json::to_value(&event).unwrap();
+        assert_eq!(value["body"]["kind"], "verdict");
+        assert_eq!(value["body"]["verdict"], "Approved");
+    }
+
+    #[test]
+    fn role_default_labels_are_distinct() {
+        assert_eq!(CircleChannelRole::Lead.default_label(), "Lead");
+        assert_eq!(CircleChannelRole::Worker.default_label(), "Worker");
+        assert_eq!(CircleChannelRole::Critic.default_label(), "Critic");
+        assert_eq!(
+            CircleChannelRole::Referee.default_label(),
+            "Referee/Integrator"
+        );
+    }
+}

--- a/rust/crates/sera-types/src/lib.rs
+++ b/rust/crates/sera-types/src/lib.rs
@@ -8,6 +8,7 @@ pub mod capability;
 pub mod circle;
 pub mod circle_activity;
 pub mod circle_validator;
+pub mod circle_channel;
 pub mod config_manifest;
 pub mod connector;
 pub mod content_block;


### PR DESCRIPTION
## Summary
- add `sera circle run --to <circle>` as an offline deterministic resident Circle proof slice
- introduce channel-address parsing/events for `to:circle:<name>`
- emit and validate a `CollaborationProofBundle` with receipts, lineage, and verdict footer

## Verification
- `cargo test -p sera-cli --test circle_run -- --nocapture`
- `cargo test -p sera-types --lib circle -- --nocapture`

## Notes
- additive CLI/types slice; no live LLM, gateway, or Discord behavior
- supports the `sera-nqh3` common-goal Circle demo path
